### PR TITLE
Instead of hard coding / to in nodeSettings.DataDir use Path.Combine

### DIFF
--- a/Stratis.Bitcoin/Configuration/NodeSettings.cs
+++ b/Stratis.Bitcoin/Configuration/NodeSettings.cs
@@ -91,7 +91,7 @@ namespace Stratis.Bitcoin.Configuration
 			nodeSettings.Network = nodeSettings.GetNetwork();
 			if (nodeSettings.DataDir == null)
 			{
-				nodeSettings.DataDir = GetDefaultDataDir($"StratisNode/{nodeSettings.Name}", nodeSettings.Network);
+				nodeSettings.DataDir = GetDefaultDataDir(Path.Combine("StratisNode", nodeSettings.Name), nodeSettings.Network);
 			}
 
 			if (nodeSettings.ConfigurationFile == null)


### PR DESCRIPTION
The path in the nodeSettings.DataDir variable contains a mixture of \ and / characters. This change will ensure we use the appropriate operating system specific path separator.