### PR TITLE
Increase timeout on tests (from 10s to 30s) so that they pass

### DIFF
--- a/Stratis.Bitcoin.Tests/Class1.cs
+++ b/Stratis.Bitcoin.Tests/Class1.cs
@@ -330,7 +330,7 @@ namespace Stratis.Bitcoin.Tests
 
 		public static void Eventually(Func<bool> act)
 		{
-			var cancel = new CancellationTokenSource(Debugger.IsAttached ? 1000000 : 10000);
+			var cancel = new CancellationTokenSource(Debugger.IsAttached ? 15 * 60 * 1000 : 30 * 1000);
 			while(!act())
 			{
 				cancel.Token.ThrowIfCancellationRequested();


### PR DESCRIPTION
Increase timeout on tests (from 10s to 30s) so that they pass on my machine.

Also make it easy to see minutes, seconds, in the values.
