### PR TITLE
Added mnemonic as optional input to the create wallet method

### DIFF
--- a/Stratis.Bitcoin/Wallet/Controllers/WalletController.cs
+++ b/Stratis.Bitcoin/Wallet/Controllers/WalletController.cs
@@ -115,7 +115,7 @@ namespace Stratis.Bitcoin.Wallet.Controllers
             {
                 // get the wallet folder 
                 DirectoryInfo walletFolder = this.GetWalletFolder();
-                Mnemonic mnemonic = this.walletManager.CreateWallet(request.Password, request.Name);
+                Mnemonic mnemonic = this.walletManager.CreateWallet(request.Password, request.Name, mnemonic:request.Mnemonic);
 
                 return this.Json(mnemonic.ToString());
             }
@@ -123,6 +123,10 @@ namespace Stratis.Bitcoin.Wallet.Controllers
             {
                 // indicates that this wallet already exists
                 return ErrorHelpers.BuildErrorResponse(HttpStatusCode.Conflict, "This wallet already exists.", e.ToString());
+            }
+            catch (NotSupportedException e)
+            {                
+                return ErrorHelpers.BuildErrorResponse(HttpStatusCode.BadRequest, "There was a problem creating a wallet.", e.ToString());
             }
         }
 

--- a/Stratis.Bitcoin/Wallet/Controllers/WalletController.cs
+++ b/Stratis.Bitcoin/Wallet/Controllers/WalletController.cs
@@ -48,6 +48,55 @@ namespace Stratis.Bitcoin.Wallet.Controllers
 
         /// <summary>
         /// Creates a new wallet on the local machine.
+        /// </summary>        
+        /// <param name="language">The language for the words in the mnemonic. Options are: English, French, Spanish, Japanese, ChineseSimplified and ChineseTraditional. The default is 'English'.</param>
+        /// <param name="wordCount">The number of words in the mnemonic. Options are: 12,15,18,21 or 24. the default is 12.</param>
+        /// <returns>A JSON object containing the mnemonic created for the new wallet.</returns>
+        [Route("mnemonic")]
+        [HttpGet]
+        public IActionResult GenerateMnemonic([FromQuery] string language = "English", int wordCount = 12)
+        {
+            try
+            {
+                Wordlist wordList;
+                switch (language.ToLowerInvariant())
+                {
+                    case "english":
+                        wordList = Wordlist.English;
+                        break;
+                    case "french":
+                        wordList = Wordlist.French;
+                        break;
+                    case "spanish":
+                        wordList = Wordlist.Spanish;
+                        break;
+                    case "japanese":
+                        wordList = Wordlist.Japanese;
+                        break;
+                    case "chinesetraditional":
+                        wordList = Wordlist.ChineseTraditional;
+                        break;
+                    case "chinesesimplified":
+                        wordList = Wordlist.ChineseSimplified;
+                        break;
+                    default:
+                        throw new FormatException($"Invalid language '{language}'. Choices are: English, French, Spanish, Japanese, ChineseSimplified and ChineseTraditional.");
+                }
+
+                WordCount count = (WordCount)wordCount;
+
+                // generate the mnemonic 
+                Mnemonic mnemonic = new Mnemonic(wordList, count);
+                return this.Json(mnemonic.ToString());
+            }
+            catch (Exception e)
+            {
+                return ErrorHelpers.BuildErrorResponse(HttpStatusCode.BadRequest, e.Message, e.ToString());
+            }
+        }
+
+        /// <summary>
+        /// Creates a new wallet on the local machine.
         /// </summary>
         /// <param name="request">The object containing the parameters used to create the wallet.</param>
         /// <returns>A JSON object containing the mnemonic created for the new wallet.</returns>
@@ -271,7 +320,7 @@ namespace Stratis.Bitcoin.Wallet.Controllers
                             // that makes the fee negative if thats the case ignore the fee
                             if (sentItem.Fee < 0)
                                 sentItem.Fee = 0;
