### PR TITLE
configurable api uri

### DIFF
--- a/Stratis.Bitcoin/Configuration/NodeSettings.cs
+++ b/Stratis.Bitcoin/Configuration/NodeSettings.cs
@@ -42,7 +42,7 @@ namespace Stratis.Bitcoin.Configuration
 		public Network Network { get; private set; }
 		public string Name { get; set; }
 
-	    public Uri ApiUri { get; set; }
+		public Uri ApiUri { get; set; }
 
 		public static NodeSettings Default(Network network = null,
 			ProtocolVersion protocolVersion = SupportedProtocolVersion)
@@ -74,10 +74,10 @@ namespace Stratis.Bitcoin.Configuration
 					nodeSettings.ConfigurationFile = Path.Combine(nodeSettings.DataDir, nodeSettings.ConfigurationFile);
 				}
 			}
-            nodeSettings.Testnet = args.Contains("-testnet", StringComparer.CurrentCultureIgnoreCase);
-            nodeSettings.RegTest = args.Contains("-regtest", StringComparer.CurrentCultureIgnoreCase);
+			nodeSettings.Testnet = args.Contains("-testnet", StringComparer.CurrentCultureIgnoreCase);
+			nodeSettings.RegTest = args.Contains("-regtest", StringComparer.CurrentCultureIgnoreCase);
 
-            if (nodeSettings.ConfigurationFile != null)
+			if (nodeSettings.ConfigurationFile != null)
 			{
 				AssetConfigFileExists(nodeSettings);
 				var configTemp = TextFileConfiguration.Parse(File.ReadAllText(nodeSettings.ConfigurationFile));
@@ -111,9 +111,9 @@ namespace Stratis.Bitcoin.Configuration
 
 			nodeSettings.RequireStandard = config.GetOrDefault("acceptnonstdtxn", !(nodeSettings.RegTest || nodeSettings.Testnet));
 			nodeSettings.MaxTipAge = config.GetOrDefault("maxtipage", DEFAULT_MAX_TIP_AGE);
-		    nodeSettings.ApiUri = config.GetOrDefault("apiuri", new Uri("http://localhost:5000"));
+			nodeSettings.ApiUri = config.GetOrDefault("apiuri", new Uri("http://localhost:5000"));
 
-            nodeSettings.RPC = config.GetOrDefault<bool>("server", false) ? new RpcSettings() : null;
+			nodeSettings.RPC = config.GetOrDefault<bool>("server", false) ? new RpcSettings() : null;
 			if (nodeSettings.RPC != null)
 			{
 				nodeSettings.RPC.RpcUser = config.GetOrDefault<string>("rpcuser", null);

--- a/Stratis.Bitcoin/Configuration/NodeSettings.cs
+++ b/Stratis.Bitcoin/Configuration/NodeSettings.cs
@@ -42,6 +42,8 @@ namespace Stratis.Bitcoin.Configuration
 		public Network Network { get; private set; }
 		public string Name { get; set; }
 
+	    public Uri ApiUri { get; set; }
+
 		public static NodeSettings Default(Network network = null,
 			ProtocolVersion protocolVersion = SupportedProtocolVersion)
 		{
@@ -109,8 +111,9 @@ namespace Stratis.Bitcoin.Configuration
 
 			nodeSettings.RequireStandard = config.GetOrDefault("acceptnonstdtxn", !(nodeSettings.RegTest || nodeSettings.Testnet));
 			nodeSettings.MaxTipAge = config.GetOrDefault("maxtipage", DEFAULT_MAX_TIP_AGE);
+		    nodeSettings.ApiUri = config.GetOrDefault("apiuri", new Uri("http://localhost:5000"));
 
-			nodeSettings.RPC = config.GetOrDefault<bool>("server", false) ? new RpcSettings() : null;
+            nodeSettings.RPC = config.GetOrDefault<bool>("server", false) ? new RpcSettings() : null;
 			if (nodeSettings.RPC != null)
 			{
 				nodeSettings.RPC.RpcUser = config.GetOrDefault<string>("rpcuser", null);

--- a/Stratis.Bitcoin/Configuration/NodeSettings.cs
+++ b/Stratis.Bitcoin/Configuration/NodeSettings.cs
@@ -91,7 +91,7 @@ namespace Stratis.Bitcoin.Configuration
 			nodeSettings.Network = nodeSettings.GetNetwork();
 			if (nodeSettings.DataDir == null)
 			{
-				nodeSettings.DataDir = GetDefaultDataDir($"stratis{nodeSettings.Name}", nodeSettings.Network);
+				nodeSettings.DataDir = GetDefaultDataDir($"StratisNode/{nodeSettings.Name}", nodeSettings.Network);
 			}
 
 			if (nodeSettings.ConfigurationFile == null)

--- a/Stratis.Bitcoin/Configuration/TextFileConfiguration.cs
+++ b/Stratis.Bitcoin/Configuration/TextFileConfiguration.cs
@@ -139,9 +139,9 @@ namespace Stratis.Bitcoin.Configuration
 			}
 			else if (typeof(T) == typeof(Uri))
 			{
-			    return (T)(object)new Uri(str);
+				return (T)(object)new Uri(str);
 			}
-            else
+			else
 			{
 				throw new NotSupportedException("Configuration value does not support time " + typeof(T).Name);
 			}

--- a/Stratis.Bitcoin/Configuration/TextFileConfiguration.cs
+++ b/Stratis.Bitcoin/Configuration/TextFileConfiguration.cs
@@ -137,7 +137,11 @@ namespace Stratis.Bitcoin.Configuration
 			{
 				return (T)(object)int.Parse(str, CultureInfo.InvariantCulture);
 			}
-			else
+			else if (typeof(T) == typeof(Uri))
+			{
+			    return (T)(object)new Uri(str);
+			}
+            else
 			{
 				throw new NotSupportedException("Configuration value does not support time " + typeof(T).Name);
 			}


### PR DESCRIPTION
* Added a configurable uri for the api. there are default URIs for bitcoin and stratis but the URI can be set manually in the cli using `apiuri=http://localhost:5200`
* Changed the root directory for the stratis full node.
 The new folders structure is as follows
in Roaming (on windows):
```
StratisNode
                  |_ bitcoin
                           |_ Main
                           |_ TestNet
                  |_ stratis
                           |_ StratisMain
                           |_ StratisTest

```
@dangershony @dev0tion 
Guys, if you approve, don't merge yet, I want to merge and then explain to the testers how to move their files to the new structure.