### PR TITLE
Introduce WalletAccountReference type

### DIFF
--- a/Stratis.Bitcoin.IntegrationTests/WalletTests.cs
+++ b/Stratis.Bitcoin.IntegrationTests/WalletTests.cs
@@ -31,7 +31,7 @@ namespace Stratis.Bitcoin.IntegrationTests
                 var mnemonic2 = stratisReceiver.FullNode.WalletManager.CreateWallet("123456", "mywallet");
                 Assert.Equal(12, mnemonic1.Words.Length);
                 Assert.Equal(12, mnemonic2.Words.Length);
-                var addr = stratisSender.FullNode.WalletManager.GetUnusedAddress("mywallet", "account 0");
+                var addr = stratisSender.FullNode.WalletManager.GetUnusedAddress(new WalletAccountReference("mywallet", "account 0"));
                 var key = stratisSender.FullNode.WalletManager.GetKeyForAddress("123456", addr).PrivateKey;
 
                 stratisSender.SetDummyMinerSecret(new BitcoinSecret(key, stratisSender.FullNode.Network));
@@ -50,8 +50,8 @@ namespace Stratis.Bitcoin.IntegrationTests
                 TestHelper.WaitLoop(() => TestHelper.AreNodesSynced(stratisReceiver, stratisSender));
 
                 // send coins to the receiver
-                var sendto = stratisReceiver.FullNode.WalletManager.GetUnusedAddress("mywallet", "account 0");
-                var trx = stratisSender.FullNode.WalletManager.BuildTransaction("mywallet", "account 0", "123456", sendto.Address, Money.COIN * 100, FeeType.Medium, 101);
+                var sendto = stratisReceiver.FullNode.WalletManager.GetUnusedAddress(new WalletAccountReference("mywallet", "account 0"));
+                var trx = stratisSender.FullNode.WalletManager.BuildTransaction(new WalletAccountReference("mywallet", "account 0"), "123456", sendto.Address, Money.COIN * 100, FeeType.Medium, 101);
 
                 // broadcast to the other node
                 stratisSender.FullNode.WalletManager.SendTransaction(trx.hex);
@@ -130,7 +130,7 @@ namespace Stratis.Bitcoin.IntegrationTests
                 var mnemonic2 = stratisReceiver.FullNode.WalletManager.CreateWallet("123456", "mywallet");
                 Assert.Equal(12, mnemonic1.Words.Length);
                 Assert.Equal(12, mnemonic2.Words.Length);
-                var addr = stratisSender.FullNode.WalletManager.GetUnusedAddress("mywallet", "account 0");
+                var addr = stratisSender.FullNode.WalletManager.GetUnusedAddress(new WalletAccountReference("mywallet", "account 0"));
                 var key = stratisSender.FullNode.WalletManager.GetKeyForAddress("123456", addr).PrivateKey;
 
                 stratisSender.SetDummyMinerSecret(new BitcoinSecret(key, stratisSender.FullNode.Network));
@@ -157,8 +157,8 @@ namespace Stratis.Bitcoin.IntegrationTests
                 // Build Transaction 1
                 // ====================
                 // send coins to the receiver
-                var sendto = stratisReceiver.FullNode.WalletManager.GetUnusedAddress("mywallet", "account 0");
-                var transaction1 = stratisSender.FullNode.WalletManager.BuildTransaction("mywallet", "account 0", "123456", sendto.Address, Money.COIN * 100, FeeType.Medium, 101);
+                var sendto = stratisReceiver.FullNode.WalletManager.GetUnusedAddress(new WalletAccountReference("mywallet", "account 0"));
+                var transaction1 = stratisSender.FullNode.WalletManager.BuildTransaction(new WalletAccountReference("mywallet", "account 0"), "123456", sendto.Address, Money.COIN * 100, FeeType.Medium, 101);
 
                 // broadcast to the other node
                 stratisSender.FullNode.WalletManager.SendTransaction(transaction1.hex);
@@ -193,8 +193,8 @@ namespace Stratis.Bitcoin.IntegrationTests
                 var forkblock = stratisReceiver.FullNode.Chain.Tip;
 
                 // send more coins to the wallet
-                sendto = stratisReceiver.FullNode.WalletManager.GetUnusedAddress("mywallet", "account 0");
-                var transaction2 = stratisSender.FullNode.WalletManager.BuildTransaction("mywallet", "account 0", "123456", sendto.Address, Money.COIN * 10, FeeType.Medium, 101);
+                sendto = stratisReceiver.FullNode.WalletManager.GetUnusedAddress(new WalletAccountReference("mywallet", "account 0"));
+                var transaction2 = stratisSender.FullNode.WalletManager.BuildTransaction(new WalletAccountReference("mywallet", "account 0"), "123456", sendto.Address, Money.COIN * 10, FeeType.Medium, 101);
                 stratisSender.FullNode.WalletManager.SendTransaction(transaction2.hex);
                 // wait for the trx to arrive
                 TestHelper.WaitLoop(() => stratisReceiver.CreateRPCClient().GetRawMempool().Length > 0);
