### PR TITLE
Set Maximum Allowable Connections

### DIFF
--- a/Stratis.Bitcoin/Connection/ConnectionManager.cs
+++ b/Stratis.Bitcoin/Connection/ConnectionManager.cs
@@ -78,6 +78,7 @@ namespace Stratis.Bitcoin.Connection
 				DiscoveredNodeGroup = CreateNodeGroup(cloneParameters, _DiscoveredNodeRequiredService);
 				DiscoveredNodeGroup.CustomGroupSelector = WellKnownGroupSelectors.ByNetwork; //is the default, but I want to use it
 				DiscoveredNodeGroup.Connect();
+				DiscoveredNodeGroup.MaximumNodeConnection = 16; //allow maximum 16 connections (outbound/inbound)
 			}
 			else
 			{


### PR DESCRIPTION
 In The Stratis.Bitcoin.Connection.ConnectionManager class,  change the NodesGroup's MaximumNodeConnection :

Add to DiscoveredNodeGroup.MaximumNodeConnection = 16

I've tested this with 125 connections with success, furthermore, doing so increases the list of peers in addrman.dat and improves connection performance upon restart of the node.