-                            
+
                             model.TransactionsHistory.Add(sentItem);
                         }
                     }

--- a/Stratis.Bitcoin/Wallet/IWalletManager.cs
+++ b/Stratis.Bitcoin/Wallet/IWalletManager.cs
@@ -31,8 +31,9 @@ namespace Stratis.Bitcoin.Wallet
         /// <param name="password">The password used to encrypt sensitive info.</param>
         /// <param name="name">The name of the wallet.</param>
         /// <param name="passphrase">The passphrase used in the seed.</param>
+        /// <param name="mnemonic">The user's mnemonic for the wallet.</param>		
         /// <returns>A mnemonic defining the wallet's seed used to generate addresses.</returns>
-        Mnemonic CreateWallet(string password, string name, string passphrase = null);
+        Mnemonic CreateWallet(string password, string name, string passphrase = null, string mnemonic = null);
 
         /// <summary>
         /// Loads a wallet from a file.

--- a/Stratis.Bitcoin/Wallet/Models/RequestModels.cs
+++ b/Stratis.Bitcoin/Wallet/Models/RequestModels.cs
@@ -20,6 +20,8 @@ namespace Stratis.Bitcoin.Wallet.Models
     /// </summary>
     public class WalletCreationRequest : RequestModel
     {
+        public string Mnemonic { get; set; }
+
         [Required(ErrorMessage = "A password is required.")]
         public string Password { get; set; }
 

--- a/Stratis.Bitcoin/Wallet/WalletManager.cs
+++ b/Stratis.Bitcoin/Wallet/WalletManager.cs
@@ -84,7 +84,7 @@ namespace Stratis.Bitcoin.Wallet
         }
 
         /// <inheritdoc />
-        public Mnemonic CreateWallet(string password, string name, string passphrase = null)
+        public Mnemonic CreateWallet(string password, string name, string passphrase = null, string mnemonicList = null)
         {
             // for now the passphrase is set to be the password by default.
             if (passphrase == null)
@@ -93,8 +93,8 @@ namespace Stratis.Bitcoin.Wallet
             }
 
             // generate the root seed used to generate keys from a mnemonic picked at random 
-            // and a passphrase optionally provided by the user
-            Mnemonic mnemonic = new Mnemonic(Wordlist.English, WordCount.Twelve);
+            // and a passphrase optionally provided by the user            
+            Mnemonic mnemonic = string.IsNullOrEmpty(mnemonicList) ? new Mnemonic(Wordlist.English, WordCount.Twelve) : new Mnemonic(mnemonicList);
             ExtKey extendedKey = mnemonic.DeriveExtKey(passphrase);
 
             // create a wallet file 

--- a/Stratis.Bitcoin/Wallet/WalletManager.cs
+++ b/Stratis.Bitcoin/Wallet/WalletManager.cs
@@ -942,11 +942,8 @@ namespace Stratis.Bitcoin.Wallet
                 EncryptedSeed = extendedKey.PrivateKey.GetEncryptedBitcoinSecret(password, this.network).ToWif(),
                 ChainCode = extendedKey.ChainCode,
                 CreationTime = creationTime ?? DateTimeOffset.Now,
-                Network = network,
-                AccountsRoot = new List<AccountRoot> {
-                    new AccountRoot { Accounts = new List<HdAccount>(), CoinType = CoinType.Bitcoin },
-                    new AccountRoot { Accounts = new List<HdAccount>(), CoinType = CoinType.Testnet },
-                    new AccountRoot { Accounts = new List<HdAccount>(), CoinType = CoinType.Stratis} },
+                Network = this.network,
+                AccountsRoot = new List<AccountRoot> { new AccountRoot { Accounts = new List<HdAccount>(), CoinType = this.coinType } },
             };
 
             // create a folder if none exists and persist the file


### PR DESCRIPTION
so in order to create a wallet you call:
1. api/wallet/mnemonic and get a mnemonic
2. api/wallet/create twice with the same mnemonic

@dev0tion @dangershony 