### PR TITLE
WalletManager refactoring part 1

### DIFF
--- a/Stratis.Bitcoin.Tests/Wallet/HdAccountTest.cs
+++ b/Stratis.Bitcoin.Tests/Wallet/HdAccountTest.cs
@@ -1,8 +1,7 @@
-﻿using NBitcoin;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
+using NBitcoin;
 using Stratis.Bitcoin.Features.Wallet;
 using Xunit;
 
@@ -22,9 +21,9 @@ namespace Stratis.Bitcoin.Tests.Wallet
         }
 
         [Fact]
-        public void GetCoinTypeWithInvalidHdPathThrowsException()
+        public void GetCoinTypeWithInvalidHdPathThrowsFormatException()
         {
-            Assert.Throws<InvalidOperationException>(() =>
+            Assert.Throws<FormatException>(() =>
             {
                 var account = new HdAccount();
                 account.HdPath = "1/";
@@ -34,9 +33,9 @@ namespace Stratis.Bitcoin.Tests.Wallet
         }
 
         [Fact]
-        public void GetCoinTypeWithoutHdPathThrowsException()
+        public void GetCoinTypeWithoutHdPathThrowsArgumentNullException()
         {
-            Assert.Throws<InvalidOperationException>(() =>
+            Assert.Throws<ArgumentNullException> (() =>
             {
                 var account = new HdAccount();
                 account.HdPath = null;
@@ -46,9 +45,9 @@ namespace Stratis.Bitcoin.Tests.Wallet
         }
 
         [Fact]
-        public void GetCoinTypeWithEmptyHdPathThrowsException()
+        public void GetCoinTypeWithEmptyHdPathThrowsArgumentException()
         {
-            Assert.Throws<InvalidOperationException>(() =>
+            Assert.Throws<ArgumentException> (() =>
             {
                 var account = new HdAccount();
                 account.HdPath = string.Empty;

--- a/Stratis.Bitcoin.Tests/Wallet/HdAddressTest.cs
+++ b/Stratis.Bitcoin.Tests/Wallet/HdAddressTest.cs
@@ -1,8 +1,7 @@
-﻿using NBitcoin;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
+using NBitcoin;
 using Stratis.Bitcoin.Features.Wallet;
 using Xunit;
 
@@ -50,9 +49,9 @@ namespace Stratis.Bitcoin.Tests.Wallet
         }
 
         [Fact]
-        public void IsChangeAddressWithInvalidHdPathThrowsInvalidOperationException()
+        public void IsChangeAddressWithInvalidHdPathThrowsFormatException()
         {
-            Assert.Throws<InvalidOperationException>(() =>
+            Assert.Throws<FormatException>(() =>
             {
                 var address = new HdAddress()
                 {
@@ -64,9 +63,9 @@ namespace Stratis.Bitcoin.Tests.Wallet
         }
 
         [Fact]
-        public void IsChangeAddressWithEmptyHdPathThrowsInvalidOperationException()
+        public void IsChangeAddressWithEmptyHdPathThrowsArgumentException()
         {
-            Assert.Throws<InvalidOperationException>(() =>
+            Assert.Throws<ArgumentException> (() =>
             {
                 var address = new HdAddress()
                 {
@@ -78,9 +77,9 @@ namespace Stratis.Bitcoin.Tests.Wallet
         }
 
         [Fact]
-        public void IsChangeAddressWithNulledHdPathThrowsInvalidOperationException()
+        public void IsChangeAddressWithNulledHdPathThrowsArgumentNullException()
         {
-            Assert.Throws<InvalidOperationException>(() =>
+            Assert.Throws<ArgumentNullException>(() =>
             {
                 var address = new HdAddress()
                 {

--- a/Stratis.Bitcoin.Tests/Wallet/WalletManagerTest.cs
+++ b/Stratis.Bitcoin.Tests/Wallet/WalletManagerTest.cs
@@ -2787,7 +2787,7 @@ namespace Stratis.Bitcoin.Tests.Wallet
         [Fact]
         public void CreateBip44PathWithChangeAddressReturnsPath()
         {
-            var result = WalletManager.CreateBip44Path(CoinType.Stratis, 4, 3, true);
+            var result = HdOperations.CreateHdPath((int)CoinType.Stratis, 4, 3, true);
 
             Assert.Equal("m/44'/105'/4'/1/3", result);
         }
@@ -2795,7 +2795,7 @@ namespace Stratis.Bitcoin.Tests.Wallet
         [Fact]
         public void CreateBip44PathWithoutChangeAddressReturnsPath()
         {
-            var result = WalletManager.CreateBip44Path(CoinType.Stratis, 4, 3, false);
+            var result = HdOperations.CreateHdPath((int)CoinType.Stratis, 4, 3, false);
 
             Assert.Equal("m/44'/105'/4'/0/3", result);
         }

--- a/Stratis.Bitcoin.Tests/Wallet/WalletManagerTest.cs
+++ b/Stratis.Bitcoin.Tests/Wallet/WalletManagerTest.cs
@@ -652,12 +652,13 @@ namespace Stratis.Bitcoin.Tests.Wallet
         {
             var dataFolder = AssureEmptyDirAsDataFolder("TestData/WalletManagerTest/GetUnusedAccountUsingWalletNameWithoutUnusedAccountsCreatesAccountAndSavesWallet");
 
-            var walletManager = new WalletManager(this.LoggerFactory.Object, It.IsAny<ConnectionManager>(), Network.Main, new Mock<ConcurrentChain>().Object, NodeSettings.Default(),
+            var network = Network.Main;
+            var walletManager = new WalletManager(this.LoggerFactory.Object, It.IsAny<ConnectionManager>(), network, new Mock<ConcurrentChain>().Object, NodeSettings.Default(),
               dataFolder, new Mock<IWalletFeePolicy>().Object, new Mock<IAsyncLoopFactory>().Object, new NodeLifetime());
             var wallet = WalletTestsHelpers.GenerateBlankWallet("testWallet", "password");
             wallet.AccountsRoot.ElementAt(0).Accounts.Clear();
 
-            var result = walletManager.CreateNewAccount(wallet, "password");
+            var result = wallet.AddNewAccount("password", (CoinType)network.Consensus.CoinType);
 
             Assert.Equal(1, wallet.AccountsRoot.ElementAt(0).Accounts.Count);
             var extKey = new ExtKey(Key.Parse(wallet.EncryptedSeed, "password", wallet.Network), wallet.ChainCode);
@@ -675,12 +676,13 @@ namespace Stratis.Bitcoin.Tests.Wallet
         {
             var dataFolder = AssureEmptyDirAsDataFolder("TestData/WalletManagerTest/GetUnusedAccountUsingWalletNameWithoutUnusedAccountsCreatesAccountAndSavesWallet");
 
-            var walletManager = new WalletManager(this.LoggerFactory.Object, It.IsAny<ConnectionManager>(), Network.Main, new Mock<ConcurrentChain>().Object, NodeSettings.Default(),
+            var network = Network.Main;
+            var walletManager = new WalletManager(this.LoggerFactory.Object, It.IsAny<ConnectionManager>(), network, new Mock<ConcurrentChain>().Object, NodeSettings.Default(),
               dataFolder, new Mock<IWalletFeePolicy>().Object, new Mock<IAsyncLoopFactory>().Object, new NodeLifetime());
             var wallet = WalletTestsHelpers.GenerateBlankWallet("testWallet", "password");
             wallet.AccountsRoot.ElementAt(0).Accounts.Add(new HdAccount() { Name = "unused" });
 
-            var result = walletManager.CreateNewAccount(wallet, "password");
+            var result = wallet.AddNewAccount("password", (CoinType)network.Consensus.CoinType);
 
             Assert.Equal(2, wallet.AccountsRoot.ElementAt(0).Accounts.Count);
             var extKey = new ExtKey(Key.Parse(wallet.EncryptedSeed, "password", wallet.Network), wallet.ChainCode);

--- a/Stratis.Bitcoin/Features/Wallet/HdOperations.cs
+++ b/Stratis.Bitcoin/Features/Wallet/HdOperations.cs
@@ -1,0 +1,211 @@
+﻿using System;
+using NBitcoin;
+using Stratis.Bitcoin.Utilities;
+
+namespace Stratis.Bitcoin.Features.Wallet
+{
+    /// <summary>
+    /// Class providing helper methods for working with Hierarchical Deterministic (HD) wallets.
+    /// </summary>
+    /// <seealso cref="https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki" />
+    public class HdOperations
+    {
+        /// <summary>
+        /// Generates an HD public key derived from an extended public key.
+        /// </summary>
+        /// <param name="accountExtPubKey">The extended public key used to generate child keys.</param>
+        /// <param name="index">The index of the child key to generate.</param>
+        /// <param name="isChange">A value indicating whether the public key to generate corresponds to a change address.</param>
+        /// <returns>
+        /// An HD public key derived from an extended public key.
+        /// </returns>
+        public static PubKey GeneratePublicKey(string accountExtPubKey, int index, bool isChange)
+        {
+            Guard.NotEmpty(accountExtPubKey, nameof(accountExtPubKey));
+
+            int change = isChange ? 1 : 0;
+            KeyPath keyPath = new KeyPath($"{change}/{index}");
+            ExtPubKey extPubKey = ExtPubKey.Parse(accountExtPubKey).Derive(keyPath);
+            return extPubKey.PubKey;
+        }
+
+        /// <summary>
+        /// Gets the extended private key for an account.
+        /// </summary>
+        /// <param name="privateKey">The private key from which to generate the extended private key.</param>
+        /// <param name="chainCode">The chain code used in creating the extended private key.</param>
+        /// <param name="hdPath">The HD path of the account for which to get the extended private key.</param>
+        /// <param name="network">The network for which to generate this extended private key.</param>
+        /// <returns></returns>
+        public static ISecret GetExtendedPrivateKey(Key privateKey, byte[] chainCode, string hdPath, Network network)
+        {
+            Guard.NotNull(privateKey, nameof(privateKey));
+            Guard.NotNull(chainCode, nameof(chainCode));
+            Guard.NotEmpty(hdPath, nameof(hdPath));
+            Guard.NotNull(network, nameof(network));
+
+            // Get the extended key.
+            ExtKey seedExtKey = new ExtKey(privateKey, chainCode);
+            ExtKey addressExtKey = seedExtKey.Derive(new KeyPath(hdPath));
+            BitcoinExtKey addressPrivateKey = addressExtKey.GetWif(network);
+            return addressPrivateKey;
+        }
+
+        /// <summary>
+        /// Gets the extended public key for an account.
+        /// </summary>
+        /// <param name="privateKey">The private key from which to generate the extended public key.</param>
+        /// <param name="chainCode">The chain code used in creating the extended public key.</param>
+        /// <param name="coinType">Type of the coin of the account for which to generate an extended public key.</param>
+        /// <param name="accountIndex">Index of the account for which to generate an extended public key.</param>
+        /// <returns>The extended public key for an account, used to derive child keys.</returns>
+        public static ExtPubKey GetExtendedPublicKey(Key privateKey, byte[] chainCode, int coinType, int accountIndex)
+        {
+            Guard.NotNull(privateKey, nameof(privateKey));
+            Guard.NotNull(chainCode, nameof(chainCode));
+
+            var accountHdPath = GetAccountHdPath(coinType, accountIndex);
+            return GetExtendedPublicKey(privateKey, chainCode, accountHdPath);
+        }
+
+        /// <summary>
+        /// Gets the extended public key for an account.
+        /// </summary>
+        /// <param name="privateKey">The private key from which to generate the extended public key.</param>
+        /// <param name="chainCode">The chain code used in creating the extended public key.</param>
+        /// <param name="hdPath">The HD path of the account for which to get the extended public key.</param>
+        /// <returns>The extended public key for an account, used to derive child keys.</returns>
+        public static ExtPubKey GetExtendedPublicKey(Key privateKey, byte[] chainCode, string hdPath)
+        {
+            Guard.NotNull(privateKey, nameof(privateKey));
+            Guard.NotNull(chainCode, nameof(chainCode));
+            Guard.NotEmpty(hdPath, nameof(hdPath));
+
+            // get extended private key
+            ExtKey seedExtKey = new ExtKey(privateKey, chainCode);
+            ExtKey addressExtKey = seedExtKey.Derive(new KeyPath(hdPath));
+            ExtPubKey accountExtPubKey = addressExtKey.Neuter();
+            return accountExtPubKey;
+        }
+
+        /// <summary>
+        /// Gets the HD path of an account.
+        /// </summary>
+        /// <param name="coinType">Type of the coin this account is in.</param>
+        /// <param name="accountIndex">Index of the account.</param>
+        /// <returns>The HD path of an account.</returns>
+        public static string GetAccountHdPath(int coinType, int accountIndex)
+        {
+            return $"m/44'/{coinType}'/{accountIndex}'";
+        }
+
+        /// <summary>
+        /// Gets the HD private key generated by this mnemonic and passphrase.
+        /// </summary>
+        /// <param name="mnemonic">The mnemonic used to generate the key.</param>
+        /// <param name="passphrase">The passphrase used in generating the key.</param>
+        /// <returns>The HD private key generated by this mnemonic and passphrase.</returns>
+        /// <remarks>This key is sometimes referred to as the 'root seed' or the 'master key'.</remarks>
+        public static ExtKey GetHdPrivateKey(string mnemonic, string passphrase)
+        {
+            Guard.NotEmpty(mnemonic, nameof(mnemonic));
+            Guard.NotEmpty(passphrase, nameof(passphrase));
+
+            return GetHdPrivateKey(new Mnemonic(mnemonic), passphrase);
+        }
+
+        /// <summary>
+        /// Gets the HD private key generated by this mnemonic and passphrase.
+        /// </summary>
+        /// <param name="mnemonic">The mnemonic used to generate the key.</param>
+        /// <param name="passphrase">The passphrase used in generating the key.</param>
+        /// <returns>The HD private key generated by this mnemonic and passphrase.</returns>
+        /// <remarks>This key is sometimes referred to as the 'root seed' or the 'master key'.</remarks>
+        public static ExtKey GetHdPrivateKey(Mnemonic mnemonic, string passphrase)
+        {
+            Guard.NotNull(mnemonic, nameof(mnemonic));
+            Guard.NotEmpty(passphrase, nameof(passphrase));
+
+            return mnemonic.DeriveExtKey(passphrase);
+        }
+
+        /// <summary>
+        /// Creates an address' HD path, according to BIP 44.
+        /// </summary>
+        /// <param name="coinType">Type of coin in the HD path.</param>
+        /// <param name="accountIndex">Index of the account in the HD path.</param>
+        /// <param name="addressIndex">Index of the address in the HD path.</param>
+        /// <param name="isChange">A value indicating whether the HD path to generate corresponds to a change address.</param>
+        /// <returns>The HD path.</returns>
+        /// <remarks>Refer to <seealso cref="https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki#path-levels"/> for the format of the HD path.</remarks>
+        public static string CreateHdPath(int coinType, int accountIndex, int addressIndex, bool isChange = false)
+        {
+            int change = isChange ? 1 : 0;
+            return $"m/44'/{coinType}'/{accountIndex}'/{change}/{addressIndex}";
+        }
+
+        /// <summary>
+        /// Gets the type of coin this HD path is for.
+        /// </summary>
+        /// <param name="hdPath">The HD path.</param>
+        /// <returns>The type of coin. <seealso cref="https://github.com/satoshilabs/slips/blob/master/slip-0044.md"/>.</returns>        
+        /// <exception cref="FormatException">An exception is thrown if the HD path is not well-formed.</exception>
+        /// <remarks>Refer to <seealso cref="https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki#path-levels"/> for the format of the HD path.</remarks>
+        public static int GetCoinType(string hdPath)
+        {
+            Guard.NotEmpty(hdPath, nameof(hdPath));
+
+            string[] pathElements = hdPath.Split('/');
+            if (pathElements.Length < 3)
+                throw new FormatException($"Could not parse CoinType from HdPath {hdPath}.");
+
+            var coinType = 0;
+            if (int.TryParse(pathElements[2].Replace("'", string.Empty), out coinType))
+            {
+                return coinType;
+            }
+
+            throw new FormatException($"Could not parse CoinType from HdPath {hdPath}.");
+        }
+
+        /// <summary>
+        /// Determines whether the HD path corresponds to a change address.
+        /// </summary>
+        /// <param name="hdPath">The HD path.</param>
+        /// <returns>A value indicating if the HD path corresponds to a change address.</returns>
+        /// <exception cref="FormatException">An exception is thrown if the HD path is not well-formed.</exception>
+        /// <remarks>Refer to <seealso cref="https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki#path-levels"/> for the format of the HD path.</remarks>
+        public static bool IsChangeAddress(string hdPath)
+        {
+            Guard.NotEmpty(hdPath, nameof(hdPath));
+
+            var hdPathParts = hdPath.Split('/');
+            if (hdPathParts.Length < 5)
+                throw new FormatException($"Could not parse value from HdPath {hdPath}.");
+
+            int result = 0;
+            if (int.TryParse(hdPathParts[4], out result))
+            {
+                return result == 1;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Decrypts the encrypted private key (seed).
+        /// </summary>
+        /// <param name="encryptedSeed">The encrypted seed to decrypt.</param>
+        /// <param name="password">The password used to decrypt the encrypted seed.</param>
+        /// <param name="network">The network this seed applies to.</param>
+        /// <returns></returns>
+        public static Key DecryptSeed(string encryptedSeed, string password, Network network)
+        {
+            Guard.NotEmpty(encryptedSeed, nameof(encryptedSeed));
+            Guard.NotEmpty(password, nameof(password));
+            Guard.NotNull(network, nameof(network));
+
+            return Key.Parse(encryptedSeed, password, network);
+        }
+    }
+}

--- a/Stratis.Bitcoin/Features/Wallet/HdOperations.cs
+++ b/Stratis.Bitcoin/Features/Wallet/HdOperations.cs
@@ -69,12 +69,12 @@ namespace Stratis.Bitcoin.Features.Wallet
         }
 
         /// <summary>
-        /// Gets the extended public key for an account.
+        /// Gets the extended public key corresponding to an HD path.
         /// </summary>
         /// <param name="privateKey">The private key from which to generate the extended public key.</param>
         /// <param name="chainCode">The chain code used in creating the extended public key.</param>
-        /// <param name="hdPath">The HD path of the account for which to get the extended public key.</param>
-        /// <returns>The extended public key for an account, used to derive child keys.</returns>
+        /// <param name="hdPath">The HD path for which to get the extended public key.</param>
+        /// <returns>The extended public key, used to derive child keys.</returns>
         public static ExtPubKey GetExtendedPublicKey(Key privateKey, byte[] chainCode, string hdPath)
         {
             Guard.NotNull(privateKey, nameof(privateKey));
@@ -84,8 +84,8 @@ namespace Stratis.Bitcoin.Features.Wallet
             // get extended private key
             ExtKey seedExtKey = new ExtKey(privateKey, chainCode);
             ExtKey addressExtKey = seedExtKey.Derive(new KeyPath(hdPath));
-            ExtPubKey accountExtPubKey = addressExtKey.Neuter();
-            return accountExtPubKey;
+            ExtPubKey extPubKey = addressExtKey.Neuter();
+            return extPubKey;
         }
 
         /// <summary>

--- a/Stratis.Bitcoin/Features/Wallet/IWalletManager.cs
+++ b/Stratis.Bitcoin/Features/Wallet/IWalletManager.cs
@@ -105,19 +105,7 @@ namespace Stratis.Bitcoin.Features.Wallet
         /// </remarks>
         /// <returns>An unused account.</returns>
         HdAccount GetUnusedAccount(Wallet wallet, string password);
-
-        /// <summary>
-        /// Creates a new account.
-        /// </summary>
-        /// <param name="wallet">The wallet in which this account will be created.</param>
-        /// <param name="password">The password used to decrypt the private key.</param>
-        /// <remarks>
-        /// According to BIP44, an account at index (i) can only be created when the account
-        /// at index (i - 1) contains transactions.
-        /// </remarks>
-        /// <returns>The new account.</returns>
-        HdAccount CreateNewAccount(Wallet wallet, string password);
-
+        
         /// <summary>
         /// Gets an address that contains no transaction.
         /// </summary>

--- a/Stratis.Bitcoin/Features/Wallet/Wallet.cs
+++ b/Stratis.Bitcoin/Features/Wallet/Wallet.cs
@@ -1,11 +1,11 @@
-﻿using NBitcoin;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using NBitcoin;
 using NBitcoin.JsonConverters;
 using Newtonsoft.Json;
 using Stratis.Bitcoin.Features.Wallet.JsonConverters;
 using Stratis.Bitcoin.Utilities;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 
 namespace Stratis.Bitcoin.Features.Wallet
 {
@@ -95,7 +95,7 @@ namespace Stratis.Bitcoin.Features.Wallet
         }
 
         /// <summary>
-        /// Gets all the pub keys conatined in this wallet.
+        /// Gets all the pub keys contained in this wallet.
         /// </summary>
         /// <param name="coinType">Type of the coin.</param>
         /// <returns></returns>
@@ -111,12 +111,14 @@ namespace Stratis.Bitcoin.Features.Wallet
         /// <summary>
         /// Adds an account to the current wallet.
         /// </summary>
-        /// <remarks>The name given to the account is of the form "account (i)" by default, where (i) is an incremental index starting at 0.
-        /// According to BIP44, an account at index (i) can only be created when the account at index (i - 1) contains at least one transaction.
-        /// <seealso cref="https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki"/></remarks>
+        /// <remarks>
+        /// The name given to the account is of the form "account (i)" by default, where (i) is an incremental index starting at 0.
+        /// According to BIP44, an account at index (i) can only be created when the account at index (i - 1) contains at least one transaction.        
+        /// </remarks>
+        /// <seealso cref="https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki"/>
         /// <param name="password">The password used to decrypt the wallet's <see cref="EncryptedSeed"/>.</param>
         /// <param name="coinType">The type of coin this account is for.</param>
-        /// <returns>A new hd account.</returns>
+        /// <returns>A new HD account.</returns>
         public HdAccount AddNewAccount(string password, CoinType coinType)
         {
             Guard.NotEmpty(password, nameof(password));
@@ -215,7 +217,7 @@ namespace Stratis.Bitcoin.Features.Wallet
             Guard.NotEmpty(encryptedSeed, nameof(encryptedSeed));
             Guard.NotNull(chainCode, nameof(chainCode));
 
-            // Get the accounts for this type of coin.
+            // Get the current collection of accounts.
             var accounts = this.Accounts.ToList();
 
             int newAccountIndex = 0;

--- a/Stratis.Bitcoin/Features/Wallet/WalletManager.cs
+++ b/Stratis.Bitcoin/Features/Wallet/WalletManager.cs
@@ -1,4 +1,10 @@
-﻿using Microsoft.Extensions.Logging;
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using NBitcoin;
 using NBitcoin.Protocol;
 using Newtonsoft.Json;
@@ -6,12 +12,6 @@ using Stratis.Bitcoin.Configuration;
 using Stratis.Bitcoin.Connection;
 using Stratis.Bitcoin.Features.MemoryPool;
 using Stratis.Bitcoin.Utilities;
-using System;
-using System.Collections.Concurrent;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Threading.Tasks;
 using Transaction = NBitcoin.Transaction;
 
 namespace Stratis.Bitcoin.Features.Wallet
@@ -136,7 +136,7 @@ namespace Stratis.Bitcoin.Features.Wallet
             Mnemonic mnemonic = string.IsNullOrEmpty(mnemonicList)
                 ? new Mnemonic(Wordlist.English, WordCount.Twelve)
                 : new Mnemonic(mnemonicList);
-            ExtKey extendedKey = mnemonic.DeriveExtKey(passphrase);
+            ExtKey extendedKey = HdOperations.GetHdPrivateKey(mnemonic, passphrase);
 
             // create a wallet file 
             Wallet wallet = this.GenerateWalletFile(password, name, extendedKey);
@@ -189,7 +189,7 @@ namespace Stratis.Bitcoin.Features.Wallet
             }
 
             // generate the root seed used to generate keys
-            ExtKey extendedKey = (new Mnemonic(mnemonic)).DeriveExtKey(passphrase);
+            ExtKey extendedKey = HdOperations.GetHdPrivateKey(mnemonic, passphrase);
 
             // create a wallet file 
             Wallet wallet = this.GenerateWalletFile(password, name, extendedKey, creationTime);
@@ -357,14 +357,14 @@ namespace Stratis.Bitcoin.Features.Wallet
             for (int i = firstNewAddressIndex; i < firstNewAddressIndex + addressesQuantity; i++)
             {
                 // generate new receiving address
-                var pubkey = this.GenerateAddress(account.ExtendedPubKey, i, isChange);
+                PubKey pubkey = HdOperations.GeneratePublicKey(account.ExtendedPubKey, i, isChange);
                 BitcoinPubKeyAddress address = pubkey.GetAddress(this.network);
 
                 // add address details
                 addresses.Add(new HdAddress
                 {
                     Index = i,
-                    HdPath = CreateBip44Path(account.GetCoinType(), account.Index, i, isChange),
+                    HdPath = HdOperations.CreateHdPath((int)account.GetCoinType(), account.Index, i, isChange),
                     ScriptPubKey = address.ScriptPubKey,
                     Pubkey = pubkey.ScriptPubKey,
                     Address = address.ToString(),
@@ -517,11 +517,8 @@ namespace Stratis.Bitcoin.Features.Wallet
             }
 
             // get extended private key
-            var privateKey = Key.Parse(wallet.EncryptedSeed, password, wallet.Network);
-            var seedExtKey = new ExtKey(privateKey, wallet.ChainCode);
-            ExtKey addressExtKey = seedExtKey.Derive(new KeyPath(address.HdPath));
-            BitcoinExtKey addressPrivateKey = addressExtKey.GetWif(wallet.Network);
-            return addressPrivateKey;
+            Key privateKey = HdOperations.DecryptSeed(wallet.EncryptedSeed, password, wallet.Network);
+            return HdOperations.GetExtendedPrivateKey(privateKey, wallet.ChainCode, address.HdPath, wallet.Network);
         }
         
         /// <inheritdoc />
@@ -990,32 +987,7 @@ namespace Stratis.Bitcoin.Features.Wallet
         {
             return wallet.AccountsRoot.Single(a => a.CoinType == this.coinType);
         }
-
-        private PubKey GenerateAddress(string accountExtPubKey, int index, bool isChange)
-        {
-            int change = isChange ? 1 : 0;
-            KeyPath keyPath = new KeyPath($"{change}/{index}");
-            ExtPubKey extPubKey = ExtPubKey.Parse(accountExtPubKey).Derive(keyPath);
-            return extPubKey.PubKey;
-        }
-
-        /// <summary>
-        /// Creates the bip44 path.
-        /// </summary>
-        /// <param name="coinType">Type of the coin.</param>
-        /// <param name="accountIndex">Index of the account.</param>
-        /// <param name="addressIndex">Index of the address.</param>
-        /// <param name="isChange">if set to <c>true</c> [is change].</param>
-        /// <returns></returns>
-        public static string CreateBip44Path(CoinType coinType, int accountIndex, int addressIndex, bool isChange = false)
-        {
-            //// populate the items according to the BIP44 path 
-            //// [m/purpose'/coin_type'/account'/change/address_index]
-
-            int change = isChange ? 1 : 0;
-            return $"m/44'/{(int) coinType}'/{accountIndex}'/{change}/{addressIndex}";
-        }
-
+        
         /// <summary>
         /// Loads the keys and transactions we're tracking in memory for faster lookups.
         /// </summary>


### PR DESCRIPTION
* Moved the IWalletManager.CreateNewAccount method to the Wallet object and renamed it to AddNewAccount to better reflect this method's functionalities. 
I started with doing this but then instead of moving further along I worked on extracting HD-related methods to a separate class.
* Extracted all the methods relating to HD wallets' addresses and accounts to a separate class.
* Updated NStratis to the latest submodule





