### PR TITLE
Solve System.InvalidOperationException: Collection was modified

### DIFF
--- a/Stratis.Bitcoin.Tests/Wallet/WalletManagerTest.cs
+++ b/Stratis.Bitcoin.Tests/Wallet/WalletManagerTest.cs
@@ -1,0 +1,83 @@
+﻿using Microsoft.Extensions.Logging;
+using Moq;
+using NBitcoin;
+using Stratis.Bitcoin.Configuration;
+using Stratis.Bitcoin.Connection;
+using Stratis.Bitcoin.Logging;
+using Stratis.Bitcoin.Tests.Logging;
+using Stratis.Bitcoin.Wallet;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+using static Stratis.Bitcoin.FullNode;
+
+namespace Stratis.Bitcoin.Tests.Wallet
+{
+    public class WalletManagerTest : TestBase
+    {
+
+        [Fact]
+        public void UpdateLastBlockSyncedHeightWhileWalletCreatedDoesNotThrowInvalidOperationException()
+        {
+            string dir = AssureEmptyDir("TestData/WalletManagerTest/UpdateLastBlockSyncedHeightWhileWalletCreatedDoesNotThrowInvalidOperationException");
+            var dataFolder = new DataFolder(new NodeSettings { DataDir = dir });            
+            var loggerFactory = new Mock<ILoggerFactory>();
+            loggerFactory.Setup(l => l.CreateLogger(It.IsAny<string>()))
+               .Returns(new Mock<ILogger>().Object);           
+            Logs.Configure(loggerFactory.Object);
+
+            var walletManager = new WalletManager(loggerFactory.Object, It.IsAny<ConnectionManager>(), Network.Main, new Mock<ConcurrentChain>().Object, NodeSettings.Default(),
+                                                  dataFolder, new Mock<IWalletFeePolicy>().Object, new Mock<IAsyncLoopFactory>().Object, new CancellationProvider()
+                                                  {
+                                                      Cancellation = new System.Threading.CancellationTokenSource()
+                                                  });
+
+            var concurrentChain = new ConcurrentChain(Network.Main);
+            ChainedBlock tip = AppendBlock(null, concurrentChain);
+
+            walletManager.Wallets.Add(CreateWallet("wallet1"));
+            walletManager.Wallets.Add(CreateWallet("wallet2"));
+
+            Parallel.For(0, 500, new ParallelOptions() { MaxDegreeOfParallelism = 10 }, (int iteration) =>
+            {
+                walletManager.UpdateLastBlockSyncedHeight(tip);
+                walletManager.Wallets.Add(CreateWallet("wallet"));
+                walletManager.UpdateLastBlockSyncedHeight(tip);
+            });
+
+            Assert.Equal(502, walletManager.Wallets.Count);
+            Assert.True(walletManager.Wallets.All(w => w.BlockLocator != null));
+        }
+
+        private Bitcoin.Wallet.Wallet CreateWallet(string name)
+        {
+            return new Bitcoin.Wallet.Wallet()
+            {
+                Name = name,
+                AccountsRoot = new List<AccountRoot>(),
+                BlockLocator = null
+            };
+        }
+
+        private ChainedBlock AppendBlock(ChainedBlock previous, params ConcurrentChain[] chains)
+        {
+            ChainedBlock last = null;
+            var nonce = RandomUtils.GetUInt32();
+            foreach (ConcurrentChain chain in chains)
+            {
+                var block = new Block();
+                block.AddTransaction(new Transaction());
+                block.UpdateMerkleRoot();
+                block.Header.HashPrevBlock = previous == null ? chain.Tip.HashBlock : previous.HashBlock;
+                block.Header.Nonce = nonce;
+                if (!chain.TrySetTip(block.Header, out last))
+                    throw new InvalidOperationException("Previous not existing");
+            }
+            return last;
+        }
+    }
+}

--- a/Stratis.Bitcoin/Wallet/WalletManager.cs
+++ b/Stratis.Bitcoin/Wallet/WalletManager.cs
@@ -13,6 +13,7 @@ using Stratis.Bitcoin.Connection;
 using Stratis.Bitcoin.MemoryPool;
 using Stratis.Bitcoin.Utilities;
 using Transaction = NBitcoin.Transaction;
