### PR TITLE
Fix command line help text for testnet and regtest flags

### DIFF
--- a/Stratis.Bitcoin.Tests/Builder/FullNodeBuilderExtensionsTest.cs
+++ b/Stratis.Bitcoin.Tests/Builder/FullNodeBuilderExtensionsTest.cs
@@ -44,17 +44,37 @@ namespace Stratis.Bitcoin.Tests.Builder
 			Assert.Equal(NodeSettings.Default().DataDir, this.fullNodeBuilder.NodeSettings.DataDir);
 			Assert.NotNull(this.fullNodeBuilder.Network);
 			Assert.Equal(NodeSettings.Default().GetNetwork(),this.fullNodeBuilder.Network);
-			Assert.Equal(1, serviceCollectionDelegates.Count);
+			Assert.Equal(1, this.serviceCollectionDelegates.Count);
 		}
 
-		[Fact]
-		public void UseDefaultNodeSettingsConfiguresNodeBuilderWithDefaultSettings()
+        [Fact]
+        public void UseDefaultNodeSettingsConfiguresNodeBuilderWithDefaultSettings()
+        {
+            Logs.Configure(new LoggerFactory());
+
+            var nodeSettings = NodeSettings.Default();
+            nodeSettings.ConfigurationFile = "TestData/FullNodeBuilder/UseNodeSettingsConfFile";
+            nodeSettings.DataDir = "TestData/FullNodeBuilder/UseNodeSettings";
+            nodeSettings.Testnet = true;
+
+            FullNodeBuilderExtensions.UseNodeSettings(this.fullNodeBuilder, nodeSettings);
+
+            Assert.NotNull(this.fullNodeBuilder.NodeSettings);
+            Assert.Equal(nodeSettings.ConfigurationFile, this.fullNodeBuilder.NodeSettings.ConfigurationFile);
+            Assert.Equal(nodeSettings.DataDir, this.fullNodeBuilder.NodeSettings.DataDir);
+            Assert.NotNull(this.fullNodeBuilder.Network);
+            Assert.Equal(Network.Main, this.fullNodeBuilder.Network);
+            Assert.Equal(1, this.serviceCollectionDelegates.Count);
+        }
+
+        [Fact]
+		public void UseNodeSettingsUsingTestNetConfiguresNodeBuilderWithTestnetSettings()
 		{
 			Logs.Configure(new LoggerFactory());
 
-			var nodeSettings = NodeSettings.Default();
+			var nodeSettings = NodeSettings.FromArguments(new string[] { "-testnet" });
 			nodeSettings.ConfigurationFile = "TestData/FullNodeBuilder/UseNodeSettingsConfFile";
-			nodeSettings.DataDir = "TestData/FullNodeBuilder/UseNodeSettings";
+			nodeSettings.DataDir = "TestData/FullNodeBuilder/UseNodeSettings";			
 
 			FullNodeBuilderExtensions.UseNodeSettings(this.fullNodeBuilder, nodeSettings);
 			
@@ -62,7 +82,27 @@ namespace Stratis.Bitcoin.Tests.Builder
 			Assert.Equal(nodeSettings.ConfigurationFile, this.fullNodeBuilder.NodeSettings.ConfigurationFile);
 			Assert.Equal(nodeSettings.DataDir, this.fullNodeBuilder.NodeSettings.DataDir);
 			Assert.NotNull(this.fullNodeBuilder.Network);
-			Assert.Equal(1, serviceCollectionDelegates.Count);
+			Assert.Equal(Network.TestNet, this.fullNodeBuilder.Network);
+			Assert.Equal(1, this.serviceCollectionDelegates.Count);
 		}
-	}
+
+        [Fact]
+        public void UseNodeSettingsUsingRegTestNetConfiguresNodeBuilderWithRegTestNet()
+        {
+            Logs.Configure(new LoggerFactory());
+
+            var nodeSettings = NodeSettings.FromArguments(new string[] { "-regtest" });
+            nodeSettings.ConfigurationFile = "TestData/FullNodeBuilder/UseNodeSettingsConfFile";
+            nodeSettings.DataDir = "TestData/FullNodeBuilder/UseNodeSettings";
+
+            FullNodeBuilderExtensions.UseNodeSettings(this.fullNodeBuilder, nodeSettings);
+
+            Assert.NotNull(this.fullNodeBuilder.NodeSettings);
+            Assert.Equal(nodeSettings.ConfigurationFile, this.fullNodeBuilder.NodeSettings.ConfigurationFile);
+            Assert.Equal(nodeSettings.DataDir, this.fullNodeBuilder.NodeSettings.DataDir);
+            Assert.NotNull(this.fullNodeBuilder.Network);
+            Assert.Equal(Network.RegTest, this.fullNodeBuilder.Network);
+            Assert.Equal(1, this.serviceCollectionDelegates.Count);
+        }
+    }
 }

--- a/Stratis.Bitcoin/Configuration/NodeSettings.cs
+++ b/Stratis.Bitcoin/Configuration/NodeSettings.cs
@@ -72,10 +72,10 @@ namespace Stratis.Bitcoin.Configuration
 					nodeSettings.ConfigurationFile = Path.Combine(nodeSettings.DataDir, nodeSettings.ConfigurationFile);
 				}
 			}
-			nodeSettings.Testnet = args.Contains("-testnet", StringComparer.CurrentCultureIgnoreCase);
-			nodeSettings.RegTest = args.Contains("-regtest", StringComparer.CurrentCultureIgnoreCase);
+            nodeSettings.Testnet = args.Contains("-testnet", StringComparer.CurrentCultureIgnoreCase);
+            nodeSettings.RegTest = args.Contains("-regtest", StringComparer.CurrentCultureIgnoreCase);
 
-			if (nodeSettings.ConfigurationFile != null)
+            if (nodeSettings.ConfigurationFile != null)
 			{
 				AssetConfigFileExists(nodeSettings);
 				var configTemp = TextFileConfiguration.Parse(File.ReadAllText(nodeSettings.ConfigurationFile));
@@ -352,8 +352,8 @@ namespace Stratis.Bitcoin.Configuration
 				builder.AppendLine("-help/--help		Show this help.");
 				builder.AppendLine($"-conf=<Path>		Path to the configuration file. Default {defaults.ConfigurationFile}.");
 				builder.AppendLine($"-datadir=<Path>		Path to the data directory. Default {defaults.DataDir}.");
-				builder.AppendLine($"-testnet=<0 or 1>		Use the testnet chain. Default {defaults.Testnet}.");
-				builder.AppendLine($"-regtest=<0 or 1>		Use the regtestnet chain. Default {defaults.RegTest}.");
+				builder.AppendLine($"-testnet		        Use the testnet chain.");
+				builder.AppendLine($"-regtest		        Use the regtestnet chain.");
 				builder.AppendLine($"-acceptnonstdtxn=<0 or 1>	Accept non-standard transactions. Default {defaults.RequireStandard}.");
 				builder.AppendLine($"-maxtipage=<number>	Max tip age. Default {DEFAULT_MAX_TIP_AGE}.");
 				builder.AppendLine($"-server=<0 or 1>		Accept command line and JSON-RPC commands. Default {defaults.RPC != null}.");


### PR DESCRIPTION
The help stated -testnet=1or0 and -regtest=1or0 which didn't work when I was trying to get onto the testnet. Looking at how the arguments are parsed in the nodesettings and program.cs led me to believe the help text is wrong so I corrected it. Also made some tests to see if they are now picked up correctly.