### PR TITLE
Fix failing TransactionData unit tests

### DIFF
--- a/Stratis.Bitcoin.Tests/Wallet/TransactionDataTest.cs
+++ b/Stratis.Bitcoin.Tests/Wallet/TransactionDataTest.cs
@@ -98,7 +98,7 @@ namespace Stratis.Bitcoin.Tests.Wallet
         }
 
         [Fact]
-        public void SpendableAmountConfirmedOnlyGivenBeingConfirmedAndSpentUnconfirmedReturnsAmount()
+        public void SpendableAmountConfirmedOnlyGivenBeingConfirmedAndSpentUnconfirmedReturnsZero()
         {
             var transaction = new TransactionData()
             {
@@ -109,7 +109,7 @@ namespace Stratis.Bitcoin.Tests.Wallet
 
             var result = transaction.SpendableAmount(true);
 
-            Assert.Equal(15, result);
+            Assert.Equal(Money.Zero, result);
         }
 
         [Fact]
@@ -166,6 +166,21 @@ namespace Stratis.Bitcoin.Tests.Wallet
             var result = transaction.SpendableAmount(true);
 
             Assert.Equal(Money.Zero, result);
+        }
+
+        [Fact]
+        public void SpendableAmountConfirmedOnlyGivenSpendableAndConfirmedReturnsAmount()
+        {
+            var transaction = new TransactionData()
+            {
+                SpendingDetails = null,
+                Amount = new Money(15),
+                BlockHeight = 15
+            };
+
+            var result = transaction.SpendableAmount(true);
+
+            Assert.Equal(new Money(15), result);
         }
     }
 }


### PR DESCRIPTION
Because these tests were merged after some updates have been made to the class one was failing. I also noticed I missed a test case so added that.