### PR TITLE
Bug Fix: Prevent Null Network in NodeSettings

### DIFF
--- a/Stratis.Bitcoin/Configuration/NodeSettings.cs
+++ b/Stratis.Bitcoin/Configuration/NodeSettings.cs
@@ -298,7 +298,7 @@ namespace Stratis.Bitcoin.Configuration
 
 		private string GetDefaultConfigurationFile()
 		{
-			var config = Path.Combine(this.DataDir, this.Network.GetDefaultConfigurationFilename());
+			var config = Path.Combine(this.DataDir, this.GetNetwork().GetDefaultConfigurationFilename());
 			Logs.Configuration.LogInformation("Configuration file set to " + config);
 			if (!File.Exists(config))
 			{


### PR DESCRIPTION
Previous commit [ https://github.com/stratisproject/StratisBitcoinFullNode/pull/125 ] causes null reference error in startup on non-Stratis network. This fixes by preventing NodeSettings.Network from being null.