### PR TITLE
Stratis Validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -247,3 +247,4 @@ ModelManifest.xml
 /Stratis.Bitcoin.IntegrationTests/ValidSomeBlocks
 /Stratis.BitcoinD/Properties/launchSettings.json
 /Stratis.Bitcoin.Tests/TestData/
+/Stratis.Bitcoin.Tests/Stratis.Bitcoin.Tests/TestData

--- a/Stratis.Bitcoin.IntegrationTests/Class1.cs
+++ b/Stratis.Bitcoin.IntegrationTests/Class1.cs
@@ -513,13 +513,14 @@ namespace Stratis.Bitcoin.IntegrationTests
 					Height = 10111
 				},
 				NextWorkRequired = block.Header.Bits,
-				Time = DateTimeOffset.UtcNow
+				Time = DateTimeOffset.UtcNow,
+				BlockResult = new BlockResult { Block = block },
+				Flags = consensusFlags,
 			};
-			var validator = new ConsensusValidator(new NBitcoin.Consensus());
-			validator.CheckBlockHeader(block.Header);
-			validator.ContextualCheckBlockHeader(block.Header, context);
-			validator.ContextualCheckBlock(block, consensusFlags, context);
-			validator.CheckBlock(block);
+			var validator = new PowConsensusValidator(Network.Main, new BitcoinConsensusOptions());
+			//validator.CheckBlockHeader(context);
+			validator.ContextualCheckBlock(context);
+			validator.CheckBlock(context);
 		}
 	}
 }

--- a/Stratis.Bitcoin.IntegrationTests/MemoryPoolTests.cs
+++ b/Stratis.Bitcoin.IntegrationTests/MemoryPoolTests.cs
@@ -10,6 +10,7 @@ using NBitcoin.BitcoinCore;
 using NBitcoin.Protocol;
 using Stratis.Bitcoin.Configuration;
 using Stratis.Bitcoin.Connection;
+using Stratis.Bitcoin.Consensus;
 using Stratis.Bitcoin.Logging;
 using Stratis.Bitcoin.MemoryPool;
 using Stratis.Bitcoin.Utilities;
@@ -550,7 +551,7 @@ namespace Stratis.Bitcoin.IntegrationTests
 			var options = new ParallelOptions {MaxDegreeOfParallelism = 10};
 			Parallel.ForEach(txs, options, transaction =>
 			{
-				var entry = new TxMempoolEntry(transaction, new Money(rand.Next(100)), 0, 0.0, 1, transaction.TotalOut, false, 4, new LockPoints());
+				var entry = new TxMempoolEntry(transaction, new Money(rand.Next(100)), 0, 0.0, 1, transaction.TotalOut, false, 4, new LockPoints(), new BitcoinConsensusOptions());
 				tasks.Add(scheduler.WriteAsync(() => pool.AddUnchecked(transaction.GetHash(), entry)));
 			});
 
@@ -946,8 +947,7 @@ namespace Stratis.Bitcoin.IntegrationTests
 			Money inChainValue = (pool != null && pool.HasNoInputsOf(tx)) ? tx.TotalOut : 0;
 
 			return new TxMempoolEntry(tx, nFee, nTime, dPriority, nHeight,
-				inChainValue, spendsCoinbase, sigOpCost, lp);
-
+				inChainValue, spendsCoinbase, sigOpCost, lp, new BitcoinConsensusOptions());
 		}
 
 		// Change the default value

--- a/Stratis.Bitcoin.IntegrationTests/project.json
+++ b/Stratis.Bitcoin.IntegrationTests/project.json
@@ -7,7 +7,7 @@
     "dotnet-test-xunit": "1.0.0-rc2-build10025",
     // xunit hack https://github.com/xunit/xunit/issues/1015
     "Microsoft.DotNet.InternalAbstractions": "1.0.0",
-    "NStratis": "3.0.2.15",
+    "NStratis": "3.0.2.16",
     "Stratis.Bitcoin": "1.0.*"
   },
 

--- a/Stratis.Bitcoin.Tests/Builder/FullNodeBuilderTest.cs
+++ b/Stratis.Bitcoin.Tests/Builder/FullNodeBuilderTest.cs
@@ -224,7 +224,7 @@ namespace Stratis.Bitcoin.Tests.Builder
             var network = serviceProvider.GetService<Network>();
             var settings = serviceProvider.GetService<NodeSettings>();
             var consensusLoop = serviceProvider.GetService<ConsensusLoop>();
-            var consensus = serviceProvider.GetService<ConsensusValidator>();
+            var consensus = serviceProvider.GetService<PowConsensusValidator>();
             var chain = serviceProvider.GetService<NBitcoin.ConcurrentChain>();
             var chainState = serviceProvider.GetService<ChainBehavior.ChainState>();
             var blockStoreManager = serviceProvider.GetService<BlockStoreManager>();

--- a/Stratis.Bitcoin.Tests/RPC/Controller/MempoolActionTests.cs
+++ b/Stratis.Bitcoin.Tests/RPC/Controller/MempoolActionTests.cs
@@ -6,6 +6,8 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Stratis.Bitcoin.Logging;
 using Xunit;
 
 namespace Stratis.Bitcoin.Tests.RPC.Controller
