### PR TITLE
Update BlockStore to index address hash -> transaction hashes

### DIFF
--- a/Stratis.Bitcoin.Tests/AsyncLoopTest.cs
+++ b/Stratis.Bitcoin.Tests/AsyncLoopTest.cs
@@ -24,7 +24,7 @@ namespace Stratis.Bitcoin.Tests
                 await DoOperationCanceledExceptionTask(token);
             });
 
-            await asyncLoop.Run(new CancellationTokenSource(80).Token, TimeSpan.FromMilliseconds(33));
+            await asyncLoop.Run(new CancellationTokenSource(800).Token, TimeSpan.FromMilliseconds(300));
 
             AssertLog(this.FullNodeLogger, LogLevel.Information, "TestLoop starting");
             AssertLog(this.FullNodeLogger, LogLevel.Information, "TestLoop stopping");
@@ -40,7 +40,7 @@ namespace Stratis.Bitcoin.Tests
                 await DoExceptionalTask(token);
             });
 
-            await asyncLoop.Run(TimeSpan.FromMilliseconds(33));
+            await asyncLoop.Run(TimeSpan.FromMilliseconds(330));
 
             AssertLog(this.FullNodeLogger, LogLevel.Information, "TestLoop starting");
             AssertLog(this.FullNodeLogger, LogLevel.Information, "TestLoop stopping");
@@ -56,7 +56,7 @@ namespace Stratis.Bitcoin.Tests
                 await DoExceptionalTask(token);
             });
 
-            await asyncLoop.Run(new CancellationTokenSource(150).Token, TimeSpan.FromMilliseconds(33));
+            await asyncLoop.Run(new CancellationTokenSource(1500).Token, TimeSpan.FromMilliseconds(330));
 
             AssertLog(this.FullNodeLogger, LogLevel.Information, "TestLoop starting");
             AssertLog(this.FullNodeLogger, LogLevel.Information, "TestLoop stopping");
@@ -72,7 +72,7 @@ namespace Stratis.Bitcoin.Tests
                 await DoTask(token);
             });
 
-            await asyncLoop.Run(new CancellationTokenSource(100).Token, TimeSpan.FromMilliseconds(33));
+            await asyncLoop.Run(new CancellationTokenSource(1000).Token, TimeSpan.FromMilliseconds(330));
 
             AssertLog(this.FullNodeLogger, LogLevel.Information, "TestLoop starting");
             AssertLog(this.FullNodeLogger, LogLevel.Information, "TestLoop stopping");
@@ -86,7 +86,7 @@ namespace Stratis.Bitcoin.Tests
                 await DoTask(token);
             });
 
-            await asyncLoop.Run(new CancellationTokenSource(90).Token, TimeSpan.FromMilliseconds(33));
+            await asyncLoop.Run(new CancellationTokenSource(900).Token, TimeSpan.FromMilliseconds(330));
 
             Assert.Equal(3, this.iterationCount);
         }
@@ -99,7 +99,7 @@ namespace Stratis.Bitcoin.Tests
                 await DoTask(token);
             });
 
-            await asyncLoop.Run(new CancellationTokenSource(100).Token, TimeSpan.FromMilliseconds(33), TimeSpan.FromMilliseconds(40));
+            await asyncLoop.Run(new CancellationTokenSource(1000).Token, TimeSpan.FromMilliseconds(330), TimeSpan.FromMilliseconds(400));
 
             Assert.Equal(2, this.iterationCount);
         }

--- a/Stratis.Bitcoin.Tests/DateTimeProviderTest.cs
+++ b/Stratis.Bitcoin.Tests/DateTimeProviderTest.cs
@@ -22,7 +22,7 @@ namespace Stratis.Bitcoin.Tests
         {
             var result = DateTimeProvider.Default.GetTimeOffset();
 
-            Assert.Equal(DateTimeOffset.UtcNow, result);
+            Assert.Equal(DateTimeOffset.UtcNow.ToString("yyyyMMddhhmmss"), result.ToString("yyyyMMddhhmmss"));
         }
 
         [Fact]

--- a/Stratis.Bitcoin.Tests/PeriodicTaskTest.cs
+++ b/Stratis.Bitcoin.Tests/PeriodicTaskTest.cs
@@ -44,9 +44,9 @@ namespace Stratis.Bitcoin.Tests
                 await DoTask(token);
             });
 
