### PR TITLE
Introduce AsyncLoopFactory and fix flaky blocknotification test

### DIFF
--- a/Stratis.Bitcoin.Tests/Notifications/BlockNotificationFeatureTest.cs
+++ b/Stratis.Bitcoin.Tests/Notifications/BlockNotificationFeatureTest.cs
@@ -27,7 +27,7 @@ namespace Stratis.Bitcoin.Tests.Notifications
 			var chain = new Mock<ConcurrentChain>();
 			var chainState = new Mock<ChainBehavior.ChainState>(new Mock<FullNode>().Object);
 			var blockPuller = new Mock<LookaheadBlockPuller>(chain.Object, connectionManager.Object);
-			var blockNotification = new Mock<BlockNotification>(chain.Object, blockPuller.Object, new Signals());
+			var blockNotification = new Mock<BlockNotification>(chain.Object, blockPuller.Object, new Signals(), new AsyncLoopFactory());
 
 			var blockNotificationFeature = new BlockNotificationFeature(blockNotification.Object, cancellationProvider, connectionManager.Object, blockPuller.Object, chainState.Object, chain.Object);
 			blockNotificationFeature.Start();

--- a/Stratis.Bitcoin/AsyncLoopFactory.cs
+++ b/Stratis.Bitcoin/AsyncLoopFactory.cs
@@ -1,0 +1,43 @@
+﻿using Stratis.Bitcoin.Utilities;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Stratis.Bitcoin
+{
+    public interface IAsyncLoopFactory
+    {
+        IAsyncLoop Create(string name, Func<CancellationToken, Task> loop);
+
+        Task Run(string name, Func<CancellationToken, Task> loop, TimeSpan? repeatEvery = null, TimeSpan? startAfter = null);
+        Task Run(string name, Func<CancellationToken, Task> loop, CancellationToken cancellation, TimeSpan? repeatEvery = null, TimeSpan? startAfter = null);
+    }
+
+    public class AsyncLoopFactory : IAsyncLoopFactory
+    {
+        public AsyncLoopFactory()
+        {
+        }
+
+        public IAsyncLoop Create(string name, Func<CancellationToken, Task> loop)
+        {
+            return new AsyncLoop(name, loop);
+        }
+
+        public Task Run(string name, Func<CancellationToken, Task> loop, TimeSpan? repeatEvery = null, TimeSpan? startAfter = null)
+        {
+            return new AsyncLoop(name, loop).Run(repeatEvery, startAfter);
+        }
+
+        public Task Run(string name, Func<CancellationToken, Task> loop, CancellationToken cancellation, TimeSpan? repeatEvery = null, TimeSpan? startAfter = null)
+        {
+            Guard.NotNull(cancellation, nameof(cancellation));
+            Guard.NotEmpty(name, nameof(name));
+            Guard.NotNull(loop, nameof(loop));
+
+            return new AsyncLoop(name, loop).Run(cancellation, repeatEvery ?? TimeSpan.FromMilliseconds(1000), startAfter);
+        }
+    }
+}

--- a/Stratis.Bitcoin/Notifications/BlockNotification.cs
+++ b/Stratis.Bitcoin/Notifications/BlockNotification.cs
@@ -13,17 +13,20 @@ namespace Stratis.Bitcoin.Notifications
 	{
 		private readonly ISignals signals;
         private ChainedBlock tip;
+        private IAsyncLoopFactory asyncLoopFactory;
 
-		public BlockNotification(ConcurrentChain chain, ILookaheadBlockPuller puller, ISignals signals)
+        public BlockNotification(ConcurrentChain chain, ILookaheadBlockPuller puller, ISignals signals, IAsyncLoopFactory asyncLoopFactory)
 		{
 			Guard.NotNull(chain, nameof(chain));
 			Guard.NotNull(puller, nameof(puller));
 			Guard.NotNull(signals, nameof(signals));
+            Guard.NotNull(asyncLoopFactory, nameof(asyncLoopFactory));
 
 			this.Chain = chain;
 			this.Puller = puller;
 			this.signals = signals;
-		}
+            this.asyncLoopFactory = asyncLoopFactory;
+        }
 
 		public ILookaheadBlockPuller Puller { get; }
 
@@ -55,9 +58,9 @@ namespace Stratis.Bitcoin.Notifications
 		/// Notifies about blocks, starting from block with hash passed as parameter.
 		/// </summary>
 		/// <param name="cancellationToken">A cancellation token</param>
-		public virtual void Notify(CancellationToken cancellationToken)
+		public virtual Task Notify(CancellationToken cancellationToken)
 		{
-			AsyncLoop.Run("block notifier", token =>
+			return this.asyncLoopFactory.Run("block notifier", token =>
 			{
 				// if the StartHash hasn't been set yet
 				if (this.StartHash == null)


### PR DESCRIPTION
This makes testing methods using the AsyncLoop class easier by providing a factory that can be injected into the constructor of the class. 
Methods using this asyncloop should slowly be refactored from void to Task as their return type.