### PR TITLE
Added controller providing operations on blocks and transactions notifications.

### DIFF
--- a/Stratis.Bitcoin.Tests/Notifications/NotificationsControllerTest.cs
+++ b/Stratis.Bitcoin.Tests/Notifications/NotificationsControllerTest.cs
@@ -92,7 +92,7 @@ namespace Stratis.Bitcoin.Tests.Notifications
             var notificationController = new NotificationsController(blockNotification.Object, chain.Object);
 
             // Assert
-            Assert.ThrowsAny<Exception>(() => notificationController.SyncFrom(hashLocation));
+            Assert.Throws<FormatException>(() => notificationController.SyncFrom(hashLocation));
         }
     }
 }

--- a/Stratis.Bitcoin.Tests/Notifications/NotificationsControllerTest.cs
+++ b/Stratis.Bitcoin.Tests/Notifications/NotificationsControllerTest.cs
@@ -1,0 +1,98 @@
+﻿using System;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Moq;
+using NBitcoin;
+using Stratis.Bitcoin.BlockPulling;
+using Stratis.Bitcoin.Features.Notifications;
+using Stratis.Bitcoin.Features.Notifications.Controllers;
+using Stratis.Bitcoin.Tests.Logging;
+using Stratis.Bitcoin.Utilities;
+using Stratis.Bitcoin.Utilities.JsonErrors;
+using Xunit;
+
+namespace Stratis.Bitcoin.Tests.Notifications
+{
+    public class NotificationsControllerTest : LogsTestBase
+    {
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [Trait("Module", "NotificationsController")]
+        public void Given_SyncActionIsCalled_When_QueryParameterIsNullOrEmpty_Then_ReturnBadRequest(string from)
+        {
+            var chain = new Mock<ConcurrentChain>();
+            var blockNotification = new Mock<BlockNotification>(chain.Object, new Mock<ILookaheadBlockPuller>().Object, new Bitcoin.Signals.Signals(), new AsyncLoopFactory(new LoggerFactory()), new NodeLifetime());
+
+            var notificationController = new NotificationsController(blockNotification.Object, chain.Object);
+            IActionResult result = notificationController.SyncFrom(from);
+
+            ErrorResult errorResult = Assert.IsType<ErrorResult>(result);
+            ErrorResponse errorResponse = Assert.IsType<ErrorResponse>(errorResult.Value);
+            Assert.Equal(1, errorResponse.Errors.Count);
+
+            ErrorModel error = errorResponse.Errors[0];
+            Assert.Equal(400, error.Status);
+        }
+        
+        [Fact]
+        public void Given_SyncActionIsCalled_When_ABlockHeightIsSpecified_Then_TheChainIsSyncedFromTheHash()
+        {
+            // Set up
+            int heightLocation = 480946;
+            string hashLocation = "000000000000000000c03dbe6ee5fedb25877a12e32aa95bc1d3bd480d7a93f9";
+            uint256 hash = uint256.Parse(hashLocation);
+
+            ChainedBlock chainedBlock = new ChainedBlock(new BlockHeader(), hash, null);
+            var chain = new Mock<ConcurrentChain>();
+            chain.Setup(c => c.GetBlock(heightLocation)).Returns(chainedBlock);
+            var blockNotification = new Mock<BlockNotification>(chain.Object, new Mock<ILookaheadBlockPuller>().Object, new Bitcoin.Signals.Signals(), new AsyncLoopFactory(new LoggerFactory()), new NodeLifetime());
+
+            // Act
+            var notificationController = new NotificationsController(blockNotification.Object, chain.Object);
+            IActionResult result = notificationController.SyncFrom(heightLocation.ToString());
+
+            // Assert
+            chain.Verify(c => c.GetBlock(heightLocation), Times.Once);
+            blockNotification.Verify(b => b.SyncFrom(hash), Times.Once);
+        }
+
+        [Fact]
+        public void Given_SyncActionIsCalled_When_ABlockHashIsSpecified_Then_TheChainIsSyncedFromTheHash()
+        {
+            // Set up
+            int heightLocation = 480946;
+            string hashLocation = "000000000000000000c03dbe6ee5fedb25877a12e32aa95bc1d3bd480d7a93f9";
+            uint256 hash = uint256.Parse(hashLocation);
+
+            ChainedBlock chainedBlock = new ChainedBlock(new BlockHeader(), hash, null);
+            var chain = new Mock<ConcurrentChain>();
+            chain.Setup(c => c.GetBlock(heightLocation)).Returns(chainedBlock);
+            var blockNotification = new Mock<BlockNotification>(chain.Object, new Mock<ILookaheadBlockPuller>().Object, new Bitcoin.Signals.Signals(), new AsyncLoopFactory(new LoggerFactory()), new NodeLifetime());
+
+            // Act
+            var notificationController = new NotificationsController(blockNotification.Object, chain.Object);
+            IActionResult result = notificationController.SyncFrom(hashLocation);
+
+            // Assert
+            chain.Verify(c => c.GetBlock(heightLocation), Times.Never);
+            blockNotification.Verify(b => b.SyncFrom(hash), Times.Once);
+        }
+
+
+        [Fact]
+        public void Given_SyncActionIsCalled_When_AnInvalidBlockHashIsSpecified_Then_AnExceptionIsThrown()
+        {
+            // Set up
+            string hashLocation = "notAValidHash";
+            var chain = new Mock<ConcurrentChain>();
+            var blockNotification = new Mock<BlockNotification>(chain.Object, new Mock<ILookaheadBlockPuller>().Object, new Bitcoin.Signals.Signals(), new AsyncLoopFactory(new LoggerFactory()), new NodeLifetime());
+
+            // Act
+            var notificationController = new NotificationsController(blockNotification.Object, chain.Object);
+
+            // Assert
+            Assert.ThrowsAny<Exception>(() => notificationController.SyncFrom(hashLocation));
+        }
+    }
+}

