### PR TITLE
Bugfix/issue 247

### DIFF
--- a/Documentation/using-logging.md
+++ b/Documentation/using-logging.md
@@ -29,7 +29,7 @@ Class logger is little more difficult as you may not have access to any factory.
 ```
 ILoggerFactory loggerFactory = new LoggerFactory();
 loggerFactory.AddConsole();  // Only if you want to include logging to the console.
-loggerFactory.AddNLog()();   // Only if you want to include logging to the disk. This requires using NLog.Extensions.Logging.
+loggerFactory.AddNLog();   // Only if you want to include logging to the disk. This requires using NLog.Extensions.Logging.
 
 ```
 

--- a/Stratis.Bitcoin.IntegrationTests/MinerTests.cs
+++ b/Stratis.Bitcoin.IntegrationTests/MinerTests.cs
@@ -126,7 +126,7 @@ namespace Stratis.Bitcoin.IntegrationTests
 			    this.entry = new TestMemPoolEntryHelper();
 			    this.chain = new ConcurrentChain(network);
 			    this.network.Consensus.Options = new PowConsensusOptions();
-			    this.cachedCoinView = new CachedCoinView(new InMemoryCoinView(chain.Tip.HashBlock));
+                this.cachedCoinView = new CachedCoinView(new InMemoryCoinView(chain.Tip.HashBlock));
 			    this.consensus = new ConsensusLoop(new PowConsensusValidator(network), chain, cachedCoinView, new LookaheadBlockPuller(chain, new ConnectionManager(network, new NodeConnectionParameters(), new NodeSettings(), new LoggerFactory()), new LoggerFactory()), new NodeDeployments(this.network));
 			    this.consensus.Initialize();
 

--- a/Stratis.Bitcoin.Tests/BlockPulling/PullerDownloadAssignmentsTest.cs
+++ b/Stratis.Bitcoin.Tests/BlockPulling/PullerDownloadAssignmentsTest.cs
@@ -1,4 +1,5 @@
 ﻿using Stratis.Bitcoin.BlockPulling;
+using Stratis.Bitcoin.Utilities;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -70,7 +71,7 @@ namespace Stratis.Bitcoin.Tests.BlockPulling
                 },
                 new PullerDownloadAssignments.PeerInformation()
                 {
-                    PeerId = "C",
+                    PeerId = "D",
                     QualityScore = 150,
                     ChainHeight = 40,
                     TasksAssignedCount = 0
@@ -82,7 +83,7 @@ namespace Stratis.Bitcoin.Tests.BlockPulling
 
             // Check the assignment is valid per our requirements.
             int tasksAssigned = 0;
-            Assert.Equal(4, assignments.Count);
+            Assert.Equal(availablePeersInformation.Count, assignments.Count);
             foreach (KeyValuePair<PullerDownloadAssignments.PeerInformation, List<int>> kvp in assignments)
             {
                 PullerDownloadAssignments.PeerInformation peer = kvp.Key;
@@ -174,6 +175,163 @@ namespace Stratis.Bitcoin.Tests.BlockPulling
                 int taskShouldAssign = requiredBlockHeights.Where(r => r <= maxPeerChainLength).Count();
                 Assert.Equal(taskShouldAssign, tasksAssigned);
             }
+        }
+
+        /// <summary>
+        /// Assignment of tasks to nodes should prevent the very next blocks that the consumer will need 
+        /// in the nearest future to be assigned to nodes that are considered of poor quality.
+        /// This test checks that this protection works as intended.
+        /// <para>
+        /// We will request assignment of blocks A to B, and check that the lower half of these requests 
+        /// (i.e. blocks from A to median(A..B) are not assigned to nodes having quality score worse than median.
+        /// </para>
+        /// </summary>
+        [Fact]
+        public void AssignBlocksToPeersWithNodesWithLowQualityProtectsLowerHalfRequestsFromBeingAssignedToPoorQualityNodes()
+        {
+            Random rnd = new Random();
+            int ourBlockCount = rnd.Next(1000) + 1;
+            int bestBlockCount = rnd.Next(1000) + ourBlockCount + 1;
+
+            // Create list of numbers ourBlockCount + 1 to bestBlockCount and shuffle it.
+            List<int> requiredBlockHeights = new List<int>();
+            for (int i = ourBlockCount + 1; i <= bestBlockCount; i++)
+                requiredBlockHeights.Add(i);
+
+            requiredBlockHeights = requiredBlockHeights.OrderBy(a => rnd.Next()).ToList();
+            int medianBlockHeight = requiredBlockHeights.Median();
+
+            // Initialize node's peers. We have 5 peers with median quality 100.
+            // Thus peers A and E should not receive any work from the lower half of the requests.
+            List<PullerDownloadAssignments.PeerInformation> availablePeersInformation = new List<PullerDownloadAssignments.PeerInformation>()
+            {
+                new PullerDownloadAssignments.PeerInformation()
+                {
+                    PeerId = "A",
+                    QualityScore = 20,
+                    ChainHeight = bestBlockCount,
+                    TasksAssignedCount = rnd.Next(1000)
+                },
+                new PullerDownloadAssignments.PeerInformation()
+                {
+                    PeerId = "B",
+                    QualityScore = 100,
+                    ChainHeight = bestBlockCount,
+                    TasksAssignedCount = rnd.Next(1000)
+                },
+                new PullerDownloadAssignments.PeerInformation()
+                {
+                    PeerId = "C",
+                    QualityScore = 150,
+                    ChainHeight = bestBlockCount,
+                    TasksAssignedCount = rnd.Next(1000)
+                },
+                new PullerDownloadAssignments.PeerInformation()
+                {
+                    PeerId = "D",
+                    QualityScore = 120,
+                    ChainHeight = bestBlockCount,
+                    TasksAssignedCount = rnd.Next(1000)
+                },
+                new PullerDownloadAssignments.PeerInformation()
+                {
+                    PeerId = "E",
+                    QualityScore = 90,
+                    ChainHeight = bestBlockCount,
+                    TasksAssignedCount = rnd.Next(1000)
+                },
+            };
+
+            // Use the assignment strategy to assign tasks to peers.
+            Dictionary<PullerDownloadAssignments.PeerInformation, List<int>> assignments = PullerDownloadAssignments.AssignBlocksToPeers(requiredBlockHeights, availablePeersInformation);
+
+            // Check the assignment is valid per our requirements.
+            int tasksAssigned = 0;
+            Assert.Equal(availablePeersInformation.Count, assignments.Count);
+            foreach (KeyValuePair<PullerDownloadAssignments.PeerInformation, List<int>> kvp in assignments)
+            {
+                PullerDownloadAssignments.PeerInformation peer = kvp.Key;
+                List<int> assignedBlockHeights = kvp.Value;
+                tasksAssigned += assignedBlockHeights.Count;
+
+                switch ((string)peer.PeerId)
+                {
+                    case "A":
+                    case "E":
+                        // Peers A and E should not get work.
+                        Assert.True((assignedBlockHeights.Count == 0) || (assignedBlockHeights.Max() >= medianBlockHeight));
+                        break;
+
+                    case "B":
+                    case "C":
+                    case "D":
+                        // PeerS B, C, D can be assigned anything.
+                        break;
+
+                    default:
+                        // This should never occur.
+                        Assert.True(false, "Invalid peer ID.");
+                        break;
+                }
+            }
+            Assert.Equal(requiredBlockHeights.Count, tasksAssigned);
+        }
+
+        /// <summary>
+        /// Same as <see cref="AssignBlocksToPeersWithNodesWithLowQualityProtectsLowerHalfRequestsFromBeingAssignedToPoorQualityNodes"/>
+        /// except that we generate a large number of peers with random qualities.
+        /// </summary>
+        [Fact]
+        public void AssignBlocksToPeersWithManyNodesWithLowQualityProtectsLowerHalfRequestsFromBeingAssignedToPoorQualityNodes()
+        {
+            Random rnd = new Random();
+            int ourBlockCount = rnd.Next(1000) + 1;
+            int bestBlockCount = rnd.Next(1000) + ourBlockCount + 1;
+
+            // Create list of numbers ourBlockCount + 1 to bestBlockCount and shuffle it.
+            List<int> requiredBlockHeights = new List<int>();
+            for (int i = ourBlockCount + 1; i <= bestBlockCount; i++)
+                requiredBlockHeights.Add(i);
+
+            requiredBlockHeights = requiredBlockHeights.OrderBy(a => rnd.Next()).ToList();
+            int medianBlockHeight = requiredBlockHeights.Median();
+
+            // Randomly generate peers and count median quality.
+            List<PullerDownloadAssignments.PeerInformation> availablePeersInformation = new List<PullerDownloadAssignments.PeerInformation>();
+            int peerCount = rnd.Next(1000) + 1;
+            List<double> qualities = new List<double>();
+            for (int i = 0; i < peerCount; i++)
+            {
+                var peerInfo = new PullerDownloadAssignments.PeerInformation()
+                {
+                    PeerId = i.ToString(),
+                    QualityScore = rnd.NextDouble() * (QualityScore.MaxScore - QualityScore.MinScore) + QualityScore.MinScore,
+                    ChainHeight = bestBlockCount,
+                    TasksAssignedCount = rnd.Next(1000)
+                };
+                qualities.Add(peerInfo.QualityScore);
+                availablePeersInformation.Add(peerInfo);
+            };
+
+            double qualityMedian = qualities.Median();
+
+            // Use the assignment strategy to assign tasks to peers.
+            Dictionary<PullerDownloadAssignments.PeerInformation, List<int>> assignments = PullerDownloadAssignments.AssignBlocksToPeers(requiredBlockHeights, availablePeersInformation);
+
+            // Check the assignment is valid per our requirements.
+            int tasksAssigned = 0;
+            Assert.Equal(availablePeersInformation.Count, assignments.Count);
+            foreach (KeyValuePair<PullerDownloadAssignments.PeerInformation, List<int>> kvp in assignments)
+            {
+                PullerDownloadAssignments.PeerInformation peer = kvp.Key;
+                List<int> assignedBlockHeights = kvp.Value;
+                tasksAssigned += assignedBlockHeights.Count;
+
+                // If the peer is poor, it must not get bottom half work assignment.
+                if (peer.QualityScore < qualityMedian)
+                    Assert.True((assignedBlockHeights.Count == 0) || (assignedBlockHeights.Max() >= medianBlockHeight));
+            }
+            Assert.Equal(requiredBlockHeights.Count, tasksAssigned);
         }
     }
 }

