### PR TITLE
Finish RPC GetInfo.timeoffset, IReadOnlyNodesCollection 

### DIFF
--- a/Stratis.Bitcoin.IntegrationTests/Class1.cs
+++ b/Stratis.Bitcoin.IntegrationTests/Class1.cs
@@ -175,13 +175,13 @@ namespace Stratis.Bitcoin.IntegrationTests
 				var node1 = builder.CreateStratisNode();
 				var node2 = builder.CreateStratisNode();
 				builder.StartAll();
-				Assert.Equal(0, node1.FullNode.ConnectionManager.ConnectedNodes.Count);
-				Assert.Equal(0, node2.FullNode.ConnectionManager.ConnectedNodes.Count);
+				Assert.Equal(0, node1.FullNode.ConnectionManager.ConnectedNodes.Count());
+				Assert.Equal(0, node2.FullNode.ConnectionManager.ConnectedNodes.Count());
 				var rpc1 = node1.CreateRPCClient();
 				var rpc2 = node2.CreateRPCClient();
 				rpc1.AddNode(node2.Endpoint, true);
-				Assert.Equal(1, node1.FullNode.ConnectionManager.ConnectedNodes.Count);
-				Assert.Equal(1, node2.FullNode.ConnectionManager.ConnectedNodes.Count);
+				Assert.Equal(1, node1.FullNode.ConnectionManager.ConnectedNodes.Count());
+				Assert.Equal(1, node2.FullNode.ConnectionManager.ConnectedNodes.Count());
 
 				var behavior = node1.FullNode.ConnectionManager.ConnectedNodes.First().Behaviors.Find<ConnectionManagerBehavior>();
 				Assert.False(behavior.Inbound);

--- a/Stratis.Bitcoin.IntegrationTests/MemoryPoolTests.cs
+++ b/Stratis.Bitcoin.IntegrationTests/MemoryPoolTests.cs
@@ -908,7 +908,7 @@ namespace Stratis.Bitcoin.IntegrationTests
 				Class1.Eventually(() => stratisNodeSync.CreateRPCClient().GetRawMempool().Length == 5);
 
 				// the full node should be connected to both nodes
-				Assert.Equal(stratisNodeSync.FullNode.ConnectionManager.ConnectedNodes.Count, 2);
+				Assert.Equal(stratisNodeSync.FullNode.ConnectionManager.ConnectedNodes.Count(), 2);
 
 				// reset the trickle timer on the full node that has the transactions in the pool
 				foreach (var node in stratisNodeSync.FullNode.ConnectionManager.ConnectedNodes) node.Behavior<MempoolBehavior>().NextInvSend = 0;

--- a/Stratis.Bitcoin.IntegrationTests/Stratis.Bitcoin.IntegrationTests.csproj
+++ b/Stratis.Bitcoin.IntegrationTests/Stratis.Bitcoin.IntegrationTests.csproj
@@ -25,7 +25,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="NStratis" Version="3.0.2.13" />
+    <PackageReference Include="NStratis" Version="3.0.2.14" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="Microsoft.DotNet.InternalAbstractions" Version="1.0.500-preview2-1-003177" />

--- a/Stratis.Bitcoin.IntegrationTests/Stratis.Bitcoin.IntegrationTests.csproj
+++ b/Stratis.Bitcoin.IntegrationTests/Stratis.Bitcoin.IntegrationTests.csproj
@@ -25,7 +25,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="NStratis" Version="3.0.2.14" />
+    <PackageReference Include="NStratis" Version="3.0.2.15" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="Microsoft.DotNet.InternalAbstractions" Version="1.0.500-preview2-1-003177" />

--- a/Stratis.Bitcoin.IntegrationTests/project.json
+++ b/Stratis.Bitcoin.IntegrationTests/project.json
@@ -7,7 +7,7 @@
     "dotnet-test-xunit": "1.0.0-rc2-build10025",
     // xunit hack https://github.com/xunit/xunit/issues/1015
     "Microsoft.DotNet.InternalAbstractions": "1.0.0",
-    "NStratis": "3.0.2.14",
+    "NStratis": "3.0.2.15",
     "Stratis.Bitcoin": "1.0.*"
   },
 

--- a/Stratis.Bitcoin.IntegrationTests/project.json
+++ b/Stratis.Bitcoin.IntegrationTests/project.json
@@ -7,7 +7,7 @@
     "dotnet-test-xunit": "1.0.0-rc2-build10025",
     // xunit hack https://github.com/xunit/xunit/issues/1015
     "Microsoft.DotNet.InternalAbstractions": "1.0.0",
-    "NStratis": "3.0.2.13",
+    "NStratis": "3.0.2.14",
     "Stratis.Bitcoin": "1.0.*"
   },
 

--- a/Stratis.Bitcoin.Tests/Stratis.Bitcoin.Tests.csproj
+++ b/Stratis.Bitcoin.Tests/Stratis.Bitcoin.Tests.csproj
@@ -25,7 +25,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="NStratis" Version="3.0.2.13" />
+    <PackageReference Include="NStratis" Version="3.0.2.14" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="Microsoft.DotNet.InternalAbstractions" Version="1.0.500-preview2-1-003177" />

--- a/Stratis.Bitcoin.Tests/Stratis.Bitcoin.Tests.csproj
+++ b/Stratis.Bitcoin.Tests/Stratis.Bitcoin.Tests.csproj
@@ -25,7 +25,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="NStratis" Version="3.0.2.14" />
+    <PackageReference Include="NStratis" Version="3.0.2.15" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="Microsoft.DotNet.InternalAbstractions" Version="1.0.500-preview2-1-003177" />

