### PR TITLE
Bugfix/issue 275 compiler warnings

### DIFF
--- a/Stratis.Bitcoin.IntegrationTests/BlockStoreTests.cs
+++ b/Stratis.Bitcoin.IntegrationTests/BlockStoreTests.cs
@@ -15,9 +15,7 @@ namespace Stratis.Bitcoin.IntegrationTests
 {
     public class BlockStoreTests
     {
-
-		// [Fact]
-		public void BlockRepositoryBench()
+		private void BlockRepositoryBench()
 		{
 			using (var dir = TestDirectory.Create())
 			{

--- a/Stratis.Bitcoin.IntegrationTests/MinerTests.cs
+++ b/Stratis.Bitcoin.IntegrationTests/MinerTests.cs
@@ -563,7 +563,7 @@ namespace Stratis.Bitcoin.IntegrationTests
 		}
 
 		//NOTE: These tests rely on CreateNewBlock doing its own self-validation!
-		public void MinerCreateNewBlockValidity()
+		private void MinerCreateNewBlockValidity()
 		{
 			//TODO: fix this test
 			// orphan in mempool, template creation fails

--- a/Stratis.Bitcoin.IntegrationTests/UtilTests.cs
+++ b/Stratis.Bitcoin.IntegrationTests/UtilTests.cs
@@ -36,12 +36,13 @@ namespace Stratis.Bitcoin.IntegrationTests
 				{
 					collector.Add(1);
 					// push another exclusive task to the scheduler
-					session.WriteAsync(() => collector.Add(2));
+					Task exclusiveTask = session.WriteAsync(() => collector.Add(2));
 					// await a concurrent task, this will split the current method in two tasks
 					// the pushed exclusive task will processes before the await yields back control
 				    await session.ReadAsync(() =>  collector.Add(3));
 					collector.Add(4);
-				});
+                    await exclusiveTask;
+                });
 
 			});
 

--- a/Stratis.Bitcoin/Features/Consensus/ConsensusStats.cs
+++ b/Stratis.Bitcoin/Features/Consensus/ConsensusStats.cs
@@ -12,7 +12,6 @@ namespace Stratis.Bitcoin.Features.Consensus
 {
     public class ConsensusStats
     {
-        private CoinViewStack stack;
         private CachedCoinView cache;
         private DBreezeCoinView dbreeze;
         private CoinView bottom;

--- a/Stratis.Bitcoin/Features/Miner/PosMinting.cs
+++ b/Stratis.Bitcoin/Features/Miner/PosMinting.cs
@@ -44,7 +44,6 @@ namespace Stratis.Bitcoin.Features.Miner
 		private readonly PosConsensusValidator posConsensusValidator;
 	    private readonly ILogger logger;
 
-        private uint256 hashPrevBlock;
 		private Task mining;
 		private readonly long lastCoinStakeSearchTime;
 		private Money reserveBalance;

--- a/Stratis.Bitcoin/Features/RPC/RPCRouteHandler.cs
+++ b/Stratis.Bitcoin/Features/RPC/RPCRouteHandler.cs
@@ -17,8 +17,6 @@ namespace Stratis.Bitcoin.Features.RPC
 
 	public class RPCRouteHandler : IRPCRouteHandler
 	{
-		private Dictionary<string, string> contollerMapping;
-
 		private IRouter inner;
 		private IActionDescriptorCollectionProvider actionDescriptor;
 


### PR DESCRIPTION
Just getting rid of compiler warnings. Not everything is cleaned up, some code is just prevented to produce warning, but removing some of the code might be beneficial in the future.

Fix #275