+using System.Collections.Concurrent;
 
 namespace Stratis.Bitcoin.Wallet
 {
@@ -21,7 +22,7 @@ namespace Stratis.Bitcoin.Wallet
     /// </summary>
     public class WalletManager : IWalletManager
     {
-        public List<Wallet> Wallets { get; }
+        public ConcurrentBag<Wallet> Wallets { get; }
 
         private const int UnusedAddressesBuffer = 20;
         private const int WalletRecoveryAccountsCount = 3;
@@ -57,7 +58,7 @@ namespace Stratis.Bitcoin.Wallet
             NodeSettings settings, DataFolder dataFolder, IWalletFeePolicy walletFeePolicy, IAsyncLoopFactory asyncLoopFactory, FullNode.CancellationProvider cancellationProvider, MempoolValidator mempoolValidator = null) // mempool does not exist in a light wallet
         {
             this.logger = loggerFactory.CreateLogger(this.GetType().FullName);
-            this.Wallets = new List<Wallet>();
+            this.Wallets = new ConcurrentBag<Wallet>();
 
             this.connectionManager = connectionManager;
             this.network = network;
@@ -897,10 +898,9 @@ namespace Stratis.Bitcoin.Wallet
         /// <inheritdoc />
         public void UpdateLastBlockSyncedHeight(ChainedBlock chainedBlock)
         {
-            // update the wallets with the last processed block height
-            foreach (var wallet in this.Wallets)
-            {
-                this.UpdateLastBlockSyncedHeight(wallet, chainedBlock);
+            // update the wallets with the last processed block height                        
+            foreach(var wallet in this.Wallets) { 
+                this.UpdateLastBlockSyncedHeight(wallet, chainedBlock);                
             }
 
             this.WalletTipHash = chainedBlock.HashBlock;


### PR DESCRIPTION
```
The following error occurred while creating wallet

[2:55] 
crit: Stratis.Bitcoin.Consensus[0]
      Consensus loop unhandled exception (Tip:118471)
System.InvalidOperationException: Collection was modified; enumeration operation may not execute.
   at System.ThrowHelper.ThrowInvalidOperationException(ExceptionResource resource)
   at System.Collections.Generic.List`1.Enumerator.MoveNextRare()
   at Stratis.Bitcoin.Wallet.WalletManager.UpdateLastBlockSyncedHeight(ChainedBlock chainedBlock) in C:\Users\stratis dev\Documents\StratisBitcoinFullNode\Stratis.Bitcoin\Wallet\WalletManager.cs:line 881
   at Stratis.Bitcoin.Wallet.WalletManager.ProcessBlock(Block block, ChainedBlock chainedBlock) in C:\Users\stratis dev\Documents\StratisBitcoinFullNode\Stratis.Bitcoin\Wallet\WalletManager.cs:line 629
   at Stratis.Bitcoin.Wallet.WalletSyncManager.ProcessBlock(Block block) in C:\Users\stratis dev\Documents\StratisBitcoinFullNode\Stratis.Bitcoin\Wallet\WalletSyncManager.cs:line 134
   at Stratis.Bitcoin.Wallet.Notifications.BlockObserver.OnNextCore(Block block) in C:\Users\stratis dev\Documents\StratisBitcoinFullNode\Stratis.Bitcoin\Wallet\Notifications\BlockObserver.cs:line 24
   at System.Reactive.SafeObserver`1.OnNext(TSource value)
   at System.Reactive.Observer`1.OnNext(T value)
   at System.Reactive.SynchronizedObserver`1.OnNextCore(T value)
   at Stratis.Bitcoin.Signaler`1.Broadcast(T item) in C:\Users\stratis dev\Documents\StratisBitcoinFullNode\Stratis.Bitcoin\Signaler.cs:line 46
   at Stratis.Bitcoin.Consensus.ConsensusFeature.RunLoop() in C:\Users\stratis dev\Documents\StratisBitcoinFullNode\Stratis.Bitcoin\Consensus\ConsensusFeature.cs:line 149

Unhandled Exception: System.InvalidOperationException: Collection was modified; enumeration operation may not execute.
   at System.ThrowHelper.ThrowInvalidOperationException(ExceptionResource resource)
   at System.Collections.Generic.List`1.Enumerator.MoveNextRare()
   at Stratis.Bitcoin.Wallet.WalletManager.UpdateLastBlockSyncedHeight(ChainedBlock chainedBlock) in C:\Users\stratis dev\Documents\StratisBitcoinFullNode\Stratis.Bitcoin\Wallet\WalletManager.cs:line 881
   at Stratis.Bitcoin.Wallet.WalletManager.ProcessBlock(Block block, ChainedBlock chainedBlock) in C:\Users\stratis dev\Documents\StratisBitcoinFullNode\Stratis.Bitcoin\Wallet\WalletManager.cs:line 629
   at Stratis.Bitcoin.Wallet.WalletSyncManager.ProcessBlock(Block block) in C:\Users\stratis dev\Documents\StratisBitcoinFullNode\Stratis.Bitcoin\Wallet\WalletSyncManager.cs:line 134
   at Stratis.Bitcoin.Wallet.Notifications.BlockObserver.OnNextCore(Block block) in C:\Users\stratis dev\Documents\StratisBitcoinFullNode\Stratis.Bitcoin\Wallet\Notifications\BlockObserver.cs:line 24
   at System.Reactive.SafeObserver`1.OnNext(TSource value)
   at System.Reactive.Observer`1.OnNext(T value)
   at System.Reactive.SynchronizedObserver`1.OnNextCore(T value)
   at Stratis.Bitcoin.Signaler`1.Broadcast(T item) in C:\Users\stratis dev\Documents\StratisBitcoinFullNode\Stratis.Bitcoin\Signaler.cs:line 46
   at Stratis.Bitcoin.Consensus.ConsensusFeature.RunLoop() in C:\Users\stratis dev\Documents\StratisBitcoinFullNode\Stratis.Bitcoin\Consensus\ConsensusFeature.cs:line 168
   at System.Threading.ExecutionContext.Run(ExecutionContext executionContext, ContextCallback callback, Object state)
```

Made a test for it to prove it is solved. We have to consider using ConcurrentBag or a different thread safe collection instead of List<T> in the future because List<T> is not thread safe and do not handle concurrency well. This will lead to issues with the signal/observer pattern.