### PR TITLE
Fix for issue #76: Daemon crashes if first ran as root, then as regular user on Linux

### DIFF
--- a/Stratis.BitcoinD/Checks.cs
+++ b/Stratis.BitcoinD/Checks.cs
@@ -1,0 +1,27 @@
+using System;
+using Stratis.Bitcoin.Configuration;
+
+namespace Stratis.BitcoinD
+{
+	public class Checks
+	{
+		public static void VerifyAccess(NodeSettings nodeSettings) 
+		{
+			// Verify folders are accessible by attempting to create sub directories,
+			// and removing them after the test.  Need to test write access.
+			var dataFolder = new DataFolder(nodeSettings);
+			foreach(var path in new []{ dataFolder.BlockPath, dataFolder.ChainPath, dataFolder.CoinViewPath }) 
+			{
+				try 
+				{
+				    var subDir = new System.IO.DirectoryInfo(path).CreateSubdirectory(Guid.NewGuid().ToString());
+				    subDir.Delete();
+				}
+				catch(UnauthorizedAccessException)
+				{
+				    throw new UnauthorizedAccessException(string.Format("Access to the path '{0}' was denied.", path));
+				}
+			}
+		}
+	}
+}

--- a/Stratis.BitcoinD/Program.cs
+++ b/Stratis.BitcoinD/Program.cs
@@ -23,30 +23,39 @@ namespace Stratis.BitcoinD
 		{
 			Logs.Configure(new LoggerFactory().AddConsole(LogLevel.Trace, false));
 			NodeSettings nodeSettings = NodeSettings.FromArguments(args);
-
-			var node = (FullNode)new FullNodeBuilder()
-				.UseNodeSettings(nodeSettings)
-				.UseConsensus()
-				.UseBlockStore()
-				.UseMempool()
-				.AddMining(args.Any(a => a.Contains("mine")))
-				.AddRPC()
-				.Build();
-
-			// == shut down thread ==
-			new Thread(() =>
+			
+			try 
 			{
-				Console.WriteLine("Press one key to stop");
-				Console.ReadLine();
+				Checks.VerifyAccess(nodeSettings);
+
+				var node = (FullNode)new FullNodeBuilder()
+					.UseNodeSettings(nodeSettings)
+					.UseConsensus()
+					.UseBlockStore()
+					.UseMempool()
+					.AddMining(args.Any(a => a.Contains("mine")))
+					.AddRPC()
+					.Build();
+
+				// == shut down thread ==
+				new Thread(() =>
+				{
+					Console.WriteLine("Press one key to stop");
+					Console.ReadLine();
+					node.Dispose();
+				})
+				{
+					IsBackground = true //so the process terminates
+				}.Start();
+
+				node.Start();
+				node.WaitDisposed();
 				node.Dispose();
-			})
+			}
+			catch(UnauthorizedAccessException ex) 
 			{
-				IsBackground = true //so the process terminates
-			}.Start();
-
-			node.Start();
-			node.WaitDisposed();
-			node.Dispose();
+				Logs.Configuration.LogCritical(ex.Message);
+			}
 		}
 	}
 }


### PR DESCRIPTION
This code checks for read/write access to the file system, for each of the data directories found in NodeSettings.  I've added a file called Checks.cs, with the Checks class, and VerifyAccess method that performs the check by attempting to create temporary sub-directories, and then deleting them after the test.  Throws an UnauthorizedAccessException, which is handled by Main, and lets the user know which, if any, directories are inaccessible, instead of just giving an unhandled exception.