### PR TITLE
Persist mempool to disk and load it on node start

### DIFF
--- a/Stratis.Bitcoin.Tests/MemoryPool/MempoolPersistenceTest.cs
+++ b/Stratis.Bitcoin.Tests/MemoryPool/MempoolPersistenceTest.cs
@@ -57,7 +57,6 @@ namespace Stratis.Bitcoin.Tests.MemoryPool
             Assert.True(result.Succeeded);
             Assert.Equal((uint)numTx, result.TrxSaved);
             Assert.Equal(loaded, toSave.ToArray());
-
         }
 
         [Fact]
@@ -128,7 +127,7 @@ namespace Stratis.Bitcoin.Tests.MemoryPool
             List<MempoolPersistenceEntry> toSave = new List<MempoolPersistenceEntry>
             {
                 new MempoolPersistenceEntry{
-                    Tx = tx1.ToBytes(),
+                    Tx = tx1,
                     Time = 1491948625,
                     FeeDelta = expectedTx1FeeDelta
                 },

--- a/Stratis.Bitcoin.Tests/MemoryPool/MempoolPersistenceTest.cs
+++ b/Stratis.Bitcoin.Tests/MemoryPool/MempoolPersistenceTest.cs
@@ -1,6 +1,8 @@
-﻿using Moq;
+﻿using Microsoft.Extensions.Logging;
+using Moq;
 using NBitcoin;
 using Stratis.Bitcoin.Configuration;
+using Stratis.Bitcoin.Logging;
 using Stratis.Bitcoin.MemoryPool;
 using System;
 using System.Collections.Generic;
@@ -18,6 +20,7 @@ namespace Stratis.Bitcoin.Tests.MemoryPool
 
         public MempoolPersistenceTest()
         {
+            Logs.Configure(new LoggerFactory());
             string dir = "Stratis.Bitcoin.Tests/TestData/MempoolPersistenceTest/";
             this.settings = NodeSettings.Default();
             this.settings.DataDir = dir;

--- a/Stratis.Bitcoin.Tests/MemoryPool/MempoolPersistenceTest.cs
+++ b/Stratis.Bitcoin.Tests/MemoryPool/MempoolPersistenceTest.cs
@@ -1,0 +1,89 @@
+﻿using Moq;
+using NBitcoin;
+using Stratis.Bitcoin.Configuration;
+using Stratis.Bitcoin.MemoryPool;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Stratis.Bitcoin.Tests.MemoryPool
+{
+    public class MempoolPersistenceTest
+    {
+        readonly NodeSettings settings;
+
+        public MempoolPersistenceTest()
+        {
+            string dir = "Stratis.Bitcoin.Tests/TestData/MempoolPersistenceTest/";
+            this.settings = NodeSettings.Default();
+            this.settings.DataDir = dir;
+        }
+
+        [Fact]
+        public void SaveToStreamTest()
+        {
+            int numTx = 22;
+            int expectedLinesPerTransaction = 3;
+            int expectedHeaderLines = 2;
+            int expectedLines = numTx * expectedLinesPerTransaction + expectedHeaderLines;
+            MempoolPersistence persistence = new MempoolPersistence(this.settings);
+            IEnumerable<MempoolPersistenceEntry> toSave = CreateTestEntries(numTx);
+
+            long actualStreamLength = 0;
+            ulong actualVersion = 0;
+            int actualCount = -1;
+            using (MemoryStream ms = new MemoryStream())
+            {
+                var bitcoinWriter = new BitcoinStream(ms, true);
+                persistence.DumpToStream(toSave, bitcoinWriter);
+                actualStreamLength = ms.Length;
+                ms.Seek(0, SeekOrigin.Begin);
+                var bitcoinReader = new BitcoinStream(ms, false);
+
+                bitcoinReader.ReadWrite(ref actualVersion);
+                bitcoinReader.ReadWrite(ref actualCount);
+            }
+
+            Assert.True(actualStreamLength > 0);
+            Assert.Equal(MempoolPersistence.MEMPOOL_DUMP_VERSION, actualVersion);
+            Assert.Equal(numTx, actualCount);
+        }
+
+        private IEnumerable<MempoolPersistenceEntry> CreateTestEntries(int numTx)
+        {
+            var entries = new List<TxMempoolEntry>(numTx);
+            for (int i = 0; i < numTx; i++)
+            {
+                var amountSat = 10 * i;
+                Transaction tx = MakeRandomTx(amountSat);
+                entries.Add(new TxMempoolEntry(tx, Money.FromUnit(0.1m, MoneyUnit.MilliBTC), DateTimeOffset.Now.ToUnixTimeSeconds(), i * 100, i, amountSat, i == 0, 10, null));
+            }
+            return entries.Select(entry => MempoolPersistenceEntry.FromTxMempoolEntry(entry));
+        }
+
+        private Transaction MakeRandomTx(int satAmount = 10)
+        {
+            var amount = Money.FromUnit(satAmount, MoneyUnit.Satoshi);
+            var trx = new Transaction();
+            trx.AddInput(new TxIn(Script.Empty));
+            trx.AddOutput(amount, RandomScript());
+            trx.AddInput(new TxIn(Script.Empty));
+            trx.AddOutput(amount, RandomScript());
+            return trx;
+        }
+
+        private static Script RandomScript()
+        {
+            return new Script(Guid.NewGuid().ToByteArray()
+                            .Concat(Guid.NewGuid().ToByteArray())
+                            .Concat(Guid.NewGuid().ToByteArray())
+                            .Concat(Guid.NewGuid().ToByteArray())
+                            .Concat(Guid.NewGuid().ToByteArray())
+                            .Concat(Guid.NewGuid().ToByteArray()));
+        }
+    }
+}

--- a/Stratis.Bitcoin.Tests/MemoryPool/MempoolPersistenceTest.cs
+++ b/Stratis.Bitcoin.Tests/MemoryPool/MempoolPersistenceTest.cs
@@ -19,42 +19,43 @@ namespace Stratis.Bitcoin.Tests.MemoryPool
 {
     public class MempoolPersistenceTest : IDisposable
     {
-        readonly NodeSettings settings;
         private readonly bool shouldDeleteFolder = false;
+        private readonly string dir;
 
         public MempoolPersistenceTest()
         {
             Logs.Configure(new LoggerFactory());
-            string dir = "Stratis.Bitcoin.Tests/TestData/MempoolPersistenceTest/";
-            this.settings = NodeSettings.Default();
-            this.settings.DataDir = dir;
+            this.dir = "Stratis.Bitcoin.Tests/TestData/MempoolPersistenceTest/";
 
-            if (!Directory.Exists(dir))
+            if (!Directory.Exists(this.dir))
             {
                 this.shouldDeleteFolder = true;
-                Directory.CreateDirectory(this.settings.DataDir);
+                Directory.CreateDirectory(this.dir);
             }
         }
 
         public void Dispose()
         {
             if (this.shouldDeleteFolder)
-                Directory.Delete(this.settings.DataDir, true);
+                Directory.Delete(this.dir, true);
         }
 
         [Fact]
         public void SaveLoadFileTest()
         {
             int numTx = 22;
-            string fileName = "SaveLoadFileTest_mempool.dat";
-            MempoolPersistence persistence = new MempoolPersistence(this.settings);
+            string fileName = @"mempool.dat";
+            string dir = "Stratis.Bitcoin.Tests/TestData/MempoolPersistenceTest/";
+            var settings = NodeSettings.Default();
+            settings.DataDir = Directory.CreateDirectory(Path.Combine(dir, "SaveLoadFileTest")).FullName;
+            MempoolPersistence persistence = new MempoolPersistence(settings);
             IEnumerable<MempoolPersistenceEntry> toSave = CreateTestEntries(numTx);
             IEnumerable<MempoolPersistenceEntry> loaded;
 
             MemPoolSaveResult result = persistence.Save(toSave, fileName);
             loaded = persistence.Load(fileName);
 
-            Assert.True(File.Exists(Path.Combine(this.settings.DataDir, fileName)));
+            Assert.True(File.Exists(Path.Combine(settings.DataDir, fileName)));
             Assert.True(result.Succeeded);
             Assert.Equal((uint)numTx, result.TrxSaved);
             Assert.Equal(loaded, toSave.ToArray());
@@ -62,11 +63,13 @@ namespace Stratis.Bitcoin.Tests.MemoryPool
         }
 
         [Fact]
-        public async Task LoadPoolTest_WithBadTransactions()
+        public void LoadPoolTest_WithBadTransactions()
         {
             int numTx = 5;
-            string fileName = "LoadPoolTest_WithBadTransactions_mempool.dat";
-            var fullNodeBuilder = new FullNodeBuilder(this.settings);
+            string fileName = @"LoadPoolTest_WithBadTransactions_mempool.dat";
+            var settings = NodeSettings.Default();
+            settings.DataDir = Directory.CreateDirectory(Path.Combine(this.dir, "LoadPoolTest_WithBadTransactions")).FullName;
+            var fullNodeBuilder = new FullNodeBuilder(settings);
             IFullNode fullNode = fullNodeBuilder
                 .UseConsensus()
                 .UseMempool()
@@ -75,47 +78,51 @@ namespace Stratis.Bitcoin.Tests.MemoryPool
             MempoolManager mempoolManager = fullNode.Services.ServiceProvider.GetService<MempoolManager>();
             IEnumerable<MempoolPersistenceEntry> toSave = CreateTestEntries(numTx);
 
-            MemPoolSaveResult result = (new MempoolPersistence(this.settings)).Save(toSave, fileName);
-            await mempoolManager.LoadPool(fileName);
-            long actualSize = await mempoolManager.MempoolSize();
+            MemPoolSaveResult result = (new MempoolPersistence(settings)).Save(toSave, fileName);
+            mempoolManager.LoadPool(fileName).GetAwaiter().GetResult();
+            long actualSize = mempoolManager.MempoolSize().GetAwaiter().GetResult();
 
             Assert.Equal(0, actualSize);
 
         }
 
-        //TODO: doesn't work. Find some valid transactions
-        //[Fact]
-        //public async Task LoadPoolTest_WithGoodTransactions()
-        //{
-        //    string fileName = "LoadPoolTest_WithGoodTransactions_mempool.dat";
-        //    var fullNodeBuilder = new FullNodeBuilder(this.settings);
-        //    using (IFullNode fullNode = fullNodeBuilder
-        //        .UseConsensus()
-        //        .UseMempool()
-        //        .Build())
-        //    {
-        //        MempoolManager mempoolManager = fullNode.Services.ServiceProvider.GetService<MempoolManager>();
-        //        List<MempoolPersistenceEntry> toSave = new List<MempoolPersistenceEntry>
-        //    {
-        //        new MempoolPersistenceEntry{
-        //            Tx = new Transaction("0100000001055c4c42511f9d05f2fa817c7f023df567f3d501bebec14ddce7c05a9d5fda52000000006b483045022100de552f011768887141b9a767ae184f61aa3743a32aad394ac1e1ec35345415420220070b3d0afd28414f188c966e334e9f7b65e7440538d93bc1d61f82067fcfd3fa012103b47b6ffce08f54be286620a29f45407fedb7b33acfec938551938ec96a1e1b0bffffffff019f053e000000000017a91493e31884769545a237f164aa07b3caef6b62f6b68700000000").ToBytes(),
-        //            Time=1491948625,
-        //            FeeDelta=10
-        //        },
-        //        new MempoolPersistenceEntry{
-        //            Tx = new Transaction("01000000010000000000000000000000000000000000000000000000000000000000000000ffffffff30039d0a0700040620ed5804e6b8cc2d089d1beb58000405f9172f426974667572792f5345475749542f4249503134382fffffffff02e93a2652000000001976a914ab0fcc2fb04ee80d29a00a80140b16323bed3d6e88ac0000000000000000266a24aa21a9ed6481269d055522a05e0f2b26fde26ffc5635e4a59c4592767a32b125b562fba800000000").ToBytes(),
-        //            Time=1491949656,
-        //            FeeDelta=20
-        //        }
-        //    };
+        [Fact]
+        public async Task LoadPoolTest_WithGoodTransactions()
+        {
+            string fileName = @"LoadPoolTest_WithGoodTransactions_mempool.dat";
+            var settings = NodeSettings.Default();
+            settings.DataDir = Directory.CreateDirectory(Path.Combine(this.dir, "LoadPoolTest_WithGoodTransactions")).FullName;
+            var fullNodeBuilder = new FullNodeBuilder(settings);
+            IFullNode fullNode = fullNodeBuilder
+                .UseConsensus()
+                .UseMempool()
+                .Build();
 
-        //        MemPoolSaveResult result = (new MempoolPersistence(this.settings)).Save(toSave, fileName);
-        //        await mempoolManager.LoadPool(fileName);
-        //        long actualSize = await mempoolManager.MempoolSize();
+            MempoolManager mempoolManager = fullNode.Services.ServiceProvider.GetService<MempoolManager>();
+            var tx1_input_orphan = new Transaction("0100000001c4fadb806f9679c27c30c11b694523f6ac9614f7a69076b8940082ce636040fb000000006b4830450221009ad4b969a40b95017d133b13f7d465031829731f3b0ae4bcdcb5e393f5e919f902207f33aad2c3af48d6d65aaf5dd15a85a1f588ee3d6f477b2236cda1d81d88c43b012102eb184a906e082db44a95347de64110952b5821c42068a2054947aec4bc60db2fffffffff02685e3e00000000001976a9149ed35c9c42543ec67f9e6d1033e2ac1ac76f86ba88acd33e4500000000001976a9143c88fada9101f660d77feec1dd8db4ee9ea01d6788ac00000000");
+            var tx1 = new Transaction("0100000001055c4c42511f9d05f2fa817c7f023df567f3d501bebec14ddce7c05a9d5fda52000000006b483045022100de552f011768887141b9a767ae184f61aa3743a32aad394ac1e1ec35345415420220070b3d0afd28414f188c966e334e9f7b65e7440538d93bc1d61f82067fcfd3fa012103b47b6ffce08f54be286620a29f45407fedb7b33acfec938551938ec96a1e1b0bffffffff019f053e000000000017a91493e31884769545a237f164aa07b3caef6b62f6b68700000000");
+            await mempoolManager.Orphans.AddOrphanTx(0, tx1_input_orphan);
+            List<MempoolPersistenceEntry> toSave = new List<MempoolPersistenceEntry>
+            {
+                new MempoolPersistenceEntry{
+                    Tx = tx1.ToBytes(),
+                    Time=1491948625,
+                    FeeDelta=10
+                },
+                //new MempoolPersistenceEntry{
+                //    Tx = new Transaction("01000000010000000000000000000000000000000000000000000000000000000000000000ffffffff30039d0a0700040620ed5804e6b8cc2d089d1beb58000405f9172f426974667572792f5345475749542f4249503134382fffffffff02e93a2652000000001976a914ab0fcc2fb04ee80d29a00a80140b16323bed3d6e88ac0000000000000000266a24aa21a9ed6481269d055522a05e0f2b26fde26ffc5635e4a59c4592767a32b125b562fba800000000").ToBytes(),
+                //    Time=1491949656,
+                //    FeeDelta=20
+                //}
+            };
 
-        //        Assert.Equal(2, actualSize);
-        //    }
-        //}
+            MemPoolSaveResult result = (new MempoolPersistence(settings)).Save(toSave, fileName);
+            await mempoolManager.LoadPool(fileName);
+            long actualSize = await mempoolManager.MempoolSize();
+
+            Assert.Equal(2, actualSize);
+
+        }
 
 
         [Fact]
@@ -125,7 +132,9 @@ namespace Stratis.Bitcoin.Tests.MemoryPool
             int expectedLinesPerTransaction = 3;
             int expectedHeaderLines = 2;
             int expectedLines = numTx * expectedLinesPerTransaction + expectedHeaderLines;
-            MempoolPersistence persistence = new MempoolPersistence(this.settings);
+            var settings = NodeSettings.Default();
+            settings.DataDir = Path.Combine(this.dir, "SaveStreamTest");
+            MempoolPersistence persistence = new MempoolPersistence(settings);
             IEnumerable<MempoolPersistenceEntry> toSave = CreateTestEntries(numTx);
             List<MempoolPersistenceEntry> loaded;
 

--- a/Stratis.Bitcoin.Tests/RPC/Controller/BaseRPCControllerTest.cs
+++ b/Stratis.Bitcoin.Tests/RPC/Controller/BaseRPCControllerTest.cs
@@ -1,10 +1,12 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using NBitcoin;
 using Stratis.Bitcoin.BlockStore;
 using Stratis.Bitcoin.Builder;
 using Stratis.Bitcoin.Configuration;
 using Stratis.Bitcoin.Connection;
 using Stratis.Bitcoin.Consensus;
+using Stratis.Bitcoin.Logging;
 using Stratis.Bitcoin.MemoryPool;
 using Stratis.Bitcoin.RPC;
 using Stratis.Bitcoin.RPC.Controllers;
@@ -17,6 +19,11 @@ namespace Stratis.Bitcoin.Tests.RPC.Controller
 {
     public abstract class BaseRPCControllerTest : TestBase
     {
+        public BaseRPCControllerTest()
+        {
+            Logs.Configure(new LoggerFactory());
+        }
+
         public IFullNode BuildServicedNode(string dir)
         {
             var nodeSettings = NodeSettings.Default();

--- a/Stratis.Bitcoin/Builder/BaseFeature.cs
+++ b/Stratis.Bitcoin/Builder/BaseFeature.cs
@@ -115,7 +115,7 @@ namespace Stratis.Bitcoin.Builder
 			}
 			else
 			{
-				Logs.FullNode.LogInformation("Loading  {dataFolder.AddrManFile}");
+				Logs.FullNode.LogInformation($"Loading  {dataFolder.AddrManFile}");
 				addressManager = AddressManager.LoadPeerFile(dataFolder.AddrManFile);
 				Logs.FullNode.LogInformation("Loaded");
 			}

--- a/Stratis.Bitcoin/MemoryPool/MempoolFeature.cs
+++ b/Stratis.Bitcoin/MemoryPool/MempoolFeature.cs
@@ -1,8 +1,10 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using NBitcoin;
 using Stratis.Bitcoin.Builder;
 using Stratis.Bitcoin.Builder.Feature;
 using Stratis.Bitcoin.Connection;
+using Stratis.Bitcoin.Logging;
 
 namespace Stratis.Bitcoin.MemoryPool
 {
@@ -12,13 +14,15 @@ namespace Stratis.Bitcoin.MemoryPool
 		private readonly ConnectionManager connectionManager;
 		private readonly MempoolSignaled mempoolSignaled;
 		private readonly MempoolBehavior mempoolBehavior;
+		private readonly MempoolManager mempoolManager;
 
-		public MempoolFeature(ConnectionManager connectionManager, Signals signals, MempoolSignaled mempoolSignaled, MempoolBehavior mempoolBehavior)
+		public MempoolFeature(ConnectionManager connectionManager, Signals signals, MempoolSignaled mempoolSignaled, MempoolBehavior mempoolBehavior, MempoolManager mempoolManager)
 		{
 			this.signals = signals;
 			this.connectionManager = connectionManager;
 			this.mempoolSignaled = mempoolSignaled;
 			this.mempoolBehavior = mempoolBehavior;
+			this.mempoolManager = mempoolManager;
 		}
 
 		public override void Start()
@@ -26,7 +30,25 @@ namespace Stratis.Bitcoin.MemoryPool
 			this.connectionManager.Parameters.TemplateBehaviors.Add(this.mempoolBehavior);
 			this.signals.Blocks.Subscribe(this.mempoolSignaled);
 		}
-	}
+
+        public override void Stop()
+        {
+            if (this.mempoolManager != null)
+            {
+                Logs.Mempool.LogInformation("Saving Memory Pool...");
+
+                MemPoolSaveResult result = this.mempoolManager.SavePool().GetAwaiter().GetResult();
+                if (result.Succeeded)
+                {
+                    Logs.Mempool.LogInformation($"...Memory Pool Saved {result.TrxSaved} transactions");
+                }
+                else
+                {
+                    Logs.Mempool.LogWarning("...Memory Pool Not Saved!");
+                }
+            }
+        }
+    }
 
 	public static class MempoolBuilderExtension
 	{
@@ -46,6 +68,7 @@ namespace Stratis.Bitcoin.MemoryPool
 						services.AddSingleton<MempoolManager>();
 						services.AddSingleton<MempoolBehavior>();
 						services.AddSingleton<MempoolSignaled>();
+						services.AddSingleton<IMempoolPersistence, MempoolPersistence>();
 					});
 			});
 

--- a/Stratis.Bitcoin/MemoryPool/MempoolFeature.cs
+++ b/Stratis.Bitcoin/MemoryPool/MempoolFeature.cs
@@ -27,9 +27,12 @@ namespace Stratis.Bitcoin.MemoryPool
 
 		public override void Start()
 		{
-			this.connectionManager.Parameters.TemplateBehaviors.Add(this.mempoolBehavior);
+            this.mempoolManager.LoadPool().GetAwaiter().GetResult();
+
+            this.connectionManager.Parameters.TemplateBehaviors.Add(this.mempoolBehavior);
 			this.signals.Blocks.Subscribe(this.mempoolSignaled);
-		}
+
+        }
 
         public override void Stop()
         {

--- a/Stratis.Bitcoin/MemoryPool/MempoolFeature.cs
+++ b/Stratis.Bitcoin/MemoryPool/MempoolFeature.cs
@@ -37,7 +37,7 @@ namespace Stratis.Bitcoin.MemoryPool
             {
                 Logs.Mempool.LogInformation("Saving Memory Pool...");
 
-                MemPoolSaveResult result = this.mempoolManager.SavePool().GetAwaiter().GetResult();
+                MemPoolSaveResult result = this.mempoolManager.SavePool();
                 if (result.Succeeded)
                 {
                     Logs.Mempool.LogInformation($"...Memory Pool Saved {result.TrxSaved} transactions");

--- a/Stratis.Bitcoin/MemoryPool/MempoolManager.cs
+++ b/Stratis.Bitcoin/MemoryPool/MempoolManager.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using NBitcoin;
 using Stratis.Bitcoin.Configuration;
 using Stratis.Bitcoin.Utilities;
+using Microsoft.Extensions.Logging;
 
 namespace Stratis.Bitcoin.MemoryPool
 {
@@ -60,6 +61,7 @@ namespace Stratis.Bitcoin.MemoryPool
 		{
 			if (this.mempoolPersistence != null && this.memPool?.MapTx != null && this.Validator != null)
 			{
+				Logging.Logs.Mempool.LogInformation("Loading Memory Pool...");
 				IEnumerable<MempoolPersistenceEntry> entries = this.mempoolPersistence.Load(fileName);
 				if (entries != null)
 				{

--- a/Stratis.Bitcoin/MemoryPool/MempoolManager.cs
+++ b/Stratis.Bitcoin/MemoryPool/MempoolManager.cs
@@ -56,11 +56,11 @@ namespace Stratis.Bitcoin.MemoryPool
 			}).ToList();
 		}
 
-        internal async Task<MemPoolSaveResult> SavePool()
+        internal MemPoolSaveResult SavePool()
         {
             if (this.mempoolPersistence == null)
                 return MemPoolSaveResult.NonSuccess;
-            return await this.mempoolPersistence.Save(this.memPool);
+            return this.mempoolPersistence.Save(this.memPool);
         }
 
         public TxMempoolInfo Info(uint256 hash)

--- a/Stratis.Bitcoin/MemoryPool/MempoolManager.cs
+++ b/Stratis.Bitcoin/MemoryPool/MempoolManager.cs
@@ -69,7 +69,7 @@ namespace Stratis.Bitcoin.MemoryPool
 					{
                         Transaction trx = entry.Tx;
 						uint256 trxHash = trx.GetHash();
-						if (!this.memPool.MapTx.ContainsKey(trxHash))
+						if (!this.memPool.Exists(trxHash))
 						{
 							MempoolValidationState state = new MempoolValidationState(false) { AcceptTime = entry.Time, OverrideMempoolLimit = true };
 							if (await this.Validator.AcceptToMemoryPoolWithTime(state, trx) && this.memPool.MapTx.ContainsKey(trxHash))

--- a/Stratis.Bitcoin/MemoryPool/MempoolManager.cs
+++ b/Stratis.Bitcoin/MemoryPool/MempoolManager.cs
@@ -71,7 +71,7 @@ namespace Stratis.Bitcoin.MemoryPool
 						uint256 trxHash = trx.GetHash();
 						if (!this.memPool.MapTx.ContainsKey(trxHash))
 						{
-							MempoolValidationState state = new MempoolValidationState(false) { AcceptTime = entry.Time };
+							MempoolValidationState state = new MempoolValidationState(false) { AcceptTime = entry.Time, OverrideMempoolLimit = true };
 							if (await this.Validator.AcceptToMemoryPoolWithTime(state, trx) && this.memPool.MapTx.ContainsKey(trxHash))
 							{
 								this.memPool.MapTx[trxHash].UpdateFeeDelta(entry.FeeDelta);

--- a/Stratis.Bitcoin/MemoryPool/MempoolManager.cs
+++ b/Stratis.Bitcoin/MemoryPool/MempoolManager.cs
@@ -67,7 +67,7 @@ namespace Stratis.Bitcoin.MemoryPool
 				{
 					foreach (MempoolPersistenceEntry entry in entries)
 					{
-						var trx = new Transaction(entry.Tx);
+                        Transaction trx = entry.Tx;
 						uint256 trxHash = trx.GetHash();
 						if (!this.memPool.MapTx.ContainsKey(trxHash))
 						{

--- a/Stratis.Bitcoin/MemoryPool/MempoolPersistence.cs
+++ b/Stratis.Bitcoin/MemoryPool/MempoolPersistence.cs
@@ -119,12 +119,19 @@ namespace Stratis.Bitcoin.MemoryPool
             {
                 try
                 {
-                    using (var fs = new FileStream(tempFilePath, FileMode.Create))
+                    if (!toSave.Any())
                     {
-                        DumpToStream(toSave, fs);
+                        File.Delete(filePath);
                     }
-                    File.Delete(filePath);
-                    File.Move(tempFilePath, filePath);
+                    else
+                    {
+                        using (var fs = new FileStream(tempFilePath, FileMode.Create))
+                        {
+                            DumpToStream(toSave, fs);
+                        }
+                        File.Delete(filePath);
+                        File.Move(tempFilePath, filePath);
+                    }
                     return MemPoolSaveResult.Success((uint)toSave.LongCount());
                 }
                 catch (Exception ex)

--- a/Stratis.Bitcoin/MemoryPool/MempoolPersistence.cs
+++ b/Stratis.Bitcoin/MemoryPool/MempoolPersistence.cs
@@ -1,0 +1,108 @@
+﻿using Stratis.Bitcoin.Configuration;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NBitcoin;
+using System.IO;
+using Stratis.Bitcoin.Utilities;
+using Stratis.Bitcoin.Logging;
+using Microsoft.Extensions.Logging;
+
+namespace Stratis.Bitcoin.MemoryPool
+{
+    public interface IMempoolPersistence
+    {
+        Task<MemPoolSaveResult> Save(TxMempool memPool);
+    }
+
+    public struct MemPoolSaveResult
+    {
+        public static MemPoolSaveResult NonSuccess { get { return new MemPoolSaveResult { Succeeded = false }; } }
+        public static MemPoolSaveResult Success(uint trxSaved) { return new MemPoolSaveResult { Succeeded = true, TrxSaved = trxSaved }; }
+
+        public bool Succeeded { get; private set; }
+        public uint TrxSaved { get; private set; }
+    }
+
+    internal class MempoolPersistenceEntry: IBitcoinSerializable
+    {
+        public uint256 Tx { get; set; }
+        public long Time { get; set; }
+        public long Feedelta { get; set; }
+
+        public static MempoolPersistenceEntry FromTxMempoolEntry(TxMempoolEntry tx)
+        {
+            return new MempoolPersistenceEntry()
+            {
+                Tx = tx.TransactionHash,
+                Time = tx.Time,
+                Feedelta = tx.feeDelta
+            };
+        }
+
+        public void ReadWrite(BitcoinStream stream)
+        {
+            stream.ReadWrite(this.Tx);
+            stream.ReadWrite(this.Time);
+            stream.ReadWrite(this.Feedelta);
+        }
+    }
+
+    internal class MempoolPersistence : IMempoolPersistence
+    {
+        public const ulong MEMPOOL_DUMP_VERSION = 1;
+
+        public string DataDir;
+
+        public MempoolPersistence(NodeSettings settings)
+        {
+            this.DataDir = settings?.DataDir;
+        }
+
+
+        public async Task<MemPoolSaveResult> Save(TxMempool memPool)
+        {
+            Guard.NotEmpty(this.DataDir, nameof(DataDir));
+
+            if (Directory.Exists(this.DataDir))
+            {
+
+                IEnumerable<MempoolPersistenceEntry> toSave = memPool.MapTx.Values.ToArray().Select(tx => MempoolPersistenceEntry.FromTxMempoolEntry(tx));
+
+                try
+                {
+                    string filePath = Path.Combine(this.DataDir, "mempool.dat");
+                    string tempFilePath = $"{filePath}.dat";
+                    using (var fs = new FileStream(tempFilePath, FileMode.Create))
+                    {
+                        var bs = new BitcoinStream(fs, true);
+                        DumpToStream(toSave, bs);
+                    }
+                    File.Move(tempFilePath, filePath);
+                    return MemPoolSaveResult.Success((uint)toSave.LongCount());
+                }
+                catch (Exception ex)
+                {
+                    Logs.Mempool.LogError(ex.Message);
+                    throw;
+                }
+            }
+
+            return MemPoolSaveResult.NonSuccess;
+        }
+
+        internal void DumpToStream(IEnumerable<MempoolPersistenceEntry> toSave, BitcoinStream stream)
+        {
+            stream.ReadWrite(MEMPOOL_DUMP_VERSION);
+            stream.ReadWrite(toSave.LongCount());
+
+            foreach (MempoolPersistenceEntry entry in toSave)
+            {
+                stream.ReadWrite(entry);
+            }
+        }
+
+    }
+}

--- a/Stratis.Bitcoin/MemoryPool/MempoolPersistence.cs
+++ b/Stratis.Bitcoin/MemoryPool/MempoolPersistence.cs
@@ -14,7 +14,7 @@ namespace Stratis.Bitcoin.MemoryPool
 {
     public interface IMempoolPersistence
     {
-        MemPoolSaveResult Save(TxMempool memPool, string fileName=null);
+        MemPoolSaveResult Save(TxMempool memPool, string fileName = null);
         IEnumerable<MempoolPersistenceEntry> Load(string fileName = null);
     }
 
@@ -100,13 +100,14 @@ namespace Stratis.Bitcoin.MemoryPool
             this.dataDir = settings?.DataDir;
         }
 
-        public MemPoolSaveResult Save(TxMempool memPool, string fileName = defaultFilename)
+        public MemPoolSaveResult Save(TxMempool memPool, string fileName = null)
         {
+            fileName = fileName ?? defaultFilename;
             IEnumerable<MempoolPersistenceEntry> toSave = memPool.MapTx.Values.ToArray().Select(tx => MempoolPersistenceEntry.FromTxMempoolEntry(tx));
             return Save(toSave, fileName);
         }
 
-        internal MemPoolSaveResult Save(IEnumerable<MempoolPersistenceEntry> toSave, string fileName = defaultFilename)
+        internal MemPoolSaveResult Save(IEnumerable<MempoolPersistenceEntry> toSave, string fileName)
         {
             Guard.NotEmpty(this.dataDir, nameof(dataDir));
             Guard.NotEmpty(fileName, nameof(fileName));
@@ -149,8 +150,9 @@ namespace Stratis.Bitcoin.MemoryPool
             }
         }
 
-        public IEnumerable<MempoolPersistenceEntry> Load(string fileName = defaultFilename)
+        public IEnumerable<MempoolPersistenceEntry> Load(string fileName = null)
         {
+            fileName = fileName ?? defaultFilename;
             Guard.NotEmpty(this.dataDir, nameof(dataDir));
             Guard.NotEmpty(fileName, nameof(fileName));
 

--- a/Stratis.Bitcoin/MemoryPool/TxMemPoolEntry.cs
+++ b/Stratis.Bitcoin/MemoryPool/TxMemPoolEntry.cs
@@ -33,7 +33,7 @@ namespace Stratis.Bitcoin.MemoryPool
 		public Money InChainInputValue { get; private set; } //!< Sum of all txin values that are already in blockchain
 		public bool SpendsCoinbase { get; private set; } //!< keep track of transactions that spend a coinbase
 		public long SigOpCost { get; private set; } //!< Total sigop cost
-		private long feeDelta; //!< Used for determining the priority of the transaction for mining in a block
+		internal long feeDelta { get; private set; } //!< Used for determining the priority of the transaction for mining in a block
 		public LockPoints LockPoints { get; private set; } //!< Track the height and time at which tx was final
 
 		// Information about descendants of this transaction that are in the


### PR DESCRIPTION
Persist mempool to disk and load it on node start
Use binary format for memorypool.dat in node data directory
Add IMempoolPersistence to MempoolFeatures
Load MemoryPool on MemoryPoolFeature.Start(); Save on  .Stop().
Push loaded transactions to MemPool with validation.
Handle bad files with ignore.
Delete mempool.dat on Stop() if there are no memory pool entries to persist.

Fixes https://github.com/stratisproject/StratisBitcoinFullNode/issues/109