@@ -15,7 +17,9 @@ namespace Stratis.Bitcoin.Tests.RPC.Controller
         [Fact]
         public async Task CanCall()
         {
-            string dir = AssureEmptyDir("Stratis.Bitcoin.Tests/TestData/GetRawMempoolActionTest/CanCall");
+			Logs.Configure(new LoggerFactory());
+
+			string dir = AssureEmptyDir("Stratis.Bitcoin.Tests/TestData/GetRawMempoolActionTest/CanCall");
             IFullNode fullNode = this.BuildServicedNode(dir);
             MempoolController controller = fullNode.Services.ServiceProvider.GetService<MempoolController>();
 

--- a/Stratis.Bitcoin.Tests/project.json
+++ b/Stratis.Bitcoin.Tests/project.json
@@ -9,7 +9,7 @@
     // xunit hack https://github.com/xunit/xunit/issues/1015
     "Microsoft.DotNet.InternalAbstractions": "1.0.0",
     "Moq": "4.7.1",
-    "NStratis": "3.0.2.15"
+    "NStratis": "3.0.2.16"
   },
   "frameworks": {
     "netcoreapp1.0": {

--- a/Stratis.Bitcoin/Consensus/CoinViews/DBreezeCoinView.cs
+++ b/Stratis.Bitcoin/Consensus/CoinViews/DBreezeCoinView.cs
@@ -13,9 +13,10 @@ namespace Stratis.Bitcoin.Consensus
 {
 	public class DBreezeCoinView : CoinView, IDisposable
 	{
-
-		DBreezeSingleThreadSession _Session;
-		Network _Network;
+		private readonly DBreezeSingleThreadSession session;
+		private readonly Network network;
+		private uint256 blockHash;
+		private readonly BackendPerformanceCounter performanceCounter;
 
 		public DBreezeCoinView(Network network, DataFolder dataFolder) 
 			: this(network, dataFolder.CoinViewPath)
@@ -27,38 +28,48 @@ namespace Stratis.Bitcoin.Consensus
 			Guard.NotNull(network, nameof(network));
 			Guard.NotEmpty(folder, nameof(folder));
 			
-			_Session = new DBreezeSingleThreadSession("DBreeze CoinView", folder);
-			_Network = network;
+			session = new DBreezeSingleThreadSession("DBreeze CoinView", folder);
+			this.network = network;
+			this.performanceCounter = new BackendPerformanceCounter();
+		}
+
+		static readonly byte[] BlockHashKey = new byte[0];
+		static readonly UnspentOutputs[] NoOutputs = new UnspentOutputs[0];
+
+		public BackendPerformanceCounter PerformanceCounter
+		{
+			get
+			{
+				return performanceCounter;
+			}
 		}
 
 		public Task Initialize()
 		{
-			var genesis = this._Network.GetGenesis();
+			var genesis = this.network.GetGenesis();
 
-			var sync = _Session.Do(() =>
+			var sync = session.Do(() =>
 			{
-				_Session.Transaction.SynchronizeTables("Coins", "BlockHash", "Rewind");
-				_Session.Transaction.ValuesLazyLoadingIsOn = false;
+				session.Transaction.SynchronizeTables("Coins", "BlockHash", "Rewind", "Stake");
+				session.Transaction.ValuesLazyLoadingIsOn = false;
 			});
 
-			var hash = _Session.Do(() =>
+			var hash = session.Do(() =>
 			{
 				if(GetCurrentHash() == null)
 				{
 					SetBlockHash(genesis.GetHash());
 					//Genesis coin is unspendable so do not add the coins
-					_Session.Transaction.Commit();
+					session.Transaction.Commit();
 				}
 			});
 
 			return Task.WhenAll(new[] { sync, hash });
 		}
 
-		static byte[] BlockHashKey = new byte[0];
-		static readonly UnspentOutputs[] NoOutputs = new UnspentOutputs[0];
 		public override Task<FetchCoinsResponse> FetchCoinsAsync(uint256[] txIds)
 		{
-			return _Session.Do(() =>
+			return session.Do(() =>
 			{
 				using(StopWatch.Instance.Start(o => PerformanceCounter.AddQueryTime(o)))
 				{
@@ -68,7 +79,7 @@ namespace Stratis.Bitcoin.Consensus
 					PerformanceCounter.AddQueriedEntities(txIds.Length);
 					foreach(var input in txIds)
 					{
-						var coin = _Session.Transaction.Select<byte[], Coins>("Coins", input.ToBytes(false))?.Value;
+						var coin = session.Transaction.Select<byte[], Coins>("Coins", input.ToBytes(false))?.Value;
 						result[i++] = coin == null ? null : new UnspentOutputs(input, coin);
 					}
 					return new FetchCoinsResponse(result, blockHash);
@@ -76,23 +87,21 @@ namespace Stratis.Bitcoin.Consensus
 			});
 		}
 
-
-		uint256 _BlockHash;
 		private uint256 GetCurrentHash()
 		{
-			_BlockHash = _BlockHash ?? _Session.Transaction.Select<byte[], uint256>("BlockHash", BlockHashKey)?.Value;
-			return _BlockHash;
+			blockHash = blockHash ?? session.Transaction.Select<byte[], uint256>("BlockHash", BlockHashKey)?.Value;
+			return blockHash;
 		}
 
 		private void SetBlockHash(uint256 nextBlockHash)
 		{
-			_BlockHash = nextBlockHash;
-			_Session.Transaction.Insert<byte[], uint256>("BlockHash", BlockHashKey, nextBlockHash);
+			blockHash = nextBlockHash;
+			session.Transaction.Insert<byte[], uint256>("BlockHash", BlockHashKey, nextBlockHash);
 		}
 
 		public override Task SaveChangesAsync(IEnumerable<UnspentOutputs> unspentOutputs, IEnumerable<TxOut[]> originalOutputs, uint256 oldBlockHash, uint256 nextBlockHash)
 		{
-			return _Session.Do(() =>
+			return session.Do(() =>
 			{
 				RewindData rewindData = originalOutputs == null ? null : new RewindData(oldBlockHash);
 				int insertedEntities = 0;
@@ -117,9 +126,9 @@ namespace Stratis.Bitcoin.Consensus
 					foreach(var coin in all)
 					{
 						if(coin.IsPrunable)
-							_Session.Transaction.RemoveKey("Coins", coin.TransactionId.ToBytes(false));
+							session.Transaction.RemoveKey("Coins", coin.TransactionId.ToBytes(false));
 						else
-							_Session.Transaction.Insert("Coins", coin.TransactionId.ToBytes(false), coin.ToCoins());
+							session.Transaction.Insert("Coins", coin.TransactionId.ToBytes(false), coin.ToCoins());
 						if(originalOutputs != null)
 						{
 							TxOut[] original = null;
@@ -142,10 +151,10 @@ namespace Stratis.Bitcoin.Consensus
 					if(rewindData != null)
 					{
 						int nextRewindIndex = GetRewindIndex() + 1;
-						_Session.Transaction.Insert<int, RewindData>("Rewind", nextRewindIndex, rewindData);
+						session.Transaction.Insert<int, RewindData>("Rewind", nextRewindIndex, rewindData);
 					}
 					insertedEntities += all.Count;
-					_Session.Transaction.Commit();
+					session.Transaction.Commit();
 				}
 				PerformanceCounter.AddInsertedEntities(insertedEntities);
 			});
@@ -153,53 +162,69 @@ namespace Stratis.Bitcoin.Consensus
 
 		private int GetRewindIndex()
 		{
-			_Session.Transaction.ValuesLazyLoadingIsOn = true;
-			var first = _Session.Transaction.SelectBackward<int, RewindData>("Rewind").FirstOrDefault();
-			_Session.Transaction.ValuesLazyLoadingIsOn = false;
+			session.Transaction.ValuesLazyLoadingIsOn = true;
+			var first = session.Transaction.SelectBackward<int, RewindData>("Rewind").FirstOrDefault();
+			session.Transaction.ValuesLazyLoadingIsOn = false;
 			return first == null ? -1 : first.Key;
 		}
 
 		public override Task<uint256> Rewind()
 		{
-			return _Session.Do(() =>
+			return session.Do(() =>
 			{
 				if(GetRewindIndex() == -1)
 				{
-					_Session.Transaction.RemoveAllKeys("Coins", true);
-					SetBlockHash(_Network.GenesisHash);
-					_Session.Transaction.Commit();
-					return _Network.GenesisHash;
+					session.Transaction.RemoveAllKeys("Coins", true);
+					SetBlockHash(network.GenesisHash);
+					session.Transaction.Commit();
+					return network.GenesisHash;
 				}
 				else
 				{
-					var first = _Session.Transaction.SelectBackward<int, RewindData>("Rewind").FirstOrDefault();
-					_Session.Transaction.RemoveKey("Rewind", first.Key);
+					var first = session.Transaction.SelectBackward<int, RewindData>("Rewind").FirstOrDefault();
+					session.Transaction.RemoveKey("Rewind", first.Key);
 					SetBlockHash(first.Value.PreviousBlockHash);
 					foreach(var txId in first.Value.TransactionsToRemove)
 					{
-						_Session.Transaction.RemoveKey("Coins", txId.ToBytes(false));
+						session.Transaction.RemoveKey("Coins", txId.ToBytes(false));
 					}
 					foreach(var coin in first.Value.OutputsToRestore)
 					{
-						_Session.Transaction.Insert("Coins", coin.TransactionId.ToBytes(false), coin.ToCoins());
+						session.Transaction.Insert("Coins", coin.TransactionId.ToBytes(false), coin.ToCoins());
 					}
-					_Session.Transaction.Commit();
+					session.Transaction.Commit();
 					return first.Value.PreviousBlockHash;
 				}
 			});
 		}
-		private readonly BackendPerformanceCounter _PerformanceCounter = new BackendPerformanceCounter();
-		public BackendPerformanceCounter PerformanceCounter
+
+		public Task PutStake(uint256 blockid, BlockStake blockStake)
 		{
-			get
+			return session.Do(() =>
 			{
-				return _PerformanceCounter;
-			}
+				session.Transaction.Insert<byte[], BlockStake>("Stake", blockid.ToBytes(false), blockStake);
+				session.Transaction.Commit();
+			});
+		}
+
+		public Task<BlockStake> GetStake(uint256 blockid)
+		{
+			return session.Do(() =>
+			{
+				var stake = session.Transaction.Select<byte[], BlockStake>("Stake", blockid.ToBytes(false));
+				return stake?.Value ?? null;
+			});
+		}
+
+		public Task DeleteStake(uint256 blockid, BlockStake blockStake)
+		{
+			// TODO: implement delete stake on rewind
+			throw new NotImplementedException();
 		}
 
 		public void Dispose()
 		{
-			_Session.Dispose();
+			session.Dispose();
 		}
 	}
 }

--- a/Stratis.Bitcoin/Consensus/ConsensusErrors.cs
+++ b/Stratis.Bitcoin/Consensus/ConsensusErrors.cs
@@ -119,6 +119,8 @@ namespace Stratis.Bitcoin.Consensus
 		public readonly static ConsensusError BadTransactionMissingInput = new ConsensusError("bad-txns-inputs-missingorspent", "input missing/spent");
 
 		public readonly static ConsensusError BadCoinbaseAmount = new ConsensusError("bad-cb-amount", "coinbase pays too much");
+		public readonly static ConsensusError BadCoinstakeAmount = new ConsensusError("bad-cs-amount", "coinstake pays too much");
+
 		public readonly static ConsensusError BadTransactionPrematureCoinbaseSpending = new ConsensusError("bad-txns-premature-spend-of-coinbase", "tried to spend coinbase before maturity");
 
 		public readonly static ConsensusError BadTransactionInputValueOutOfRange = new ConsensusError("bad-txns-inputvalues-outofrange", "input value out of range");

--- a/Stratis.Bitcoin/Consensus/ConsensusFeature.cs
+++ b/Stratis.Bitcoin/Consensus/ConsensusFeature.cs
@@ -20,7 +20,7 @@ namespace Stratis.Bitcoin.Consensus
 		private readonly DBreezeCoinView dBreezeCoinView;
 		private readonly Network network;
 		private readonly ConcurrentChain chain;
-		private readonly ConsensusValidator consensusValidator;
+		private readonly PowConsensusValidator consensusValidator;
 		private readonly LookaheadBlockPuller blockPuller;
 		private readonly CoinView coinView;
 		private readonly ChainBehavior.ChainState chainState;
@@ -29,11 +29,12 @@ namespace Stratis.Bitcoin.Consensus
 		private readonly Signals signals;
 		private readonly ConsensusLoop consensusLoop;
 		private readonly NodeSettings nodeSettings;
+		private readonly StakeChain stakeChain;
 
 		public ConsensusFeature(
 			DBreezeCoinView dBreezeCoinView,
 			Network network,
-			ConsensusValidator consensusValidator,
+			PowConsensusValidator consensusValidator,
 			ConcurrentChain chain,
 			LookaheadBlockPuller blockPuller,
 			CoinView coinView,
@@ -42,7 +43,8 @@ namespace Stratis.Bitcoin.Consensus
 			CancellationProvider globalCancellation,
 			Signals signals,
 			ConsensusLoop consensusLoop,
-			NodeSettings nodeSettings)
+			NodeSettings nodeSettings,
+			StakeChain stakeChain = null)
 		{
 			this.dBreezeCoinView = dBreezeCoinView;
 			this.consensusValidator = consensusValidator;
@@ -56,6 +58,7 @@ namespace Stratis.Bitcoin.Consensus
 			this.network = network;
 			this.consensusLoop = consensusLoop;
 			this.nodeSettings = nodeSettings;
+			this.stakeChain = stakeChain;
 		}
 
 		public override void Start()
@@ -75,6 +78,11 @@ namespace Stratis.Bitcoin.Consensus
 			if (flags.ScriptFlags.HasFlag(ScriptVerify.Witness))
 				connectionManager.AddDiscoveredNodesRequirement(NodeServices.NODE_WITNESS);
 
+			if (stakeChain != null)
+			{
+				// load the stake chain
+			}
+
 			new Thread(RunLoop)
 			{
 				Name = "Consensus Loop"
@@ -83,6 +91,11 @@ namespace Stratis.Bitcoin.Consensus
 
 		public override void Stop()
 		{
+			if (stakeChain != null)
+			{
+				// save the stake chain
+			}
+
 			var cache = this.coinView as CachedCoinView;
 			if (cache != null)
 			{
@@ -171,18 +184,41 @@ namespace Stratis.Bitcoin.Consensus
 	{
 		public static IFullNodeBuilder UseConsensus(this IFullNodeBuilder fullNodeBuilder)
 		{
-
 			fullNodeBuilder.ConfigureFeature(features =>
 			{
 				features
 				.AddFeature<ConsensusFeature>()
 				.FeatureServices(services =>
 				{
-					services.AddSingleton(new ConsensusValidator(fullNodeBuilder.Network.Consensus));
+					services.AddSingleton<ConsensusOptions, BitcoinConsensusOptions>();
+					services.AddSingleton<PowConsensusValidator>();
 					services.AddSingleton<DBreezeCoinView>();
 					services.AddSingleton<CoinView, CachedCoinView>();
 					services.AddSingleton<LookaheadBlockPuller>();
 					services.AddSingleton<ConsensusLoop>();
+				});
+			});
+
+			return fullNodeBuilder;
+		}
+
+		public static IFullNodeBuilder UseStratisConsensus(this IFullNodeBuilder fullNodeBuilder)
+		{
+			fullNodeBuilder.ConfigureFeature(features =>
+			{
+				features
+				.AddFeature<ConsensusFeature>()
+				.FeatureServices(services =>
+				{
+					
+
+					services.AddSingleton<ConsensusOptions, StratisConsensusOptions>();
+					services.AddSingleton<PowConsensusValidator, PosConsensusValidator>();
+					services.AddSingleton<DBreezeCoinView>();
+					services.AddSingleton<CoinView, CachedCoinView>();
+					services.AddSingleton<LookaheadBlockPuller>();
+					services.AddSingleton<ConsensusLoop>();
+					services.AddSingleton<StakeChain, StakeChainStore>();
 				});
 			});
 

--- a/Stratis.Bitcoin/Consensus/ConsensusOptions.cs
+++ b/Stratis.Bitcoin/Consensus/ConsensusOptions.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using NBitcoin;
+
+namespace Stratis.Bitcoin.Consensus
+{
+	public class StratisConsensusOptions : BitcoinConsensusOptions
+	{
+		public override long MAX_MONEY => long.MaxValue;
+		public override long COINBASE_MATURITY => 50;
+
+		public override Money ProofOfWorkReward => Money.Coins(4);
+
+		public override Money ProofOfStakeReward => Money.COIN;
+
+		public override Money PremineReward => Money.Coins(98000000);
+
+		public override long PremineHeight => 2;
+	}
+
+	/// <summary>
+	/// A set of options with default values of the Bitcoin network
+	/// This can be easily overridable for alternative networks (i.e Stratis)
+	/// Capital style param nameing is kept to mimic core
+	/// </summary>
+	public class BitcoinConsensusOptions : ConsensusOptions
+	{
+		public override int MAX_BLOCK_WEIGHT => 4000000;
+
+		public override int WITNESS_SCALE_FACTOR => 4;
+		public override int SERIALIZE_TRANSACTION_NO_WITNESS => 0x40000000;
+
+		// Changing the default transaction version requires a two step process: first
+		// adapting relay policy by bumping MAX_STANDARD_VERSION, and then later date
+		// bumping the default CURRENT_VERSION at which point both CURRENT_VERSION and
+		// MAX_STANDARD_VERSION will be equal.
+		public override int MAX_STANDARD_VERSION => 2;
+		// The maximum weight for transactions we're willing to relay/mine 
+		public override int MAX_STANDARD_TX_WEIGHT => 400000;
+		public override int MAX_BLOCK_BASE_SIZE => 1000000;
+		/** The maximum allowed number of signature check operations in a block (network rule) */
+		public override int MAX_BLOCK_SIGOPS_COST => 80000;
+		public override long MAX_MONEY => 21000000 * Money.COIN;
+		public override long COINBASE_MATURITY => 100;
+		public override Money ProofOfWorkReward => Money.Coins(50);
+
+		public override Money ProofOfStakeReward
+		{
+			get { throw new NotImplementedException(); }
+		}
+
+		public override Money PremineReward
+		{
+			get { throw new NotImplementedException(); }
+		}
+	}
+
+	public abstract class ConsensusOptions
+	{
+		public abstract int MAX_BLOCK_WEIGHT { get; }
+		public abstract int WITNESS_SCALE_FACTOR { get; }
+		public abstract int SERIALIZE_TRANSACTION_NO_WITNESS { get; }
+
+		// Changing the default transaction version requires a two step process: first
+		// adapting relay policy by bumping MAX_STANDARD_VERSION, and then later date
+		// bumping the default CURRENT_VERSION at which point both CURRENT_VERSION and
+		// MAX_STANDARD_VERSION will be equal.
+		public abstract int MAX_STANDARD_VERSION { get; }
+		// The maximum weight for transactions we're willing to relay/mine 
+		public abstract int MAX_STANDARD_TX_WEIGHT { get; }
+		public abstract int MAX_BLOCK_BASE_SIZE { get; }
+		/** The maximum allowed number of signature check operations in a block (network rule) */
+		public abstract int MAX_BLOCK_SIGOPS_COST { get; }
+		public abstract long MAX_MONEY { get; }
+		public abstract long COINBASE_MATURITY { get; }
+
+		public abstract Money ProofOfWorkReward { get; }
+		public abstract Money ProofOfStakeReward { get; }
+		public virtual Money PremineReward => 0 ;
+		public virtual long PremineHeight => 0;
+
+	}
+}

--- a/Stratis.Bitcoin/Consensus/ContextualInformation.cs
+++ b/Stratis.Bitcoin/Consensus/ContextualInformation.cs
@@ -47,15 +47,34 @@ namespace Stratis.Bitcoin.Consensus
 			
 		}
 
-		public ContextInformation(ChainedBlock nextBlock, NBitcoin.Consensus consensus)
+		public ContextInformation(BlockResult blockResult, NBitcoin.Consensus consensus, ConsensusOptions options)
 		{
-			Guard.NotNull(nextBlock, nameof(nextBlock));
+			Guard.NotNull(blockResult, nameof(blockResult));
+			Guard.NotNull(consensus, nameof(consensus));
+			Guard.NotNull(options, nameof(options));
 
-			BestBlock = new ContextBlockInformation(nextBlock.Previous, consensus);
-			Time = DateTimeOffset.UtcNow;
-			NextWorkRequired = nextBlock.GetWorkRequired(consensus);
+			this.BlockResult = blockResult;
+			this.Consensus = consensus;
+			this.ConsensusOptions = options;
+
 		}
 
+		public void SetBestBlock()
+		{
+			BestBlock = new ContextBlockInformation(this.BlockResult.ChainedBlock.Previous, this.Consensus);
+			Time = DateTimeOffset.UtcNow;
+		}
+
+		public NBitcoin.Consensus Consensus
+		{
+			get;
+			set;
+		}
+		public ConsensusOptions ConsensusOptions
+		{
+			get;
+			set;
+		}
 		public DateTimeOffset Time
 		{
 			get;
@@ -69,6 +88,36 @@ namespace Stratis.Bitcoin.Consensus
 		}
 
 		public Target NextWorkRequired
+		{
+			get;
+			set;
+		}
+
+		public BlockResult BlockResult
+		{
+			get;
+			set;
+		}
+
+		public ConsensusFlags Flags
+		{
+			get;
+			set;
+		}
+
+		public UnspentOutputSet Set
+		{
+			get;
+			set;
+		}
+
+		public BlockStake BlockStake
+		{
+			get;
+			set;
+		}
+
+		public Money TotalCoinStakeValueIn
 		{
 			get;
 			set;

--- a/Stratis.Bitcoin/Consensus/PosConsensusValidator.cs
+++ b/Stratis.Bitcoin/Consensus/PosConsensusValidator.cs
@@ -1,0 +1,90 @@
+﻿using System;
+using System.Threading.Tasks;
+using NBitcoin;
+using Stratis.Bitcoin.Utilities;
+
+namespace Stratis.Bitcoin.Consensus
+{
+	public class PosConsensusValidator : PowConsensusValidator
+	{
+		private readonly StakeChain stakeChain;
+
+		public PosConsensusValidator(Network network, ConsensusOptions consensusOptions, StakeChain stakeChain) 
+			: base(network, consensusOptions)
+		{
+			this.stakeChain = stakeChain;
+		}
+
+		public override void CheckBlockReward(ContextInformation context, Money nFees, ChainedBlock chainedBlock, Block block)
+		{
+			if (BlockStake.IsProofOfStake(block))
+			{
+				// proof of stake invalidates previous inputs 
+				// and spends the inputs to new outputs with the 
+				// additional  stake reward, this will calculate the  
+				// reward does not exceed the consensu rules  
+
+				var stakeReward = block.Transactions[1].TotalOut - context.TotalCoinStakeValueIn;
+				var calcStakeReward = GetProofOfStakeReward(chainedBlock, nFees);
+
+				if (stakeReward > calcStakeReward)
+					ConsensusErrors.BadCoinstakeAmount.Throw();
+			}
+			else
+			{
+				var blockReward = GetProofOfWorkReward(chainedBlock, nFees);
+				if (block.Transactions[0].TotalOut > blockReward)
+					ConsensusErrors.BadCoinbaseAmount.Throw();
+			}
+		}
+
+		public override void ExecuteBlock(ContextInformation context, TaskScheduler taskScheduler)
+		{
+			base.ExecuteBlock(context, taskScheduler);
+
+			var blockstake = context.BlockStake;
+			
+			// TODO: calculate the stake modifiers
+
+			stakeChain.Set(context.BlockResult.ChainedBlock.HashBlock, blockstake);
+		}
+
+		public override void CheckBlockHeader(ContextInformation context)
+		{
+			var blockstake = new BlockStake(context.BlockResult.Block);
+			context.BlockStake = blockstake;
+
+			if (blockstake.IsProofOfWork())
+			{
+				if (!context.BlockResult.Block.Header.CheckProofOfWork())
+					ConsensusErrors.HighHash.Throw();
+			}
+
+			context.NextWorkRequired = stakeChain.GetWorkRequired(context.BlockResult.ChainedBlock, blockstake, context.Consensus);
+		}
+
+		public Money GetProofOfWorkReward(ChainedBlock chainedBlock, long nFees)
+		{
+			if (this.IsPremine(chainedBlock))
+				return this.ConsensusOptions.PremineReward;
+
+			return this.ConsensusOptions.ProofOfWorkReward + nFees;
+		}
+
+		// miner's coin stake reward
+		public Money GetProofOfStakeReward(ChainedBlock chainedBlock, long nFees)
+		{
+			if (this.IsPremine(chainedBlock))
+				return this.ConsensusOptions.PremineReward;
+
+			return this.ConsensusOptions.ProofOfStakeReward + nFees;
+		}
+
+		private bool IsPremine(ChainedBlock chainedBlock)
+		{
+			return this.ConsensusOptions.PremineHeight > 0 &&
+			       this.ConsensusOptions.PremineReward > 0 &&
+			       chainedBlock.Height == this.ConsensusOptions.PremineHeight;
+		}
+	}
+}

--- a/Stratis.Bitcoin/Consensus/PowConsensusValidator.cs
+++ b/Stratis.Bitcoin/Consensus/PowConsensusValidator.cs
@@ -14,56 +14,44 @@ using static NBitcoin.Transaction;
 
 namespace Stratis.Bitcoin.Consensus
 {
-	public class ConsensusValidator
+	public class PowConsensusValidator
 	{
-		NBitcoin.Consensus _ConsensusParams;
-		const int MAX_BLOCK_WEIGHT = 4000000;
-		public const int WITNESS_SCALE_FACTOR = 4;
-		public const int SERIALIZE_TRANSACTION_NO_WITNESS = 0x40000000;
-		
-		// Changing the default transaction version requires a two step process: first
-		// adapting relay policy by bumping MAX_STANDARD_VERSION, and then later date
-		// bumping the default CURRENT_VERSION at which point both CURRENT_VERSION and
-		// MAX_STANDARD_VERSION will be equal.
-		public const int MAX_STANDARD_VERSION = 2;
-		// The maximum weight for transactions we're willing to relay/mine 
-		public const int MAX_STANDARD_TX_WEIGHT = 400000;
+		private readonly NBitcoin.Consensus consensusParams;
+		private readonly ConsensusOptions consensusOptions;
 
 		// Used as the flags parameter to sequence and nLocktime checks in non-consensus code. 
 		public static LockTimeFlags StandardLocktimeVerifyFlags = LockTimeFlags.VerifySequence | LockTimeFlags.MedianTimePast;
 
-		public ConsensusValidator(NBitcoin.Consensus consensusParams)
+		public PowConsensusValidator(Network network, ConsensusOptions consensusOptions)
 		{
-			Guard.NotNull(consensusParams, nameof(consensusParams));
+			Guard.NotNull(network, nameof(network));
+			Guard.NotNull(consensusOptions, nameof(consensusOptions));
 
-			_ConsensusParams = consensusParams;
+			this.consensusParams = network.Consensus;
+			this.consensusOptions = consensusOptions;
+			this.PerformanceCounter = new ConsensusPerformanceCounter();
 		}
 
-		public NBitcoin.Consensus ConsensusParams
-		{
-			get
-			{
-				return _ConsensusParams;
-			}
-		}
+		public NBitcoin.Consensus ConsensusParams => this.consensusParams;
 
-		private readonly ConsensusPerformanceCounter _PerformanceCounter = new ConsensusPerformanceCounter();
-		public ConsensusPerformanceCounter PerformanceCounter
-		{
-			get
-			{
-				return _PerformanceCounter;
-			}
-		}
+		public ConsensusOptions ConsensusOptions => this.consensusOptions;
 
-		public void CheckBlockHeader(BlockHeader header)
+		public ConsensusPerformanceCounter PerformanceCounter { get; }
+
+		public virtual void CheckBlockHeader(ContextInformation context)
 		{
-			if(!header.CheckProofOfWork())
+			if (!context.BlockResult.Block.Header.CheckProofOfWork())
 				ConsensusErrors.HighHash.Throw();
+
+			context.NextWorkRequired = context.BlockResult.ChainedBlock.GetWorkRequired(context.Consensus);
+
 		}
 
-		public void ContextualCheckBlock(Block block, ConsensusFlags consensusFlags, ContextInformation context)
+		public virtual void ContextualCheckBlock(ContextInformation context)
 		{
+			var block = context.BlockResult.Block;
+			var consensusFlags = context.Flags;
+
 			int nHeight = context.BestBlock == null ? 0 : context.BestBlock.Height + 1;
 
 			// Start enforcing BIP113 (Median Time Past) using versionbits logic.
@@ -146,12 +134,17 @@ namespace Stratis.Bitcoin.Consensus
 			// large by filling up the coinbase witness, which doesn't change
 			// the block hash, so we couldn't mark the block as permanently
 			// failed).
-			if(GetBlockWeight(block) > MAX_BLOCK_WEIGHT)
+			if(GetBlockWeight(block) > this.consensusOptions.MAX_BLOCK_WEIGHT)
 				ConsensusErrors.BadCoinbaseHeight.Throw();
 		}
 
-		public void ExecuteBlock(Block block, ChainedBlock index, ConsensusFlags flags, UnspentOutputSet view, TaskScheduler taskScheduler)
+		public virtual void ExecuteBlock(ContextInformation context, TaskScheduler taskScheduler)
 		{
+			Block block = context.BlockResult.Block;
+			ChainedBlock index = context.BlockResult.ChainedBlock;
+			ConsensusFlags flags = context.Flags;
+			UnspentOutputSet view = context.Set;
+
 			PerformanceCounter.AddProcessedBlocks(1);
 			taskScheduler = taskScheduler ?? TaskScheduler.Default;
 			if(flags.EnforceBIP30)
@@ -170,7 +163,7 @@ namespace Stratis.Bitcoin.Consensus
 			{
 				PerformanceCounter.AddProcessedTransactions(1);
 				var tx = block.Transactions[i];
-				if(!tx.IsCoinBase)
+				if(!tx.IsCoinBase && !tx.IsCoinStake)
 				{
 					int[] prevheights;
 
@@ -195,10 +188,10 @@ namespace Stratis.Bitcoin.Consensus
 				// * p2sh (when P2SH enabled in flags and excludes coinbase)
 				// * witness (when witness enabled in flags and excludes coinbase)
 				nSigOpsCost += GetTransactionSigOpCost(tx, view, flags);
-				if(nSigOpsCost > MAX_BLOCK_SIGOPS_COST)
+				if(nSigOpsCost > this.consensusOptions.MAX_BLOCK_SIGOPS_COST)
 					ConsensusErrors.BadBlockSigOps.Throw();
 
-				if(!tx.IsCoinBase)
+				if(!tx.IsCoinBase && !tx.IsCoinStake)
 				{
 					CheckInputs(tx, view, index.Height);
 					nFees += view.GetValueIn(tx) - tx.TotalOut;
@@ -230,14 +223,25 @@ namespace Stratis.Bitcoin.Consensus
 						checkInputs.Add(checkInput);
 					}
 				}
+
+				if (tx.IsCoinStake)
+					context.TotalCoinStakeValueIn = view.GetValueIn(tx);
+
 				view.Update(tx, index.Height);
 			}
-			Money blockReward = nFees + GetBlockSubsidy(index.Height);
-			if(block.Transactions[0].TotalOut > blockReward)
-				ConsensusErrors.BadCoinbaseAmount.Throw();
+
+			this.CheckBlockReward(context, nFees, index, block);
+
 			var passed = checkInputs.All(c => c.GetAwaiter().GetResult());
 			if(!passed)
 				ConsensusErrors.BadTransactionScriptError.Throw();
+		}
+
+		public virtual void CheckBlockReward(ContextInformation context, Money nFees, ChainedBlock chainedBlock, Block block)
+		{
+			Money blockReward = nFees + GetBlockSubsidy(chainedBlock.Height);
+			if (block.Transactions[0].TotalOut > blockReward)
+				ConsensusErrors.BadCoinbaseAmount.Throw();
 		}
 
 		public bool UseConsensusLib
@@ -246,7 +250,7 @@ namespace Stratis.Bitcoin.Consensus
 			set;
 		}
 
-		public void CheckInputs(Transaction tx, UnspentOutputSet inputs, int nSpendHeight)
+		public virtual void CheckInputs(Transaction tx, UnspentOutputSet inputs, int nSpendHeight)
 		{
 			if(!inputs.HaveInputs(tx))
 				ConsensusErrors.BadTransactionMissingInput.Throw();
@@ -260,15 +264,21 @@ namespace Stratis.Bitcoin.Consensus
 				// If prev is coinbase, check that it's matured
 				if(coins.IsCoinbase)
 				{
-					if(nSpendHeight - coins.Height < COINBASE_MATURITY)
+					if(nSpendHeight - coins.Height < this.consensusOptions.COINBASE_MATURITY)
 						ConsensusErrors.BadTransactionPrematureCoinbaseSpending.Throw();
 				}
+
+				// TODO: add coinstake to Coins
+				//if (coins.IsCoinstake) 
+				//{
+				//	if (nSpendHeight - coins.Height < this.consensusOptions.COINBASE_MATURITY)
+				//		ConsensusErrors.BadTransactionPrematureCoinbaseSpending.Throw();
+				//}
 
 				// Check for negative or overflow input values
 				nValueIn += coins.TryGetOutput(prevout.N).Value;
 				if(!MoneyRange(coins.TryGetOutput(prevout.N).Value) || !MoneyRange(nValueIn))
 					ConsensusErrors.BadTransactionInputValueOutOfRange.Throw();
-
 			}
 
 			if(nValueIn < tx.TotalOut)
@@ -283,14 +293,14 @@ namespace Stratis.Bitcoin.Consensus
 				ConsensusErrors.BadTransactionFeeOutOfRange.Throw();
 		}
 
-		Money GetBlockSubsidy(int nHeight)
+		private Money GetBlockSubsidy(int nHeight)
 		{
-			int halvings = nHeight / _ConsensusParams.SubsidyHalvingInterval;
+			int halvings = nHeight / consensusParams.SubsidyHalvingInterval;
 			// Force block reward to zero when right shift is undefined.
 			if(halvings >= 64)
 				return 0;
 
-			Money nSubsidy = Money.Coins(50);
+			Money nSubsidy = this.consensusOptions.ProofOfWorkReward;
 			// Subsidy is cut in half every 210,000 blocks which will occur approximately every 4 years.
 			nSubsidy >>= halvings;
 			return nSubsidy;
@@ -298,14 +308,14 @@ namespace Stratis.Bitcoin.Consensus
 
 		public long GetTransactionSigOpCost(Transaction tx, UnspentOutputSet inputs, ConsensusFlags flags)
 		{
-			long nSigOps = GetLegacySigOpCount(tx) * WITNESS_SCALE_FACTOR;
+			long nSigOps = GetLegacySigOpCount(tx) * this.consensusOptions.WITNESS_SCALE_FACTOR;
 
 			if(tx.IsCoinBase)
 				return nSigOps;
 
 			if(flags.ScriptFlags.HasFlag(ScriptVerify.P2SH))
 			{
-				nSigOps += GetP2SHSigOpCount(tx, inputs) * WITNESS_SCALE_FACTOR;
+				nSigOps += GetP2SHSigOpCount(tx, inputs) * this.consensusOptions.WITNESS_SCALE_FACTOR;
 			}
 
 			for(var i = 0; i < tx.Inputs.Count; i++)
@@ -374,9 +384,10 @@ namespace Stratis.Bitcoin.Consensus
 			return nSigOps;
 		}
 
-		const int MAX_BLOCK_BASE_SIZE = 1000000;
-		public void CheckBlock(Block block)
+		public virtual void CheckBlock(ContextInformation context)
 		{
+			Block block = context.BlockResult.Block;
+
 			bool mutated = false;
 			uint256 hashMerkleRoot2 = BlockMerkleRoot(block, ref mutated);
 			if(block.Header.HashMerkleRoot != hashMerkleRoot2)
@@ -396,7 +407,7 @@ namespace Stratis.Bitcoin.Consensus
 			// checks that use witness data may be performed here.
 
 			// Size limits
-			if(block.Transactions.Count == 0 || block.Transactions.Count > MAX_BLOCK_BASE_SIZE || GetSize(block, TransactionOptions.None) > MAX_BLOCK_BASE_SIZE)
+			if(block.Transactions.Count == 0 || block.Transactions.Count > this.consensusOptions.MAX_BLOCK_BASE_SIZE || GetSize(block, TransactionOptions.None) > this.consensusOptions.MAX_BLOCK_BASE_SIZE)
 				ConsensusErrors.BadBlockLength.Throw();
 
 			// First transaction must be coinbase, the rest must not be
@@ -415,7 +426,7 @@ namespace Stratis.Bitcoin.Consensus
 			{
 				nSigOps += GetLegacySigOpCount(tx);
 			}
-			if(nSigOps * WITNESS_SCALE_FACTOR > MAX_BLOCK_SIGOPS_COST)
+			if(nSigOps * this.consensusOptions.WITNESS_SCALE_FACTOR > this.consensusOptions.MAX_BLOCK_SIGOPS_COST)
 				ConsensusErrors.BadBlockSigOps.Throw();
 		}
 
@@ -433,7 +444,7 @@ namespace Stratis.Bitcoin.Consensus
 			return nSigOps;
 		}
 
-		public void CheckTransaction(Transaction tx)
+		public virtual void CheckTransaction(Transaction tx)
 		{
 			// Basic checks that don't depend on any context
 			if(tx.Inputs.Count == 0)
@@ -441,7 +452,7 @@ namespace Stratis.Bitcoin.Consensus
 			if(tx.Outputs.Count == 0)
 				ConsensusErrors.BadTransactionNoOutput.Throw();
 			// Size limits (this doesn't take the witness into account, as that hasn't been checked for malleability)
-			if(GetSize(tx, TransactionOptions.None) > MAX_BLOCK_BASE_SIZE)
+			if(GetSize(tx, TransactionOptions.None) > this.consensusOptions.MAX_BLOCK_BASE_SIZE)
 				ConsensusErrors.BadTransactionOversize.Throw();
 
 			// Check for negative or overflow output values
@@ -450,7 +461,7 @@ namespace Stratis.Bitcoin.Consensus
 			{
 				if(txout.Value.Satoshi < 0)
 					ConsensusErrors.BadTransactionNegativeOutput.Throw();
-				if(txout.Value.Satoshi > MAX_MONEY)
+				if(txout.Value.Satoshi > this.consensusOptions.MAX_MONEY)
 					ConsensusErrors.BadTransactionTooLargeOutput.Throw();
 				nValueOut += txout.Value;
 				if(!MoneyRange(nValueOut))
@@ -481,13 +492,9 @@ namespace Stratis.Bitcoin.Consensus
 
 		private bool MoneyRange(long nValue)
 		{
-			return (nValue >= 0 && nValue <= MAX_MONEY);
+			return (nValue >= 0 && nValue <= this.consensusOptions.MAX_MONEY);
 		}
 
-		/** The maximum allowed number of signature check operations in a block (network rule) */
-		public const int MAX_BLOCK_SIGOPS_COST = 80000;
-		const long MAX_MONEY = 21000000 * Money.COIN;
-		private readonly long COINBASE_MATURITY = 100;
 
 		private long GetBlockWeight(Block block)
 		{
@@ -495,7 +502,7 @@ namespace Stratis.Bitcoin.Consensus
 			// using only serialization with and without witness data. As witness_size
 			// is equal to total_size - stripped_size, this formula is identical to:
 			// weight = (stripped_size * 3) + total_size.
-			return GetSize(block, TransactionOptions.None) * (WITNESS_SCALE_FACTOR - 1) + GetSize(block, TransactionOptions.Witness);
+			return GetSize(block, TransactionOptions.None) * (this.consensusOptions.WITNESS_SCALE_FACTOR - 1) + GetSize(block, TransactionOptions.Witness);
 		}
 
 		public int GetSize(IBitcoinSerializable data, TransactionOptions options)
@@ -695,14 +702,16 @@ namespace Stratis.Bitcoin.Consensus
 			return true;
 		}
 
-		public void ContextualCheckBlockHeader(BlockHeader header, ContextInformation context)
+		public virtual void ContextualCheckBlockHeader(ContextInformation context)
 		{
 			Guard.NotNull(context.BestBlock, nameof(context.BestBlock));
+
+			BlockHeader header = context.BlockResult.Block.Header;
 
 			int nHeight = context.BestBlock.Height + 1;
 
 			// Check proof of work
-			if(header.Bits != context.NextWorkRequired)
+			if (header.Bits != context.NextWorkRequired)
 				ConsensusErrors.BadDiffBits.Throw();
 
 			// Check timestamp against prev
@@ -715,9 +724,9 @@ namespace Stratis.Bitcoin.Consensus
 
 			// Reject outdated version blocks when 95% (75% on testnet) of the network has upgraded:
 			// check for version 2, 3 and 4 upgrades
-			if((header.Version < 2 && nHeight >= _ConsensusParams.BuriedDeployments[BuriedDeployments.BIP34]) ||
-			   (header.Version < 3 && nHeight >= _ConsensusParams.BuriedDeployments[BuriedDeployments.BIP66]) ||
-			   (header.Version < 4 && nHeight >= _ConsensusParams.BuriedDeployments[BuriedDeployments.BIP65]))
+			if((header.Version < 2 && nHeight >= consensusParams.BuriedDeployments[BuriedDeployments.BIP34]) ||
+			   (header.Version < 3 && nHeight >= consensusParams.BuriedDeployments[BuriedDeployments.BIP66]) ||
+			   (header.Version < 4 && nHeight >= consensusParams.BuriedDeployments[BuriedDeployments.BIP65]))
 				ConsensusErrors.BadVersion.Throw();
 		}
 	}

--- a/Stratis.Bitcoin/Consensus/StakeChainStore.cs
+++ b/Stratis.Bitcoin/Consensus/StakeChainStore.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using NBitcoin;
+using Stratis.Bitcoin.Utilities;
+
+namespace Stratis.Bitcoin.Consensus
+{
+	public class StakeChainStore : StakeChain
+	{
+		// TODO: to use the coin view persist logic (store to disk after a trashold)
+		// the code to push to DBreezeCoinView can be included in CachedCoinView
+		// then when the CachedCoinView flushes all uncommited entreis the stake entries can also
+		// be commited (before thre coin view save) from the CachedCoinView to the DBreezeCoinView
+
+		private readonly Network network;
+		private readonly ConcurrentChain chain;
+		private readonly DBreezeCoinView dBreezeCoinView;
+		private readonly AsyncDictionary<uint256, Tuple<long, BlockStake>> items = new AsyncDictionary<uint256, Tuple<long, BlockStake>>();
+		private readonly int trashold;
+
+		public StakeChainStore(Network network, ConcurrentChain chain , DBreezeCoinView dBreezeCoinView)
+		{
+			this.network = network;
+			this.chain = chain;
+			this.dBreezeCoinView = dBreezeCoinView;
+			this.trashold = 100; // keep this items in memory
+		}
+
+		public async Task<BlockStake> GetAsync(uint256 blockid)
+		{
+			var block = await this.items.TryGetValue(blockid).ConfigureAwait(false);
+			return block?.Item2 ?? await this.dBreezeCoinView.GetStake(blockid).ConfigureAwait(false);
+		}
+
+		public override BlockStake Get(uint256 blockid)
+		{
+			return this.GetAsync(blockid).GetAwaiter().GetResult();
+		}
+
+		public async Task SetAsync(uint256 blockid, BlockStake blockStake)
+		{
+			if(await this.items.ContainsKey(blockid))
+				return;
+
+			await this.dBreezeCoinView.PutStake(blockid, blockStake).ConfigureAwait(false);
+			var chainedBlock = this.chain.GetBlock(blockid);
+			if (await this.items.TryAdd(blockid, new Tuple<long, BlockStake>(chainedBlock.Height, blockStake)).ConfigureAwait(false))
+			{
+				if (await this.items.Count > this.trashold)
+				{
+					// pop an item.
+					var select = await this.items.Query(q => true);
+					var oldes = select.OrderBy(o => o.Value.Item1).First();
+					await this.items.Remove(oldes.Key);
+				}
+			}
+		}
+
+		public sealed override void Set(uint256 blockid, BlockStake blockStake)
+		{
+			this.SetAsync(blockid, blockStake).GetAwaiter().GetResult();
+		}
+	}
+}

--- a/Stratis.Bitcoin/Consensus/ThresholdConditionCache.cs
+++ b/Stratis.Bitcoin/Consensus/ThresholdConditionCache.cs
@@ -47,8 +47,8 @@ namespace Stratis.Bitcoin.Consensus
 		{
 			int nPeriod = _Consensus.MinerConfirmationWindow;
 			int nThreshold = _Consensus.RuleChangeActivationThreshold;
-			var nTimeStart = _Consensus.BIP9Deployments[deployment].StartTime;
-			var nTimeTimeout = _Consensus.BIP9Deployments[deployment].Timeout;
+			var nTimeStart = _Consensus.BIP9Deployments[deployment]?.StartTime;
+			var nTimeTimeout = _Consensus.BIP9Deployments[deployment]?.Timeout;
 
 			// A block's state is always the same as that of the first of its period, so it is computed based on a pindexPrev whose height equals a multiple of nPeriod - 1.
 			if(pindexPrev != null)

--- a/Stratis.Bitcoin/DBreezeSingleThreadSession.cs
+++ b/Stratis.Bitcoin/DBreezeSingleThreadSession.cs
@@ -76,6 +76,11 @@ namespace Stratis.Bitcoin
 			{
 				return new Block(bytes);
 			}
+			if (type == typeof(BlockStake))
+			{
+				return new BlockStake(bytes);
+			}
+
 			throw new NotSupportedException();
 		}
 

--- a/Stratis.Bitcoin/FullNode.cs
+++ b/Stratis.Bitcoin/FullNode.cs
@@ -141,7 +141,7 @@ public FullNode Initialize(IFullNodeServiceProvider serviceProvider)
 			//	return true;
 			if (this.ConsensusLoop.Tip == null)
 				return true;
-			if (this.ConsensusLoop.Tip.ChainWork < this.Network.Consensus.MinimumChainWork)
+			if (this.ConsensusLoop.Tip.ChainWork < (this.Network.Consensus.MinimumChainWork ?? uint256.Zero))
 				return true;
 			if (this.ConsensusLoop.Tip.Header.BlockTime.ToUnixTimeSeconds() < (this.DateTimeProvider.GetTime() - this.Settings.MaxTipAge))
 				return true;

--- a/Stratis.Bitcoin/MemoryPool/MemPoolCoinView.cs
+++ b/Stratis.Bitcoin/MemoryPool/MemPoolCoinView.cs
@@ -14,15 +14,17 @@ namespace Stratis.Bitcoin.MemoryPool
     {
 	    private readonly TxMempool memPool;
 		private readonly AsyncLock mempoolScheduler;
+	    private readonly MempoolValidator mempoolValidator;
 
-		public UnspentOutputSet Set { get; private set; }
+	    public UnspentOutputSet Set { get; private set; }
 	    public CoinView Inner { get; }
 
-		public MempoolCoinView(CoinView inner, TxMempool memPool, AsyncLock mempoolScheduler)
+		public MempoolCoinView(CoinView inner, TxMempool memPool, AsyncLock mempoolScheduler, MempoolValidator mempoolValidator)
 		{
 			this.Inner = inner;
 			this.memPool = memPool;
 			this.mempoolScheduler = mempoolScheduler;
+			this.mempoolValidator = mempoolValidator;
 			this.Set = new UnspentOutputSet();
 		}
 
@@ -77,7 +79,7 @@ namespace Stratis.Bitcoin.MemoryPool
 
 	    private double ComputePriority(Transaction trx, double dPriorityInputs, int nTxSize = 0)
 	    {
-		    nTxSize = MempoolValidator.CalculateModifiedSize(nTxSize, trx);
+		    nTxSize = MempoolValidator.CalculateModifiedSize(nTxSize, trx, this.mempoolValidator.ConsensusOptions);
 		    if (nTxSize == 0) return 0.0;
 
 		    return dPriorityInputs/nTxSize;

--- a/Stratis.Bitcoin/MemoryPool/MempoolValidator.cs
+++ b/Stratis.Bitcoin/MemoryPool/MempoolValidator.cs
@@ -35,9 +35,9 @@ namespace Stratis.Bitcoin.MemoryPool
 		private readonly ConcurrentChain chain;
 		private readonly CoinView coinView;
 		private readonly TxMempool memPool;
-		private readonly ConsensusValidator consensusValidator;
+		private readonly PowConsensusValidator consensusValidator;
 		public MempoolPerformanceCounter PerformanceCounter { get; }
-
+		public ConsensusOptions ConsensusOptions => this.consensusValidator.ConsensusOptions;
 		public static readonly FeeRate MinRelayTxFee = new FeeRate(DefaultMinRelayTxFee);
 		private readonly FreeLimiterSection freeLimiter;
 
@@ -48,7 +48,7 @@ namespace Stratis.Bitcoin.MemoryPool
 		}
 
 		public MempoolValidator(TxMempool memPool, MempoolScheduler mempoolScheduler,
-			ConsensusValidator consensusValidator, IDateTimeProvider dateTimeProvider, NodeSettings nodeArgs,
+			PowConsensusValidator consensusValidator, IDateTimeProvider dateTimeProvider, NodeSettings nodeArgs,
 			ConcurrentChain chain, CoinView coinView)
 		{
 			this.memPool = memPool;
@@ -103,7 +103,7 @@ namespace Stratis.Bitcoin.MemoryPool
 			this.PreMempoolChecks(context);
 
 			// create the MemPoolCoinView and load relevant utxoset
-			context.View = new MempoolCoinView(this.coinView, this.memPool, this.mempoolScheduler);
+			context.View = new MempoolCoinView(this.coinView, this.memPool, this.mempoolScheduler, this);
 			await context.View.LoadView(context.Transaction).ConfigureAwait(false);
 
 			// adding to the mem pool can only be done sequentially
@@ -242,7 +242,7 @@ namespace Stratis.Bitcoin.MemoryPool
 			// Only accept nLockTime-using transactions that can be mined in the next
 			// block; we don't want our mempool filled up with transactions that can't
 			// be mined yet.
-			if (!CheckFinalTransaction(context.Transaction, ConsensusValidator.StandardLocktimeVerifyFlags))
+			if (!CheckFinalTransaction(context.Transaction, PowConsensusValidator.StandardLocktimeVerifyFlags))
 				context.State.Fail(MempoolErrors.NonFinal).Throw();
 		}
 
@@ -251,15 +251,15 @@ namespace Stratis.Bitcoin.MemoryPool
 			// TODO: Implement Witness Code
 
 			var tx = context.Transaction;
-			if (tx.Version > ConsensusValidator.MAX_STANDARD_VERSION || tx.Version < 1)
+			if (tx.Version > this.consensusValidator.ConsensusOptions.MAX_STANDARD_VERSION || tx.Version < 1)
 				context.State.Fail(MempoolErrors.Version).Throw();
 
 			// Extremely large transactions with lots of inputs can cost the network
 			// almost as much to process as they cost the sender in fees, because
 			// computing signature hashes is O(ninputs*txsize). Limiting transactions
 			// to MAX_STANDARD_TX_WEIGHT mitigates CPU exhaustion attacks.
-			var sz = GetTransactionWeight(tx);
-			if (sz >= ConsensusValidator.MAX_STANDARD_TX_WEIGHT)
+			var sz = GetTransactionWeight(tx, this.consensusValidator.ConsensusOptions);
+			if (sz >= this.consensusValidator.ConsensusOptions.MAX_STANDARD_TX_WEIGHT)
 				context.State.Fail(MempoolErrors.TxSize).Throw();
 
 			foreach (var txin in tx.Inputs)
@@ -363,7 +363,7 @@ namespace Stratis.Bitcoin.MemoryPool
 			// itself can contain sigops MAX_STANDARD_TX_SIGOPS is less than
 			// MAX_BLOCK_SIGOPS; we still consider this an invalid rather than
 			// merely non-standard transaction.
-			if (context.SigOpsCost > ConsensusValidator.MAX_BLOCK_SIGOPS_COST)
+			if (context.SigOpsCost > this.consensusValidator.ConsensusOptions.MAX_BLOCK_SIGOPS_COST)
 				context.State.Fail(MempoolErrors.TooManySigops).Throw();
 		}
 
@@ -374,7 +374,7 @@ namespace Stratis.Bitcoin.MemoryPool
 			// be mined yet.
 			// Must keep pool.cs for this unless we change CheckSequenceLocks to take a
 			// CoinsViewCache instead of create its own
-			if (!CheckSequenceLocks(context, ConsensusValidator.StandardLocktimeVerifyFlags, context.LockPoints))
+			if (!CheckSequenceLocks(context, PowConsensusValidator.StandardLocktimeVerifyFlags, context.LockPoints))
 				context.State.Fail(MempoolErrors.NonBIP68Final).Throw();
 
 			// Check for non-standard pay-to-script-hash in inputs
@@ -407,7 +407,7 @@ namespace Stratis.Bitcoin.MemoryPool
 			bool spendsCoinbase = context.View.SpendsCoinBase(context.Transaction);
 
 			context.Entry = new TxMempoolEntry(context.Transaction, context.Fees, acceptTime, dPriority, this.chain.Height, inChainInputValue,
-				spendsCoinbase, context.SigOpsCost, context.LockPoints);
+				spendsCoinbase, context.SigOpsCost, context.LockPoints, this.ConsensusOptions);
 			context.EntrySize = (int)context.Entry.GetTxSize();
 		}
 
@@ -744,7 +744,7 @@ namespace Stratis.Bitcoin.MemoryPool
 			// When the next block is created its previous block will be the current
 			// chain tip, so we use that to calculate the median time passed to
 			// IsFinalTx() if LOCKTIME_MEDIAN_TIME_PAST is set.
-			var blockTime = flags.HasFlag(ConsensusValidator.StandardLocktimeVerifyFlags)
+			var blockTime = flags.HasFlag(PowConsensusValidator.StandardLocktimeVerifyFlags)
 				? this.chain.Tip.Header.BlockTime
 				: DateTimeOffset.FromUnixTimeMilliseconds(this.dateTimeProvider.GetTime());
 
@@ -834,7 +834,6 @@ namespace Stratis.Bitcoin.MemoryPool
 			return lockPair.Evaluate(index);
 		}
 
-
 		// Check for standard transaction types
 		// @param[in] mapInputs    Map of previous transactions that have outputs we're spending
 		// @return True if all inputs (scriptSigs) use only standard transaction forms
@@ -866,16 +865,16 @@ namespace Stratis.Bitcoin.MemoryPool
 			return true;
 		}
 
-		public static int GetTransactionWeight(Transaction tx)
+		public static int GetTransactionWeight(Transaction tx, ConsensusOptions consensusOptions)
 		{
 			return tx.GetSerializedSize(
 				       (ProtocolVersion)
-				       ((uint) ProtocolVersion.PROTOCOL_VERSION | ConsensusValidator.SERIALIZE_TRANSACTION_NO_WITNESS),
-				       SerializationType.Network)*(ConsensusValidator.WITNESS_SCALE_FACTOR - 1) +
+				       ((uint) ProtocolVersion.PROTOCOL_VERSION | consensusOptions.SERIALIZE_TRANSACTION_NO_WITNESS),
+				       SerializationType.Network)*(consensusOptions.WITNESS_SCALE_FACTOR - 1) +
 			       tx.GetSerializedSize(ProtocolVersion.PROTOCOL_VERSION, SerializationType.Network);
 		}
 
-		public static int CalculateModifiedSize(int nTxSize, Transaction trx)
+		public static int CalculateModifiedSize(int nTxSize, Transaction trx, ConsensusOptions consensusOptions)
 		{
 			// In order to avoid disincentivizing cleaning up the UTXO set we don't count
 			// the constant overhead for each txin and up to 110 bytes of scriptSig (which
@@ -883,7 +882,7 @@ namespace Stratis.Bitcoin.MemoryPool
 			// Providing any more cleanup incentive than making additional inputs free would
 			// risk encouraging people to create junk outputs to redeem later.
 			if (nTxSize == 0)
-				nTxSize = (GetTransactionWeight(trx) + ConsensusValidator.WITNESS_SCALE_FACTOR - 1)/ ConsensusValidator.WITNESS_SCALE_FACTOR;
+				nTxSize = (GetTransactionWeight(trx, consensusOptions) + consensusOptions.WITNESS_SCALE_FACTOR - 1)/ consensusOptions.WITNESS_SCALE_FACTOR;
 
 			foreach (var txInput in trx.Inputs)
 			{

--- a/Stratis.Bitcoin/MemoryPool/TxMemPoolEntry.cs
+++ b/Stratis.Bitcoin/MemoryPool/TxMemPoolEntry.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using NBitcoin;
 using NBitcoin.Protocol;
+using Stratis.Bitcoin.Consensus;
 using Stratis.Bitcoin.Utilities;
 
 namespace Stratis.Bitcoin.MemoryPool
@@ -58,7 +59,7 @@ namespace Stratis.Bitcoin.MemoryPool
 		public TxMempoolEntry(Transaction transaction, Money nFee,
 			long nTime, double entryPriority, int entryHeight,
 			Money inChainInputValue, bool spendsCoinbase,
-			long nSigOpsCost, LockPoints lp)
+			long nSigOpsCost, LockPoints lp, ConsensusOptions consensusOptions)
 		{
 			this.Transaction = transaction;
 			this.TransactionHash = transaction.GetHash();
@@ -71,8 +72,8 @@ namespace Stratis.Bitcoin.MemoryPool
 			this.SigOpCost = nSigOpsCost;
 			this.LockPoints = lp;
 
-			this.TxWeight = MempoolValidator.GetTransactionWeight(transaction);
-			nModSize = MempoolValidator.CalculateModifiedSize(this.Transaction.GetSerializedSize(), this.Transaction);
+			this.TxWeight = MempoolValidator.GetTransactionWeight(transaction, consensusOptions);
+			nModSize = MempoolValidator.CalculateModifiedSize(this.Transaction.GetSerializedSize(), this.Transaction, consensusOptions);
 
 			nUsageSize = transaction.GetSerializedSize(); // RecursiveDynamicUsage(*tx) + memusage::DynamicUsage(Transaction);
 

--- a/Stratis.Bitcoin/RPC/Controllers/BaseRPCController.cs
+++ b/Stratis.Bitcoin/RPC/Controllers/BaseRPCController.cs
@@ -16,7 +16,7 @@ namespace Stratis.Bitcoin.RPC.Controllers
         protected IFullNode _FullNode;
         protected NodeSettings _Settings;
         protected Network _Network;
-        protected ConsensusValidator _ConsensusValidator;
+        protected PowConsensusValidator _ConsensusValidator;
         protected ConsensusLoop _ConsensusLoop;
         protected ChainBase _Chain;
         protected ChainBehavior.ChainState _ChainState;
@@ -28,7 +28,7 @@ namespace Stratis.Bitcoin.RPC.Controllers
             IFullNode fullNode = null,
             NodeSettings nodeSettings = null,
             Network network = null,
-            ConsensusValidator consensusValidator = null,
+            PowConsensusValidator consensusValidator = null,
             ConsensusLoop consensusLoop = null,
             ConcurrentChain chain = null,
             ChainBehavior.ChainState chainState = null,

--- a/Stratis.Bitcoin/RPC/Controllers/FullNodeController.cs
+++ b/Stratis.Bitcoin/RPC/Controllers/FullNodeController.cs
@@ -21,7 +21,7 @@ namespace Stratis.Bitcoin.RPC.Controllers
             IFullNode fullNode = null,
             NodeSettings nodeSettings = null,
             Network network = null,
-            ConsensusValidator consensusValidator = null,
+            PowConsensusValidator consensusValidator = null,
             ConcurrentChain chain = null,
             ChainBehavior.ChainState chainState = null,
             BlockStoreManager blockManager = null,

--- a/Stratis.Bitcoin/Utilities/AsyncDictionary.cs
+++ b/Stratis.Bitcoin/Utilities/AsyncDictionary.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 using System.Threading.Tasks;
+using NBitcoin;
 
 namespace Stratis.Bitcoin.Utilities
 {
@@ -49,7 +50,12 @@ namespace Stratis.Bitcoin.Utilities
             return this.asyncLock.WriteAsync(() => this.dictionary.Add(key, value));
         }
 
-        public Task Clear()
+		public Task<bool> TryAdd(TKey key, TValue value)
+		{
+			return this.asyncLock.WriteAsync(() => this.dictionary.TryAdd(key, value));
+		}
+
+		public Task Clear()
         {
             return this.asyncLock.WriteAsync(() => this.dictionary.Clear());
         }
@@ -90,7 +96,12 @@ namespace Stratis.Bitcoin.Utilities
             }
         }
 
-        public Task<Collection<TValue>> Values
+	    public Task<List<KeyValuePair<TKey, TValue>>> Query(Func<KeyValuePair<TKey, TValue>, bool> func)
+	    {
+		    return this.asyncLock.ReadAsync(() => this.dictionary.Where(func).ToList());
+	    }
+
+	    public Task<Collection<TValue>> Values
         {
             get
             {

--- a/Stratis.Bitcoin/project.json
+++ b/Stratis.Bitcoin/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.1.5-alpha",
+  "version": "1.0.1.4-alpha",
   "title": "Stratis.Bitcoin",
   "description": "Stratis Bitcoin FullNode",
 
@@ -20,7 +20,7 @@
     "System.Reactive": "3.1.1",
     "System.Xml.XmlSerializer": "4.3.0",
     "Microsoft.Extensions.DependencyInjection": "1.1.0",
-    "NStratis": "3.0.2.15"
+    "NStratis": "3.0.2.16"
   },
 
   "frameworks": {

--- a/Stratis.BitcoinD/project.json
+++ b/Stratis.BitcoinD/project.json
@@ -13,7 +13,7 @@
     "Stratis.Bitcoin": "1.0.*",
     "Microsoft.Extensions.Logging.Abstractions": "1.1.0",
     "Microsoft.Extensions.Logging.Console": "1.1.0",
-    "NStratis": "3.0.2.15"
+    "NStratis": "3.0.2.16"
   },
 
   "frameworks": {

--- a/Stratis.StratisD/Program.cs
+++ b/Stratis.StratisD/Program.cs
@@ -36,6 +36,7 @@ namespace Stratis.StratisD
 
 			var node = new FullNodeBuilder()
 				.UseNodeSettings(nodeSettings)
+				.UseStratisConsensus()
 				.Build();
 
 			// TODO: bring the logic out of IWebHost.Run()

--- a/Stratis.StratisD/project.json
+++ b/Stratis.StratisD/project.json
@@ -13,7 +13,7 @@
     "Stratis.Bitcoin": "1.0.*",
     "Microsoft.Extensions.Logging.Abstractions": "1.1.0",
     "Microsoft.Extensions.Logging.Console": "1.1.0",
-    "NStratis": "3.0.2.15"
+    "NStratis": "3.0.2.16"
   },
 
   "frameworks": {


### PR DESCRIPTION
This commit adds support for validating the stratis consensus rules but without any calculation of stake proofs.

Also the ConsensusValidator was split up to a PowConsensusValidator and a PosConsensusValidator that inherits the from the pow class with additional logic to calculate stake work and stake reward.
