### PR TITLE
Validate feature dependencies on feature startup

### DIFF
--- a/Stratis.Bitcoin.Tests/Builder/Feature/FeatureCollectionTest.cs
+++ b/Stratis.Bitcoin.Tests/Builder/Feature/FeatureCollectionTest.cs
@@ -1,49 +1,52 @@
 ﻿using Stratis.Bitcoin.Builder.Feature;
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using Xunit;
 
 namespace Stratis.Bitcoin.Tests.Builder.Feature
 {
     public class FeatureCollectionTest
     {
-		[Fact]
-		public void AddToCollectionReturnsOfGivenType()
-		{
-			var collection = new FeatureCollection();
+        [Fact]
+        public void AddToCollectionReturnsOfGivenType()
+        {
+            var collection = new FeatureCollection();
 
-			collection.AddFeature<FeatureCollectionFullNodeFeature>();
+            collection.AddFeature<FeatureCollectionFullNodeFeature>();
 
-			Assert.Equal(1, collection.FeatureRegistrations.Count);
-			Assert.Equal(typeof(FeatureCollectionFullNodeFeature), collection.FeatureRegistrations[0].FeatureType);
-		}
+            Assert.Equal(1, collection.FeatureRegistrations.Count);
+            Assert.Equal(typeof(FeatureCollectionFullNodeFeature), collection.FeatureRegistrations[0].FeatureType);
+        }
 
-		[Fact]
-		public void AddFeatureAlreadyInCollectionThrowsException()
-		{
-			Assert.Throws(typeof(ArgumentException), () =>
-			{
-				var collection = new FeatureCollection();
+        [Fact]
+        public void AddFeatureAlreadyInCollectionThrowsException()
+        {
+            Assert.Throws(typeof(ArgumentException), () =>
+            {
+                var collection = new FeatureCollection();
 
-				collection.AddFeature<FeatureCollectionFullNodeFeature>();
-				collection.AddFeature<FeatureCollectionFullNodeFeature>();
-			});
-		}
+                collection.AddFeature<FeatureCollectionFullNodeFeature>();
+                collection.AddFeature<FeatureCollectionFullNodeFeature>();
+            });
+        }
 
 
-		private class FeatureCollectionFullNodeFeature : IFullNodeFeature
-		{
-			public void Start()
-			{
-				throw new NotImplementedException();
-			}
+        private class FeatureCollectionFullNodeFeature : IFullNodeFeature
+        {
+            public void Start()
+            {
+                throw new NotImplementedException();
+            }
 
-			public void Stop()
-			{
-				throw new NotImplementedException();
-			}
-		}
-	}
+            public void Stop()
+            {
+                throw new NotImplementedException();
+            }
+
+            public void ValidateDependencies(IEnumerable<IFullNodeFeature> features)
+            {
+                throw new NotImplementedException();
+            }
+        }
+    }
 }