--- a/Stratis.Bitcoin.Tests/Utilities/LinqExtensionsTest.cs
+++ b/Stratis.Bitcoin.Tests/Utilities/LinqExtensionsTest.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Xunit;
+
+namespace Stratis.Bitcoin.Tests.Utilities
+{
+    public class LinqExtensionsTest
+    {
+        [Fact]
+        public void EmptySetTest()
+        {
+            List<long> list = new List<long> { };
+
+            var median = list.Median();
+
+            Assert.Equal(0, median);
+        }
+
+        [Fact]
+        public void SingleSetTest()
+        {
+            List<long> list = new List<long> { 22 };
+
+            var median = list.Median();
+
+            Assert.Equal(22, median);
+        }
+
+        [Fact]
+        public void OddSetTest()
+        {
+            List<long> list = new List<long> { 0, 1, 4, 8, 9, 12 };
+
+            var median = list.Median();
+
+            Assert.Equal(6, median);
+        }
+
+        [Fact]
+        public void EvenSetTest()
+        {
+            List<long> list = new List<long> { 1, 4, 8, 9, 12 };
+
+            var median = list.Median();
+
+            Assert.Equal(8, median);
+        }
+
+        [Fact]
+        public void UnorderedSetTest()
+        {
+            List<long> list = new List<long> { 12, 0, 1, 4, 8, 9 };
+
+            var median = list.Median();
+
+            Assert.Equal(6, median);
+        }
+
+
+    }
+}

--- a/Stratis.Bitcoin.Tests/project.json
+++ b/Stratis.Bitcoin.Tests/project.json
@@ -9,7 +9,7 @@
     // xunit hack https://github.com/xunit/xunit/issues/1015
     "Microsoft.DotNet.InternalAbstractions": "1.0.0",
     "Moq": "4.7.1",