--- a/Stratis.Bitcoin.Tests/BlockPulling/PullerDownloadAssignmentsTest.cs
+++ b/Stratis.Bitcoin.Tests/BlockPulling/PullerDownloadAssignmentsTest.cs
@@ -7,7 +7,7 @@ using Xunit;
 namespace Stratis.Bitcoin.Tests.BlockPulling
 {
     /// <summary>
-    /// Tests of PullerDownloadAssignments class.
+    /// Tests of <see cref="PullerDownloadAssignments"/> class.
     /// </summary>
     public class PullerDownloadAssignmentsTest
     {

--- a/Stratis.Bitcoin.Tests/BlockPulling/PullerDownloadAssignmentsTest.cs
+++ b/Stratis.Bitcoin.Tests/BlockPulling/PullerDownloadAssignmentsTest.cs
@@ -34,10 +34,11 @@ namespace Stratis.Bitcoin.Tests.BlockPulling
         [Fact]
         public void AssignBlocksToPeersWithNodesWithDifferentChainsCorrectlyDistributesDownloadTasks()
         {
-            // Create list of numbers 6 to 40 and shuffle it.
+            int ourBlockCount = 5;
+            // Create list of numbers ourBlockCount + 1 to 40 and shuffle it.
             Random rnd = new Random();
             List<int> requiredBlockHeights = new List<int>();
-            for (int i = 6; i <= 40; i++)
+            for (int i = ourBlockCount + 1; i <= 40; i++)
                 requiredBlockHeights.Add(i);
 
             requiredBlockHeights = requiredBlockHeights.OrderBy(a => rnd.Next()).ToList();
@@ -49,31 +50,34 @@ namespace Stratis.Bitcoin.Tests.BlockPulling
                 {
                     PeerId = "A",
                     QualityScore = 100,
-                    ChainHeight = 4
+                    ChainHeight = 4,
+                    TasksAssignedCount = 0
                 },
                 new PullerDownloadAssignments.PeerInformation()
                 {
                     PeerId = "B",
                     QualityScore = 100,
-                    ChainHeight = 20
+                    ChainHeight = 20,
+                    TasksAssignedCount = 0
                 },
                 new PullerDownloadAssignments.PeerInformation()
                 {
                     PeerId = "C",
                     QualityScore = 50,
-                    ChainHeight = 30
+                    ChainHeight = 30,
+                    TasksAssignedCount = 0
                 },
                 new PullerDownloadAssignments.PeerInformation()
                 {
                     PeerId = "C",
                     QualityScore = 150,
-                    ChainHeight = 40
+                    ChainHeight = 40,
+                    TasksAssignedCount = 0
                 },
             };
 
             // Use the assignment strategy to assign tasks to peers.
-            Dictionary<PullerDownloadAssignments.PeerInformation, List<int>> assignments = PullerDownloadAssignments.AssignBlocksToPeers(requiredBlockHeights, availablePeersInformation);
-
+            Dictionary<PullerDownloadAssignments.PeerInformation, List<int>> assignments = PullerDownloadAssignments.AssignBlocksToPeers(requiredBlockHeights, availablePeersInformation, ourBlockCount);
 
             // Check the assignment is valid per our requirements.
             int tasksAssigned = 0;
@@ -140,14 +144,15 @@ namespace Stratis.Bitcoin.Tests.BlockPulling
                     {
                         ChainHeight = rnd.Next(bestChainBlockCount) + 1,
                         PeerId = peerIndex,
-                        QualityScore = rnd.Next(BlockPuller.MaxQualityScore) + 1
+                        QualityScore = rnd.NextDouble() * (QualityScore.MaxScore - QualityScore.MinScore) + QualityScore.MinScore,
+                        TasksAssignedCount = rnd.Next(100)
                     };
                     availablePeersInformation.Add(peerInfo);
                     maxPeerChainLength = Math.Max(maxPeerChainLength, peerInfo.ChainHeight);
                 }
 
                 // Use the assignment strategy to assign tasks to peers.
-                Dictionary<PullerDownloadAssignments.PeerInformation, List<int>> assignments = PullerDownloadAssignments.AssignBlocksToPeers(requiredBlockHeights, availablePeersInformation);
+                Dictionary<PullerDownloadAssignments.PeerInformation, List<int>> assignments = PullerDownloadAssignments.AssignBlocksToPeers(requiredBlockHeights, availablePeersInformation, ourBlockCount);
 
                 // Check the assignment is valid per our requirements.
                 int tasksAssigned = 0;

--- a/Stratis.Bitcoin.Tests/BlockPulling/PullerDownloadAssignmentsTest.cs
+++ b/Stratis.Bitcoin.Tests/BlockPulling/PullerDownloadAssignmentsTest.cs
@@ -100,7 +100,7 @@ namespace Stratis.Bitcoin.Tests.BlockPulling
                     case "D":
                         // Peers B and C should only get tasks to download blocks up to its chain height.
                         // Peer D can be assigned anything.
-                        Assert.True(assignedBlockHeights.Max() <= peer.ChainHeight);
+                        Assert.True((assignedBlockHeights.Count == 0) || (assignedBlockHeights.Max() <= peer.ChainHeight));
                         break;
 
                     default:

--- a/Stratis.Bitcoin.Tests/BlockPulling/PullerDownloadAssignmentsTest.cs
+++ b/Stratis.Bitcoin.Tests/BlockPulling/PullerDownloadAssignmentsTest.cs
@@ -1,8 +1,8 @@
-﻿using System;
+﻿using Stratis.Bitcoin.BlockPulling;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Xunit;
-using Stratis.Bitcoin.BlockPulling;
 
 namespace Stratis.Bitcoin.Tests.BlockPulling
 {
@@ -35,6 +35,7 @@ namespace Stratis.Bitcoin.Tests.BlockPulling
         public void AssignBlocksToPeersWithNodesWithDifferentChainsCorrectlyDistributesDownloadTasks()
         {
             int ourBlockCount = 5;
+
             // Create list of numbers ourBlockCount + 1 to 40 and shuffle it.
             Random rnd = new Random();
             List<int> requiredBlockHeights = new List<int>();

--- a/Stratis.Bitcoin.Tests/BlockPulling/PullerDownloadAssignmentsTest.cs
+++ b/Stratis.Bitcoin.Tests/BlockPulling/PullerDownloadAssignmentsTest.cs
@@ -77,7 +77,7 @@ namespace Stratis.Bitcoin.Tests.BlockPulling
             };
 
             // Use the assignment strategy to assign tasks to peers.
-            Dictionary<PullerDownloadAssignments.PeerInformation, List<int>> assignments = PullerDownloadAssignments.AssignBlocksToPeers(requiredBlockHeights, availablePeersInformation, ourBlockCount);
+            Dictionary<PullerDownloadAssignments.PeerInformation, List<int>> assignments = PullerDownloadAssignments.AssignBlocksToPeers(requiredBlockHeights, availablePeersInformation);
 
             // Check the assignment is valid per our requirements.
             int tasksAssigned = 0;
@@ -152,7 +152,7 @@ namespace Stratis.Bitcoin.Tests.BlockPulling
                 }
 
                 // Use the assignment strategy to assign tasks to peers.
-                Dictionary<PullerDownloadAssignments.PeerInformation, List<int>> assignments = PullerDownloadAssignments.AssignBlocksToPeers(requiredBlockHeights, availablePeersInformation, ourBlockCount);
+                Dictionary<PullerDownloadAssignments.PeerInformation, List<int>> assignments = PullerDownloadAssignments.AssignBlocksToPeers(requiredBlockHeights, availablePeersInformation);
 
                 // Check the assignment is valid per our requirements.
                 int tasksAssigned = 0;

--- a/Stratis.Bitcoin.Tests/BlockPulling/QualityScoreTest.cs
+++ b/Stratis.Bitcoin.Tests/BlockPulling/QualityScoreTest.cs
@@ -1,0 +1,191 @@
+﻿using Microsoft.Extensions.Logging;
+using Moq;
+using Stratis.Bitcoin.BlockPulling;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+
+namespace Stratis.Bitcoin.Tests.BlockPulling
+{
+    /// <summary>
+    /// Tests of <see cref="QualityScore"/> class.
+    /// </summary>
+    public class QualityScoreTest
+    {
+        /// <summary>
+        /// Checks that <see cref="QualityScore.AverageBlockTimePerKb"/> is correctly calculated 
+        /// if the number of samples is low.
+        /// </summary>
+        [Fact]
+        public void AddSampleWithFewSamplesCorrectlyCalculatesRecentHistoryAverage()
+        {
+            QualityScore qualityScore = new QualityScore(5, new LoggerFactory());
+
+            int peerCount = 3;
+            Mock<IBlockPullerBehavior>[] peers = new Mock<IBlockPullerBehavior>[peerCount];
+
+            for (int i = 0; i < peerCount; i++)
+            {
+                peers[i] = new Mock<IBlockPullerBehavior>();
+                peers[i].Setup(b => b.QualityScore).Returns(QualityScore.MaxScore / 3);
+            }
+
+            qualityScore.AddSample(peers[0].Object, 30, 2048); // 15 ms/Kb
+            Assert.True(Math.Abs(qualityScore.AverageBlockTimePerKb - 15.0) < 0.00001);
+
+            qualityScore.AddSample(peers[1].Object, 50, 1024); // 50 ms/Kb
+            Assert.True(Math.Abs(qualityScore.AverageBlockTimePerKb - 32.5) < 0.00001);
+
+            qualityScore.AddSample(peers[2].Object, 40, 1024); // 40 ms/Kb
+            Assert.True(Math.Abs(qualityScore.AverageBlockTimePerKb - 35.0) < 0.00001);
+
+            qualityScore.AddSample(peers[2].Object, 30, 2048); // 15 ms/Kb
+            Assert.True(Math.Abs(qualityScore.AverageBlockTimePerKb - 30.0) < 0.00001);
+
+            qualityScore.AddSample(peers[2].Object, 30, 3072); // 10 ms/Kb
+            Assert.True(Math.Abs(qualityScore.AverageBlockTimePerKb - 26.0) < 0.00001);
+        }
+
+        /// <summary>
+        /// Checks that <see cref="QualityScore.AverageBlockTimePerKb"/> is correctly calculated 
+        /// if the number of samples exceeds the capacity of the history.
+        /// </summary>
+        [Fact]
+        public void AddSampleWithMoreSamplesThanHistoryCapacityCorrectlyCalculatesRecentHistoryAverage()
+        {
+            QualityScore qualityScore = new QualityScore(5, new LoggerFactory());
+
+            int peerCount = 3;
+            Mock<IBlockPullerBehavior>[] peers = new Mock<IBlockPullerBehavior>[peerCount];
+
+            for (int i = 0; i < peerCount; i++)
+            {
+                peers[i] = new Mock<IBlockPullerBehavior>();
+                peers[i].Setup(b => b.QualityScore).Returns(QualityScore.MaxScore / 3);
+            }
+
+            Random rnd = new Random();
+            for (int i = 0; i < 1000; i++)
+            {
+                int peerIndex = rnd.Next(peerCount);
+                int time = rnd.Next(100000);
+                int size = rnd.Next(1024 * 1024);
+                qualityScore.AddSample(peers[peerIndex].Object, time, size);
+            }
+
+            // Only last 5 samples will be remembered.
+            qualityScore.AddSample(peers[0].Object, 30, 2048); // 15 ms/Kb
+            qualityScore.AddSample(peers[1].Object, 50, 1024); // 50 ms/Kb
+            qualityScore.AddSample(peers[2].Object, 40, 1024); // 40 ms/Kb
+            qualityScore.AddSample(peers[2].Object, 30, 2048); // 15 ms/Kb
+            qualityScore.AddSample(peers[2].Object, 30, 3072); // 10 ms/Kb
+
+            Assert.True(Math.Abs(qualityScore.AverageBlockTimePerKb - 26.0) < 0.00001);
+        }
+
+        /// <summary>
+        /// Checks that <see cref="QualityScore.CalculateQualityAdjustment"/> is correctly calculated. 
+        /// More specifically, we check if the score adjustment is positive (i.e. rewarding) if the block time 
+        /// is less then 2x current average and negative (i.e. penalizing) if the block time is more than 2x average.
+        /// </summary>
+        [Fact]
+        public void CalculateQualityAdjustmentCorrectlyCalculates()
+        {
+            QualityScore qualityScore = new QualityScore(5, new LoggerFactory());
+
+            int peerCount = 3;
+            Mock<IBlockPullerBehavior>[] peers = new Mock<IBlockPullerBehavior>[peerCount];
+
+            for (int i = 0; i < peerCount; i++)
+            {
+                peers[i] = new Mock<IBlockPullerBehavior>();
+                peers[i].Setup(b => b.QualityScore).Returns(QualityScore.MaxScore / 3);
+            }
+
+            qualityScore.AddSample(peers[0].Object, 30, 2048);
+            qualityScore.AddSample(peers[1].Object, 50, 1024);
+            qualityScore.AddSample(peers[2].Object, 40, 1024);
+            qualityScore.AddSample(peers[2].Object, 30, 2048);
+            qualityScore.AddSample(peers[2].Object, 30, 3072);
+
+            // Average of the five samples above is now 26 ms/Kb.
+            double avg = 26.0;
+
+            Random rnd = new Random();
+
+            // First we test values that should lead to reward adjustments, these are block times with less than 2x the current average.
+            long timePerKb = 1;
+            for (; timePerKb < 2 * avg; timePerKb++)
+            {
+                double coef = rnd.NextDouble() * 10;
+                Assert.True(qualityScore.CalculateQualityAdjustment((long)(Math.Floor(coef * timePerKb)), (int)(Math.Ceiling(coef * 1024))) > 0);
+            }
+
+            // Then we test values that should lead to penalty adjustment, these are block times with more than 2x the current average.
+            for (timePerKb = (long)(2 * avg) + 1; timePerKb < 10 * avg; timePerKb++)
+            {
+                double coef = rnd.NextDouble() * 10 + 0.1;
+                Assert.True(qualityScore.CalculateQualityAdjustment((long)(Math.Ceiling(coef * timePerKb)), (int)(Math.Floor(coef * 1024))) < 0);
+            }
+        }
+
+        /// <summary>
+        /// Checks that <see cref="QualityScore.AverageBlockTimePerKb"/> is correctly evaluated.
+        /// </summary>
+        [Fact]
+        public void IsPenaltyDiscardedEvaluatesCorrectly()
+        {
+            QualityScore qualityScore = new QualityScore(5, new LoggerFactory());
+
+            int peerCount = 3;
+            Mock<IBlockPullerBehavior>[] peers = new Mock<IBlockPullerBehavior>[peerCount];
+            double[] peerScores = new double[] { 3.3, 1.0, 1.5 };
+
+            for (int i = 0; i < peerCount; i++)
+            {
+                peers[i] = new Mock<IBlockPullerBehavior>();
+                peers[i].Setup(b => b.QualityScore).Returns(peerScores[i]);
+            }
+
+            qualityScore.AddSample(peers[0].Object, 30, 2048); 
+            Assert.False(qualityScore.IsPenaltyDiscarded());
+
+            qualityScore.AddSample(peers[1].Object, 50, 1024); 
+            Assert.False(qualityScore.IsPenaltyDiscarded());
+
+            qualityScore.AddSample(peers[2].Object, 40, 1024); 
+            Assert.True(qualityScore.IsPenaltyDiscarded());
+
+            qualityScore.AddSample(peers[0].Object, 30, 2048); 
+            Assert.True(qualityScore.IsPenaltyDiscarded());
+
+            qualityScore.AddSample(peers[0].Object, 30, 3072); 
+            Assert.True(qualityScore.IsPenaltyDiscarded());
+
+            qualityScore.AddSample(peers[0].Object, 30, 2048);
+            Assert.True(qualityScore.IsPenaltyDiscarded());
+
+            qualityScore.AddSample(peers[1].Object, 30, 2048);
+            Assert.True(qualityScore.IsPenaltyDiscarded());
+
+            qualityScore.AddSample(peers[1].Object, 50, 1024);
+            Assert.False(qualityScore.IsPenaltyDiscarded());
+
+            qualityScore.AddSample(peers[2].Object, 40, 1024);
+            Assert.True(qualityScore.IsPenaltyDiscarded());
+
+            qualityScore.AddSample(peers[2].Object, 40, 1024);
+            Assert.True(qualityScore.IsPenaltyDiscarded());
+
+            qualityScore.AddSample(peers[2].Object, 40, 1024);
+            Assert.True(qualityScore.IsPenaltyDiscarded());
+
+            qualityScore.AddSample(peers[2].Object, 40, 1024);
+            Assert.True(qualityScore.IsPenaltyDiscarded());
+
+            qualityScore.AddSample(peers[0].Object, 30, 3072);
+            Assert.False(qualityScore.IsPenaltyDiscarded());
+        }
+    }
+}

--- a/Stratis.Bitcoin/BlockPulling/BlockPuller.cs
+++ b/Stratis.Bitcoin/BlockPulling/BlockPuller.cs
@@ -411,9 +411,8 @@ namespace Stratis.Bitcoin.BlockPulling
                 if (this.pendingInventoryVectors.Count > 0)
                 {
                     blockHash = this.pendingInventoryVectors.Dequeue();
-                    this.assignedBlockTasks.Add(blockHash, peer);
-
-                    AddPeerPendingDownloadLocked(peer, blockHash);
+                    if (this.assignedBlockTasks.TryAdd(blockHash, peer))
+                        AddPeerPendingDownloadLocked(peer, blockHash);
                 }
             }
 

