### PR TITLE
Position the chain state at the tip of the chain when using the block…

### DIFF
--- a/Stratis.Bitcoin/Features/Notifications/BlockNotificationFeature.cs
+++ b/Stratis.Bitcoin/Features/Notifications/BlockNotificationFeature.cs
@@ -36,7 +36,7 @@ namespace Stratis.Bitcoin.Features.Notifications
             var connectionParameters = this.connectionManager.Parameters;
             connectionParameters.TemplateBehaviors.Add(new BlockPullerBehavior(this.blockPuller, new LoggerFactory()));
             this.blockNotification.Notify();
-            this.chainState.HighestValidatedPoW = this.chain.Genesis;
+            this.chainState.HighestValidatedPoW = this.chain.Tip;
         }
     }
 


### PR DESCRIPTION
… notification feature.

Previously using Genesis lead to the headers being downloaded every time the wallet started.
@dangershony 