-    "NStratis": "3.0.2.13"
+    "NStratis": "3.0.2.14"
   },
   "frameworks": {
     "netcoreapp1.0": {

--- a/Stratis.Bitcoin.Tests/project.json
+++ b/Stratis.Bitcoin.Tests/project.json
@@ -9,7 +9,7 @@
     // xunit hack https://github.com/xunit/xunit/issues/1015
     "Microsoft.DotNet.InternalAbstractions": "1.0.0",
     "Moq": "4.7.1",
-    "NStratis": "3.0.2.14"
+    "NStratis": "3.0.2.15"
   },
   "frameworks": {
     "netcoreapp1.0": {

--- a/Stratis.Bitcoin/BlockPulling/BlockPuller.cs
+++ b/Stratis.Bitcoin/BlockPulling/BlockPuller.cs
@@ -6,6 +6,8 @@ using NBitcoin;
 using System.Collections.Concurrent;
 using NBitcoin.Protocol.Behaviors;
 using System.Threading;
+// TODO: Remove this alias once IReadOnlyNodesCollection is available in NStratis
+using IReadOnlyNodesCollection = System.Collections.Generic.IEnumerable<NBitcoin.Protocol.Node>;
 
 namespace Stratis.Bitcoin.BlockPulling
 {
@@ -203,11 +205,11 @@ namespace Stratis.Bitcoin.BlockPulling
 			//}
 		}
 
-		protected readonly NodesCollection Nodes;
+		protected readonly IReadOnlyNodesCollection Nodes;
 		protected readonly ConcurrentChain Chain;
 		private readonly NodeRequirement requirements;
 
-		protected BlockPuller(ConcurrentChain chain, NodesCollection nodes, ProtocolVersion protocolVersion)
+		protected BlockPuller(ConcurrentChain chain, IReadOnlyNodesCollection nodes, ProtocolVersion protocolVersion)
 		{
 			this.Chain = chain;
 			this.Nodes = nodes;

--- a/Stratis.Bitcoin/BlockPulling/BlockPuller.cs
+++ b/Stratis.Bitcoin/BlockPulling/BlockPuller.cs
@@ -6,8 +6,6 @@ using NBitcoin;
 using System.Collections.Concurrent;
 using NBitcoin.Protocol.Behaviors;
 using System.Threading;
-// TODO: Remove this alias once IReadOnlyNodesCollection is available in NStratis
-using IReadOnlyNodesCollection = System.Collections.Generic.IEnumerable<NBitcoin.Protocol.Node>;
 
 namespace Stratis.Bitcoin.BlockPulling
 {

--- a/Stratis.Bitcoin/Connection/ConnectionManager.cs
+++ b/Stratis.Bitcoin/Connection/ConnectionManager.cs
@@ -21,107 +21,85 @@ namespace Stratis.Bitcoin.Connection
 		// The maximum number of entries in an 'inv' protocol message 
 		public const int MAX_INV_SZ = 50000;
 
-		public NodesGroup DiscoveredNodeGroup
-		{
-			get; set;
-		}
+		private readonly NodesCollection connectedNodes = new NodesCollection();
+		private readonly Dictionary<Node, PerformanceSnapshot> downloads = new Dictionary<Node, PerformanceSnapshot>();
+		private NodeServices discoveredNodeRequiredService = NodeServices.Network;
+		private readonly ConnectionManagerSettings connectionManagerSettings;
+		private readonly Network network;
+		private readonly NodeConnectionParameters parameters;
+		private readonly NodeSettings nodeSettings;
 
+		public Network Network { get { return this.network; } }
+		public NodeConnectionParameters Parameters { get { return this.parameters; } }
+		public NodeSettings NodeSettings { get { return this.nodeSettings; } }
+		public IReadOnlyNodesCollection ConnectedNodes { get { return this.connectedNodes; } }
+		public List<NodeServer> Servers { get; } = new List<NodeServer>();
+		public NodesGroup ConnectNodeGroup { get; private set; }
+		public NodesGroup AddNodeNodeGroup { get; private set; }
+		public NodesGroup DiscoveredNodeGroup { get; set; }
 
-		private readonly Network _Network;
-		public Network Network
-		{
-			get
-			{
-				return _Network;
-			}
-		}
-
-		public NodesGroup ConnectNodeGroup
-		{
-			get;
-			private set;
-		}
-		public NodesGroup AddNodeNodeGroup
-		{
-			get;
-			private set;
-		}
-
-		public NodeConnectionParameters Parameters
-		{
-			get { return this._Parameters; }
-		}
-
-		private NodeSettings _NodeSettings;
-		public NodeSettings NodeSettings
-		{
-			get { return this._NodeSettings; }
-		}
-
-		NodeConnectionParameters _Parameters;
-		ConnectionManagerSettings _ConnectionManagerSettings;
 		public ConnectionManager(Network network, NodeConnectionParameters parameters, NodeSettings nodeSettings)
 		{
-			_Network = network;
-			this._NodeSettings = nodeSettings;
-			_ConnectionManagerSettings = nodeSettings.ConnectionManager;
-			_Parameters = parameters;
+			this.network = network;
+			this.nodeSettings = nodeSettings;
+			this.connectionManagerSettings = nodeSettings.ConnectionManager;
+			this.parameters = parameters;
 		}
 
 		public void Start()
 		{
-			_Parameters.UserAgent = "StratisBitcoin:" + GetVersion();
-			_Parameters.Version = NodeSettings.ProtocolVersion;
-			if (_ConnectionManagerSettings.Connect.Count == 0)
+			this.parameters.UserAgent = "StratisBitcoin:" + GetVersion();
+			this.parameters.Version = this.NodeSettings.ProtocolVersion;
+			if (this.connectionManagerSettings.Connect.Count == 0)
 			{
-				var cloneParameters = _Parameters.Clone();
+				NodeConnectionParameters cloneParameters = this.parameters.Clone();
 				cloneParameters.TemplateBehaviors.Add(new ConnectionManagerBehavior(false, this));
-				DiscoveredNodeGroup = CreateNodeGroup(cloneParameters, _DiscoveredNodeRequiredService);
-				DiscoveredNodeGroup.CustomGroupSelector = WellKnownGroupSelectors.ByNetwork; //is the default, but I want to use it
-				DiscoveredNodeGroup.Connect();
+				this.DiscoveredNodeGroup = CreateNodeGroup(cloneParameters, this.discoveredNodeRequiredService);
+				this.DiscoveredNodeGroup.CustomGroupSelector = WellKnownGroupSelectors.ByNetwork; //is the default, but I want to use it
+				this.DiscoveredNodeGroup.Connect();
 			}
 			else
 			{
-				var cloneParameters = _Parameters.Clone();
+				NodeConnectionParameters cloneParameters = this.parameters.Clone();
 				cloneParameters.TemplateBehaviors.Add(new ConnectionManagerBehavior(false, this));
 				cloneParameters.TemplateBehaviors.Remove<AddressManagerBehavior>();
 				var addrman = new AddressManager();
-				addrman.Add(_ConnectionManagerSettings.Connect.Select(c => new NetworkAddress(c)).ToArray(), IPAddress.Loopback);
+				addrman.Add(this.connectionManagerSettings.Connect.Select(c => new NetworkAddress(c)).ToArray(), IPAddress.Loopback);
 				var addrmanBehavior = new AddressManagerBehavior(addrman);
 				addrmanBehavior.Mode = AddressManagerBehaviorMode.None;
 				cloneParameters.TemplateBehaviors.Add(addrmanBehavior);
 
-				ConnectNodeGroup = CreateNodeGroup(cloneParameters, NodeServices.Nothing);
-				ConnectNodeGroup.MaximumNodeConnection = _ConnectionManagerSettings.Connect.Count;
-				ConnectNodeGroup.CustomGroupSelector = WellKnownGroupSelectors.ByEndpoint;
-				ConnectNodeGroup.Connect();
+				this.ConnectNodeGroup = CreateNodeGroup(cloneParameters, NodeServices.Nothing);
+				this.ConnectNodeGroup.MaximumNodeConnection = this.connectionManagerSettings.Connect.Count;
+				this.ConnectNodeGroup.CustomGroupSelector = WellKnownGroupSelectors.ByEndpoint;
+				this.ConnectNodeGroup.Connect();
 			}
 
 			{
-				var cloneParameters = _Parameters.Clone();
+				NodeConnectionParameters cloneParameters = this.parameters.Clone();
 				cloneParameters.TemplateBehaviors.Add(new ConnectionManagerBehavior(false, this));
 				cloneParameters.TemplateBehaviors.Remove<AddressManagerBehavior>();
 				var addrman = new AddressManager();
-				addrman.Add(_ConnectionManagerSettings.AddNode.Select(c => new NetworkAddress(c)).ToArray(), IPAddress.Loopback);
+				addrman.Add(this.connectionManagerSettings.AddNode.Select(c => new NetworkAddress(c)).ToArray(), IPAddress.Loopback);
 				var addrmanBehavior = new AddressManagerBehavior(addrman);
 				addrmanBehavior.Mode = AddressManagerBehaviorMode.AdvertizeDiscover;
 				cloneParameters.TemplateBehaviors.Add(addrmanBehavior);
 
-				AddNodeNodeGroup = CreateNodeGroup(cloneParameters, NodeServices.Nothing);
-				AddNodeNodeGroup.MaximumNodeConnection = _ConnectionManagerSettings.AddNode.Count;
-				AddNodeNodeGroup.CustomGroupSelector = WellKnownGroupSelectors.ByEndpoint;
-				AddNodeNodeGroup.Connect();
+				this.AddNodeNodeGroup = CreateNodeGroup(cloneParameters, NodeServices.Nothing);
+				this.AddNodeNodeGroup.MaximumNodeConnection = this.connectionManagerSettings.AddNode.Count;
+				this.AddNodeNodeGroup.CustomGroupSelector = WellKnownGroupSelectors.ByEndpoint;
+				this.AddNodeNodeGroup.Connect();
 			}
 
 			StringBuilder logs = new StringBuilder();
 			logs.AppendLine("Node listening on:");
-			foreach (var listen in _ConnectionManagerSettings.Listen)
+			foreach (NodeServerEndpoint listen in this.connectionManagerSettings.Listen)
 			{
-				var cloneParameters = _Parameters.Clone();
-				var server = new NodeServer(Network);
+				NodeConnectionParameters cloneParameters = this.parameters.Clone();
+				var server = new NodeServer(this.Network);
 				server.LocalEndpoint = listen.Endpoint;
-				server.ExternalEndpoint = _ConnectionManagerSettings.ExternalEndpoint;
-				_Servers.Add(server);
+				server.ExternalEndpoint = this.connectionManagerSettings.ExternalEndpoint;
+				this.Servers.Add(server);
 				cloneParameters.TemplateBehaviors.Add(new ConnectionManagerBehavior(true, this)
 				{
 					Whitelisted = listen.Whitelisted
@@ -136,16 +114,15 @@ namespace Stratis.Bitcoin.Connection
 			Logs.ConnectionManager.LogInformation(logs.ToString());
 		}
 
-		NodeServices _DiscoveredNodeRequiredService = NodeServices.Network;
 		public void AddDiscoveredNodesRequirement(NodeServices services)
 		{
-			_DiscoveredNodeRequiredService |= services;
-			var group = DiscoveredNodeGroup;
+			this.discoveredNodeRequiredService |= services;
+			NodesGroup group = this.DiscoveredNodeGroup;
 			if (group != null &&
 			   !group.Requirements.RequiredServices.HasFlag(services))
 			{
 				group.Requirements.RequiredServices |= NodeServices.NODE_WITNESS;
-				foreach (var node in group.ConnectedNodes)
+				foreach (Node node in group.ConnectedNodes)
 				{
 					if (!node.PeerVersion.Services.HasFlag(services))
 						node.DisconnectAsync("The peer does not support the required services requirement");
@@ -156,19 +133,19 @@ namespace Stratis.Bitcoin.Connection
 		public string GetStats()
 		{
 			StringBuilder builder = new StringBuilder();
-			lock (_Downloads)
+			lock (this.downloads)
 			{
 				PerformanceSnapshot diffTotal = new PerformanceSnapshot(0, 0);
 				builder.AppendLine("=======Connections=======");
-				foreach (var node in ConnectedNodes)
+				foreach (Node node in this.ConnectedNodes)
 				{
-					var newSnapshot = node.Counter.Snapshot();
+					PerformanceSnapshot newSnapshot = node.Counter.Snapshot();
 					PerformanceSnapshot lastSnapshot = null;
-					if (_Downloads.TryGetValue(node, out lastSnapshot))
+					if (this.downloads.TryGetValue(node, out lastSnapshot))
 					{
-						var behavior = node.Behaviors.OfType<BlockPuller.BlockPullerBehavior>()
-								.FirstOrDefault(b => b.Puller.GetType() == typeof(LookaheadBlockPuller));
-						var diff = newSnapshot - lastSnapshot;
+						BlockPuller.BlockPullerBehavior behavior = node.Behaviors.OfType<BlockPuller.BlockPullerBehavior>()
+																	.FirstOrDefault(b => b.Puller.GetType() == typeof(LookaheadBlockPuller));
+						PerformanceSnapshot diff = newSnapshot - lastSnapshot;
 						diffTotal = new PerformanceSnapshot(diff.TotalReadenBytes + diffTotal.TotalReadenBytes, diff.TotalWrittenBytes + diffTotal.TotalWrittenBytes) { Start = diff.Start, Taken = diff.Taken };
 						builder.Append((node.RemoteSocketAddress + ":" + node.RemoteSocketPort).PadRight(Logs.ColumnLength * 2) + "R:" + ToKBSec(diff.ReadenBytesPerSecond) + "\tW:" + ToKBSec(diff.WrittenBytesPerSecond));
 						if (behavior != null)
@@ -177,15 +154,15 @@ namespace Stratis.Bitcoin.Connection
 						}
 						builder.AppendLine();
 					}
-					_Downloads.AddOrReplace(node, newSnapshot);
+					this.downloads.AddOrReplace(node, newSnapshot);
 				}
 				builder.AppendLine("=================");
 				builder.AppendLine("Total".PadRight(Logs.ColumnLength * 2) + "R:" + ToKBSec(diffTotal.ReadenBytesPerSecond) + "\tW:" + ToKBSec(diffTotal.WrittenBytesPerSecond));
 				builder.AppendLine("==========================");
 
 				//TODO: Hack, we should just clean nodes that are not connect anymore
-				if (_Downloads.Count > 1000)
-					_Downloads.Clear();
+				if (this.downloads.Count > 1000)
+					this.downloads.Clear();
 			}
 			return builder.ToString();
 		}
@@ -194,10 +171,10 @@ namespace Stratis.Bitcoin.Connection
 		{
 			var builder = new StringBuilder();
 
-			foreach (var node in this.ConnectedNodes)
+			foreach (Node node in this.ConnectedNodes)
 			{
-				var connectionManagerBehavior = node.Behavior<ConnectionManagerBehavior>();
-				var chainBehavior = node.Behavior<BlockStore.ChainBehavior>();
+				ConnectionManagerBehavior connectionManagerBehavior = node.Behavior<ConnectionManagerBehavior>();
+				BlockStore.ChainBehavior chainBehavior = node.Behavior<BlockStore.ChainBehavior>();
 				builder.AppendLine(
 					"Node:" + (node.RemoteInfo() + ", ").PadRight(Logs.ColumnLength + 15) +
 					(" connected" + " (" + (connectionManagerBehavior.Inbound ? "inbound" : "outbound") + "),").PadRight(Logs.ColumnLength + 7) +
@@ -213,12 +190,6 @@ namespace Stratis.Bitcoin.Connection
 			return speed.ToString("0.00") + " KB/S";
 		}
 
-		Dictionary<Node, PerformanceSnapshot> _Downloads = new Dictionary<Node, PerformanceSnapshot>();
-
-		List<NodeServer> _Servers = new List<NodeServer>();
-
-		public List<NodeServer> Servers => this._Servers;
-
 		private NodesGroup CreateNodeGroup(NodeConnectionParameters cloneParameters, NodeServices requiredServices)
 		{
 			return new NodesGroup(this.Network, cloneParameters, new NodeRequirement()
@@ -230,7 +201,7 @@ namespace Stratis.Bitcoin.Connection
 
 		private string GetVersion()
 		{
-			var match = Regex.Match(this.GetType().AssemblyQualifiedName, "Version=([0-9]+\\.[0-9]+\\.[0-9]+)\\.");
+			Match match = Regex.Match(this.GetType().AssemblyQualifiedName, "Version=([0-9]+\\.[0-9]+\\.[0-9]+)\\.");
 			return match.Groups[1].Value;
 		}
 
@@ -242,38 +213,35 @@ namespace Stratis.Bitcoin.Connection
 				this.ConnectNodeGroup.Dispose();
 			if (this.AddNodeNodeGroup != null)
 				this.AddNodeNodeGroup.Dispose();
-			foreach (NodeServer server in this._Servers)
+			foreach (NodeServer server in this.Servers)
 				server.Dispose();
-			foreach (Node node in this.ConnectedNodes.Where(n => n.Behaviors.Find<ConnectionManagerBehavior>().OneTry))
+			foreach (Node node in this.connectedNodes.Where(n => n.Behaviors.Find<ConnectionManagerBehavior>().OneTry))
 				node.Disconnect();
 		}
 
-		private readonly NodesCollection _ConnectedNodes = new NodesCollection();
-		public IReadOnlyNodesCollection ConnectedNodes { get { return this._ConnectedNodes; } }
-
 		internal void AddConnectedNode(Node node)
 		{
-			this._ConnectedNodes.Add(node);
+			this.connectedNodes.Add(node);
 		}
 
 		internal void RemoveConnectedNode(Node node)
 		{
-			this._ConnectedNodes.Remove(node);
+			this.connectedNodes.Remove(node);
 		}
 
 		public Node FindNodeByEndpoint(IPEndPoint endpoint)
 		{
-			return this._ConnectedNodes.FindByEndpoint(endpoint);
+			return this.connectedNodes.FindByEndpoint(endpoint);
 		}
 
 		public Node FindNodeByIp(IPAddress ip)
 		{
-			return this._ConnectedNodes.FindByIp(ip);
+			return this.connectedNodes.FindByIp(ip);
 		}
 
 		public Node FindLocalNode()
 		{
-			return this._ConnectedNodes.FindLocal();
+			return this.connectedNodes.FindLocal();
 		}
 
 		public void AddNodeAddress(IPEndPoint endpoint)
@@ -285,14 +253,14 @@ namespace Stratis.Bitcoin.Connection
 
 		public void RemoveNodeAddress(IPEndPoint endpoint)
 		{
-			Node node = this._ConnectedNodes.FindByEndpoint(endpoint);
+			Node node = this.connectedNodes.FindByEndpoint(endpoint);
 			if (node != null)
 				node.DisconnectAsync("Requested by user");
 		}
 
 		public Node Connect(IPEndPoint endpoint)
 		{
-			NodeConnectionParameters cloneParameters = this._Parameters.Clone();
+			NodeConnectionParameters cloneParameters = this.parameters.Clone();
 			cloneParameters.TemplateBehaviors.Add(new ConnectionManagerBehavior(false, this)
 			{
 				OneTry = true

--- a/Stratis.Bitcoin/Connection/ConnectionManager.cs
+++ b/Stratis.Bitcoin/Connection/ConnectionManager.cs
@@ -223,7 +223,7 @@ namespace Stratis.Bitcoin.Connection
 
 		private NodesGroup CreateNodeGroup(NodeConnectionParameters cloneParameters, NodeServices requiredServices)
 		{
-			return new NodesGroup(Network, cloneParameters, new NodeRequirement()
+			return new NodesGroup(this.Network, cloneParameters, new NodeRequirement()
 			{
 				MinVersion = this.NodeSettings.ProtocolVersion,
 				RequiredServices = requiredServices,
@@ -238,18 +238,17 @@ namespace Stratis.Bitcoin.Connection
 
 		public void Dispose()
 		{
-			if (DiscoveredNodeGroup != null)
-				DiscoveredNodeGroup.Dispose();
-			if (ConnectNodeGroup != null)
-				ConnectNodeGroup.Dispose();
-			if (AddNodeNodeGroup != null)
-				AddNodeNodeGroup.Dispose();
-			foreach (var server in _Servers)
+			if (this.DiscoveredNodeGroup != null)
+				this.DiscoveredNodeGroup.Dispose();
+			if (this.ConnectNodeGroup != null)
+				this.ConnectNodeGroup.Dispose();
+			if (this.AddNodeNodeGroup != null)
+				this.AddNodeNodeGroup.Dispose();
+			foreach (NodeServer server in this._Servers)
 				server.Dispose();
-			foreach (var node in ConnectedNodes.Where(n => n.Behaviors.Find<ConnectionManagerBehavior>().OneTry))
+			foreach (Node node in this.ConnectedNodes.Where(n => n.Behaviors.Find<ConnectionManagerBehavior>().OneTry))
 				node.Disconnect();
 		}
-
 
 		private readonly NodesCollection _ConnectedNodes = new NodesCollection();
 		public IReadOnlyNodesCollection ConnectedNodes { get { return this._ConnectedNodes; } }
@@ -295,12 +294,12 @@ namespace Stratis.Bitcoin.Connection
 
 		public Node Connect(IPEndPoint endpoint)
 		{
-			var cloneParameters = _Parameters.Clone();
+			NodeConnectionParameters cloneParameters = this._Parameters.Clone();
 			cloneParameters.TemplateBehaviors.Add(new ConnectionManagerBehavior(false, this)
 			{
 				OneTry = true
 			});
-			var node = Node.Connect(Network, endpoint, cloneParameters);
+			var node = Node.Connect(this.Network, endpoint, cloneParameters);
 			node.VersionHandshake();
 			return node;
 		}

--- a/Stratis.Bitcoin/Connection/ConnectionManager.cs
+++ b/Stratis.Bitcoin/Connection/ConnectionManager.cs
@@ -13,8 +13,6 @@ using Stratis.Bitcoin.Configuration;
 using Stratis.Bitcoin.Connection;
 using Stratis.Bitcoin.Logging;
 using Stratis.Bitcoin.Configuration.Settings;
-// TODO: Remove this alias once IReadOnlyNodesCollection is available in NStratis
-using IReadOnlyNodesCollection = System.Collections.Generic.IEnumerable<NBitcoin.Protocol.Node>;
 
 namespace Stratis.Bitcoin.Connection
 {

--- a/Stratis.Bitcoin/Connection/ConnectionManagerBehavior.cs
+++ b/Stratis.Bitcoin/Connection/ConnectionManagerBehavior.cs
@@ -11,8 +11,8 @@ namespace Stratis.Bitcoin.Connection
 	{
 		public ConnectionManagerBehavior(bool inbound, ConnectionManager connectionManager)
 		{
-			Inbound = inbound;
-			ConnectionManager = connectionManager;
+			this.Inbound = inbound;
+			this.ConnectionManager = connectionManager;
 		}
 
 		public ConnectionManager ConnectionManager
@@ -38,10 +38,10 @@ namespace Stratis.Bitcoin.Connection
 
 		public override object Clone()
 		{
-			return new ConnectionManagerBehavior(Inbound, ConnectionManager)
+			return new ConnectionManagerBehavior(this.Inbound, this.ConnectionManager)
 			{
-				OneTry = OneTry,
-				Whitelisted = Whitelisted,
+				OneTry = this.OneTry,
+				Whitelisted = this.Whitelisted,
 			};
 		}
 
@@ -49,13 +49,13 @@ namespace Stratis.Bitcoin.Connection
 		{
 			this.AttachedNode.StateChanged += AttachedNode_StateChanged;
 			this.AttachedNode.MessageReceived += AttachedNode_MessageReceived;
-			_ChainBehavior = this.AttachedNode.Behaviors.Find<BlockStore.ChainBehavior>();
+			this._ChainBehavior = this.AttachedNode.Behaviors.Find<BlockStore.ChainBehavior>();
 		}
 
 		BlockStore.ChainBehavior _ChainBehavior;
 		private void AttachedNode_MessageReceived(Node node, IncomingMessage message)
 		{
-			if(_ChainBehavior.InvalidHeaderReceived && !Whitelisted)
+			if(this._ChainBehavior.InvalidHeaderReceived && !this.Whitelisted)
 			{
 				node.DisconnectAsync("Invalid block received");
 			}
@@ -65,16 +65,16 @@ namespace Stratis.Bitcoin.Connection
 		{
 			if(node.State == NodeState.HandShaked)
 			{
-				ConnectionManager.ConnectedNodes.Add(node);
-				Logs.ConnectionManager.LogInformation("Node " + node.RemoteSocketEndpoint + " connected (" + (Inbound ? "inbound" : "outbound") + "), agent " + node.PeerVersion.UserAgent + ", height " + node.PeerVersion.StartHeight);
+				this.ConnectionManager.AddConnectedNode(node);
+				Logs.ConnectionManager.LogInformation("Node " + node.RemoteSocketEndpoint + " connected (" + (this.Inbound ? "inbound" : "outbound") + "), agent " + node.PeerVersion.UserAgent + ", height " + node.PeerVersion.StartHeight);
 				node.SendMessageAsync(new SendHeadersPayload());
 			}
 			if(node.State == NodeState.Failed || node.State == NodeState.Offline)
 			{
 				Logs.ConnectionManager.LogInformation("Node " + node.RemoteSocketEndpoint + " offline");
-				if(node.DisconnectReason != null && !String.IsNullOrEmpty(node.DisconnectReason.Reason))
+				if(node.DisconnectReason != null && !string.IsNullOrEmpty(node.DisconnectReason.Reason))
 					Logs.ConnectionManager.LogInformation("Reason: " + node.DisconnectReason.Reason);
-				ConnectionManager.ConnectedNodes.Remove(node);
+				this.ConnectionManager.RemoveConnectedNode(node);
 			}
 		}
 

--- a/Stratis.Bitcoin/RPC/Controllers/ConnectionManagerController.cs
+++ b/Stratis.Bitcoin/RPC/Controllers/ConnectionManagerController.cs
@@ -25,10 +25,10 @@ namespace Stratis.Bitcoin.RPC.Controllers
             switch (command)
             {
                 case "add":
-                    this._ConnectionManager.AddNode(endpoint);
+                    this._ConnectionManager.AddNodeAddress(endpoint);
                     break;
                 case "remove":
-                    this._ConnectionManager.RemoveNode(endpoint);
+                    this._ConnectionManager.RemoveNodeAddress(endpoint);
                     break;
                 case "onetry":
                     this._ConnectionManager.Connect(endpoint);

--- a/Stratis.Bitcoin/RPC/Controllers/FullNodeController.cs
+++ b/Stratis.Bitcoin/RPC/Controllers/FullNodeController.cs
@@ -11,6 +11,7 @@ using Stratis.Bitcoin.MemoryPool;
 using Stratis.Bitcoin.Consensus;
 using Stratis.Bitcoin.Utilities;
 using Stratis.Bitcoin.Builder;
+using NBitcoin.Protocol;
 
 namespace Stratis.Bitcoin.RPC.Controllers
 {
@@ -80,7 +81,7 @@ namespace Stratis.Bitcoin.RPC.Controllers
                 version = this._FullNode?.Version.ToUint() ?? 0,
                 protocolversion = (uint)(this._Settings?.ProtocolVersion ?? NodeSettings.SupportedProtocolVersion),
                 blocks = this._ChainState?.HighestValidatedPoW?.Height ?? 0,
-                timeoffset = 0, // TODO: Calculate median time offset of connected nodes
+                timeoffset = this._ConnectionManager?.ConnectedNodes?.GetMedianTimeOffset() ?? 0,
                 connections = this._ConnectionManager?.ConnectedNodes?.Count(),
                 proxy = string.Empty,
                 difficulty = GetNetworkDifficulty()?.Difficulty ?? 0,

--- a/Stratis.Bitcoin/RPC/Models/GetInfoModel.cs
+++ b/Stratis.Bitcoin/RPC/Models/GetInfoModel.cs
@@ -24,7 +24,7 @@ namespace Stratis.Bitcoin.RPC.Models
         public int blocks { get; set; }
 
         [JsonProperty(Order = 5)]
-        public double timeoffset { get; set; }
+        public long timeoffset { get; set; }
 
         [JsonProperty(Order = 6, DefaultValueHandling = DefaultValueHandling.Ignore)]
         public int? connections { get; set; }

--- a/Stratis.Bitcoin/Stratis.Bitcoin.csproj
+++ b/Stratis.Bitcoin/Stratis.Bitcoin.csproj
@@ -19,7 +19,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="1.0.0" />
-    <PackageReference Include="NStratis" Version="3.0.2.14" />
+    <PackageReference Include="NStratis" Version="3.0.2.15" />
     <PackageReference Include="System.Reactive" Version="3.1.1" />
     <PackageReference Include="DBreeze" Version="1.83.0" />
     <PackageReference Include="Microsoft.AspNetCore.Diagnostics" Version="1.1.1" />

--- a/Stratis.Bitcoin/Stratis.Bitcoin.csproj
+++ b/Stratis.Bitcoin/Stratis.Bitcoin.csproj
@@ -19,7 +19,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="1.0.0" />
-    <PackageReference Include="NStratis" Version="3.0.2.13" />
+    <PackageReference Include="NStratis" Version="3.0.2.14" />
     <PackageReference Include="System.Reactive" Version="3.1.1" />
     <PackageReference Include="DBreeze" Version="1.83.0" />
     <PackageReference Include="Microsoft.AspNetCore.Diagnostics" Version="1.1.1" />

--- a/Stratis.Bitcoin/Utilities/LinqExtensions.cs
+++ b/Stratis.Bitcoin/Utilities/LinqExtensions.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace System.Linq
+{
+    public static class LinqExtensions
+    {
+        public static long Median(this IEnumerable<long> source)
+        {
+            long count = source.LongCount();
+            if (count == 0)
+                return 0;
+            int midpoint = source.Count() / 2;
+            IOrderedEnumerable<long> ordered = source.OrderBy(n => n);
+            if ((count % 2) == 0)
+                return (long)Math.Round(ordered.Skip(midpoint-1).Take(2).Average());
+            else
+                return ordered.ElementAt(midpoint);
+        }
+    }
+}

--- a/Stratis.Bitcoin/Utilities/NodeExtensions.cs
+++ b/Stratis.Bitcoin/Utilities/NodeExtensions.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace NBitcoin.Protocol
+{
+    public static class NodeExtensions
+    {
+        public static long GetMedianTimeOffset(this IEnumerable<Node> source)
+        {
+            return source
+                .Where(node => node.TimeOffset.HasValue)
+                .Select(node => (long)node.TimeOffset.Value.TotalSeconds)
+                .Median();
+        }
+    }
+}

--- a/Stratis.Bitcoin/project.json
+++ b/Stratis.Bitcoin/project.json
@@ -20,7 +20,7 @@
     "System.Reactive": "3.1.1",
     "System.Xml.XmlSerializer": "4.3.0",
     "Microsoft.Extensions.DependencyInjection": "1.1.0",
-    "NStratis": "3.0.2.13"
+    "NStratis": "3.0.2.14"
   },
 
   "frameworks": {

--- a/Stratis.Bitcoin/project.json
+++ b/Stratis.Bitcoin/project.json
@@ -20,7 +20,7 @@
     "System.Reactive": "3.1.1",
     "System.Xml.XmlSerializer": "4.3.0",
     "Microsoft.Extensions.DependencyInjection": "1.1.0",
-    "NStratis": "3.0.2.14"
+    "NStratis": "3.0.2.15"
   },
 
   "frameworks": {

--- a/Stratis.BitcoinD/Stratis.BitcoinD.csproj
+++ b/Stratis.BitcoinD/Stratis.BitcoinD.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="1.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="1.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.1.1" />
-    <PackageReference Include="NStratis" Version="3.0.2.13" />
+    <PackageReference Include="NStratis" Version="3.0.2.14" />
   </ItemGroup>
 
 </Project>

--- a/Stratis.BitcoinD/Stratis.BitcoinD.csproj
+++ b/Stratis.BitcoinD/Stratis.BitcoinD.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="1.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="1.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.1.1" />
-    <PackageReference Include="NStratis" Version="3.0.2.14" />
+    <PackageReference Include="NStratis" Version="3.0.2.15" />
   </ItemGroup>
 
 </Project>

--- a/Stratis.BitcoinD/project.json
+++ b/Stratis.BitcoinD/project.json
@@ -13,7 +13,7 @@
     "Stratis.Bitcoin": "1.0.*",
     "Microsoft.Extensions.Logging.Abstractions": "1.1.0",
     "Microsoft.Extensions.Logging.Console": "1.1.0",
-    "NStratis": "3.0.2.14"
+    "NStratis": "3.0.2.15"
   },
 
   "frameworks": {

--- a/Stratis.BitcoinD/project.json
+++ b/Stratis.BitcoinD/project.json
@@ -13,7 +13,7 @@
     "Stratis.Bitcoin": "1.0.*",
     "Microsoft.Extensions.Logging.Abstractions": "1.1.0",
     "Microsoft.Extensions.Logging.Console": "1.1.0",
-    "NStratis": "3.0.2.13"
+    "NStratis": "3.0.2.14"
   },
 
   "frameworks": {

--- a/Stratis.StratisD/Stratis.StratisD.csproj
+++ b/Stratis.StratisD/Stratis.StratisD.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="1.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="1.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.1.1" />
-    <PackageReference Include="NStratis" Version="3.0.2.14" />	
+    <PackageReference Include="NStratis" Version="3.0.2.15" />	
   </ItemGroup>
 
 </Project>

--- a/Stratis.StratisD/Stratis.StratisD.csproj
+++ b/Stratis.StratisD/Stratis.StratisD.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="1.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="1.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.1.1" />
-    <PackageReference Include="NStratis" Version="3.0.2.13" />	
+    <PackageReference Include="NStratis" Version="3.0.2.14" />	
   </ItemGroup>
 
 </Project>

--- a/Stratis.StratisD/project.json
+++ b/Stratis.StratisD/project.json
@@ -13,7 +13,7 @@
     "Stratis.Bitcoin": "1.0.*",
     "Microsoft.Extensions.Logging.Abstractions": "1.1.0",
     "Microsoft.Extensions.Logging.Console": "1.1.0",
-    "NStratis": "3.0.2.14"
+    "NStratis": "3.0.2.15"
   },
 
   "frameworks": {

--- a/Stratis.StratisD/project.json
+++ b/Stratis.StratisD/project.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "version": "1.0.0-*",
   "buildOptions": {
     "emitEntryPoint": true,
@@ -13,7 +13,7 @@
     "Stratis.Bitcoin": "1.0.*",
     "Microsoft.Extensions.Logging.Abstractions": "1.1.0",
     "Microsoft.Extensions.Logging.Console": "1.1.0",
-    "NStratis": "3.0.2.13"
+    "NStratis": "3.0.2.14"
   },
 
   "frameworks": {


### PR DESCRIPTION
Implement GetInfo.timeoffset property, which was stubbed as a zero when RPC command was initially implemented.
  Add LinqExtension to calculate median
  Add GetMedianTimeOffset extension for Nodes collection
  RPC GetInfo uses ConnectionManager.NodesCollection.GetMedianTimeOffset()

Disallow direct updates to ConnectionManager.ConnectedNodes via IReadOnlyNodesCollection 
Rename ConnectionManager.(Add/Remove)Node to ConnectionManager.(Add/Remove)NodeAddress

Fix some style violations in ConnectionManager

Fixes: https://github.com/stratisproject/StratisBitcoinFullNode/issues/115