--- a/Stratis.Bitcoin/BlockPulling/BlockPuller.cs
+++ b/Stratis.Bitcoin/BlockPulling/BlockPuller.cs
@@ -380,10 +380,8 @@ namespace Stratis.Bitcoin.BlockPulling
                 return;
             }
 
-            // TODO: This is wrong, what we want here is the height of the last consensus block - how do I get ChainState in the puller?
-            int chainHeight = minHeight;
             List<int> requestedBlockHeights = vectors.Keys.ToList();
-            Dictionary<PullerDownloadAssignments.PeerInformation, List<int>> blocksAssignedToPeers = PullerDownloadAssignments.AssignBlocksToPeers(requestedBlockHeights, peerInformation, chainHeight);
+            Dictionary<PullerDownloadAssignments.PeerInformation, List<int>> blocksAssignedToPeers = PullerDownloadAssignments.AssignBlocksToPeers(requestedBlockHeights, peerInformation);
 
             // Go through the assignments and start download tasks.
             foreach (KeyValuePair<PullerDownloadAssignments.PeerInformation, List<int>> kvp in blocksAssignedToPeers)

--- a/Stratis.Bitcoin/BlockPulling/BlockPuller.cs
+++ b/Stratis.Bitcoin/BlockPulling/BlockPuller.cs
@@ -624,7 +624,7 @@ namespace Stratis.Bitcoin.BlockPulling
                 res = this.downloadedBlocks.TryGet(blockHash);
             }
 