--- a/Stratis.Bitcoin.Tests/Builder/Feature/FeatureRegistrationTest.cs
+++ b/Stratis.Bitcoin.Tests/Builder/Feature/FeatureRegistrationTest.cs
@@ -1,121 +1,123 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
-using Moq;
 using Stratis.Bitcoin.Builder.Feature;
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using Xunit;
 
 namespace Stratis.Bitcoin.Tests.Builder.Feature
 {
     public class FeatureRegistrationTest
     {
-		[Fact]
-		public void FeatureServicesAddServiceCollectionToDelegates()
-		{
-			var collection = new ServiceCollection();			
-			var registration = new FeatureRegistration<FeatureRegistrationFullNodeFeature>();
-			
-			registration.FeatureServices(d => { d.AddSingleton<FeatureCollection>(); });
+        [Fact]
+        public void FeatureServicesAddServiceCollectionToDelegates()
+        {
+            var collection = new ServiceCollection();			
+            var registration = new FeatureRegistration<FeatureRegistrationFullNodeFeature>();
+            
+            registration.FeatureServices(d => { d.AddSingleton<FeatureCollection>(); });
 
-			Assert.Equal(typeof(FeatureRegistrationFullNodeFeature), registration.FeatureType);
-			Assert.Equal(1, registration.ConfigureServicesDelegates.Count);
-			registration.ConfigureServicesDelegates[0].Invoke(collection);
-			var descriptors = collection as IList<ServiceDescriptor>;
-			Assert.Equal(1, descriptors.Count);
-			Assert.Equal(typeof(FeatureCollection), descriptors[0].ImplementationType);
-			Assert.Equal(ServiceLifetime.Singleton, descriptors[0].Lifetime);
-		}
+            Assert.Equal(typeof(FeatureRegistrationFullNodeFeature), registration.FeatureType);
+            Assert.Equal(1, registration.ConfigureServicesDelegates.Count);
+            registration.ConfigureServicesDelegates[0].Invoke(collection);
+            var descriptors = collection as IList<ServiceDescriptor>;
+            Assert.Equal(1, descriptors.Count);
+            Assert.Equal(typeof(FeatureCollection), descriptors[0].ImplementationType);
+            Assert.Equal(ServiceLifetime.Singleton, descriptors[0].Lifetime);
+        }
 
-		[Fact]
-		public void UseStartupSetsFeatureStartupType()
-		{			
-			var registration = new FeatureRegistration<FeatureRegistrationFullNodeFeature>();
-			Assert.Null(registration.FeatureStartupType);
+        [Fact]
+        public void UseStartupSetsFeatureStartupType()
+        {			
+            var registration = new FeatureRegistration<FeatureRegistrationFullNodeFeature>();
+            Assert.Null(registration.FeatureStartupType);
 
-			registration.UseStartup<ServiceCollection>();
+            registration.UseStartup<ServiceCollection>();
 
-			Assert.Equal(typeof(ServiceCollection), registration.FeatureStartupType);		
-		}
+            Assert.Equal(typeof(ServiceCollection), registration.FeatureStartupType);		
+        }
 
-		[Fact]
-		public void BuildFeatureWithoutFeatureStartupTypeBootstrapsStartup()
-		{
-			var collection = new ServiceCollection();
-			var registration = new FeatureRegistration<FeatureRegistrationFullNodeFeature>();
-			registration.FeatureServices(d => { d.AddSingleton<FeatureCollection>(); });
+        [Fact]
+        public void BuildFeatureWithoutFeatureStartupTypeBootstrapsStartup()
+        {
+            var collection = new ServiceCollection();
+            var registration = new FeatureRegistration<FeatureRegistrationFullNodeFeature>();
+            registration.FeatureServices(d => { d.AddSingleton<FeatureCollection>(); });
 
-			registration.BuildFeature(collection);
+            registration.BuildFeature(collection);
 
-			var descriptors = collection as IList<ServiceDescriptor>;
-			Assert.Equal(3, descriptors.Count);			
-			Assert.Equal(typeof(FeatureRegistrationFullNodeFeature), descriptors[0].ImplementationType);
-			Assert.Equal(ServiceLifetime.Singleton, descriptors[0].Lifetime);
-			Assert.Equal(typeof(IFullNodeFeature), descriptors[1].ServiceType);
-			Assert.NotNull(descriptors[1].ImplementationFactory);
-			Assert.Equal(ServiceLifetime.Singleton, descriptors[1].Lifetime);
-			Assert.Equal(typeof(FeatureCollection), descriptors[2].ImplementationType);
-			Assert.Equal(ServiceLifetime.Singleton, descriptors[2].Lifetime);
-		}
+            var descriptors = collection as IList<ServiceDescriptor>;
+            Assert.Equal(3, descriptors.Count);			
+            Assert.Equal(typeof(FeatureRegistrationFullNodeFeature), descriptors[0].ImplementationType);
+            Assert.Equal(ServiceLifetime.Singleton, descriptors[0].Lifetime);
+            Assert.Equal(typeof(IFullNodeFeature), descriptors[1].ServiceType);
+            Assert.NotNull(descriptors[1].ImplementationFactory);
+            Assert.Equal(ServiceLifetime.Singleton, descriptors[1].Lifetime);
+            Assert.Equal(typeof(FeatureCollection), descriptors[2].ImplementationType);
+            Assert.Equal(ServiceLifetime.Singleton, descriptors[2].Lifetime);
+        }
 
-		[Fact]
-		public void BuildFeatureWithFeatureStartupTypeBootstrapsStartupAndInvokesStartupWithCollection()
-		{						
-			var collection = new ServiceCollection();
-			var registration = new FeatureRegistration<FeatureRegistrationFullNodeFeature>();
-			registration.FeatureServices(d => { d.AddSingleton<FeatureCollection>(); });
-			registration.UseStartup<FeatureStartup>();
+        [Fact]
+        public void BuildFeatureWithFeatureStartupTypeBootstrapsStartupAndInvokesStartupWithCollection()
+        {						
+            var collection = new ServiceCollection();
+            var registration = new FeatureRegistration<FeatureRegistrationFullNodeFeature>();
+            registration.FeatureServices(d => { d.AddSingleton<FeatureCollection>(); });
+            registration.UseStartup<FeatureStartup>();
 
-			registration.BuildFeature(collection);
-		}
+            registration.BuildFeature(collection);
+        }
 
-		[Fact]
-		public void BuildFeatureWithFeatureStartupNotHavingStaticConfigureServicesMethodDoesNotCrash()
-		{
-			var collection = new ServiceCollection();
-			var registration = new FeatureRegistration<FeatureRegistrationFullNodeFeature>();
-			registration.FeatureServices(d => { d.AddSingleton<FeatureCollection>(); });
-			registration.UseStartup<FeatureNonStaticStartup>();
+        [Fact]
+        public void BuildFeatureWithFeatureStartupNotHavingStaticConfigureServicesMethodDoesNotCrash()
+        {
+            var collection = new ServiceCollection();
+            var registration = new FeatureRegistration<FeatureRegistrationFullNodeFeature>();
+            registration.FeatureServices(d => { d.AddSingleton<FeatureCollection>(); });
+            registration.UseStartup<FeatureNonStaticStartup>();
 
-			registration.BuildFeature(collection);
-		}
+            registration.BuildFeature(collection);
+        }
 
-		private class FeatureNonStaticStartup
-		{
-			public void ConfigureServices(IServiceCollection services)
-			{			
-			}
-		}
+        private class FeatureNonStaticStartup
+        {
+            public void ConfigureServices(IServiceCollection services)
+            {			
+            }
+        }
 
-		private class FeatureStartup
-		{
-			public static void ConfigureServices(IServiceCollection services)
-			{
-				var descriptors = services as IList<ServiceDescriptor>;
-				Assert.Equal(3, descriptors.Count);
-				Assert.Equal(typeof(FeatureRegistrationFullNodeFeature), descriptors[0].ImplementationType);
-				Assert.Equal(ServiceLifetime.Singleton, descriptors[0].Lifetime);
-				Assert.Equal(typeof(IFullNodeFeature), descriptors[1].ServiceType);
-				Assert.NotNull(descriptors[1].ImplementationFactory);
-				Assert.Equal(ServiceLifetime.Singleton, descriptors[1].Lifetime);
-				Assert.Equal(typeof(FeatureCollection), descriptors[2].ImplementationType);
-				Assert.Equal(ServiceLifetime.Singleton, descriptors[2].Lifetime);
-			}
-		}
+        private class FeatureStartup
+        {
+            public static void ConfigureServices(IServiceCollection services)
+            {
+                var descriptors = services as IList<ServiceDescriptor>;
+                Assert.Equal(3, descriptors.Count);
+                Assert.Equal(typeof(FeatureRegistrationFullNodeFeature), descriptors[0].ImplementationType);
+                Assert.Equal(ServiceLifetime.Singleton, descriptors[0].Lifetime);
+                Assert.Equal(typeof(IFullNodeFeature), descriptors[1].ServiceType);
+                Assert.NotNull(descriptors[1].ImplementationFactory);
+                Assert.Equal(ServiceLifetime.Singleton, descriptors[1].Lifetime);
+                Assert.Equal(typeof(FeatureCollection), descriptors[2].ImplementationType);
+                Assert.Equal(ServiceLifetime.Singleton, descriptors[2].Lifetime);
+            }
+        }
 
-		private class FeatureRegistrationFullNodeFeature : IFullNodeFeature
-		{
-			public void Start()
-			{
-				throw new NotImplementedException();
-			}
+        private class FeatureRegistrationFullNodeFeature : IFullNodeFeature
+        {
+            public void Start()
+            {
+                throw new NotImplementedException();
+            }
 
-			public void Stop()
-			{
-				throw new NotImplementedException();
-			}
-		}
-	}
+            public void Stop()
+            {
+                throw new NotImplementedException();
+            }
+
+            public void ValidateDependencies(IEnumerable<IFullNodeFeature> features)
+            {
+                throw new NotImplementedException();
+            }
+        }
+    }
 }
 