@@ -270,7 +270,7 @@ namespace Stratis.Bitcoin.IntegrationTests
                 // get a key from the wallet
                 var mnemonic = stratisminer.FullNode.WalletManager.CreateWallet("123456", "mywallet");
                 Assert.Equal(12, mnemonic.Words.Length);
-                var addr = stratisminer.FullNode.WalletManager.GetUnusedAddress("mywallet", "account 0");
+                var addr = stratisminer.FullNode.WalletManager.GetUnusedAddress(new WalletAccountReference("mywallet", "account 0"));
                 var key = stratisminer.FullNode.WalletManager.GetKeyForAddress("123456", addr).PrivateKey;
 
                 stratisminer.SetDummyMinerSecret(key.GetBitcoinSecret(stratisminer.FullNode.Network));
@@ -299,7 +299,7 @@ namespace Stratis.Bitcoin.IntegrationTests
                 // get a key from the wallet
                 var mnemonic = stratisNodeSync.FullNode.WalletManager.CreateWallet("123456", "mywallet");
                 Assert.Equal(12, mnemonic.Words.Length);
-                var addr = stratisNodeSync.FullNode.WalletManager.GetUnusedAddress("mywallet", "account 0");
+                var addr = stratisNodeSync.FullNode.WalletManager.GetUnusedAddress(new WalletAccountReference("mywallet", "account 0"));
                 var key = stratisNodeSync.FullNode.WalletManager.GetKeyForAddress("123456", addr).PrivateKey;
 
                 stratisNodeSync.SetDummyMinerSecret(key.GetBitcoinSecret(stratisNodeSync.FullNode.Network));