--- a/Stratis.Bitcoin/Features/Notifications/BlockNotification.cs
+++ b/Stratis.Bitcoin/Features/Notifications/BlockNotification.cs
@@ -10,91 +10,91 @@ namespace Stratis.Bitcoin.Features.Notifications
     /// Class used to broadcast about new blocks.
     /// </summary>
     public class BlockNotification
-	{
-		private readonly ISignals signals;
+    {
+        private readonly ISignals signals;
         private readonly IAsyncLoopFactory asyncLoopFactory;
-	    private readonly INodeLifetime nodeLifetime;
+        private readonly INodeLifetime nodeLifetime;
 
-	    private ChainedBlock tip;
+        private ChainedBlock tip;
 
-        public BlockNotification(ConcurrentChain chain, ILookaheadBlockPuller puller, ISignals signals, 
+        public BlockNotification(ConcurrentChain chain, ILookaheadBlockPuller puller, ISignals signals,
             IAsyncLoopFactory asyncLoopFactory, INodeLifetime nodeLifetime)
-		{
-			Guard.NotNull(chain, nameof(chain));
-			Guard.NotNull(puller, nameof(puller));
-			Guard.NotNull(signals, nameof(signals));
+        {
+            Guard.NotNull(chain, nameof(chain));
+            Guard.NotNull(puller, nameof(puller));
+            Guard.NotNull(signals, nameof(signals));
             Guard.NotNull(asyncLoopFactory, nameof(asyncLoopFactory));
 
-			this.Chain = chain;
-			this.Puller = puller;
-			this.signals = signals;
+            this.Chain = chain;
+            this.Puller = puller;
+            this.signals = signals;
             this.asyncLoopFactory = asyncLoopFactory;
-		    this.nodeLifetime = nodeLifetime;
-		}
+            this.nodeLifetime = nodeLifetime;
+        }
 
-		public ILookaheadBlockPuller Puller { get; }
+        public ILookaheadBlockPuller Puller { get; }
 
-		public ConcurrentChain Chain { get; }
+        public ConcurrentChain Chain { get; }
 
-		public uint256 StartHash { get; private set; }
+        public uint256 StartHash { get; private set; }
 
-		private bool reSync;
+        private bool reSync;
 
-		public virtual void SyncFrom(uint256 startHash)
-		{
-			if (this.StartHash != null)
-			{
-				this.reSync = true;
-			    ChainedBlock startBlock = this.Chain.GetBlock(startHash);
-			    if (startBlock != null)
-			    {
-			        // sets the location of the puller to the latest hash that was broadcasted
-			        this.Puller.SetLocation(startBlock);
+        public virtual void SyncFrom(uint256 startHash)
+        {
+            if (this.StartHash != null)
+            {
+                this.reSync = true;
+                ChainedBlock startBlock = this.Chain.GetBlock(startHash);
+                if (startBlock != null)
+                {
+                    // sets the location of the puller to the latest hash that was broadcasted
+                    this.Puller.SetLocation(startBlock);
                     this.tip = startBlock;
                 }
-                
+
             }
 
-			this.StartHash = startHash;
-		}
-		
-		/// <summary>
-		/// Notifies about blocks, starting from block with hash passed as parameter.
-		/// </summary>
-		public virtual Task Notify()
-		{
-			return this.asyncLoopFactory.Run("block notifier", token =>
-			{
-				// if the StartHash hasn't been set yet
-				if (this.StartHash == null)
-				{
-					return Task.CompletedTask;
-				}
+            this.StartHash = startHash;
+        }
 
-				// make sure the chain has been downloaded
-				ChainedBlock startBlock = this.Chain.GetBlock(this.StartHash);
-				if (startBlock == null)
-				{
-					return Task.CompletedTask;
-				}
+        /// <summary>
+        /// Notifies about blocks, starting from block with hash passed as parameter.
+        /// </summary>
+        public virtual Task Notify()
+        {
+            return this.asyncLoopFactory.Run("block notifier", token =>
+            {
+                // if the StartHash hasn't been set yet
+                if (this.StartHash == null)
+                {
+                    return Task.CompletedTask;
+                }
 
-				// sets the location of the puller to the latest hash that was broadcasted
-				this.Puller.SetLocation(startBlock);
+                // make sure the chain has been downloaded
+                ChainedBlock startBlock = this.Chain.GetBlock(this.StartHash);
+                if (startBlock == null)
+                {
+                    return Task.CompletedTask;
+                }
+
+                // sets the location of the puller to the latest hash that was broadcasted
+                this.Puller.SetLocation(startBlock);
                 this.tip = startBlock;
 
-				// send notifications for all the following blocks
-				while (!this.reSync)
-				{					
-					var block = this.Puller.NextBlock(token);
+                // send notifications for all the following blocks
+                while (!this.reSync)
+                {
+                    var block = this.Puller.NextBlock(token);
 
-					if (block != null)
-					{
-						// broadcast the block to the registered observers
-						this.signals.SignalBlock(block);
+                    if (block != null)
+                    {
+                        // broadcast the block to the registered observers
+                        this.signals.SignalBlock(block);
                         this.tip = this.Chain.GetBlock(block.GetHash());
-					}
-					else
-					{
+                    }
+                    else
+                    {
                         // in reorg we reset the puller to the fork
                         // when a reorg happens the puller is pushed
                         // back and continues from the current fork
@@ -105,13 +105,13 @@ namespace Stratis.Bitcoin.Features.Notifications
 
                         // set the puller to the fork location
                         this.Puller.SetLocation(this.tip);
-					}
-				}
-				
-				this.reSync = false;
+                    }
+                }
 
-				return Task.CompletedTask;
-			}, this.nodeLifetime.ApplicationStopping);
-		}		
-	}
+                this.reSync = false;
+
+                return Task.CompletedTask;
+            }, this.nodeLifetime.ApplicationStopping);
+        }
+    }
 }

--- a/Stratis.Bitcoin/Features/Notifications/BlockNotification.cs
+++ b/Stratis.Bitcoin/Features/Notifications/BlockNotification.cs
@@ -6,10 +6,10 @@ using Stratis.Bitcoin.Utilities;
 
 namespace Stratis.Bitcoin.Features.Notifications
 {
-	/// <summary>
-	/// Class used to broadcast about new blocks.
-	/// </summary>
-	public class BlockNotification
+    /// <summary>
+    /// Class used to broadcast about new blocks.
+    /// </summary>
+    public class BlockNotification
 	{
 		private readonly ISignals signals;
         private readonly IAsyncLoopFactory asyncLoopFactory;
@@ -40,7 +40,7 @@ namespace Stratis.Bitcoin.Features.Notifications
 
 		private bool reSync;
 
-		public void SyncFrom(uint256 startHash)
+		public virtual void SyncFrom(uint256 startHash)
 		{
 			if (this.StartHash != null)
 			{

--- a/Stratis.Bitcoin/Features/Notifications/BlockNotificationFeature.cs
+++ b/Stratis.Bitcoin/Features/Notifications/BlockNotificationFeature.cs
@@ -6,13 +6,14 @@ using Stratis.Bitcoin.BlockPulling;
 using Stratis.Bitcoin.Builder;
 using Stratis.Bitcoin.Builder.Feature;
 using Stratis.Bitcoin.Connection;
+using Stratis.Bitcoin.Features.Notifications.Controllers;
 
 namespace Stratis.Bitcoin.Features.Notifications
 {
-	/// <summary>
-	/// Feature enabling the broadcasting of blocks.
-	/// </summary>
-	public class BlockNotificationFeature : FullNodeFeature
+    /// <summary>
+    /// Feature enabling the broadcasting of blocks.
+    /// </summary>
+    public class BlockNotificationFeature : FullNodeFeature
 	{
 		private readonly BlockNotification blockNotification;
 		private readonly IConnectionManager connectionManager;
@@ -54,7 +55,8 @@ namespace Stratis.Bitcoin.Features.Notifications
 				{					
 					services.AddSingleton<BlockNotification>();				
 					services.AddSingleton<LookaheadBlockPuller>().AddSingleton<ILookaheadBlockPuller, LookaheadBlockPuller>(provider => provider.GetService<LookaheadBlockPuller>());
-				});
+				    services.AddSingleton<NotificationsController>();
+                });
 			});
 
 			return fullNodeBuilder;

--- a/Stratis.Bitcoin/Features/Notifications/BlockNotificationFeature.cs
+++ b/Stratis.Bitcoin/Features/Notifications/BlockNotificationFeature.cs
@@ -14,52 +14,52 @@ namespace Stratis.Bitcoin.Features.Notifications
     /// Feature enabling the broadcasting of blocks.
     /// </summary>
     public class BlockNotificationFeature : FullNodeFeature
-	{
-		private readonly BlockNotification blockNotification;
-		private readonly IConnectionManager connectionManager;
-		private readonly LookaheadBlockPuller blockPuller;
-		private readonly ChainState chainState;
-		private readonly ConcurrentChain chain;
+    {
+        private readonly BlockNotification blockNotification;
+        private readonly IConnectionManager connectionManager;
+        private readonly LookaheadBlockPuller blockPuller;
+        private readonly ChainState chainState;
+        private readonly ConcurrentChain chain;
 
-		public BlockNotificationFeature(BlockNotification blockNotification, IConnectionManager connectionManager, 
+        public BlockNotificationFeature(BlockNotification blockNotification, IConnectionManager connectionManager, 
             LookaheadBlockPuller blockPuller, ChainState chainState, ConcurrentChain chain)
-		{
-			this.blockNotification = blockNotification;
-			this.connectionManager = connectionManager;
-			this.blockPuller = blockPuller;
-			this.chainState = chainState;
-			this.chain = chain;
-		}
+        {
+            this.blockNotification = blockNotification;
+            this.connectionManager = connectionManager;
+            this.blockPuller = blockPuller;
+            this.chainState = chainState;
+            this.chain = chain;
+        }
 
-		public override void Start()
-		{
-			var connectionParameters = this.connectionManager.Parameters;
-			connectionParameters.TemplateBehaviors.Add(new BlockPullerBehavior(this.blockPuller, new LoggerFactory()));
-			this.blockNotification.Notify();
-			this.chainState.HighestValidatedPoW = this.chain.Genesis;
-		}
-	}
+        public override void Start()
+        {
+            var connectionParameters = this.connectionManager.Parameters;
+            connectionParameters.TemplateBehaviors.Add(new BlockPullerBehavior(this.blockPuller, new LoggerFactory()));
+            this.blockNotification.Notify();
+            this.chainState.HighestValidatedPoW = this.chain.Genesis;
+        }
+    }
 
     /// <summary>
     /// A class providing extension methods for <see cref="IFullNodeBuilder"/>.
     /// </summary>
     public static partial class IFullNodeBuilderExtensions
     {
-		public static IFullNodeBuilder UseBlockNotification(this IFullNodeBuilder fullNodeBuilder)
-		{
-			fullNodeBuilder.ConfigureFeature(features =>
-			{
-				features
-				.AddFeature<BlockNotificationFeature>()
-				.FeatureServices(services =>
-				{					
-					services.AddSingleton<BlockNotification>();				
-					services.AddSingleton<LookaheadBlockPuller>().AddSingleton<ILookaheadBlockPuller, LookaheadBlockPuller>(provider => provider.GetService<LookaheadBlockPuller>());
-				    services.AddSingleton<NotificationsController>();
+        public static IFullNodeBuilder UseBlockNotification(this IFullNodeBuilder fullNodeBuilder)
+        {
+            fullNodeBuilder.ConfigureFeature(features =>
+            {
+                features
+                .AddFeature<BlockNotificationFeature>()
+                .FeatureServices(services =>
+                {
+                    services.AddSingleton<BlockNotification>();
+                    services.AddSingleton<LookaheadBlockPuller>().AddSingleton<ILookaheadBlockPuller, LookaheadBlockPuller>(provider => provider.GetService<LookaheadBlockPuller>());
+                    services.AddSingleton<NotificationsController>();
                 });
-			});
+            });
 
-			return fullNodeBuilder;
-		}
-	}
+            return fullNodeBuilder;
+        }
+    }
 }

--- a/Stratis.Bitcoin/Features/Notifications/Controllers/NotificationsController.cs
+++ b/Stratis.Bitcoin/Features/Notifications/Controllers/NotificationsController.cs
@@ -1,0 +1,68 @@
+﻿using System.Net;
+using Microsoft.AspNetCore.Mvc;
+using NBitcoin;
+using Stratis.Bitcoin.Utilities.JsonErrors;
+
+namespace Stratis.Bitcoin.Features.Notifications.Controllers
+{
+    /// <summary>
+    /// Controller providing operations on blocks and transactions notifications.
+    /// </summary>
+    [Route("api/[controller]")]
+    public class NotificationsController : Controller
+    {
+        private readonly BlockNotification blockNotification;
+        private readonly ConcurrentChain chain;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NotificationsController"/> class.
+        /// </summary>
+        /// <param name="blockNotification">The block notification.</param>
+        /// <param name="chain">The chain.</param>
+        public NotificationsController(BlockNotification blockNotification, ConcurrentChain chain)
+        {
+            this.blockNotification = blockNotification;
+            this.chain = chain;
+        }
+
+        /// <summary>
+        /// Starts synchronising the chain from the provided block height or block hash.
+        /// </summary>
+        /// <param name="from">The height or the hash of the block from which to start syncing.</param>
+        /// <returns>Http OK if the request succeeded.</returns>
+        /// <example>/api/notifications/sync?from=1155695</example>
+        /// <example>/api/notifications/sync?from=000000002f7105530e69b80f9295d3bc3046cd7d8643a2fb3aaaa23f90c82c77</example>
+        [HttpGet]
+        [Route("sync")]
+        public IActionResult SyncFrom([FromQuery] string from)
+        {
+            if (string.IsNullOrEmpty(from))
+            {
+                return ErrorHelpers.BuildErrorResponse(HttpStatusCode.BadRequest, "'from' parameter is required.", "Please provide the height or the hash of a block from which you'd like to sync the chain.");
+            }
+
+            uint256 hashToSyncFrom;
+
+            // Check if an integer was provided as a parameter, meaning the request specifies a block height.
+            // If not, the request specified is a block hash.
+            bool isHeight = int.TryParse(from, out int height);
+            if (isHeight)
+            {
+                var chainedBlock = this.chain.GetBlock(height);
+                if (chainedBlock == null)
+                {
+                    return ErrorHelpers.BuildErrorResponse(HttpStatusCode.BadRequest, $"Block at height {height} not found on the blockchain.", string.Empty);
+                }
+
+                hashToSyncFrom = chainedBlock.HashBlock;
+            }
+            else
+            {
+                hashToSyncFrom = uint256.Parse(from);
+            }
+
+            this.blockNotification.SyncFrom(hashToSyncFrom);
+            return this.Ok();
+        }
+    }
+}

--- a/Stratis.Bitcoin/Features/Notifications/TransactionNotification.cs
+++ b/Stratis.Bitcoin/Features/Notifications/TransactionNotification.cs
@@ -8,27 +8,27 @@ namespace Stratis.Bitcoin.Features.Notifications
     /// Class used to broadcast about new transactions.
     /// </summary>
     public class TransactionNotification
-	{
-		private readonly ISignals signals;
+    {
+        private readonly ISignals signals;
 
-		public TransactionNotification(ISignals signals)
-		{
-			Guard.NotNull(signals, nameof(signals));
+        public TransactionNotification(ISignals signals)
+        {
+            Guard.NotNull(signals, nameof(signals));
 
-			this.signals = signals;			
-		}
+            this.signals = signals;
+        }
 
-	    /// <summary>
-	    /// Broadcast new transactions to subscribers.
-	    /// </summary>
-	    /// <param name="transaction">The transaction to braodcast.</param>
-	    public virtual void Notify(Transaction transaction)
-		{
+        /// <summary>
+        /// Broadcast new transactions to subscribers.
+        /// </summary>
+        /// <param name="transaction">The transaction to braodcast.</param>
+        public virtual void Notify(Transaction transaction)
+        {
             if (transaction != null)
             {
                 // broadcast the transaction to the registered observers
                 this.signals.SignalTransaction(transaction);
             }
-        }		
-	}
+        }
+    }
 }

--- a/Stratis.Bitcoin/Features/Notifications/TransactionNotificationFeature.cs
+++ b/Stratis.Bitcoin/Features/Notifications/TransactionNotificationFeature.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Stratis.Bitcoin.Builder;
 using Stratis.Bitcoin.Builder.Feature;
 using Stratis.Bitcoin.Connection;
+using Stratis.Bitcoin.Features.Notifications.Controllers;
 
 namespace Stratis.Bitcoin.Features.Notifications
 {
@@ -40,7 +41,8 @@ namespace Stratis.Bitcoin.Features.Notifications
                     {
                         services.AddSingleton<TransactionNotificationProgress>();
                         services.AddSingleton<TransactionNotification>();
-                        services.AddSingleton<TransactionReceiver>();                       
+                        services.AddSingleton<TransactionReceiver>();
+                        services.AddSingleton<NotificationsController>();
                     });
             });
 

--- a/Stratis.Bitcoin/Features/Notifications/TransactionReceiver.cs
+++ b/Stratis.Bitcoin/Features/Notifications/TransactionReceiver.cs
@@ -17,13 +17,13 @@ namespace Stratis.Bitcoin.Features.Notifications
         private readonly TransactionNotificationProgress notifiedTransactions;
         private readonly ILogger logger;
 
-	    public TransactionReceiver(TransactionNotification transactionNotification, TransactionNotificationProgress notifiedTransactions, ILoggerFactory loggerFactory)
-			: this(transactionNotification, notifiedTransactions, loggerFactory.CreateLogger(typeof(TransactionReceiver).FullName))
-	    {
-		    
-	    }
+        public TransactionReceiver(TransactionNotification transactionNotification, TransactionNotificationProgress notifiedTransactions, ILoggerFactory loggerFactory)
+            : this(transactionNotification, notifiedTransactions, loggerFactory.CreateLogger(typeof(TransactionReceiver).FullName))
+        {
 
-		public TransactionReceiver(TransactionNotification transactionNotification, TransactionNotificationProgress notifiedTransactions, ILogger logger)
+        }
+
+        public TransactionReceiver(TransactionNotification transactionNotification, TransactionNotificationProgress notifiedTransactions, ILogger logger)
         {
             this.transactionNotification = transactionNotification;
             this.notifiedTransactions = notifiedTransactions;
@@ -41,7 +41,7 @@ namespace Stratis.Bitcoin.Features.Notifications
         }
 
         private async void AttachedNode_MessageReceived(Node node, IncomingMessage message)
-        {            
+        {
             try
             {
                 //Guard.Assert(node == this.AttachedNode); // just in case
@@ -62,7 +62,7 @@ namespace Stratis.Bitcoin.Features.Notifications
                 // while in dev catch any unhandled exceptions
                 Debugger.Break();
                 throw;
-            }              
+            }
         }
 
         private Task AttachedNode_MessageReceivedAsync(Node node, IncomingMessage message)
@@ -72,7 +72,7 @@ namespace Stratis.Bitcoin.Features.Notifications
             var invPayload = message.Message.Payload as InvPayload;
             if (invPayload != null)
             {
-                return this.ProcessInvAsync(node, invPayload);                
+                return this.ProcessInvAsync(node, invPayload);
             }
 
             var txPayload = message.Message.Payload as TxPayload;
@@ -100,9 +100,9 @@ namespace Stratis.Bitcoin.Features.Notifications
         }
 
         private async Task ProcessInvAsync(Node node, InvPayload invPayload)
-        {            
+        {
             var txs = invPayload.Inventory.Where(inv => inv.Type.HasFlag(InventoryType.MSG_TX));
-            
+
             // get the transactions in this inventory that have never been received - either because new or requested.
             var newTxs = txs.Where(t => this.notifiedTransactions.TransactionsReceived.All(ts => ts.Key != t.Hash)).ToList();
 


### PR DESCRIPTION
With the controller method that was added, it's now easy to move the chain to a certain location using a block height or a block hash, when using the BlockNotification Feature.
This is very useful when working on the Breeze wallet when we want the sync to move backwards or forward.