--- a/Stratis.Bitcoin.Tests/Builder/Feature/FeaturesExtensionsTest.cs
+++ b/Stratis.Bitcoin.Tests/Builder/Feature/FeaturesExtensionsTest.cs
@@ -1,0 +1,96 @@
+﻿using Stratis.Bitcoin.Builder.Feature;
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Stratis.Bitcoin.Tests.Builder.Feature
+{
+    /// <summary>
+    /// Tests the features extensions.
+    /// </summary>
+    public class FeaturesExtensionsTest
+    {
+        #region Mock Features
+
+        /// <summary>
+        /// A mock feature.
+        /// </summary>
+        private class FeatureA : IFullNodeFeature
+        {
+            /// <inheritdoc />
+            public void Start()
+            {
+                throw new NotImplementedException();
+            }
+
+            /// <inheritdoc />
+            public void Stop()
+            {
+                throw new NotImplementedException();
+            }
+
+            /// <inheritdoc />
+            public void ValidateDependencies(IEnumerable<IFullNodeFeature> features)
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        /// <summary>
+        /// A mock feature.
+        /// </summary>
+        private class FeatureB : IFullNodeFeature
+        {
+            /// <inheritdoc />
+            public void Start()
+            {
+                throw new NotImplementedException();
+            }
+
+            /// <inheritdoc />
+            public void Stop()
+            {
+                throw new NotImplementedException();
+            }
+
+            /// <inheritdoc />
+            public void ValidateDependencies(IEnumerable<IFullNodeFeature> features)
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        #endregion
+
+        #region Tests
+
+        /// <summary>
+        /// Test no exceptions fired when checking features that exist.
+        /// </summary>
+        [Fact]
+        public void EnsureFeatureWithValidDependencies()
+        {
+            List<IFullNodeFeature> features = new List<IFullNodeFeature>();
+            features.Add(new FeatureA());
+            features.Add(new FeatureB());
+
+            features.EnsureFeature<FeatureA>();
+            features.EnsureFeature<FeatureB>();
+        }
+
+        /// <summary>
+        /// Test that missing feature throws exception.
+        /// </summary>
+        [Fact]
+        public void EnsureFeatureWithInvalidDependenciesThrowsException()
+        {
+            List<IFullNodeFeature> features = new List<IFullNodeFeature>();
+            features.Add(new FeatureA());
+
+            features.EnsureFeature<FeatureA>();
+            Assert.Throws<MissingDependencyException>(() => features.EnsureFeature<FeatureB>());           
+        }
+
+        #endregion
+    }
+}

--- a/Stratis.Bitcoin.Tests/Builder/FullNodeFeatureExecutorTest.cs
+++ b/Stratis.Bitcoin.Tests/Builder/FullNodeFeatureExecutorTest.cs
@@ -1,84 +1,114 @@
-﻿using Moq;
+﻿using Microsoft.Extensions.Logging;
+using Moq;
 using Stratis.Bitcoin.Builder;
 using Stratis.Bitcoin.Builder.Feature;
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using Microsoft.Extensions.Logging;
 using Xunit;
 
 namespace Stratis.Bitcoin.Tests.Builder
 {
     public class FullNodeFeatureExecutorTest
     {
-		private FullNodeFeatureExecutor executor;
-		private Mock<IFullNodeFeature> feature;
-		private Mock<IFullNodeFeature> feature2;
-		private Mock<IFullNode> fullNode;
-		private Mock<IFullNodeServiceProvider> fullNodeServiceProvider;
+        private FullNodeFeatureExecutor executor;
+        private Mock<IFullNodeFeature> feature;
+        private Mock<IFullNodeFeature> feature2;
+        private Mock<IFullNode> fullNode;
+        private Mock<IFullNodeServiceProvider> fullNodeServiceProvider;
 
-		public FullNodeFeatureExecutorTest()
-		{			
-			this.feature = new Mock<IFullNodeFeature>();
-			this.feature2 = new Mock<IFullNodeFeature>();
+        /// <summary>
+        /// Property that constructs a node feature executor.
+        /// This is used in the missing dependency test.
+        /// </summary>
+        private FullNodeFeatureExecutor MissingFeatureExecutor
+        { 
+            get
+            {
+                Mock<IFullNodeFeature> feature = new Mock<IFullNodeFeature>();
+                feature.Setup(f => f.ValidateDependencies(It.IsAny<IEnumerable<IFullNodeFeature>>()))
+                    .Throws(new MissingDependencyException());
 
-			this.fullNodeServiceProvider = new Mock<IFullNodeServiceProvider>();
-			this.fullNode = new Mock<IFullNode>();
+                var fullNodeServiceProvider = new Mock<IFullNodeServiceProvider>();
+                fullNodeServiceProvider.Setup(f => f.Features)
+                    .Returns(new List<IFullNodeFeature>() { feature.Object });
+                var fullNode = new Mock<IFullNode>();
+                fullNode.Setup(f => f.Services)
+                    .Returns(fullNodeServiceProvider.Object);             
 
-			this.fullNode.Setup(f => f.Services)
-				.Returns(this.fullNodeServiceProvider.Object);
+                return new FullNodeFeatureExecutor(fullNode.Object, new LoggerFactory());
+            }
+        }
 
-			this.fullNodeServiceProvider.Setup(f => f.Features)
-				.Returns(new List<IFullNodeFeature>() { this.feature.Object, this.feature2.Object });
+        public FullNodeFeatureExecutorTest()
+        {			
+            this.feature = new Mock<IFullNodeFeature>();
+            this.feature2 = new Mock<IFullNodeFeature>();
+
+            this.fullNodeServiceProvider = new Mock<IFullNodeServiceProvider>();
+            this.fullNode = new Mock<IFullNode>();
+
+            this.fullNode.Setup(f => f.Services)
+                .Returns(this.fullNodeServiceProvider.Object);
+
+            this.fullNodeServiceProvider.Setup(f => f.Features)
+                .Returns(new List<IFullNodeFeature>() { this.feature.Object, this.feature2.Object });
 
             this.executor = new FullNodeFeatureExecutor(this.fullNode.Object, new LoggerFactory());
-		}
+        }
 
-		[Fact]
-		public void StartCallsStartOnEachFeatureRegisterdWithFullNode()
-		{
-			this.executor.Start();
+        [Fact]
+        public void StartCallsStartOnEachFeatureRegisterdWithFullNode()
+        {
+            this.executor.Start();
 
-			this.feature.Verify(f => f.Start(), Times.Exactly(1));
-			this.feature2.Verify(f => f.Start(), Times.Exactly(1));
-		}
+            this.feature.Verify(f => f.Start(), Times.Exactly(1));
+            this.feature2.Verify(f => f.Start(), Times.Exactly(1));
+        }
 
-		[Fact]
-		public void StartFeaturesThrowExceptionsCollectedInAggregateException()
-		{
-			Assert.Throws(typeof(AggregateException), () =>
-			{
-				this.feature.Setup(f => f.Start())
-					.Throws(new ArgumentNullException());
-				this.feature2.Setup(f => f.Start())
-					.Throws(new ArgumentNullException());
+        [Fact]
+        public void StartFeaturesThrowExceptionsCollectedInAggregateException()
+        {
+            Assert.Throws(typeof(AggregateException), () =>
+            {
+                this.feature.Setup(f => f.Start())
+                    .Throws(new ArgumentNullException());
+                this.feature2.Setup(f => f.Start())
+                    .Throws(new ArgumentNullException());
 
-				this.executor.Start();
-			});
-		}
+                this.executor.Start();
+            });
+        }
 
-		[Fact]
-		public void StopCallsStopOnEachFeatureRegisterdWithFullNode()
-		{
-			this.executor.Stop();
+        [Fact]
+        public void StopCallsStopOnEachFeatureRegisterdWithFullNode()
+        {
+            this.executor.Stop();
 
-			this.feature.Verify(f => f.Stop(), Times.Exactly(1));
-			this.feature2.Verify(f => f.Stop(), Times.Exactly(1));
-		}
+            this.feature.Verify(f => f.Stop(), Times.Exactly(1));
+            this.feature2.Verify(f => f.Stop(), Times.Exactly(1));
+        }
 
-		[Fact]
-		public void StopFeaturesThrowExceptionsCollectedInAggregateException()
-		{
-			Assert.Throws(typeof(AggregateException), () =>
-			{
-				this.feature.Setup(f => f.Stop())
-					.Throws(new ArgumentNullException());
-				this.feature2.Setup(f => f.Stop())
-					.Throws(new ArgumentNullException());
+        [Fact]
+        public void StopFeaturesThrowExceptionsCollectedInAggregateException()
+        {
+            Assert.Throws(typeof(AggregateException), () =>
+            {
+                this.feature.Setup(f => f.Stop())
+                    .Throws(new ArgumentNullException());
+                this.feature2.Setup(f => f.Stop())
+                    .Throws(new ArgumentNullException());
 
-				this.executor.Stop();
-			});
-		}
-	}
+                this.executor.Stop();
+            });
+        }
+
+        /// <summary>
+        /// Test executor throws an exception from a missing feature dependency.
+        /// </summary>
+        [Fact]
+        public void TestMissingDependencyThrowsException()
+        {
+            Assert.Throws<AggregateException>(() => this.MissingFeatureExecutor.Start());
+        }
+    }
 }

--- a/Stratis.Bitcoin.Tests/Builder/FullNodeServiceProviderTest.cs
+++ b/Stratis.Bitcoin.Tests/Builder/FullNodeServiceProviderTest.cs
@@ -4,81 +4,96 @@ using Stratis.Bitcoin.Builder.Feature;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Tasks;
 using Xunit;
 
 namespace Stratis.Bitcoin.Tests.Builder
 {
-	public class FullNodeServiceProviderTest
-	{
-		private Mock<IServiceProvider> serviceProvider;
+    public class FullNodeServiceProviderTest
+    {
+        private Mock<IServiceProvider> serviceProvider;
 
-		public FullNodeServiceProviderTest()
-		{
-			this.serviceProvider = new Mock<IServiceProvider>();
-			this.serviceProvider.Setup(c => c.GetService(typeof(TestFeatureStub)))
-				.Returns(new TestFeatureStub());
-			this.serviceProvider.Setup(c => c.GetService(typeof(TestFeatureStub2)))
-				.Returns(new TestFeatureStub2());
-		}
+        public FullNodeServiceProviderTest()
+        {
+            this.serviceProvider = new Mock<IServiceProvider>();
+            this.serviceProvider.Setup(c => c.GetService(typeof(TestFeatureStub)))
+                .Returns(new TestFeatureStub());
+            this.serviceProvider.Setup(c => c.GetService(typeof(TestFeatureStub2)))
+                .Returns(new TestFeatureStub2());
+        }
 
-		[Fact]
-		public void FeaturesReturnsFullNodeFeaturesFromServiceProvider()
-		{
-			var types = new List<Type> {
-				typeof(TestFeatureStub),
-				typeof(TestFeatureStub2)
-			};
+        [Fact]
+        public void FeaturesReturnsFullNodeFeaturesFromServiceProvider()
+        {
+            var types = new List<Type> {
+                typeof(TestFeatureStub),
+                typeof(TestFeatureStub2)
+            };
 
-			var fullnodeServiceProvider = new FullNodeServiceProvider(this.serviceProvider.Object, types);
-			var result = fullnodeServiceProvider.Features.ToList();
+            var fullnodeServiceProvider = new FullNodeServiceProvider(this.serviceProvider.Object, types);
+            var result = fullnodeServiceProvider.Features.ToList();
 
-			Assert.Equal(2, result.Count);			
-			Assert.Equal(typeof(TestFeatureStub), result[0].GetType());
-			Assert.Equal(typeof(TestFeatureStub2), result[1].GetType());
-		}
+            Assert.Equal(2, result.Count);			
+            Assert.Equal(typeof(TestFeatureStub), result[0].GetType());
+            Assert.Equal(typeof(TestFeatureStub2), result[1].GetType());
+        }
 
-		[Fact]
-		public void FeaturesReturnsInGivenOrder()
-		{
-			var types = new List<Type> {
-				typeof(TestFeatureStub2),
-				typeof(TestFeatureStub)
+        [Fact]
+        public void FeaturesReturnsInGivenOrder()
+        {
+            var types = new List<Type> {
+                typeof(TestFeatureStub2),
+                typeof(TestFeatureStub)
 
-			};
+            };
 
-			var fullnodeServiceProvider = new FullNodeServiceProvider(this.serviceProvider.Object, types);
-			var result = fullnodeServiceProvider.Features.ToList();
+            var fullnodeServiceProvider = new FullNodeServiceProvider(this.serviceProvider.Object, types);
+            var result = fullnodeServiceProvider.Features.ToList();
 
-			Assert.Equal(2, result.Count);
-			Assert.Equal(typeof(TestFeatureStub2), result[0].GetType());
-			Assert.Equal(typeof(TestFeatureStub), result[1].GetType());
-		}
+            Assert.Equal(2, result.Count);
+            Assert.Equal(typeof(TestFeatureStub2), result[0].GetType());
+            Assert.Equal(typeof(TestFeatureStub), result[1].GetType());
+        }
 
-		private class TestFeatureStub : IFullNodeFeature
-		{
-			public void Start()
-			{
-				throw new NotImplementedException();
-			}
+        private class TestFeatureStub : IFullNodeFeature
+        {
+            /// <inheritdoc />
+            public void Start()
+            {
+                throw new NotImplementedException();
+            }
 
-			public void Stop()
-			{
-				throw new NotImplementedException();
-			}
-		}
+            /// <inheritdoc />
+            public void Stop()
+            {
+                throw new NotImplementedException();
+            }
 
-		private class TestFeatureStub2 : IFullNodeFeature
-		{
-			public void Start()
-			{
-				throw new NotImplementedException();
-			}
+            /// <inheritdoc />
+            public void ValidateDependencies(IEnumerable<IFullNodeFeature> features)
+            {
+                throw new NotImplementedException();
+            }
+        }
 
-			public void Stop()
-			{
-				throw new NotImplementedException();
-			}
-		}
-	}
+        private class TestFeatureStub2 : IFullNodeFeature
+        {
+            /// <inheritdoc />
+            public void Start()
+            {
+                throw new NotImplementedException();
+            }
+
+            /// <inheritdoc />
+            public void Stop()
+            {
+                throw new NotImplementedException();
+            }
+
+            /// <inheritdoc />
+            public void ValidateDependencies(IEnumerable<IFullNodeFeature> features)
+            {
+                throw new NotImplementedException();
+            }
+        }
+    }
 }

--- a/Stratis.Bitcoin/Builder/Feature/FeaturesExtensions.cs
+++ b/Stratis.Bitcoin/Builder/Feature/FeaturesExtensions.cs
@@ -9,15 +9,15 @@ namespace Stratis.Bitcoin.Builder.Feature
     public static class FeaturesExtensions
     {
         /// <summary>
-        /// Ensures a dependency feature type is present in the feature registration.
+        /// Ensures a dependency feature type is present in the feature list.
         /// </summary>
         /// <typeparam name="T">The dependency feature type.</typeparam>
-        /// <param name="features">List of feature registrations.</param>
-        /// <returns>List of feature registrations.</returns>
+        /// <param name="features">List of features.</param>
+        /// <returns>List of features.</returns>
         /// <exception cref="MissingDependencyException">Thrown if feature type is missing.</exception>
         public static IEnumerable<IFullNodeFeature> EnsureFeature<T>(this IEnumerable<IFullNodeFeature> features)
         {
-            if (!features.Any(i => i.GetType() == typeof(T)))
+            if (!features.OfType<T>().Any())
             {
                 throw new MissingDependencyException($"Dependency feature {typeof(T)} cannot be found.");
             }

--- a/Stratis.Bitcoin/Builder/Feature/FeaturesExtensions.cs
+++ b/Stratis.Bitcoin/Builder/Feature/FeaturesExtensions.cs
@@ -1,0 +1,28 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace Stratis.Bitcoin.Builder.Feature
+{
+    /// <summary>
+    /// Extensions to features collection.
+    /// </summary>
+    public static class FeaturesExtensions
+    {
+        /// <summary>
+        /// Ensures a dependency feature type is present in the feature registration.
+        /// </summary>
+        /// <typeparam name="T">The dependency feature type.</typeparam>
+        /// <param name="features">List of feature registrations.</param>
+        /// <returns>List of feature registrations.</returns>
+        /// <exception cref="MissingDependencyException">Thrown if feature type is missing.</exception>
+        public static IEnumerable<IFullNodeFeature> EnsureFeature<T>(this IEnumerable<IFullNodeFeature> features)
+        {
+            if (!features.Any(i => i.GetType() == typeof(T)))
+            {
+                throw new MissingDependencyException($"Dependency feature {typeof(T)} cannot be found.");
+            }
+
+            return features;
+        }
+    }
+}

--- a/Stratis.Bitcoin/Builder/Feature/FullNodeFeature.cs
+++ b/Stratis.Bitcoin/Builder/Feature/FullNodeFeature.cs
@@ -1,4 +1,6 @@
-﻿namespace Stratis.Bitcoin.Builder.Feature
+﻿using System.Collections.Generic;
+
+namespace Stratis.Bitcoin.Builder.Feature
 {
     /// <summary>
     /// Defines methods for features that are managed by the FullNode.
@@ -15,8 +17,15 @@
         /// Requests may still be in flight. Shutdown will block until this event completes.
         /// </summary>
         void Stop();
-    }
 
+        /// <summary>
+        /// Validates the feature's dependencies are all present in feature collection. 
+        /// </summary>
+        /// <exception cref="MissingDependencyException">should be thrown if dependency is missing</exception>
+        /// <param name="features">feature collection from builder</param>      
+        void ValidateDependencies(IEnumerable<IFullNodeFeature> features);
+    }
+    
     /// <summary>
     /// A feature is used to extend functionality into the full node.
     /// It can manage its life time or use the full node disposable resources.
@@ -34,6 +43,11 @@
 
         /// <inheritdoc />
         public virtual void Stop()
+        {
+        }
+
+        /// <inheritdoc />
+        public virtual void ValidateDependencies(IEnumerable<IFullNodeFeature> features)
         {
         }
     }

--- a/Stratis.Bitcoin/Builder/Feature/MissingDependencyException.cs
+++ b/Stratis.Bitcoin/Builder/Feature/MissingDependencyException.cs
@@ -1,0 +1,28 @@
+﻿using System;
+
+namespace Stratis.Bitcoin.Builder.Feature
+{
+    /// <summary>
+    /// Exception thrown when feature dependencies are missing.
+    /// </summary>
+    public class MissingDependencyException : Exception
+    {
+        /// <inheritdoc />
+        public MissingDependencyException() 
+            : base()
+        {
+        }
+
+        /// <inheritdoc />
+        public MissingDependencyException(string message) 
+            : base(message)
+        {
+        }
+
+        /// <inheritdoc />
+        public MissingDependencyException(string message, Exception innerException) 
+            : base(message, innerException)
+        {
+        }
+    }
+}

--- a/Stratis.Bitcoin/Builder/FullNodeFeatureExecutor.cs
+++ b/Stratis.Bitcoin/Builder/FullNodeFeatureExecutor.cs
@@ -1,8 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
-using Microsoft.Extensions.Logging;
+﻿using Microsoft.Extensions.Logging;
 using Stratis.Bitcoin.Builder.Feature;
 using Stratis.Bitcoin.Utilities;
+using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Stratis.Bitcoin.Builder
 {
@@ -52,6 +53,7 @@ namespace Stratis.Bitcoin.Builder
         {
             try
             {
+                this.Execute(service => service.ValidateDependencies(this.node.Services.Features.ToList()));
                 this.Execute(service => service.Start());
             }
             catch (Exception ex)

--- a/Stratis.Bitcoin/Features/Miner/MiningFeature.cs
+++ b/Stratis.Bitcoin/Features/Miner/MiningFeature.cs
@@ -1,56 +1,66 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using Stratis.Bitcoin.Builder;
 using Stratis.Bitcoin.Builder.Feature;
+using Stratis.Bitcoin.Features.Wallet;
+using System.Collections.Generic;
 
 namespace Stratis.Bitcoin.Features.Miner
 {
-	public class MiningFeature : FullNodeFeature
-	{		
-		public override void Start()
-		{
-		}
+    public class MiningFeature : FullNodeFeature
+    {
+        ///<inheritdoc />
+        public override void Start()
+        {
+        }
 
-		public override void Stop()
-		{
-		}
-	}
+        ///<inheritdoc />
+        public override void Stop()
+        {
+        }
+
+        ///<inheritdoc />
+        public override void ValidateDependencies(IEnumerable<IFullNodeFeature> features)
+        {
+            features.EnsureFeature<WalletFeature>();
+        }
+    }
 
     /// <summary>
     /// A class providing extension methods for <see cref="IFullNodeBuilder"/>.
     /// </summary>
     public static partial class IFullNodeBuilderExtensions
     {
-		public static IFullNodeBuilder AddMining(this IFullNodeBuilder fullNodeBuilder)
-		{
-			fullNodeBuilder.ConfigureFeature(features =>
-			{
-				features
-					.AddFeature<MiningFeature>()
-					.FeatureServices(services =>
-					{
-						services.AddSingleton<PowMining>();
-						services.AddSingleton<AssemblerFactory, PowAssemblerFactory>();
-					});
-			});
+        public static IFullNodeBuilder AddMining(this IFullNodeBuilder fullNodeBuilder)
+        {
+            fullNodeBuilder.ConfigureFeature(features =>
+            {
+                features
+                    .AddFeature<MiningFeature>()
+                    .FeatureServices(services =>
+                    {
+                        services.AddSingleton<PowMining>();
+                        services.AddSingleton<AssemblerFactory, PowAssemblerFactory>();
+                    });
+            });
 
-			return fullNodeBuilder;
-		}
+            return fullNodeBuilder;
+        }
 
-		public static IFullNodeBuilder AddPowPosMining(this IFullNodeBuilder fullNodeBuilder)
-		{
-			fullNodeBuilder.ConfigureFeature(features =>
-			{
-				features
-					.AddFeature<MiningFeature>()
-					.FeatureServices(services =>
-					{
-						services.AddSingleton<PowMining>();
-						services.AddSingleton<PosMinting>();
-						services.AddSingleton<AssemblerFactory, PosAssemblerFactory>();
-					});
-			});
+        public static IFullNodeBuilder AddPowPosMining(this IFullNodeBuilder fullNodeBuilder)
+        {
+            fullNodeBuilder.ConfigureFeature(features =>
+            {
+                features
+                    .AddFeature<MiningFeature>()
+                    .FeatureServices(services =>
+                    {
+                        services.AddSingleton<PowMining>();
+                        services.AddSingleton<PosMinting>();
+                        services.AddSingleton<AssemblerFactory, PosAssemblerFactory>();
+                    });
+            });
 
-			return fullNodeBuilder;
-		}
-	}
+            return fullNodeBuilder;
+        }
+    }
 }

--- a/Stratis.Bitcoin/Features/RPC/RPCFeature.cs
+++ b/Stratis.Bitcoin/Features/RPC/RPCFeature.cs
@@ -45,17 +45,7 @@ namespace Stratis.Bitcoin.Features.RPC
                         // also copies over singleton instances already defined
                         foreach (var service in this.fullNodeBuilder.Services)
                         {
-                            object obj = null;
-
-                            try
-                            {
-                                obj = this.fullNode.Services.ServiceProvider.GetService(service.ServiceType);
-                            }
-                            catch (InvalidOperationException)
-                            {
-                                this.logger.LogWarning("Unable to copy service {service} from Full Node to RPC. Service injection skipped.", service.ServiceType.ToString());
-                                obj = null;
-                            }
+                            object obj = this.fullNode.Services.ServiceProvider.GetService(service.ServiceType);
 
                             if (obj != null && service.Lifetime == ServiceLifetime.Singleton && service.ImplementationInstance == null)
                             {

--- a/Stratis.Bitcoin/Features/RPC/RPCFeature.cs
+++ b/Stratis.Bitcoin/Features/RPC/RPCFeature.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Microsoft.AspNetCore.Hosting;
+﻿using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Stratis.Bitcoin.Builder;
@@ -7,6 +6,7 @@ using Stratis.Bitcoin.Builder.Feature;
 using Stratis.Bitcoin.Configuration;
 using Stratis.Bitcoin.Features.RPC.Controllers;
 using Stratis.Bitcoin.Utilities;
+using System;
 
 namespace Stratis.Bitcoin.Features.RPC
 {
@@ -45,7 +45,18 @@ namespace Stratis.Bitcoin.Features.RPC
                         // also copies over singleton instances already defined
                         foreach (var service in this.fullNodeBuilder.Services)
                         {
-                            var obj = this.fullNode.Services.ServiceProvider.GetService(service.ServiceType);
+                            object obj = null;
+
+                            try
+                            {
+                                obj = this.fullNode.Services.ServiceProvider.GetService(service.ServiceType);
+                            }
+                            catch (InvalidOperationException)
+                            {
+                                this.logger.LogWarning("Unable to copy service {service} from Full Node to RPC. Service injection skipped.", service.ServiceType.ToString());
+                                obj = null;
+                            }
+
                             if (obj != null && service.Lifetime == ServiceLifetime.Singleton && service.ImplementationInstance == null)
                             {
                                 collection.AddSingleton(service.ServiceType, obj);

--- a/Stratis.StratisD/Program.cs
+++ b/Stratis.StratisD/Program.cs
@@ -8,6 +8,7 @@ using Stratis.Bitcoin.Features.BlockStore;
 using Stratis.Bitcoin.Features.Consensus;
 using Stratis.Bitcoin.Features.MemoryPool;
 using Stratis.Bitcoin.Features.Miner;
+using Stratis.Bitcoin.Features.Wallet;
 using Stratis.Bitcoin.Utilities;
 using System;
 using System.Linq;
@@ -32,6 +33,7 @@ namespace Stratis.StratisD
                 .UseStratisConsensus()
                 .UseBlockStore()
                 .UseMempool()
+                .UseWallet()
                 .AddPowPosMining()
                 .Build();
 


### PR DESCRIPTION
Add a hook for a dependency check when running node feature executor. Throw exception if a feature's dependency is missing.

Fix for issue #285 