--- a/Stratis.Bitcoin.Tests/Wallet/WalletControllerTest.cs
+++ b/Stratis.Bitcoin.Tests/Wallet/WalletControllerTest.cs
@@ -1181,7 +1181,7 @@ namespace Stratis.Bitcoin.Tests.Wallet
         {
             var mockWalletWrapper = new Mock<IWalletManager>();
             var key = new Key();
-            mockWalletWrapper.Setup(m => m.BuildTransaction("myWallet", "Account 1", "test", key.PubKey.GetAddress(Network.Main).ToString(), new Money(150000), FeeType.High, 0))
+            mockWalletWrapper.Setup(m => m.BuildTransaction(new WalletAccountReference("myWallet", "Account 1"), "test", key.PubKey.GetAddress(Network.Main).ToString(), new Money(150000), FeeType.High, 0))
                 .Returns(("hexString", new uint256(15), new Money(150)));
 
 
@@ -1211,7 +1211,7 @@ namespace Stratis.Bitcoin.Tests.Wallet
         {
             var mockWalletWrapper = new Mock<IWalletManager>();
             var key = new Key();
-            mockWalletWrapper.Setup(m => m.BuildTransaction("myWallet", "Account 1", "test", key.PubKey.GetAddress(Network.Main).ToString(), new Money(150000), FeeType.High, 1))
+            mockWalletWrapper.Setup(m => m.BuildTransaction(new WalletAccountReference("myWallet", "Account 1"), "test", key.PubKey.GetAddress(Network.Main).ToString(), new Money(150000), FeeType.High, 1))
                 .Returns(("hexString", new uint256(15), new Money(150)));
 
             var controller = new WalletController(mockWalletWrapper.Object, new Mock<IWalletSyncManager>().Object, It.IsAny<ConnectionManager>(), Network.Main, new Mock<ConcurrentChain>().Object, It.IsAny<DataFolder>());
@@ -1262,7 +1262,7 @@ namespace Stratis.Bitcoin.Tests.Wallet
         {
             var mockWalletWrapper = new Mock<IWalletManager>();
             var key = new Key();
-            mockWalletWrapper.Setup(m => m.BuildTransaction("myWallet", "Account 1", "test", key.PubKey.GetAddress(Network.Main).ToString(), new Money(150000), FeeType.High, 1))
+            mockWalletWrapper.Setup(m => m.BuildTransaction(new WalletAccountReference("myWallet", "Account 1"), "test", key.PubKey.GetAddress(Network.Main).ToString(), new Money(150000), FeeType.High, 1))
                 .Throws(new InvalidOperationException("Issue building transaction."));
 
             var controller = new WalletController(mockWalletWrapper.Object, new Mock<IWalletSyncManager>().Object, It.IsAny<ConnectionManager>(), Network.Main, new Mock<ConcurrentChain>().Object, It.IsAny<DataFolder>());
@@ -1500,7 +1500,7 @@ namespace Stratis.Bitcoin.Tests.Wallet
         {
             HdAddress address = CreateAddress();
             var mockWalletWrapper = new Mock<IWalletManager>();
-            mockWalletWrapper.Setup(m => m.GetUnusedAddress("myWallet", "Account 1"))
+            mockWalletWrapper.Setup(m => m.GetUnusedAddress(new WalletAccountReference("myWallet", "Account 1")))
                 .Returns(address);
 
             var controller = new WalletController(mockWalletWrapper.Object, new Mock<IWalletSyncManager>().Object, It.IsAny<ConnectionManager>(), Network.Main, new Mock<ConcurrentChain>().Object, It.IsAny<DataFolder>());
@@ -1542,7 +1542,7 @@ namespace Stratis.Bitcoin.Tests.Wallet
         public void GetUnusedAddressWithExceptionReturnsBadRequest()
         {
             var mockWalletWrapper = new Mock<IWalletManager>();
-            mockWalletWrapper.Setup(m => m.GetUnusedAddress("myWallet", "Account 1"))
+            mockWalletWrapper.Setup(m => m.GetUnusedAddress(new WalletAccountReference("myWallet", "Account 1")))
                 .Throws(new InvalidOperationException("Wallet not found."));
 
             var controller = new WalletController(mockWalletWrapper.Object, new Mock<IWalletSyncManager>().Object, It.IsAny<ConnectionManager>(), Network.Main, new Mock<ConcurrentChain>().Object, It.IsAny<DataFolder>());

--- a/Stratis.Bitcoin/Wallet/Controllers/WalletController.cs
+++ b/Stratis.Bitcoin/Wallet/Controllers/WalletController.cs
@@ -421,7 +421,7 @@ namespace Stratis.Bitcoin.Wallet.Controllers
 
             try
             {
-                var transactionResult = this.walletManager.BuildTransaction(request.WalletName, request.AccountName, request.Password, request.DestinationAddress, request.Amount, FeeParser.Parse(request.FeeType), request.AllowUnconfirmed ? 0 : 1);
+                var transactionResult = this.walletManager.BuildTransaction(new WalletAccountReference(request.WalletName, request.AccountName), request.Password, request.DestinationAddress, request.Amount, FeeParser.Parse(request.FeeType), request.AllowUnconfirmed ? 0 : 1);
                 var model = new WalletBuildTransactionModel
                 {
                     Hex = transactionResult.hex,
@@ -542,7 +542,7 @@ namespace Stratis.Bitcoin.Wallet.Controllers
 
             try
             {
-                var result = this.walletManager.GetUnusedAddress(request.WalletName, request.AccountName);
+                var result = this.walletManager.GetUnusedAddress(new WalletAccountReference(request.WalletName, request.AccountName));
                 return this.Json(result.Address);
             }
             catch (Exception e)

--- a/Stratis.Bitcoin/Wallet/IWalletManager.cs
+++ b/Stratis.Bitcoin/Wallet/IWalletManager.cs
@@ -98,10 +98,9 @@ namespace Stratis.Bitcoin.Wallet
         /// <summary>
         /// Gets an address that contains no transaction.
         /// </summary>
-        /// <param name="walletName">The name of the wallet in which this address is contained.</param>
-        /// <param name="accountName">The name of the account in which this address is contained.</param>
+        /// <param name="accountReference">The name of the wallet and account</param>
         /// <returns>An unused address or a newly created address, in Base58 format.</returns>
-        HdAddress GetUnusedAddress(string walletName, string accountName);
+        HdAddress GetUnusedAddress(WalletAccountReference accountReference);
 
         /// <summary>
         /// Gets a collection of addresses containing transactions for this coin.
@@ -134,15 +133,14 @@ namespace Stratis.Bitcoin.Wallet
         /// <summary>
         /// Builds a transaction to be sent to the network.
         /// </summary>
-        /// <param name="walletName">The name of the wallet in which this address is contained.</param>
-        /// <param name="accountName">The name of the account in which this address is contained.</param>
+        /// <param name="accountReference">The name of the wallet and account</param>
         /// <param name="password">The password used to decrypt the private key.</param>
         /// <param name="destinationAddress">The destination address to send the funds to.</param>
         /// <param name="amount">The amount of funds to be sent.</param>
         /// <param name="feeType">The type of fee to be included.</param>
         /// <param name="minConfirmations">The minimum number of confirmations we require for unspent outputs to be included.</param>
         /// <returns></returns>
-        (string hex, uint256 transactionId, Money fee) BuildTransaction(string walletName, string accountName, string password, string destinationAddress, Money amount, FeeType feeType, int minConfirmations);
+        (string hex, uint256 transactionId, Money fee) BuildTransaction(WalletAccountReference accountReference, string password, string destinationAddress, Money amount, FeeType feeType, int minConfirmations);
 
         /// <summary>
         /// Remove all the thransactions in the wallet that are above this block height

--- a/Stratis.Bitcoin/Wallet/WalletAccountReference.cs
+++ b/Stratis.Bitcoin/Wallet/WalletAccountReference.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Stratis.Bitcoin.Wallet
+{
+    public class WalletAccountReference
+    {
+        public WalletAccountReference()
+        {
+
+        }
+        public WalletAccountReference(string walletName, string accountName)
+        {
+            if(walletName == null)
+                throw new ArgumentNullException("walletName");
+            if(accountName == null)
+                throw new ArgumentNullException("accountName");
+            this.WalletName = walletName;
+            this.AccountName = accountName;
+        }
+
+        public string WalletName
+        {
+            get; set;
+        }
+
+        public string AccountName
+        {
+            get; set;
+        }
+
+
+        public override bool Equals(object obj)
+        {
+            WalletAccountReference item = obj as WalletAccountReference;
+            if(item == null)
+                return false;
+            return GetId().Equals(item.GetId());
+        }
+        public static bool operator ==(WalletAccountReference a, WalletAccountReference b)
+        {
+            if(System.Object.ReferenceEquals(a, b))
+                return true;
+            if(((object)a == null) || ((object)b == null))
+                return false;
+            return a.GetId().Equals(b.GetId());
+        }
+
+        public static bool operator !=(WalletAccountReference a, WalletAccountReference b)
+        {
+            return !(a == b);
+        }
+
+        public override int GetHashCode()
+        {
+            return GetId().GetHashCode();
+        }
+
+        Tuple<string, string> GetId()
+        {
+            return Tuple.Create(this.WalletName, this.AccountName);
+        }
+
+        public override string ToString()
+        {
+            return $"{WalletName}:{AccountName}";
+        }
+    }
+}

--- a/Stratis.Bitcoin/Wallet/WalletManager.cs
+++ b/Stratis.Bitcoin/Wallet/WalletManager.cs
@@ -256,12 +256,12 @@ namespace Stratis.Bitcoin.Wallet
         }
 
         /// <inheritdoc />
-        public HdAddress GetUnusedAddress(string walletName, string accountName)
+        public HdAddress GetUnusedAddress(WalletAccountReference accountReference)
         {
-            Wallet wallet = this.GetWalletByName(walletName);
+            Wallet wallet = this.GetWalletByName(accountReference.WalletName);
 
             // get the account
-            HdAccount account = wallet.AccountsRoot.Single(a => a.CoinType == this.coinType).GetAccountByName(accountName);
+            HdAccount account =  GetAccounts(wallet).GetAccountByName(accountReference.AccountName);
 
             // validate address creation
             if (account.ExternalAddresses.Any())
@@ -461,7 +461,7 @@ namespace Stratis.Bitcoin.Wallet
         }
 
         /// <inheritdoc />
-        public (string hex, uint256 transactionId, Money fee) BuildTransaction(string walletName, string accountName, string password, string destinationAddress, Money amount, FeeType feeType, int minConfirmations)
+        public (string hex, uint256 transactionId, Money fee) BuildTransaction(WalletAccountReference accountReference, string password, string destinationAddress, Money amount, FeeType feeType, int minConfirmations)
         {
             if (amount == Money.Zero)
             {
@@ -469,8 +469,8 @@ namespace Stratis.Bitcoin.Wallet
             }
 
             // get the wallet and the account
-            Wallet wallet = this.GetWalletByName(walletName);
-            HdAccount account = wallet.AccountsRoot.Single(a => a.CoinType == this.coinType).GetAccountByName(accountName);
+            Wallet wallet = this.GetWalletByName(accountReference.WalletName);
+            HdAccount account = this.GetAccounts(wallet).GetAccountByName(accountReference.AccountName);
 
             // get script destination address
             Script destinationScript = null;
@@ -537,6 +537,11 @@ namespace Stratis.Bitcoin.Wallet
             }
 
             return (tx.ToHex(), tx.GetHash(), calculationResult.fee);
+        }
+
+        private AccountRoot GetAccounts(Wallet wallet)
+        {
+            return wallet.AccountsRoot.Single(a => a.CoinType == this.coinType);
         }
 
         /// <summary>


### PR DESCRIPTION
The pair accountname and walletname will often travel together, this make sense to create a value object to bundle them together instead of passing them as individual string.