-            periodicTask.Start(new CancellationTokenSource(80).Token, TimeSpan.FromMilliseconds(33));
+            periodicTask.Start(new CancellationTokenSource(800).Token, TimeSpan.FromMilliseconds(300));
 
-            Thread.Sleep(100);
+            Thread.Sleep(1000);
             Assert.Equal(3, this.iterationCount);
         }
 
@@ -58,9 +58,9 @@ namespace Stratis.Bitcoin.Tests
                 await DoTask(token);
             });
 
-            periodicTask.Start(new CancellationTokenSource(70).Token, TimeSpan.FromMilliseconds(33), true);
+            periodicTask.Start(new CancellationTokenSource(800).Token, TimeSpan.FromMilliseconds(300), true);
 
-            Thread.Sleep(100);
+            Thread.Sleep(1000);
             Assert.Equal(2, this.iterationCount);
         }
 

--- a/Stratis.Bitcoin/BlockStore/BlockRepository.cs
+++ b/Stratis.Bitcoin/BlockStore/BlockRepository.cs
@@ -242,10 +242,9 @@ namespace Stratis.Bitcoin.BlockStore
                             var trxId = transaction.GetHash();
                             transDict[trxId] = blockId;
                             // Gather addresses
-                            foreach (var addrN in this.IndexedTransactionOutputs(transaction))
+                            foreach (var (addr, trxOutN) in this.IndexedTransactionOutputs(transaction))
                             {
-                                var addr = (uint160)addrN[0];
-                                var value = new TransactionOutputID(trxId, (uint)addrN[1]).Value;
+                                var value = new TransactionOutputID(trxId, trxOutN).Value;
 
                                 HashSet<byte[]> list = addrDict.TryGet(addr);
                                 if (list == null)
@@ -348,7 +347,7 @@ namespace Stratis.Bitcoin.BlockStore
 			});
 		}
 
-        private IEnumerable<object[]> IndexedTransactionOutputs(Transaction transaction)
+        private IEnumerable<(uint160, uint)> IndexedTransactionOutputs(Transaction transaction)
         {
             for (uint N = 0; N < transaction.Outputs.Count; N++)
             {
@@ -360,7 +359,7 @@ namespace Stratis.Bitcoin.BlockStore
                 {
                     var bytes = new byte[20];
                     Array.Copy(script, 3, bytes, 0, 20);
-                    yield return new object[2] { new uint160(bytes), N }; // Address Hash, TxOutN
+                    yield return (new uint160(bytes), N); // Address Hash, TxOutN
                 }
             }
         }
@@ -492,10 +491,9 @@ namespace Stratis.Bitcoin.BlockStore
                                 this.session.Transaction.RemoveKey<byte[]>("Transaction", trxId.ToBytes());
 
                                 // Remove transaction reference from indexed addresses
-                                foreach (var addrN in this.IndexedTransactionOutputs(transaction))
+                                foreach (var (addr, trxOutN) in this.IndexedTransactionOutputs(transaction))
                                 {
-                                    var addr = (uint160)addrN[0];
-                                    var value = new TransactionOutputID(trxId, (uint)addrN[1]).Value;
+                                    var value = new TransactionOutputID(trxId, trxOutN).Value;
 
                                     HashSet<byte[]> list;
                                     if (!removals.TryGetValue(addr, out list))


### PR DESCRIPTION
Currently the Block Repository supports NoSQL indexes for "Block" and "Transaction".

- This pull request (#205) adds "Script" and "Output" indexes. 
- Index insertion has been changed to key order as that provides performance gains.

Indexing is dependent on the "-txindex" command line switch as with "Transaction" indexing. This can be changed to give us finer grained control.

Using the new "Script" index an address hash can be used to select the list of outputs (transaction hash + output number) of the transactions that the address appears in:

- Task<List<byte[]>> GetTrxOutByAddrAsync(BitcoinAddress addr)

Using the new "Outputs" index also allows us to determine which transactions these outputs have been spent to. Null entries will appear in the output list for corresponding unspent outputs:

- Task<List<uint256.>> GetTrxOutNextAsync(List<byte[]> trxOutList);

The functionality has not yet been exposed via RPC. Once this has been done it could assist with small-footprint mobile wallets, block explorers, etc. 
