### PR TITLE
Added BlockNotification service 

### DIFF
--- a/Stratis.Bitcoin.Tests/Features/BlockNotificationFeatureTest.cs
+++ b/Stratis.Bitcoin.Tests/Features/BlockNotificationFeatureTest.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Threading;
+using Moq;
+using NBitcoin;
+using Stratis.Bitcoin.BlockPulling;
+using Stratis.Bitcoin.Notifications;
+using Stratis.Bitcoin.Tests.Logging;
+using Xunit;
+
+namespace Stratis.Bitcoin.Tests
+{
+    public class BlockNotificationFeatureTest : LogsTestBase
+    {       
+        [Fact]
+        public void BlockNotificationFeatureCallsNotifyOnStart()
+        {
+            var cancellationProvider = new FullNode.CancellationProvider
+            {
+                Cancellation = new CancellationTokenSource()
+            };
+            var blockNotification = new Mock<BlockNotification>(new ConcurrentChain(), new BlockPullerStub(), new Signals());
+         
+            var blockNotificationFeature = new BlockNotificationFeature(blockNotification.Object, new BlockNotificationStartHash(0), cancellationProvider);
+            blockNotificationFeature.Start();
+
+            blockNotification.Verify(notif => notif.Notify(0, cancellationProvider.Cancellation.Token), Times.Once);
+        }
+
+        #region stubs
+
+        public class BlockPullerStub : BlockPuller
+        {
+            public BlockPullerStub()
+            {
+
+            }
+
+            public override Block NextBlock(CancellationToken cancellationToken)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override void RequestOptions(TransactionOptions transactionOptions)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override void SetLocation(ChainedBlock location)
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        #endregion
+    }
+}

--- a/Stratis.Bitcoin/Notifications/BlockNotification.cs
+++ b/Stratis.Bitcoin/Notifications/BlockNotification.cs
@@ -1,0 +1,65 @@
+﻿using NBitcoin;
+using Stratis.Bitcoin.BlockPulling;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Stratis.Bitcoin.Notifications
+{
+    /// <summary>
+    /// Class used to broadcast about new blocks.
+    /// </summary>
+    public class BlockNotification
+    {
+        private readonly Signals signals;
+
+        public BlockNotification(ConcurrentChain chain, BlockPuller puller, Signals signals)
+        {
+            if (chain == null)
+                throw new ArgumentNullException("chain");
+            if (puller == null)
+                throw new ArgumentNullException("puller");
+            if (signals == null)
+                throw new ArgumentNullException("signals");
+
+            this.Chain = chain;
+            this.Puller = puller;
+            this.signals = signals;
+        }
+        
+        public BlockPuller Puller { get; }
+
+        public ConcurrentChain Chain { get; }
+
+        /// <summary>
+        /// Notifies about blocks, starting from block with hash passed as parameter.
+        /// </summary>
+        /// <param name="startHash">The hash of the block from which to start notifying</param>
+        /// <param name="cancellationToken">A cancellation token</param>
+        public virtual void Notify(uint256 startHash, CancellationToken cancellationToken)
+        {            
+            // sets the location of the puller to the latest hash that was broadcasted
+            this.Puller.SetLocation(this.Chain.GetBlock(startHash));
+
+            AsyncLoop.Run("block notifier", token =>
+            {
+                // send notifications for all the following blocks
+                while (true)
+                {
+                    var block = this.Puller.NextBlock(token);
+
+                    if (block != null)
+                    {
+                        this.signals.Blocks.Broadcast(block);
+                    }
+                    else
+                    {
+                        break;
+                    }
+                }
+
+                return Task.CompletedTask;
+            }, cancellationToken);
+        }
+    }
+}

--- a/Stratis.Bitcoin/Notifications/BlockNotificationFeature.cs
+++ b/Stratis.Bitcoin/Notifications/BlockNotificationFeature.cs
@@ -1,0 +1,53 @@
+using Microsoft.Extensions.DependencyInjection;
+using NBitcoin;
+using Stratis.Bitcoin.BlockPulling;
+using Stratis.Bitcoin.Builder;
+using Stratis.Bitcoin.Builder.Feature;
+
+namespace Stratis.Bitcoin.Notifications
+{
+    /// <summary>
+    /// Feature enabling the broadcasting of blocks.
+    /// </summary>
+    public class BlockNotificationFeature : FullNodeFeature
+    {
+        private readonly BlockNotification blockNotification;
+
+        private readonly uint256 startHash;
+
+        private readonly FullNode.CancellationProvider cancellationProvider;
+
+        public BlockNotificationFeature(BlockNotification blockNotification, BlockNotificationStartHash blockNotificationStartHash, FullNode.CancellationProvider cancellationProvider)
+        {
+            this.blockNotification = blockNotification;
+            this.startHash = blockNotificationStartHash.StartHash;
+            this.cancellationProvider = cancellationProvider;
+        }
+        
+        public override void Start()
+        {           
+            this.blockNotification.Notify(this.startHash, this.cancellationProvider.Cancellation.Token);
+        }
+    }
+
+    public static class BlockNotificationFeatureExtension
+    {
+        public static IFullNodeBuilder UseBlockNotification(this IFullNodeBuilder fullNodeBuilder, uint256 startHash)
+        {
+            fullNodeBuilder.ConfigureFeature(features =>
+            {
+                features
+                .AddFeature<BlockNotificationFeature>()
+                .FeatureServices(services =>
+                    {
+                        services.AddSingleton(new BlockNotificationStartHash(startHash));
+                        services.AddSingleton<BlockNotification>();
+                        services.AddSingleton<Signals>();
+                        services.AddSingleton<BlockPuller, LookaheadBlockPuller>();
+                    });
+            });
+
+            return fullNodeBuilder;
+        }
+    }
+}

--- a/Stratis.Bitcoin/Notifications/BlockNotificationStartHash.cs
+++ b/Stratis.Bitcoin/Notifications/BlockNotificationStartHash.cs
@@ -1,0 +1,20 @@
+﻿using NBitcoin;
+
+namespace Stratis.Bitcoin.Notifications
+{
+    /// <summary>
+    /// Holds a record of the hash from which the broadcasting of blocks will start.
+    /// </summary>
+    public class BlockNotificationStartHash
+    {
+        /// <summary>
+        /// The hash from which the notification will start.
+        /// </summary>
+        public uint256 StartHash { get; set; }
+
+        public BlockNotificationStartHash(uint256 startHash)
+        {
+            this.StartHash = startHash;
+        }                
+    }
+}


### PR DESCRIPTION
Added BlockNotification service whose purpose is to broadcast about blocks discovered on the network, starting from the hash of the last broadcasted block. Currently not in use.