-            this.logger.LogTrace("(-):{0}", res != null ? nameof(DownloadedBlock) : "null");
+            this.logger.LogTrace($"(-):'{res}'");
             return res;
         }
 

--- a/Stratis.Bitcoin/BlockPulling/BlockPullerBehavior.cs
+++ b/Stratis.Bitcoin/BlockPulling/BlockPullerBehavior.cs
@@ -94,7 +94,7 @@ namespace Stratis.Bitcoin.BlockPulling
         private void Node_MessageReceived(Node node, IncomingMessage message)
         {
             // TODO: https://github.com/stratisproject/StratisBitcoinFullNode/issues/292
-            this.logger.LogTrace($"[{this.GetHashCode():x}] ()");
+            this.logger.LogTrace($"[{this.GetHashCode():x}] ({nameof(node.Peer.Endpoint)}:'{node.Peer.Endpoint}')");
 
             message.Message.IfPayloadIs<BlockPayload>((block) =>
             {
@@ -134,7 +134,7 @@ namespace Stratis.Bitcoin.BlockPulling
             Node attachedNode = this.AttachedNode;
             if (attachedNode == null || attachedNode.State != NodeState.HandShaked || !this.puller.Requirements.Check(attachedNode.PeerVersion))
             {
-                this.logger.LogTrace($"[{this.GetHashCode():x}] (-)[ATTACH_NODE]");
+                this.logger.LogTrace($"[{this.GetHashCode():x}] (-)[ATTACHED_NODE]");
                 return;
             }
 
@@ -157,7 +157,7 @@ namespace Stratis.Bitcoin.BlockPulling
             Node attachedNode = this.AttachedNode;
             if (attachedNode == null || attachedNode.State != NodeState.HandShaked || !this.puller.Requirements.Check(attachedNode.PeerVersion))
             {
-                this.logger.LogTrace($"[{this.GetHashCode():x}] (-)[ATTACH_NODE]");
+                this.logger.LogTrace($"[{this.GetHashCode():x}] (-)[ATTACHED_NODE]");
                 return;
             }
 

--- a/Stratis.Bitcoin/BlockPulling/BlockPullerBehavior.cs
+++ b/Stratis.Bitcoin/BlockPulling/BlockPullerBehavior.cs
@@ -14,9 +14,22 @@ using static Stratis.Bitcoin.BlockPulling.BlockPuller;
 namespace Stratis.Bitcoin.BlockPulling
 {
     /// <summary>
-    /// Relation of the node to a network peer node.
+    /// Relation of the node's puller to a network peer node.
     /// </summary>
-    public class BlockPullerBehavior : NodeBehavior
+    public interface IBlockPullerBehavior
+    {
+        /// <summary>
+        /// Evaluation of the past experience with this node.
+        /// The higher the score, the better experience we have had with it.
+        /// </summary>
+        /// <seealso cref="QualityScore.MaxScore"/>
+        /// <seealso cref="QualityScore.MinScore"/>
+        double QualityScore { get; }
+    }
+
+
+    /// <inheritdoc />
+    public class BlockPullerBehavior : NodeBehavior, IBlockPullerBehavior
     {
         /// <summary>Logger factory to create loggers.</summary>
         private ILoggerFactory loggerFactory;
@@ -55,12 +68,7 @@ namespace Stratis.Bitcoin.BlockPulling
         /// <summary>Lock protecting write access to <see cref="QualityScore"/>.</summary>
         private readonly object qualityScoreLock = new object();
 
-        /// <summary>
-        /// Evaluation of the past experience with this node.
-        /// The higher the score, the better experience we have had with it.
-        /// </summary>
-        /// <seealso cref="MaxQualityScore"/>
-        /// <seealso cref="MinQualityScore"/>
+        /// <inheritdoc />
         /// <remarks>Write access to this object has to be protected by <see cref="qualityScoreLock"/>.</remarks>
         public double QualityScore { get; private set; }
 
@@ -72,7 +80,7 @@ namespace Stratis.Bitcoin.BlockPulling
         public BlockPullerBehavior(BlockPuller puller, ILoggerFactory loggerFactory)
         {
             this.puller = puller;
-            this.QualityScore = BlockPulling.QualityScore.MaxScore / 2;
+            this.QualityScore = BlockPulling.QualityScore.MaxScore / 3;
             // TODO: https://github.com/stratisproject/StratisBitcoinFullNode/issues/292
             this.logger = loggerFactory.CreateLogger(this.GetType().FullName);
             this.loggerFactory = loggerFactory;

--- a/Stratis.Bitcoin/BlockPulling/DownloadAssignment.cs
+++ b/Stratis.Bitcoin/BlockPulling/DownloadAssignment.cs
@@ -9,7 +9,7 @@ namespace Stratis.Bitcoin.BlockPulling
     /// <summary>
     /// Describes the assigned download tasks.
     /// </summary>
-    public class DownloadTask
+    public class DownloadAssignment
     {
         /// <summary>Hash of the block being downloaded.</summary>
         public uint256 BlockHash { get; set; }
@@ -22,7 +22,7 @@ namespace Stratis.Bitcoin.BlockPulling
         /// </summary>
         /// <param name="blockHash">Hash of the block being downloaded.</param>
         /// <param name="start">If <c>true</c>, the download task's stopwatch will be started immediately.</param>
-        public DownloadTask(uint256 blockHash, bool start = true)
+        public DownloadAssignment(uint256 blockHash, bool start = true)
         {
             this.BlockHash = blockHash;
             this.Stopwatch = new Stopwatch();

--- a/Stratis.Bitcoin/BlockPulling/DownloadTask.cs
+++ b/Stratis.Bitcoin/BlockPulling/DownloadTask.cs
@@ -1,0 +1,42 @@
+﻿using NBitcoin;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Text;
+
+namespace Stratis.Bitcoin.BlockPulling
+{
+    /// <summary>
+    /// Describes the assigned download tasks.
+    /// </summary>
+    public class DownloadTask
+    {
+        /// <summary>Hash of the block being downloaded.</summary>
+        public uint256 BlockHash { get; set; }
+
+        /// <summary>Stopwatch used to measure the time the responsible peer needed to provide the block.</summary>
+        public Stopwatch Stopwatch { get; set; }
+
+        /// <summary>
+        /// Initializes a new instance of the object and possibly starts the internal watch.
+        /// </summary>
+        /// <param name="blockHash">Hash of the block being downloaded.</param>
+        /// <param name="start">If <c>true</c>, the download task's stopwatch will be started immediately.</param>
+        public DownloadTask(uint256 blockHash, bool start = true)
+        {
+            this.BlockHash = blockHash;
+            this.Stopwatch = new Stopwatch();
+            if (start) this.Stopwatch.Start();
+        }
+
+        /// <summary>
+        /// Stops the task's stopwatch and returns elapsed time.
+        /// </summary>
+        /// <returns>Number of milliseconds since the task started.</returns>
+        public long Finish()
+        {
+            this.Stopwatch.Stop();
+            return this.Stopwatch.ElapsedMilliseconds;
+        }
+    }
+}

--- a/Stratis.Bitcoin/BlockPulling/LookaheadBlockPuller.cs
+++ b/Stratis.Bitcoin/BlockPulling/LookaheadBlockPuller.cs
@@ -1,14 +1,12 @@
-﻿using NBitcoin;
+﻿using Microsoft.Extensions.Logging;
+using NBitcoin;
+using NBitcoin.Protocol;
+using Stratis.Bitcoin.Connection;
 using Stratis.Bitcoin.Utilities;
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
-using NBitcoin.Protocol;
-using Stratis.Bitcoin.Connection;
-using Microsoft.Extensions.Logging;
-using Stratis.Bitcoin.Base;
 
 namespace Stratis.Bitcoin.BlockPulling
 {

--- a/Stratis.Bitcoin/BlockPulling/LookaheadBlockPuller.cs
+++ b/Stratis.Bitcoin/BlockPulling/LookaheadBlockPuller.cs
@@ -440,7 +440,7 @@ namespace Stratis.Bitcoin.BlockPulling
                 }
                 else
                 {
-                    // Otherwise we either have reorg, or we don't know the next block.
+                    // Otherwise we either have reorg, or we reached the best chain tip.
                     if (header == null)
                     {
                         if (!this.Chain.Contains(this.location.HashBlock))

--- a/Stratis.Bitcoin/BlockPulling/PullerDownloadAssignments.cs
+++ b/Stratis.Bitcoin/BlockPulling/PullerDownloadAssignments.cs
@@ -109,9 +109,10 @@ namespace Stratis.Bitcoin.BlockPulling
                 int totalWork = filteredPeers.Sum(p => p.TasksAssignedCount);
                 for (int i = 0; i < filteredPeers.Count; i++)
                 {
-                    if (filteredPeers[i].TasksAssignedCount > HighWorkAmountThreshold)
+                    int peerTaskCount = filteredPeers[i].TasksAssignedCount;
+                    if (peerTaskCount > HighWorkAmountThreshold)
                     {
-                        double penaltyCoef = 1 + ((filteredPeers[i].TasksAssignedCount * filteredPeers[i].TasksAssignedCount) / (totalWork * totalWork));
+                        double penaltyCoef = 1 + ((peerTaskCount * peerTaskCount) / (totalWork * totalWork));
                         scores[i] /= penaltyCoef;
                     }
                 }

--- a/Stratis.Bitcoin/BlockPulling/PullerDownloadAssignments.cs
+++ b/Stratis.Bitcoin/BlockPulling/PullerDownloadAssignments.cs
@@ -7,6 +7,9 @@ using System.Collections.Concurrent;
 using NBitcoin.Protocol.Behaviors;
 using System.Threading;
 using Stratis.Bitcoin.Connection;
+using Stratis.Bitcoin.Utilities;
+using Microsoft.Extensions.Logging;
+using NLog.Extensions.Logging;
 
 namespace Stratis.Bitcoin.BlockPulling
 {
@@ -20,17 +23,40 @@ namespace Stratis.Bitcoin.BlockPulling
         public class PeerInformation
         {
             /// <summary>Evaluation of the node's past experience with the peer.</summary>
-            public int QualityScore { get; set; }
+            public double QualityScore { get; set; }
 
             /// <summary>Length of the chain the peer maintains.</summary>
             public int ChainHeight { get; set; }
 
             /// <summary>Application defined peer identifier.</summary>
             public object PeerId { get; set; }
+
+            /// <summary>Number of tasks assigned to this peer.</summary>
+            public int TasksAssignedCount { get; set; }
         }
+
+        /// <summary>Class logger.</summary>
+        private static readonly ILogger logger;
+
+        /// <summary>Number of blocks from the currently last block that are protected from being assigned to poor peers.</summary>
+        /// <seealso cref="AssignBlocksToPeers"/>
+        private const int CriticalLookahead = 10;
+
+        /// <summary>Peer is considered to be assigned a large amount of work if it has more than this amount of download tasks assigned.</summary>
+        private const int HighWorkAmountThreshold = 50;
 
         /// <summary>Random number generator.</summary>
         private static Random Rand = new Random();
+
+        /// <summary>
+        /// Initializes class logger.
+        /// </summary>
+        static PullerDownloadAssignments()
+        {
+            ILoggerFactory loggerFactory = new LoggerFactory();
+            loggerFactory.AddNLog();
+            logger = loggerFactory.CreateLogger(typeof(PullerDownloadAssignments).FullName);
+        }
 
         /// <summary>
         /// Having a list of block heights of the blocks that needs to be downloaded and having a list of available 
@@ -43,9 +69,19 @@ namespace Stratis.Bitcoin.BlockPulling
         /// </summary>
         /// <param name="requestedBlockHeights">List of block heights that needs to be downloaded.</param>
         /// <param name="availablePeersInformation">List of peers that are available including information about lengths of their chains.</param>
+        /// <param name="currentChainHeight">Height of the current chain.</param>
         /// <returns>List of block heights that each peer is assigned, mapped by information about peers.</returns>
-        public static Dictionary<PeerInformation, List<int>> AssignBlocksToPeers(List<int> requestedBlockHeights, List<PeerInformation> availablePeersInformation)
+        /// <remarks>
+        /// Peers with a lot of work (more than <see cref="HighWorkAmountThreshold"/>) already assigned to them have less chance 
+        /// getting more work. However, the quality is stronger factor.
+        /// <para>
+        /// Tasks to download blocks between <paramref name="currentChainHeight"/> and <paramref name="currentChainHeight"/>+<see cref="CriticalLookahea"/>
+        /// are protected from being assigned to peers with quality below the median quality of available peers.</para>
+        /// </remarks>
+        public static Dictionary<PeerInformation, List<int>> AssignBlocksToPeers(List<int> requestedBlockHeights, List<PeerInformation> availablePeersInformation, int currentChainHeight)
         {
+            logger.LogTrace($"({nameof(requestedBlockHeights)}:{string.Join(",", requestedBlockHeights)},{nameof(availablePeersInformation)}.{nameof(availablePeersInformation.Count)}:{availablePeersInformation.Count},{nameof(currentChainHeight)}:{currentChainHeight})");
+
             Dictionary<PeerInformation, List<int>> res = new Dictionary<PeerInformation, List<int>>();
             foreach (PeerInformation peerInformation in availablePeersInformation)
                 res.Add(peerInformation, new List<int>());
@@ -54,21 +90,49 @@ namespace Stratis.Bitcoin.BlockPulling
             {
                 // Only consider peers that have the chain long enough to be able to provide block at blockHeight height.
                 List<PeerInformation> filteredPeers = availablePeersInformation.Where(p => p.ChainHeight >= blockHeight).ToList();
+                logger.LogTrace($"{filteredPeers.Count} peers remain after chain height filtration.");
 
                 if (filteredPeers.Count == 0)
                     continue;
 
-                int[] scores = filteredPeers.Select(n => n.QualityScore == BlockPuller.MaxQualityScore ? BlockPuller.MaxQualityScore * 2 : n.QualityScore).ToArray();
-                int totalScore = scores.Sum();
+                double[] scores = filteredPeers.Select(n => n.QualityScore).ToArray();
+                if (blockHeight < currentChainHeight + CriticalLookahead)
+                {
+                    // This block task is protected, filter out peers with low quality.
+                    double median = scores.Median();
+                    filteredPeers = filteredPeers.Where(n => n.QualityScore >= median).ToList();
+                    logger.LogTrace($"{filteredPeers.Count} peers remain after critical block protection filtration.");
+
+                    if (filteredPeers.Count == 0)
+                        continue;
+
+                    scores = filteredPeers.Select(n => n.QualityScore).ToArray();
+                }
+
+                // Modify scores based on amount of work peers already have.
+                // The peer may get up to 50 % penalty to its score if it has too much work on itself.
+                int totalWork = filteredPeers.Sum(p => p.TasksAssignedCount);
+                for (int i = 0; i < filteredPeers.Count; i++)
+                {
+                    if (filteredPeers[i].TasksAssignedCount > HighWorkAmountThreshold)
+                    {
+                        double penaltyCoef = 1 + ((filteredPeers[i].TasksAssignedCount * filteredPeers[i].TasksAssignedCount) / (totalWork * totalWork));
+                        scores[i] /= penaltyCoef;
+                    }
+                }
 
                 // Randomly choose a peer to assign the task to with respect to scores of all filtered peers.
-                int index = GetNodeIndex(scores, totalScore);
+                int[] intScores = scores.Select(s => (int)(s * 100.0)).ToArray();
+                int totalScore = intScores.Sum();
+
+                int index = GetNodeIndex(intScores, totalScore);
                 PeerInformation selectedPeer = filteredPeers[index];
 
                 // Assign the task to download block with height blockHeight to the selected peer.
                 res[selectedPeer].Add(blockHeight);
             }
 
+            logger.LogTrace($"(-):*.{nameof(res.Count)}={res.Count}");
             return res;
         }
 

--- a/Stratis.Bitcoin/BlockPulling/PullerDownloadAssignments.cs
+++ b/Stratis.Bitcoin/BlockPulling/PullerDownloadAssignments.cs
@@ -1,15 +1,10 @@
-﻿using NBitcoin.Protocol;
+﻿using Microsoft.Extensions.Logging;
+using NBitcoin;
+using NLog.Extensions.Logging;
+using Stratis.Bitcoin.Utilities;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using NBitcoin;
-using System.Collections.Concurrent;
-using NBitcoin.Protocol.Behaviors;
-using System.Threading;
-using Stratis.Bitcoin.Connection;
-using Stratis.Bitcoin.Utilities;
-using Microsoft.Extensions.Logging;
-using NLog.Extensions.Logging;
 
 namespace Stratis.Bitcoin.BlockPulling
 {

--- a/Stratis.Bitcoin/BlockPulling/PullerDownloadAssignments.cs
+++ b/Stratis.Bitcoin/BlockPulling/PullerDownloadAssignments.cs
@@ -70,7 +70,8 @@ namespace Stratis.Bitcoin.BlockPulling
         /// getting more work. However, the quality is stronger factor.
         /// <para>
         /// Tasks to download blocks with height in the lower half of the requested block heights 
-        /// are protected from being assigned to peers with quality below the median quality of available peers.</para>
+        /// are protected from being assigned to peers with quality below the median quality of available peers.
+        /// </para>
         /// </remarks>
         public static Dictionary<PeerInformation, List<int>> AssignBlocksToPeers(List<int> requestedBlockHeights, List<PeerInformation> availablePeersInformation)
         {

--- a/Stratis.Bitcoin/BlockPulling/QualityScore.cs
+++ b/Stratis.Bitcoin/BlockPulling/QualityScore.cs
@@ -1,0 +1,193 @@
+﻿using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Text;
+
+namespace Stratis.Bitcoin.BlockPulling
+{
+    /// <summary>
+    /// Single historic sample item for quality score calculations.
+    /// </summary>
+    public class PeerSample
+    {
+        /// <summary>Peer who provided the sample.</summary>
+        public BlockPullerBehavior peer { get; set; }
+
+        /// <summary>Downloading speed as number of milliseconds per KB.</summary>
+        public double timePerKb { get; set; }
+    }
+
+    /// <summary>
+    /// Implements logic of evaluation of quality of node network peers based on 
+    /// the recent past experience with them with respect to other node's network peers.
+    /// </summary>
+    /// <remarks>
+    /// Each peer is assigned with a quality score, which is a floating point number between 
+    /// <see cref="MinScore"/> and <see cref="MaxScore"/> inclusive. Each peer starts with 
+    /// the score in the middle of the score interval. The higher the score, the better the peer 
+    /// and the better chance for the peer to get more work assigned.
+    /// </remarks>
+    public class QualityScore
+    {
+        /// <summary>Maximal quality score of a peer node based on the node's past experience with the peer node.</summary>
+        public const double MinScore = 1.0;
+        /// <summary>Minimal quality score of a peer node based on the node's past experience with the peer node.</summary>
+        public const double MaxScore = 100.0;
+
+        /// <summary>Instance logger.</summary>
+        private readonly ILogger logger;
+
+        /// <summary>Lock object to protect access to samples statistics.</summary>
+        private readonly object lockObject = new object();
+
+        /// <summary>Average time of a block download among up to last <see cref="samplesCount"/> blocks.</summary>
+        /// <remarks>Write access to this object has to be protected by <see cref="lockObject"/>.</remarks>
+        private double averageBlockTimePerKb { get; set; }
+
+        /// <summary>Number of block time samples available in <see cref="samples"/>.</summary>
+        /// <remarks>All access to this object has to be protected by <see cref="lockObject"/>.</remarks>
+        private int samplesCount { get; set; }
+
+        /// <summary>Index in <see cref="samples"/> array where the next sample will be stored.</summary>
+        /// <remarks>All access to this object has to be protected by <see cref="lockObject"/>.</remarks>
+        private int samplesIndex { get; set; }
+
+        /// <summary>Circular array of recent block times in milliseconds per KB, which contains <see cref="samplesCount"/> samples.</summary>
+        /// <remarks>All access to this object has to be protected by <see cref="lockObject"/>.</remarks>
+        private readonly PeerSample[] samples;
+
+        /// <summary>Reference counter for peers. This is used for calculating how many peers contributed to the sample history we keep.</summary>
+        /// <remarks>All access to this object has to be protected by <see cref="lockObject"/>.</remarks>
+        private readonly Dictionary<BlockPullerBehavior, int> peerReferenceCounter;
+
+        /// <summary>Sum of all samples in <see cref="samples"/> array.</summary>
+        /// <remarks>All access to this object has to be protected by <see cref="lockObject"/>.</remarks>
+        private double samplesSum { get; set; }
+
+        /// <summary>
+        /// Initializes a new instance of the object.
+        /// </summary>
+        /// <param name="maxSampleCount">Maximal number of samples we calculate statistics from.</param>
+        /// <param name="loggerFactory">Factory to be used to create logger for the puller.</param>
+        public QualityScore(int maxSampleCount, ILoggerFactory loggerFactory)
+        {
+            this.logger = loggerFactory.CreateLogger(this.GetType().FullName);
+
+            this.samples = new PeerSample[maxSampleCount];
+            for (int i = 0; i < this.samples.Length; i++)
+                this.samples[i] = new PeerSample();
+
+            this.averageBlockTimePerKb = 0.0;
+            this.peerReferenceCounter = new Dictionary<BlockPullerBehavior, int>();
+        }
+
+        /// <summary>
+        /// Adds new time of a block to the list of times of recently downloaded blocks.
+        /// </summary>
+        /// <param name="peer">Peer that downloaded the block.</param>
+        /// <param name="blockDownloadTimeMs">Time in milliseconds it took to download the block from the peer.</param>
+        /// <param name="blockSize">Size of the downloaded block in bytes.</param>
+        public void AddSample(BlockPullerBehavior peer, long blockDownloadTimeMs, int blockSize)
+        {
+            this.logger.LogTrace($"({nameof(peer)}:{peer.GetHashCode():x},{nameof(blockDownloadTimeMs)}:{blockDownloadTimeMs},{nameof(blockSize)}:{blockSize})");
+
+            double timePerKb = 1024.0 * (double)blockDownloadTimeMs / (double)blockSize;
+
+            lock (this.lockObject)
+            {
+                // If we reached the maximum number of samples, we need to remove oldest sample.
+                if (this.samplesCount == this.samples.Length)
+                {
+                    PeerSample oldSample = this.samples[this.samplesIndex];
+                    this.samplesSum -= oldSample.timePerKb;
+                    this.peerReferenceCounter[oldSample.peer]--;
+
+                    if (this.peerReferenceCounter[oldSample.peer] == 0)
+                        this.peerReferenceCounter.Remove(oldSample.peer);
+                }
+                else this.samplesCount++;
+
+                // Add new sample to the mix.
+                this.samples[this.samplesIndex].timePerKb = timePerKb;
+                this.samples[this.samplesIndex].peer = peer;
+                this.samplesIndex = (this.samplesIndex + 1) % this.samples.Length;
+
+                if (this.peerReferenceCounter.ContainsKey(peer)) this.peerReferenceCounter[peer]++;
+                else this.peerReferenceCounter.Add(peer, 1);
+
+                // Update the sum and the average with the latest data.
+                this.samplesSum += timePerKb;
+                this.averageBlockTimePerKb = this.samplesSum / this.samplesCount;
+            }
+
+            this.logger.LogTrace($"(-):{nameof(this.averageBlockTimePerKb)}={this.averageBlockTimePerKb}");
+        }
+
+        /// <summary>
+        /// Calculates adjustment of peer's quality score when it finished downloading a block.
+        /// </summary>
+        /// <param name="blockDownloadTimeMs">Time in milliseconds it took to download the block from the peer.</param>
+        /// <param name="blockSize">Size of the downloaded block in bytes.</param>
+        /// <returns>Quality score adjustment for the peer.</returns>
+        public double CalculateQualityAdjustment(long blockDownloadTimeMs, int blockSize)
+        {
+            this.logger.LogTrace($"({nameof(blockDownloadTimeMs)}:{blockDownloadTimeMs},{nameof(blockSize)}:{blockSize})");
+
+            double avgTimePerKb = this.averageBlockTimePerKb;
+            double timePerKb = 1024.0 * (double)blockDownloadTimeMs / (double)blockSize;
+            this.logger.LogTrace($"Average time per KB is {avgTimePerKb} ms, this sample is {timePerKb} ms/KB.");
+
+            // If the block was received with better speed than is 2x average of the recent history we keep
+            // then we reward the peer for downloading it quickly. Otherwise, we penalize the peer for downloading 
+            // the block too slowly. If we have no history, then we give a small reward no matter what.
+            double res = 0.1;
+            if (timePerKb < 2 * avgTimePerKb) res = avgTimePerKb / timePerKb;
+            else if (Math.Abs(avgTimePerKb) > 0.00001) res = -timePerKb / (2 * avgTimePerKb);
+
+            if ((res < 0) && this.IsPenaltyDiscarded())
+                res = 0;
+
+            this.logger.LogTrace($"(-):{res}");
+            return res;
+        }
+
+        /// <summary>
+        /// Calculates peer's penalty when the wait for the next block times out.
+        /// </summary>
+        /// <returns>Quality score penalty for the peer.</returns>
+        public double CalculateNextBlockTimeoutQualityPenalty()
+        {
+            this.logger.LogTrace("()");
+
+            double res = this.IsPenaltyDiscarded() ? 0 : -1;
+
+            this.logger.LogTrace($"(-):{res}");
+            return res;
+        }
+
+        /// <summary>
+        /// Checks whether penalty should be avoided. This is when sum(score) of all peers is lower than 2x number of peers peerCount.
+        /// This mechanism also prevents single peer to go to minimum if it is alone.
+        /// </summary>
+        /// <returns><c>true</c> if the penalty should be discarded, <c>false</c> otherwise.</returns>
+        private bool IsPenaltyDiscarded()
+        {
+            this.logger.LogTrace("()");
+
+            int peerCount = 0;
+            double peerQualitySum = 0;
+            lock (this.lockObject)
+            {
+                peerCount = this.peerReferenceCounter.Keys.Count;
+                peerQualitySum = this.peerReferenceCounter.Keys.Sum(p => p.QualityScore);
+            }
+            this.logger.LogTrace($"Number of peers is {peerCount}, sum of peer qualities is {peerQualitySum}.");
+            bool res = peerQualitySum < 2 * peerCount;
+
+            this.logger.LogTrace($"(-):{res}");
+            return res;
+        }
+    }
+}

--- a/Stratis.Bitcoin/BlockPulling/QualityScore.cs
+++ b/Stratis.Bitcoin/BlockPulling/QualityScore.cs
@@ -43,7 +43,12 @@ namespace Stratis.Bitcoin.BlockPulling
         private readonly object lockObject = new object();
 
         /// <summary>Average time of a block download among up to last <see cref="samplesCount"/> blocks.</summary>
-        /// <remarks>Write access to this object has to be protected by <see cref="lockObject"/>.</remarks>
+        /// <remarks>
+        /// Write access to this object has to be protected by <see cref="lockObject"/>.
+        /// <para>
+        /// Public getter allows better testing of the class.
+        /// </para>
+        /// </remarks>
         public double AverageBlockTimePerKb { get; private set; }
 
         /// <summary>Number of block time samples available in <see cref="samples"/>.</summary>
@@ -175,7 +180,7 @@ namespace Stratis.Bitcoin.BlockPulling
         /// This mechanism also prevents single peer to go to minimum if it is alone.
         /// </summary>
         /// <returns><c>true</c> if the penalty should be discarded, <c>false</c> otherwise.</returns>
-        private bool IsPenaltyDiscarded()
+        public bool IsPenaltyDiscarded()
         {
             this.logger.LogTrace("()");
 

--- a/Stratis.Bitcoin/BlockPulling/QualityScore.cs
+++ b/Stratis.Bitcoin/BlockPulling/QualityScore.cs
@@ -13,7 +13,7 @@ namespace Stratis.Bitcoin.BlockPulling
     public class PeerSample
     {
         /// <summary>Peer who provided the sample.</summary>
-        public BlockPullerBehavior peer { get; set; }
+        public IBlockPullerBehavior peer { get; set; }
 
         /// <summary>Downloading speed as number of milliseconds per KB.</summary>
         public double timePerKb { get; set; }
@@ -60,7 +60,7 @@ namespace Stratis.Bitcoin.BlockPulling
 
         /// <summary>Reference counter for peers. This is used for calculating how many peers contributed to the sample history we keep.</summary>
         /// <remarks>All access to this object has to be protected by <see cref="lockObject"/>.</remarks>
-        private readonly Dictionary<BlockPullerBehavior, int> peerReferenceCounter;
+        private readonly Dictionary<IBlockPullerBehavior, int> peerReferenceCounter;
 
         /// <summary>Sum of all samples in <see cref="samples"/> array.</summary>
         /// <remarks>All access to this object has to be protected by <see cref="lockObject"/>.</remarks>
@@ -80,7 +80,7 @@ namespace Stratis.Bitcoin.BlockPulling
                 this.samples[i] = new PeerSample();
 
             this.averageBlockTimePerKb = 0.0;
-            this.peerReferenceCounter = new Dictionary<BlockPullerBehavior, int>();
+            this.peerReferenceCounter = new Dictionary<IBlockPullerBehavior, int>();
         }
 
         /// <summary>
@@ -89,7 +89,7 @@ namespace Stratis.Bitcoin.BlockPulling
         /// <param name="peer">Peer that downloaded the block.</param>
         /// <param name="blockDownloadTimeMs">Time in milliseconds it took to download the block from the peer.</param>
         /// <param name="blockSize">Size of the downloaded block in bytes.</param>
-        public void AddSample(BlockPullerBehavior peer, long blockDownloadTimeMs, int blockSize)
+        public void AddSample(IBlockPullerBehavior peer, long blockDownloadTimeMs, int blockSize)
         {
             this.logger.LogTrace($"({nameof(peer)}:{peer.GetHashCode():x},{nameof(blockDownloadTimeMs)}:{blockDownloadTimeMs},{nameof(blockSize)}:{blockSize})");
 

--- a/Stratis.Bitcoin/BlockPulling/StoreBlockPuller.cs
+++ b/Stratis.Bitcoin/BlockPulling/StoreBlockPuller.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Extensions.Logging;
 using NBitcoin;
+using Stratis.Bitcoin.Base;
 
 namespace Stratis.Bitcoin.BlockPulling
 {
@@ -8,6 +9,9 @@ namespace Stratis.Bitcoin.BlockPulling
     /// </summary>
     public class StoreBlockPuller : BlockPuller
     {
+        /// <summary>Instance logger.</summary>
+        private readonly ILogger logger;
+
         /// <summary>
         /// Initializes a new instance of the object having a chain of block headers and a list of available nodes. 
         /// </summary>
@@ -17,6 +21,7 @@ namespace Stratis.Bitcoin.BlockPulling
         public StoreBlockPuller(ConcurrentChain chain, Connection.IConnectionManager nodes, ILoggerFactory loggerFactory)
             : base(chain, nodes.ConnectedNodes, nodes.NodeSettings.ProtocolVersion, loggerFactory)
         {
+            this.logger = loggerFactory.CreateLogger(this.GetType().FullName);
         }
 
         /// <summary>
@@ -25,7 +30,11 @@ namespace Stratis.Bitcoin.BlockPulling
         /// <param name="downloadRequest">Description of a block to download.</param>
         public void AskBlock(ChainedBlock downloadRequest)
         {
+            this.logger.LogTrace($"({nameof(downloadRequest)}:'{downloadRequest.HashBlock}/{downloadRequest.Height}')");
+
             base.AskBlocks(new ChainedBlock[] { downloadRequest });
+
+            this.logger.LogTrace("(-)");
         }
 
         /// <summary>
@@ -36,10 +45,16 @@ namespace Stratis.Bitcoin.BlockPulling
         /// <returns>true if the function succeeds, false otherwise.</returns>
         public bool TryGetBlock(ChainedBlock chainedBlock, out DownloadedBlock block)
         {
+            this.logger.LogTrace($"({nameof(chainedBlock)}:'{chainedBlock.HashBlock}/{chainedBlock.Height}')");
+
             if (TryRemoveDownloadedBlock(chainedBlock.HashBlock, out block))
+            {
+                this.logger.LogTrace("(-):true");
                 return true;
+            }
 
             this.OnStalling(chainedBlock);
+            this.logger.LogTrace("(-):false");
             return false;
         }
     }

--- a/Stratis.Bitcoin/Connection/ConnectionManager.cs
+++ b/Stratis.Bitcoin/Connection/ConnectionManager.cs
@@ -176,7 +176,8 @@ namespace Stratis.Bitcoin.Connection
 						builder.Append((node.RemoteSocketAddress + ":" + node.RemoteSocketPort).PadRight(LoggingConfiguration.ColumnLength * 2) + "R:" + ToKBSec(diff.ReadenBytesPerSecond) + "\tW:" + ToKBSec(diff.WrittenBytesPerSecond));
 						if (behavior != null)
 						{
-							builder.Append("\tQualityScore: " + behavior.QualityScore + (behavior.QualityScore < 10 ? "\t" : "") + "\tPendingBlocks: " + behavior.PendingDownloadsCount);
+                            int intQuality = (int)behavior.QualityScore;
+                            builder.Append("\tQualityScore: " + intQuality + (intQuality < 10 ? "\t" : "") + "\tPendingBlocks: " + behavior.PendingDownloadsCount);
 						}
 						builder.AppendLine();
 					}

--- a/Stratis.Bitcoin/Utilities/LinqExtensions.cs
+++ b/Stratis.Bitcoin/Utilities/LinqExtensions.cs
@@ -27,5 +27,24 @@ namespace Stratis.Bitcoin.Utilities
             else
                 return ordered.ElementAt(midpoint);
         }
+
+        /// <summary>
+        /// Calculates a median value of a collection of doubles.
+        /// </summary>
+        /// <param name="source">Collection of numbers to count median of.</param>
+        /// <returns>Median value, or 0 if the collection is empty.</returns>
+        public static double Median(this IEnumerable<double> source)
+        {
+            long count = source.LongCount();
+            if (count == 0)
+                return 0;
+
+            int midpoint = source.Count() / 2;
+            IOrderedEnumerable<double> ordered = source.OrderBy(n => n);
+            if ((count % 2) == 0)
+                return ordered.Skip(midpoint - 1).Take(2).Average();
+            else
+                return ordered.ElementAt(midpoint);
+        }
     }
 }

--- a/Stratis.Bitcoin/Utilities/LinqExtensions.cs
+++ b/Stratis.Bitcoin/Utilities/LinqExtensions.cs
@@ -10,20 +10,39 @@ namespace Stratis.Bitcoin.Utilities
     public static class LinqExtensions
     {
         /// <summary>
-        /// Calculates a median value of a collection of integers.
+        /// Calculates a median value of a collection of long integers.
         /// </summary>
         /// <param name="source">Collection of numbers to count median of.</param>
         /// <returns>Median value, or 0 if the collection is empty.</returns>
         public static long Median(this IEnumerable<long> source)
         {
-            long count = source.LongCount();
+            int count = source.Count();
             if (count == 0)
                 return 0;
 
-            int midpoint = source.Count() / 2;
+            int midpoint = count / 2;
             IOrderedEnumerable<long> ordered = source.OrderBy(n => n);
             if ((count % 2) == 0)
-                return (long)Math.Round(ordered.Skip(midpoint-1).Take(2).Average());
+                return (long)Math.Round(ordered.Skip(midpoint - 1).Take(2).Average());
+            else
+                return ordered.ElementAt(midpoint);
+        }
+
+        /// <summary>
+        /// Calculates a median value of a collection of integers.
+        /// </summary>
+        /// <param name="source">Collection of numbers to count median of.</param>
+        /// <returns>Median value, or 0 if the collection is empty.</returns>
+        public static int Median(this IEnumerable<int> source)
+        {
+            int count = source.Count();
+            if (count == 0)
+                return 0;
+
+            int midpoint = count / 2;
+            IOrderedEnumerable<int> ordered = source.OrderBy(n => n);
+            if ((count % 2) == 0)
+                return (int)Math.Round(ordered.Skip(midpoint - 1).Take(2).Average());
             else
                 return ordered.ElementAt(midpoint);
         }
@@ -35,11 +54,11 @@ namespace Stratis.Bitcoin.Utilities
         /// <returns>Median value, or 0 if the collection is empty.</returns>
         public static double Median(this IEnumerable<double> source)
         {
-            long count = source.LongCount();
+            int count = source.Count();
             if (count == 0)
                 return 0;
 
-            int midpoint = source.Count() / 2;
+            int midpoint = count / 2;
             IOrderedEnumerable<double> ordered = source.OrderBy(n => n);
             if ((count % 2) == 0)
                 return ordered.Skip(midpoint - 1).Take(2).Average();


### PR DESCRIPTION
This is a complete rework of quality score assignment as per discussion in issue #247. It separates the logic of quality score calculation to its own class and adds couple of tests related to this new behavior.

I did make quite a lot of testing, but due to the complexity of the whole puller thing, it is **highly recommended for reviewers to run more tests for themselves** (just running the node over and over again and see what happens) as I don't feel that any number of tests here is sufficient.

Also please note that this code is the first one to take the advantage of NLog integration, so the puller is now heavily logged. If you use NLog.config, you could see extreme amounts of logs being created, slowing down the puller quite a lot. I've tested that in production, without NLog.config, those logs are not being used and the performance is excellent (I was able to sync ~75000 blocks in less than 4 minutes). 

Fix #247 