### PR TITLE
Fix for BtcDecimalJsonConverter

### DIFF
--- a/Stratis.Bitcoin/RPC/Converters/BtcDecimalJsonConverter.cs
+++ b/Stratis.Bitcoin/RPC/Converters/BtcDecimalJsonConverter.cs
@@ -1,6 +1,7 @@
 ﻿using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -15,12 +16,12 @@ namespace Stratis.Bitcoin.RPC.Converters
         {
             var d = (decimal)value;
             var rounded = Math.Round(d, _minDecimals);
-            string result = d.ToString();
+            string result = d.ToString(CultureInfo.InvariantCulture);
             if (_minDecimals > 0)
             {
                 if (!result.Contains('.') || result.Split('.')[1].Length < _minDecimals)
                 {
-                    result = d.ToString("0." + new string('0', _minDecimals));
+                    result = d.ToString("0." + new string('0', _minDecimals), CultureInfo.InvariantCulture);
                 }
             }
             writer.WriteRawValue(result);


### PR DESCRIPTION
Serializing decimal values with BtcDecimalJsonConverter  didn't work correct when a decimal separator other than a period was configured. This commit fixes this by using InvariantCulture when converting decimal to string.