### PR TITLE
Wallet tests and wallet notification tests

### DIFF
--- a/Stratis.Bitcoin.Tests/Wallet/AccountRootTest.cs
+++ b/Stratis.Bitcoin.Tests/Wallet/AccountRootTest.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+
+namespace Stratis.Bitcoin.Tests.Wallet
+{
+    public class AccountRootTest : WalletTestBase
+    {
+        [Fact]
+        public void GetFirstUnusedAccountWithoutAccountsReturnsNull()
+        {
+            var accountRoot = CreateAccountRoot(Bitcoin.Wallet.CoinType.Stratis);
+
+            var result = accountRoot.GetFirstUnusedAccount();
+
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void GetFirstUnusedAccountReturnsAccountWithLowerIndexHavingNoAddresses()
+        {
+            var accountRoot = CreateAccountRoot(Bitcoin.Wallet.CoinType.Stratis);
+            var unused = CreateAccount("unused1");
+            unused.Index = 2;
+            accountRoot.Accounts.Add(unused);
+
+            var unused2 = CreateAccount("unused2");
+            unused2.Index = 1;
+            accountRoot.Accounts.Add(unused2);
+
+            var used = CreateAccount("used");
+            used.ExternalAddresses.Add(CreateAddress());
+            used.Index = 3;
+            accountRoot.Accounts.Add(used);
+
+            var used2 = CreateAccount("used2");
+            used2.InternalAddresses.Add(CreateAddress());
+            used2.Index = 4;
+            accountRoot.Accounts.Add(used2);
+
+            var result = accountRoot.GetFirstUnusedAccount();
+
+            Assert.NotNull(result);
+            Assert.Equal(1, result.Index);
+            Assert.Equal("unused2", result.Name);
+        }
+
+        [Fact]
+        public void GetAccountByNameWithMatchingNameReturnsAccount()
+        {
+            var accountRoot = CreateAccountRootWithHdAccountHavingAddresses("Test", Bitcoin.Wallet.CoinType.Stratis);            
+            
+            var result = accountRoot.GetAccountByName("Test");
+
+            Assert.NotNull(result);            
+            Assert.Equal("Test", result.Name);
+        }
+
+        [Fact]
+        public void GetAccountByNameWithNonMatchingNameThrowsException()
+        {            
+            var accountRoot = CreateAccountRootWithHdAccountHavingAddresses("Test", Bitcoin.Wallet.CoinType.Stratis);
+
+            Assert.Throws<Exception>(() => { accountRoot.GetAccountByName("test"); });           
+        }
+    }
+}

--- a/Stratis.Bitcoin.Tests/Wallet/HdAccountTest.cs
+++ b/Stratis.Bitcoin.Tests/Wallet/HdAccountTest.cs
@@ -1,0 +1,316 @@
+﻿using NBitcoin;
+using Stratis.Bitcoin.Wallet;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Xunit;
+
+namespace Stratis.Bitcoin.Tests.Wallet
+{
+    public class HdAccountTest
+    {
+        [Fact]
+        public void GetCoinTypeHavingHdPathReturnsCointType()
+        {
+            var account = new HdAccount();
+            account.HdPath = "1/2/105";
+
+            CoinType result = account.GetCoinType();
+
+            Assert.Equal(CoinType.Stratis, result);
+        }
+
+        [Fact]
+        public void GetCoinTypeWithInvalidHdPathThrowsException()
+        {
+            Assert.Throws<InvalidOperationException>(() =>
+            {
+                var account = new HdAccount();
+                account.HdPath = "1/";
+
+                account.GetCoinType();
+            });
+        }
+
+        [Fact]
+        public void GetCoinTypeWithoutHdPathThrowsException()
+        {
+            Assert.Throws<InvalidOperationException>(() =>
+            {
+                var account = new HdAccount();
+                account.HdPath = null;
+
+                account.GetCoinType();
+            });
+        }
+
+        [Fact]
+        public void GetCoinTypeWithEmptyHdPathThrowsException()
+        {
+            Assert.Throws<InvalidOperationException>(() =>
+            {
+                var account = new HdAccount();
+                account.HdPath = string.Empty;
+
+                account.GetCoinType();
+            });
+        }
+
+        [Fact]
+        public void GetFirstUnusedReceivingAddressWithExistingUnusedReceivingAddressReturnsAddressWithLowestIndex()
+        {
+            var account = new HdAccount();
+            account.ExternalAddresses.Add(new HdAddress() { Index = 3 });
+            account.ExternalAddresses.Add(new HdAddress() { Index = 2 });
+            account.ExternalAddresses.Add(new HdAddress() { Index = 1, Transactions = new List<TransactionData>() { new TransactionData() } });
+
+            var result = account.GetFirstUnusedReceivingAddress();
+
+            Assert.Equal(account.ExternalAddresses.ElementAt(1), result);
+        }
+
+        [Fact]
+        public void GetFirstUnusedReceivingAddressWithoutExistingUnusedReceivingAddressReturnsNull()
+        {
+            var account = new HdAccount();
+            account.ExternalAddresses.Add(new HdAddress() { Index = 2, Transactions = new List<TransactionData>() { new TransactionData() } });
+            account.ExternalAddresses.Add(new HdAddress() { Index = 1, Transactions = new List<TransactionData>() { new TransactionData() } });
+
+            var result = account.GetFirstUnusedReceivingAddress();
+
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void GetFirstUnusedReceivingAddressWithoutReceivingAddressReturnsNull()
+        {
+            var account = new HdAccount();
+            account.ExternalAddresses.Clear();
+
+            var result = account.GetFirstUnusedReceivingAddress();
+
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void GetFirstUnusedChangeAddressWithExistingUnusedChangeAddressReturnsAddressWithLowestIndex()
+        {
+            var account = new HdAccount();
+            account.InternalAddresses.Add(new HdAddress() { Index = 3 });
+            account.InternalAddresses.Add(new HdAddress() { Index = 2 });
+            account.InternalAddresses.Add(new HdAddress() { Index = 1, Transactions = new List<TransactionData>() { new TransactionData() } });
+
+            var result = account.GetFirstUnusedChangeAddress();
+
+            Assert.Equal(account.InternalAddresses.ElementAt(1), result);
+        }
+
+        [Fact]
+        public void GetFirstUnusedChangeAddressWithoutExistingUnusedChangeAddressReturnsNull()
+        {
+            var account = new HdAccount();
+            account.InternalAddresses.Add(new HdAddress() { Index = 2, Transactions = new List<TransactionData>() { new TransactionData() } });
+            account.InternalAddresses.Add(new HdAddress() { Index = 1, Transactions = new List<TransactionData>() { new TransactionData() } });
+
+            var result = account.GetFirstUnusedChangeAddress();
+
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void GetFirstUnusedChangeAddressWithoutChangeAddressReturnsNull()
+        {
+            var account = new HdAccount();
+            account.InternalAddresses.Clear();
+
+            var result = account.GetFirstUnusedChangeAddress();
+
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void GetLastUsedAddressWithChangeAddressesHavingTransactionsReturnsHighestIndex()
+        {
+            var account = new HdAccount();
+            account.InternalAddresses.Add(new HdAddress() { Index = 2, Transactions = new List<TransactionData>() { new TransactionData() } });
+            account.InternalAddresses.Add(new HdAddress() { Index = 3, Transactions = new List<TransactionData>() { new TransactionData() } });
+            account.InternalAddresses.Add(new HdAddress() { Index = 1, Transactions = new List<TransactionData>() { new TransactionData() } });
+
+            var result = account.GetLastUsedAddress(isChange: true);
+
+            Assert.Equal(account.InternalAddresses.ElementAt(1), result);
+        }
+
+        [Fact]
+        public void GetLastUsedAddressLookingForChangeAddressWithoutChangeAddressesHavingTransactionsReturnsNull()
+        {
+            var account = new HdAccount();
+            account.InternalAddresses.Add(new HdAddress() { Index = 2 });
+            account.InternalAddresses.Add(new HdAddress() { Index = 3 });
+            account.InternalAddresses.Add(new HdAddress() { Index = 1 });
+
+            var result = account.GetLastUsedAddress(isChange: true);
+
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void GetLastUsedAddressLookingForChangeAddressWithoutChangeAddressesReturnsNull()
+        {
+            var account = new HdAccount();
+            account.InternalAddresses.Clear();
+
+            var result = account.GetLastUsedAddress(isChange: true);
+
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void GetLastUsedAddressWithReceivingAddressesHavingTransactionsReturnsHighestIndex()
+        {
+            var account = new HdAccount();
+            account.ExternalAddresses.Add(new HdAddress() { Index = 2, Transactions = new List<TransactionData>() { new TransactionData() } });
+            account.ExternalAddresses.Add(new HdAddress() { Index = 3, Transactions = new List<TransactionData>() { new TransactionData() } });
+            account.ExternalAddresses.Add(new HdAddress() { Index = 1, Transactions = new List<TransactionData>() { new TransactionData() } });
+
+            var result = account.GetLastUsedAddress(isChange: false);
+
+            Assert.Equal(account.ExternalAddresses.ElementAt(1), result);
+        }
+
+        [Fact]
+        public void GetLastUsedAddressLookingForReceivingAddressWithoutReceivingAddressesHavingTransactionsReturnsNull()
+        {
+            var account = new HdAccount();
+            account.ExternalAddresses.Add(new HdAddress() { Index = 2 });
+            account.ExternalAddresses.Add(new HdAddress() { Index = 3 });
+            account.ExternalAddresses.Add(new HdAddress() { Index = 1 });
+
+            var result = account.GetLastUsedAddress(isChange: false);
+
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void GetLastUsedAddressLookingForReceivingAddressWithoutReceivingAddressesReturnsNull()
+        {
+            var account = new HdAccount();
+            account.ExternalAddresses.Clear();
+
+            var result = account.GetLastUsedAddress(isChange: false);
+
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void GetTransactionsByIdHavingTransactionsWithIdReturnsTransactions()
+        {
+            var account = new HdAccount();
+            account.ExternalAddresses.Add(new HdAddress() { Index = 2, Transactions = new List<TransactionData>() { new TransactionData() { Id = new uint256(15), Index = 7 } } });
+            account.ExternalAddresses.Add(new HdAddress() { Index = 3, Transactions = new List<TransactionData>() { new TransactionData() { Id = new uint256(18), Index = 8 } } });
+            account.ExternalAddresses.Add(new HdAddress() { Index = 1, Transactions = new List<TransactionData>() { new TransactionData() { Id = new uint256(19), Index = 9 } } });
+            account.ExternalAddresses.Add(new HdAddress() { Index = 6, Transactions = null });
+
+            account.InternalAddresses.Add(new HdAddress() { Index = 4, Transactions = new List<TransactionData>() { new TransactionData() { Id = new uint256(15), Index = 10 } } });
+            account.InternalAddresses.Add(new HdAddress() { Index = 5, Transactions = new List<TransactionData>() { new TransactionData() { Id = new uint256(18), Index = 11 } } });
+            account.InternalAddresses.Add(new HdAddress() { Index = 6, Transactions = null });
+            account.InternalAddresses.Add(new HdAddress() { Index = 6, Transactions = new List<TransactionData>() { new TransactionData() { Id = new uint256(19), Index = 12 } } });
+
+            var result = account.GetTransactionsById(new uint256(18));
+
+            Assert.Equal(2, result.Count());
+            Assert.Equal(8, result.ElementAt(0).Index);
+            Assert.Equal(new uint256(18), result.ElementAt(0).Id);
+            Assert.Equal(11, result.ElementAt(1).Index);
+            Assert.Equal(new uint256(18), result.ElementAt(1).Id);
+        }
+
+        [Fact]
+        public void GetTransactionsByIdHavingNoMatchingTransactionsReturnsEmptyList()
+        {
+            var account = new HdAccount();
+            account.ExternalAddresses.Add(new HdAddress() { Index = 2, Transactions = new List<TransactionData>() { new TransactionData() { Id = new uint256(15), Index = 7 } } });
+            account.InternalAddresses.Add(new HdAddress() { Index = 4, Transactions = new List<TransactionData>() { new TransactionData() { Id = new uint256(15), Index = 10 } } });
+
+            var result = account.GetTransactionsById(new uint256(20));
+
+            Assert.Equal(0, result.Count());
+        }
+
+        [Fact]
+        public void GetSpendableTransactionsWithSpendableTransactionsReturnsSpendableTransactions()
+        {
+            var account = new HdAccount();
+            account.ExternalAddresses.Add(new HdAddress() { Index = 2, Transactions = new List<TransactionData>() { new TransactionData() { Id = new uint256(15), Index = 7, SpendingDetails = new SpendingDetails() } } });
+            account.ExternalAddresses.Add(new HdAddress() { Index = 3, Transactions = new List<TransactionData>() { new TransactionData() { Id = new uint256(18), Index = 8 } } });
+            account.ExternalAddresses.Add(new HdAddress() { Index = 1, Transactions = new List<TransactionData>() { new TransactionData() { Id = new uint256(19), Index = 9, SpendingDetails = new SpendingDetails() } } });
+            account.ExternalAddresses.Add(new HdAddress() { Index = 6, Transactions = null });
+
+            account.InternalAddresses.Add(new HdAddress() { Index = 4, Transactions = new List<TransactionData>() { new TransactionData() { Id = new uint256(15), Index = 10, SpendingDetails = new SpendingDetails() } } });
+            account.InternalAddresses.Add(new HdAddress() { Index = 5, Transactions = new List<TransactionData>() { new TransactionData() { Id = new uint256(18), Index = 11 } } });
+            account.InternalAddresses.Add(new HdAddress() { Index = 6, Transactions = null });
+            account.InternalAddresses.Add(new HdAddress() { Index = 6, Transactions = new List<TransactionData>() { new TransactionData() { Id = new uint256(19), Index = 12, SpendingDetails = new SpendingDetails() } } });
+
+            var result = account.GetSpendableTransactions();
+
+            Assert.Equal(2, result.Count());
+            Assert.Equal(8, result.ElementAt(0).Index);
+            Assert.Equal(new uint256(18), result.ElementAt(0).Id);
+            Assert.Equal(11, result.ElementAt(1).Index);
+            Assert.Equal(new uint256(18), result.ElementAt(1).Id);
+        }
+
+        [Fact]
+        public void GetSpendableTransactionsWithoutSpendableTransactionsReturnsEmptyList()
+        {
+            var account = new HdAccount();
+            account.ExternalAddresses.Add(new HdAddress() { Index = 2, Transactions = new List<TransactionData>() { new TransactionData() { Id = new uint256(15), Index = 7, SpendingDetails = new SpendingDetails() } } });
+            account.InternalAddresses.Add(new HdAddress() { Index = 4, Transactions = new List<TransactionData>() { new TransactionData() { Id = new uint256(15), Index = 10, SpendingDetails = new SpendingDetails() } } });
+
+            var result = account.GetSpendableTransactions();
+
+            Assert.Equal(0, result.Count());
+        }
+
+        [Fact]
+        public void FindAddressesForTransactionWithMatchingTransactionsReturnsTransactions()
+        {
+            var account = new HdAccount();
+            account.ExternalAddresses.Add(new HdAddress() { Index = 2, Transactions = new List<TransactionData>() { new TransactionData() { Id = new uint256(15), Index = 7 } } });
+            account.ExternalAddresses.Add(new HdAddress() { Index = 3, Transactions = new List<TransactionData>() { new TransactionData() { Id = new uint256(18), Index = 8 } } });
+            account.ExternalAddresses.Add(new HdAddress() { Index = 1, Transactions = new List<TransactionData>() { new TransactionData() { Id = new uint256(19), Index = 9 } } });
+            account.ExternalAddresses.Add(new HdAddress() { Index = 6, Transactions = null });
+
+            account.InternalAddresses.Add(new HdAddress() { Index = 4, Transactions = new List<TransactionData>() { new TransactionData() { Id = new uint256(15), Index = 10 } } });
+            account.InternalAddresses.Add(new HdAddress() { Index = 5, Transactions = new List<TransactionData>() { new TransactionData() { Id = new uint256(18), Index = 11 } } });
+            account.InternalAddresses.Add(new HdAddress() { Index = 6, Transactions = null });
+            account.InternalAddresses.Add(new HdAddress() { Index = 6, Transactions = new List<TransactionData>() { new TransactionData() { Id = new uint256(19), Index = 12 } } });
+
+            var result = account.FindAddressesForTransaction(t => t.Id == 18);
+
+            Assert.Equal(2, result.Count());
+            Assert.Equal(3, result.ElementAt(0).Index);
+            Assert.Equal(5, result.ElementAt(1).Index);
+        }
+
+        [Fact]
+        public void FindAddressesForTransactionWithoutMatchingTransactionsReturnsEmptyList()
+        {
+            var account = new HdAccount();
+            account.ExternalAddresses.Add(new HdAddress() { Index = 2, Transactions = new List<TransactionData>() { new TransactionData() { Id = new uint256(15), Index = 7 } } });
+            account.ExternalAddresses.Add(new HdAddress() { Index = 3, Transactions = new List<TransactionData>() { new TransactionData() { Id = new uint256(18), Index = 8 } } });
+            account.ExternalAddresses.Add(new HdAddress() { Index = 1, Transactions = new List<TransactionData>() { new TransactionData() { Id = new uint256(19), Index = 9 } } });
+            account.ExternalAddresses.Add(new HdAddress() { Index = 6, Transactions = null });
+
+            account.InternalAddresses.Add(new HdAddress() { Index = 4, Transactions = new List<TransactionData>() { new TransactionData() { Id = new uint256(15), Index = 10 } } });
+            account.InternalAddresses.Add(new HdAddress() { Index = 5, Transactions = new List<TransactionData>() { new TransactionData() { Id = new uint256(18), Index = 11 } } });
+            account.InternalAddresses.Add(new HdAddress() { Index = 6, Transactions = null });
+            account.InternalAddresses.Add(new HdAddress() { Index = 6, Transactions = new List<TransactionData>() { new TransactionData() { Id = new uint256(19), Index = 12 } } });
+
+            var result = account.FindAddressesForTransaction(t => t.Id == 25);
+
+            Assert.Equal(0, result.Count());
+        }
+    }
+}

--- a/Stratis.Bitcoin.Tests/Wallet/HdAddressTest.cs
+++ b/Stratis.Bitcoin.Tests/Wallet/HdAddressTest.cs
@@ -1,0 +1,140 @@
+﻿using NBitcoin;
+using Stratis.Bitcoin.Wallet;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Xunit;
+
+namespace Stratis.Bitcoin.Tests.Wallet
+{
+    public class HdAddressTest
+    {
+        [Fact]
+        public void IsChangeAddressWithValidHdPathForChangeAddressReturnsTrue()
+        {
+            var address = new HdAddress()
+            {
+                HdPath = "0/1/2/3/1"
+            };
+
+            var result = address.IsChangeAddress();
+
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void IsChangeAddressWithValidHdPathForNonChangeAddressReturnsFalse()
+        {
+            var address = new HdAddress()
+            {
+                HdPath = "0/1/2/3/0"
+            };
+
+            var result = address.IsChangeAddress();
+
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void IsChangeAddressWithTextInHdPathReturnsFalse()
+        {
+            var address = new HdAddress()
+            {
+                HdPath = "0/1/2/3/A"
+            };
+
+            var result = address.IsChangeAddress();
+
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void IsChangeAddressWithInvalidHdPathReturnsFalse()
+        {
+            var address = new HdAddress()
+            {
+                HdPath = "0/1/2"
+            };
+
+            var result = address.IsChangeAddress();
+
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void IsChangeAddressWithEmptyHdPathReturnsFalse()
+        {
+            var address = new HdAddress()
+            {
+                HdPath = string.Empty
+            };
+
+            var result = address.IsChangeAddress();
+
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void IsChangeAddressWithNulledHdPathReturnsFalse()
+        {
+            var address = new HdAddress()
+            {
+                HdPath = null
+            };
+
+            var result = address.IsChangeAddress();
+
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void UnspentTransactionsWithAddressHavingUnspentTransactionsReturnsUnspentTransactions()
+        {
+            var address = new HdAddress()
+            {
+                Transactions = new List<TransactionData>() {
+                    new TransactionData() { Id = new uint256(15)},
+                    new TransactionData() { Id = new uint256(16), SpendingDetails = new SpendingDetails() },
+                    new TransactionData() { Id = new uint256(17)},
+                    new TransactionData() { Id = new uint256(18), SpendingDetails = new SpendingDetails() }
+                }
+            };
+
+            var result = address.UnspentTransactions();
+
+            Assert.Equal(2, result.Count());
+            Assert.Equal(new uint256(15), result.ElementAt(0).Id);
+            Assert.Equal(new uint256(17), result.ElementAt(1).Id);
+        }
+
+        [Fact]
+        public void UnspentTransactionsWithAddressNotHavingUnspentTransactionsReturnsEmptyList()
+        {
+            var address = new HdAddress()
+            {
+                Transactions = new List<TransactionData>() {
+                    new TransactionData() { Id = new uint256(16), SpendingDetails = new SpendingDetails() },
+                    new TransactionData() { Id = new uint256(18), SpendingDetails = new SpendingDetails() }
+                }
+            };
+
+            var result = address.UnspentTransactions();
+
+            Assert.Equal(0, result.Count());
+        }
+
+        [Fact]
+        public void UnspentTransactionsWithAddressWithoutTransactionsReturnsEmptyList()
+        {
+            var address = new HdAddress()
+            {
+                Transactions = new List<TransactionData>()
+            };
+
+            var result = address.UnspentTransactions();
+
+            Assert.Equal(0, result.Count());
+        }
+    }
+}

--- a/Stratis.Bitcoin.Tests/Wallet/HdAddressTest.cs
+++ b/Stratis.Bitcoin.Tests/Wallet/HdAddressTest.cs
@@ -50,42 +50,45 @@ namespace Stratis.Bitcoin.Tests.Wallet
         }
 
         [Fact]
-        public void IsChangeAddressWithInvalidHdPathReturnsFalse()
+        public void IsChangeAddressWithInvalidHdPathThrowsInvalidOperationException()
         {
-            var address = new HdAddress()
+            Assert.Throws<InvalidOperationException>(() =>
             {
-                HdPath = "0/1/2"
-            };
+                var address = new HdAddress()
+                {
+                    HdPath = "0/1/2"
+                };
 
-            var result = address.IsChangeAddress();
-
-            Assert.False(result);
+                var result = address.IsChangeAddress();
+            });
         }
 
         [Fact]
-        public void IsChangeAddressWithEmptyHdPathReturnsFalse()
+        public void IsChangeAddressWithEmptyHdPathThrowsInvalidOperationException()
         {
-            var address = new HdAddress()
+            Assert.Throws<InvalidOperationException>(() =>
             {
-                HdPath = string.Empty
-            };
+                var address = new HdAddress()
+                {
+                    HdPath = string.Empty
+                };
 
-            var result = address.IsChangeAddress();
-
-            Assert.False(result);
+                var result = address.IsChangeAddress();
+            });
         }
 
         [Fact]
-        public void IsChangeAddressWithNulledHdPathReturnsFalse()
+        public void IsChangeAddressWithNulledHdPathThrowsInvalidOperationException()
         {
-            var address = new HdAddress()
+            Assert.Throws<InvalidOperationException>(() =>
             {
-                HdPath = null
-            };
+                var address = new HdAddress()
+                {
+                    HdPath = null
+                };
 
-            var result = address.IsChangeAddress();
-
-            Assert.False(result);
+                var result = address.IsChangeAddress();
+            });
         }
 
         [Fact]

--- a/Stratis.Bitcoin.Tests/Wallet/Notifications/BlockObserverTest.cs
+++ b/Stratis.Bitcoin.Tests/Wallet/Notifications/BlockObserverTest.cs
@@ -1,0 +1,26 @@
+﻿using Moq;
+using NBitcoin;
+using Stratis.Bitcoin.Wallet;
+using Stratis.Bitcoin.Wallet.Notifications;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+
+namespace Stratis.Bitcoin.Tests.Wallet.Notifications
+{
+    public class BlockObserverTest
+    {
+        [Fact]
+        public void OnNextCoreProcessesOnTheWalletSyncManager()
+        {
+            var walletSyncManager = new Mock<IWalletSyncManager>();
+            BlockObserver observer = new BlockObserver(walletSyncManager.Object);
+            Block block = new Block();
+
+            observer.OnNext(block);
+
+            walletSyncManager.Verify(w => w.ProcessBlock(block), Times.Exactly(1));
+        }
+    }
+}

--- a/Stratis.Bitcoin.Tests/Wallet/Notifications/BlockSubscriberTest.cs
+++ b/Stratis.Bitcoin.Tests/Wallet/Notifications/BlockSubscriberTest.cs
@@ -1,0 +1,26 @@
+﻿using Moq;
+using NBitcoin;
+using Stratis.Bitcoin.Wallet;
+using Stratis.Bitcoin.Wallet.Notifications;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+
+namespace Stratis.Bitcoin.Tests.Wallet.Notifications
+{
+    public class BlockSubscriberTest
+    {
+        [Fact]
+        public void SubscribeSubscribesObserverToSignaler()
+        {
+            var signaler = new Mock<ISignaler<Block>>();
+            var observer = new BlockObserver(new Mock<IWalletSyncManager>().Object);
+            var blockSubscriber = new BlockSubscriber(signaler.Object, observer);
+
+            blockSubscriber.Subscribe();
+
+            signaler.Verify(s => s.Subscribe(observer), Times.Exactly(1));
+        }
+    }
+}

--- a/Stratis.Bitcoin.Tests/Wallet/Notifications/TransactionObserverTest.cs
+++ b/Stratis.Bitcoin.Tests/Wallet/Notifications/TransactionObserverTest.cs
@@ -1,0 +1,26 @@
+﻿using Moq;
+using NBitcoin;
+using Stratis.Bitcoin.Wallet;
+using Stratis.Bitcoin.Wallet.Notifications;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+
+namespace Stratis.Bitcoin.Tests.Wallet.Notifications
+{
+    public class TransactionObserverTest
+    {
+        [Fact]
+        public void OnNextCoreProcessesOnTheWalletSyncManager()
+        {
+            var walletSyncManager = new Mock<IWalletSyncManager>();
+            TransactionObserver observer = new TransactionObserver(walletSyncManager.Object);
+            Transaction transaction = new Transaction();
+
+            observer.OnNext(transaction);
+
+            walletSyncManager.Verify(w => w.ProcessTransaction(transaction), Times.Exactly(1));
+        }
+    }
+}

--- a/Stratis.Bitcoin.Tests/Wallet/Notifications/TransactionSubscriberTest.cs
+++ b/Stratis.Bitcoin.Tests/Wallet/Notifications/TransactionSubscriberTest.cs
@@ -1,0 +1,26 @@
+﻿using Moq;
+using NBitcoin;
+using Stratis.Bitcoin.Wallet;
+using Stratis.Bitcoin.Wallet.Notifications;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+
+namespace Stratis.Bitcoin.Tests.Wallet.Notifications
+{
+    public class TransactionSubscriberTest
+    {
+        [Fact]
+        public void SubscribeSubscribesObserverToSignaler()
+        {
+            var signaler = new Mock<ISignaler<Transaction>>();
+            var observer = new TransactionObserver(new Mock<IWalletSyncManager>().Object);
+            var blockSubscriber = new TransactionSubscriber(signaler.Object, observer);
+
+            blockSubscriber.Subscribe();
+
+            signaler.Verify(s => s.Subscribe(observer), Times.Exactly(1));
+        }
+    }
+}

--- a/Stratis.Bitcoin.Tests/Wallet/SpendingDetailsTest.cs
+++ b/Stratis.Bitcoin.Tests/Wallet/SpendingDetailsTest.cs
@@ -1,0 +1,33 @@
+﻿using Stratis.Bitcoin.Wallet;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+
+namespace Stratis.Bitcoin.Tests.Wallet
+{
+    public class SpendingDetailsTest
+    {
+        [Fact]
+        public void IsSpentConfirmedHavingBlockHeightReturnsTrue()
+        {
+            var spendingDetails = new SpendingDetails()
+            {
+                BlockHeight = 15
+            };
+
+            Assert.True(spendingDetails.IsSpentConfirmed());
+        }
+
+        [Fact]
+        public void IsConfirmedHavingNoBlockHeightReturnsFalse()
+        {
+            var spendingDetails = new SpendingDetails()
+            {
+                BlockHeight = null
+            };
+
+            Assert.False(spendingDetails.IsSpentConfirmed());
+        }
+    }
+}

--- a/Stratis.Bitcoin.Tests/Wallet/TransactionDataTest.cs
+++ b/Stratis.Bitcoin.Tests/Wallet/TransactionDataTest.cs
@@ -1,0 +1,171 @@
+﻿using NBitcoin;
+using Stratis.Bitcoin.Wallet;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+
+namespace Stratis.Bitcoin.Tests.Wallet
+{
+    public class TransactionDataTest
+    {
+        [Fact]
+        public void IsConfirmedWithTransactionHavingBlockHeightReturnsTrue()
+        {
+            var transaction = new TransactionData()
+            {
+                BlockHeight = 15
+            };
+
+            Assert.True(transaction.IsConfirmed());
+        }
+
+        [Fact]
+        public void IsConfirmedWithTransactionHavingNoBlockHeightReturnsFalse()
+        {
+            var transaction = new TransactionData()
+            {
+                BlockHeight = null
+            };
+
+            Assert.False(transaction.IsConfirmed());
+        }
+
+        [Fact]
+        public void IsSpendableWithTransactionHavingSpendingDetailsReturnsFalse()
+        {
+            var transaction = new TransactionData()
+            {
+                SpendingDetails = new SpendingDetails()
+            };
+
+            Assert.False(transaction.IsSpendable());
+        }
+
+        [Fact]
+        public void IsSpendableWithTransactionHavingNoSpendingDetailsReturnsTrue()
+        {
+            var transaction = new TransactionData()
+            {
+                SpendingDetails = null
+            };
+
+            Assert.True(transaction.IsSpendable());
+        }
+
+        [Fact]
+        public void SpendableAmountNotConfirmedOnlyGivenNoSpendingDetailsReturnsTransactionAmount()
+        {
+            var transaction = new TransactionData()
+            {
+                SpendingDetails = null,
+                Amount = new Money(15)
+            };
+
+            var result = transaction.SpendableAmount(false);
+
+            Assert.Equal(new Money(15), result);
+        }
+
+        [Fact]
+        public void SpendableAmountNotConfirmedOnlyGivenBeingConfirmedAndSpentConfirmedReturnsZero()
+        {
+            var transaction = new TransactionData()
+            {
+                SpendingDetails = new SpendingDetails() { BlockHeight = 16 },
+                Amount = new Money(15),
+                BlockHeight = 15
+            };
+
+            var result = transaction.SpendableAmount(false);
+
+            Assert.Equal(Money.Zero, result);
+        }
+
+        [Fact]
+        public void SpendableAmountNotConfirmedOnlyGivenBeingConfirmedAndSpentUnconfirmedReturnsZero()
+        {
+            var transaction = new TransactionData()
+            {
+                SpendingDetails = new SpendingDetails() { },
+                Amount = new Money(15),
+                BlockHeight = 15
+            };
+
+            var result = transaction.SpendableAmount(false);
+
+            Assert.Equal(Money.Zero, result);
+        }
+
+        [Fact]
+        public void SpendableAmountConfirmedOnlyGivenBeingConfirmedAndSpentUnconfirmedReturnsAmount()
+        {
+            var transaction = new TransactionData()
+            {
+                SpendingDetails = new SpendingDetails() { },
+                Amount = new Money(15),
+                BlockHeight = 15
+            };
+
+            var result = transaction.SpendableAmount(true);
+
+            Assert.Equal(15, result);
+        }
+
+        [Fact]
+        public void SpendableAmountNotConfirmedOnlyGivenBeingUnConfirmedAndSpentUnconfirmedReturnsZero()
+        {
+            var transaction = new TransactionData()
+            {
+                SpendingDetails = new SpendingDetails() { },
+                Amount = new Money(15),
+            };
+
+            var result = transaction.SpendableAmount(false);
+
+            Assert.Equal(Money.Zero, result);
+        }
+
+        [Fact]
+        public void SpendableAmountConfirmedOnlyGivenNoSpendingDetailsReturnsZero()
+        {
+            var transaction = new TransactionData()
+            {
+                SpendingDetails = null
+            };
+
+            var result = transaction.SpendableAmount(true);
+
+            Assert.Equal(Money.Zero, result);
+        }
+
+        [Fact]
+        public void SpendableAmountConfirmedOnlyGivenBeingConfirmedAndSpentConfirmedReturnsZero()
+        {
+            var transaction = new TransactionData()
+            {
+                SpendingDetails = new SpendingDetails() { BlockHeight = 16 },
+                Amount = new Money(15),
+                BlockHeight = 15
+            };
+
+            var result = transaction.SpendableAmount(true);
+
+            Assert.Equal(Money.Zero, result);
+        }
+
+        [Fact]
+        public void SpendableAmountConfirmedOnlyGivenBeingUnConfirmedAndSpentUnconfirmedReturnsZero()
+        {
+            var transaction = new TransactionData()
+            {
+                SpendingDetails = new SpendingDetails() { },
+                Amount = new Money(15),
+            };
+
+            var result = transaction.SpendableAmount(true);
+
+            Assert.Equal(Money.Zero, result);
+        }
+    }
+}

--- a/Stratis.Bitcoin.Tests/Wallet/WalletTest.cs
+++ b/Stratis.Bitcoin.Tests/Wallet/WalletTest.cs
@@ -1,0 +1,144 @@
+﻿using NBitcoin;
+using Stratis.Bitcoin.Wallet;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Xunit;
+
+namespace Stratis.Bitcoin.Tests.Wallet
+{
+    public class WalletTest : WalletTestBase
+    {
+        [Fact]
+        public void GetAccountsByCoinTypeReturnsAccountsFromWalletByCoinType()
+        {
+            var wallet = new Stratis.Bitcoin.Wallet.Wallet();
+            wallet.AccountsRoot.Add(CreateAccountRootWithHdAccountHavingAddresses("StratisAccount", CoinType.Stratis));
+            wallet.AccountsRoot.Add(CreateAccountRootWithHdAccountHavingAddresses("BitcoinAccount", CoinType.Bitcoin));
+            wallet.AccountsRoot.Add(CreateAccountRootWithHdAccountHavingAddresses("StratisAccount2", CoinType.Stratis));
+
+            var result = wallet.GetAccountsByCoinType(CoinType.Stratis);
+
+            Assert.Equal(2, result.Count());
+            Assert.Equal("StratisAccount", result.ElementAt(0).Name);
+            Assert.Equal("StratisAccount2", result.ElementAt(1).Name);
+        }
+
+        [Fact]
+        public void GetAccountsByCoinTypeWithoutAccountsReturnsEmptyList()
+        {
+            var wallet = new Stratis.Bitcoin.Wallet.Wallet();
+
+            var result = wallet.GetAccountsByCoinType(CoinType.Stratis);
+
+            Assert.Equal(0, result.Count());
+        }
+
+        [Fact]
+        public void GetAllTransactionsByCoinTypeReturnsTransactionsFromWalletByCoinType()
+        {
+            var wallet = new Stratis.Bitcoin.Wallet.Wallet();
+            var stratisAccountRoot = CreateAccountRootWithHdAccountHavingAddresses("StratisAccount", CoinType.Stratis);
+            var bitcoinAccountRoot = CreateAccountRootWithHdAccountHavingAddresses("BitcoinAccount", CoinType.Bitcoin);
+            var stratisAccountRoot2 = CreateAccountRootWithHdAccountHavingAddresses("StratisAccount2", CoinType.Stratis);
+
+            var transaction1 = CreateTransaction(new uint256(1), new Money(15000), 1);
+            var transaction2 = CreateTransaction(new uint256(2), new Money(91209), 1);
+            var transaction3 = CreateTransaction(new uint256(3), new Money(32145), 1);
+            var transaction4 = CreateTransaction(new uint256(4), new Money(654789), 1);
+            var transaction5 = CreateTransaction(new uint256(5), new Money(52387), 1);
+            var transaction6 = CreateTransaction(new uint256(6), new Money(879873), 1);
+
+            stratisAccountRoot.Accounts.ElementAt(0).InternalAddresses.ElementAt(0).Transactions.Add(transaction1);
+            stratisAccountRoot.Accounts.ElementAt(0).ExternalAddresses.ElementAt(0).Transactions.Add(transaction2);
+            bitcoinAccountRoot.Accounts.ElementAt(0).InternalAddresses.ElementAt(0).Transactions.Add(transaction3);
+            bitcoinAccountRoot.Accounts.ElementAt(0).ExternalAddresses.ElementAt(0).Transactions.Add(transaction4);
+            stratisAccountRoot2.Accounts.ElementAt(0).InternalAddresses.ElementAt(0).Transactions.Add(transaction5);
+            stratisAccountRoot2.Accounts.ElementAt(0).ExternalAddresses.ElementAt(0).Transactions.Add(transaction6);
+
+            wallet.AccountsRoot.Add(stratisAccountRoot);
+            wallet.AccountsRoot.Add(bitcoinAccountRoot);
+            wallet.AccountsRoot.Add(stratisAccountRoot2);
+
+            var result = wallet.GetAllTransactionsByCoinType(CoinType.Stratis).ToList();
+
+            Assert.Equal(4, result.Count);
+            Assert.Equal(transaction2, result[0]);
+            Assert.Equal(transaction6, result[1]);
+            Assert.Equal(transaction1, result[2]);
+            Assert.Equal(transaction5, result[3]);
+        }
+
+        [Fact]
+        public void GetAllTransactionsByCoinTypeWithoutMatchingAccountReturnsEmptyList()
+        {
+            var wallet = new Stratis.Bitcoin.Wallet.Wallet();
+            var bitcoinAccountRoot = CreateAccountRootWithHdAccountHavingAddresses("BitcoinAccount", CoinType.Bitcoin);
+
+            var transaction1 = CreateTransaction(new uint256(3), new Money(32145), 1);
+            var transaction2 = CreateTransaction(new uint256(4), new Money(654789), 1);
+
+            bitcoinAccountRoot.Accounts.ElementAt(0).InternalAddresses.ElementAt(0).Transactions.Add(transaction1);
+            bitcoinAccountRoot.Accounts.ElementAt(0).ExternalAddresses.ElementAt(0).Transactions.Add(transaction2);
+
+            wallet.AccountsRoot.Add(bitcoinAccountRoot);
+
+            var result = wallet.GetAllTransactionsByCoinType(CoinType.Stratis).ToList();
+
+            Assert.Equal(0, result.Count);
+        }
+
+        [Fact]
+        public void GetAllTransactionsByCoinTypeWithoutAccountRootReturnsEmptyList()
+        {
+            var wallet = new Stratis.Bitcoin.Wallet.Wallet();
+
+            var result = wallet.GetAllTransactionsByCoinType(CoinType.Stratis).ToList();
+
+            Assert.Equal(0, result.Count);
+        }
+
+        [Fact]
+        public void GetAllPubKeysByCoinTypeReturnsPubkeysFromWalletByCoinType()
+        {
+            var wallet = new Stratis.Bitcoin.Wallet.Wallet();
+            var stratisAccountRoot = CreateAccountRootWithHdAccountHavingAddresses("StratisAccount", CoinType.Stratis);
+            var bitcoinAccountRoot = CreateAccountRootWithHdAccountHavingAddresses("BitcoinAccount", CoinType.Bitcoin);
+            var stratisAccountRoot2 = CreateAccountRootWithHdAccountHavingAddresses("StratisAccount2", CoinType.Stratis);
+            wallet.AccountsRoot.Add(stratisAccountRoot);
+            wallet.AccountsRoot.Add(bitcoinAccountRoot);
+            wallet.AccountsRoot.Add(stratisAccountRoot2);
+
+            var result = wallet.GetAllPubKeysByCoinType(CoinType.Stratis).ToList();
+
+            Assert.Equal(4, result.Count);
+            Assert.Equal(stratisAccountRoot.Accounts.ElementAt(0).ExternalAddresses.ElementAt(0).ScriptPubKey, result[0]);
+            Assert.Equal(stratisAccountRoot2.Accounts.ElementAt(0).ExternalAddresses.ElementAt(0).ScriptPubKey, result[1]);
+            Assert.Equal(stratisAccountRoot.Accounts.ElementAt(0).InternalAddresses.ElementAt(0).ScriptPubKey, result[2]);
+            Assert.Equal(stratisAccountRoot2.Accounts.ElementAt(0).InternalAddresses.ElementAt(0).ScriptPubKey, result[3]);
+        }
+
+        [Fact]
+        public void GetAllPubKeysByCoinTypeWithoutMatchingCoinTypeReturnsEmptyList()
+        {
+            var wallet = new Stratis.Bitcoin.Wallet.Wallet();
+            var bitcoinAccountRoot = CreateAccountRootWithHdAccountHavingAddresses("BitcoinAccount", CoinType.Bitcoin);
+            wallet.AccountsRoot.Add(bitcoinAccountRoot);
+
+            var result = wallet.GetAllPubKeysByCoinType(CoinType.Stratis).ToList();
+
+            Assert.Equal(0, result.Count);            
+        }
+
+        [Fact]
+        public void GetAllPubKeysByCoinTypeWithoutAccountRootsReturnsEmptyList()
+        {
+            var wallet = new Stratis.Bitcoin.Wallet.Wallet();            
+
+            var result = wallet.GetAllPubKeysByCoinType(CoinType.Stratis).ToList();
+
+            Assert.Equal(0, result.Count);
+        }
+    }
+}

--- a/Stratis.Bitcoin.Tests/Wallet/WalletTestBase.cs
+++ b/Stratis.Bitcoin.Tests/Wallet/WalletTestBase.cs
@@ -1,0 +1,85 @@
+﻿using NBitcoin;
+using Stratis.Bitcoin.Wallet;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Stratis.Bitcoin.Tests.Wallet
+{
+    public class WalletTestBase
+    {
+        public static AccountRoot CreateAccountRoot(CoinType coinType)
+        {
+            return new AccountRoot()
+            {
+                Accounts = new List<HdAccount>(),
+                CoinType = coinType
+            };
+        }
+
+        public static AccountRoot CreateAccountRootWithHdAccountHavingAddresses(string accountName, CoinType coinType)
+        {
+            return new AccountRoot()
+            {
+                Accounts = new List<HdAccount>() {
+                    new HdAccount() {
+                        Name = accountName,
+                        InternalAddresses = new List<HdAddress>()
+                        {
+                            CreateAddress(false),
+                        },
+                        ExternalAddresses = new List<HdAddress>()
+                        {
+                            CreateAddress(false),
+                        }
+                    }
+                },
+                CoinType = coinType
+            };
+        }
+
+        public static HdAccount CreateAccount(string name)
+        {
+            return new HdAccount()
+            {
+                Name = name,
+                HdPath = "1/2/3/4/5",
+            };
+        }
+
+        public static TransactionData CreateTransaction(uint256 id, Money amount, int? blockHeight, SpendingDetails spendingDetails = null, DateTimeOffset? creationTime = null)
+        {
+            if (creationTime == null)
+            {
+                creationTime = new DateTimeOffset(new DateTime(2017, 6, 23, 1, 2, 3));
+            }
+
+            return new TransactionData()
+            {
+                Amount = amount,
+                Id = id,
+                CreationTime = creationTime.Value,
+                BlockHeight = blockHeight,
+                SpendingDetails = spendingDetails
+            };
+        }
+
+        public static HdAddress CreateAddress(bool changeAddress = false)
+        {
+            var hdPath = "1/2/3/4/5";
+            if (changeAddress)
+            {
+                hdPath = "1/2/3/4/1";
+            }
+            var key = new Key();
+            var address = new HdAddress()
+            {
+                Address = key.PubKey.GetAddress(Network.Main).ToString(),
+                HdPath = hdPath,
+                ScriptPubKey = key.ScriptPubKey
+            };
+
+            return address;
+        }
+    }
+}

--- a/Stratis.Bitcoin/Wallet/Wallet.cs
+++ b/Stratis.Bitcoin/Wallet/Wallet.cs
@@ -332,8 +332,7 @@ namespace Stratis.Bitcoin.Wallet
         {
             Guard.NotNull(id, nameof(id));
 
-            IEnumerable<HdAddress> addresses = GetCombinedAddresses();
-
+            var addresses = this.GetCombinedAddresses();
             return addresses.Where(r => r.Transactions != null).SelectMany(a => a.Transactions.Where(t => t.Id == id));
         }       
 
@@ -368,7 +367,7 @@ namespace Stratis.Bitcoin.Wallet
             IEnumerable<HdAddress> addresses = new List<HdAddress>();
             if (this.ExternalAddresses != null)
             {
-                addresses = addresses.Concat(this.ExternalAddresses);
+                addresses = this.ExternalAddresses;
             }
 
             if (this.InternalAddresses != null)
@@ -443,11 +442,11 @@ namespace Stratis.Bitcoin.Wallet
         public bool IsChangeAddress()
         {
             if (string.IsNullOrWhiteSpace(this.HdPath))
-                return false;
+                throw new InvalidOperationException($"Empty HdPath on address {Address}");
 
             var hdPathParts = this.HdPath.Split('/');
-            if (hdPathParts.Length < 5)            
-                return false;
+            if (hdPathParts.Length < 5)
+                throw new InvalidOperationException($"Could not parse value from HdPath on address {Address}");
 
             int result = 0;
             if (int.TryParse(hdPathParts[4], out result))


### PR DESCRIPTION
Should be pretty straight forward tested the wallet model methods and made some improvements there based on the test results.

I would like to suggest as a future improvement we create an hdpath parser that returns an hdpath model to centralize that behavior. It will also make the meaning of the actual data being separated by slashes more obvious to other programmers.

Up next will be the manager and syncmanager. After that I will move to the watchonlywallet.