### PR TITLE
Allow indexes to be registered via IndexStore settings

### DIFF
--- a/Stratis.Bitcoin.Features.IndexStore/IndexSetings.cs
+++ b/Stratis.Bitcoin.Features.IndexStore/IndexSetings.cs
@@ -1,6 +1,7 @@
 ﻿using Stratis.Bitcoin.Configuration;
 using Stratis.Bitcoin.Features.BlockStore;
 using System;
+using System.Collections.Generic;
 
 namespace Stratis.Bitcoin.Features.IndexStore
 {
@@ -10,16 +11,23 @@ namespace Stratis.Bitcoin.Features.IndexStore
     public class IndexSettings:StoreSettings
     {
         private Action<IndexSettings> callback = null;
+        public Dictionary<string, IndexExpression> indexes { get; private set; }
 
         public IndexSettings()
             :base()
         {
+            this.indexes = new Dictionary<string, IndexExpression>();
         }
 
         public IndexSettings(Action<IndexSettings> callback)
             :this()
         {
             this.callback = callback;
+        }
+
+        public void RegisterIndex(string name, string builder, bool multiValue, string[] dependencies = null)
+        {
+            this.indexes[name] = new Index(null, name, multiValue, builder, dependencies);
         }
 
         /// <summary>

--- a/Stratis.Bitcoin.Features.IndexStore/IndexSetings.cs
+++ b/Stratis.Bitcoin.Features.IndexStore/IndexSetings.cs
@@ -27,7 +27,7 @@ namespace Stratis.Bitcoin.Features.IndexStore
 
         public void RegisterIndex(string name, string builder, bool multiValue, string[] dependencies = null)
         {
-            this.indexes[name] = new Index(null, name, multiValue, builder, dependencies);
+            this.indexes[name] = new IndexExpression(multiValue, builder, dependencies);
         }
 
         /// <summary>

--- a/Stratis.Bitcoin.Features.IndexStore/IndexStoreBehaviour.cs
+++ b/Stratis.Bitcoin.Features.IndexStore/IndexStoreBehaviour.cs
@@ -6,18 +6,12 @@ namespace Stratis.Bitcoin.Features.IndexStore
 {
     public interface IIndexStoreBehavior: IBlockStoreBehavior
     {
-
     }
 
     public class IndexStoreBehavior : BlockStoreBehavior
     {
-        public IndexStoreBehavior(ConcurrentChain chain, IndexRepository blockRepository, IndexStoreCache blockStoreCache, ILoggerFactory loggerFactory) : 
-            this(chain, blockRepository as IIndexRepository, blockStoreCache as IIndexStoreCache, loggerFactory)
-        {
-        }
-
-        public IndexStoreBehavior(ConcurrentChain chain, IIndexRepository blockRepository, IIndexStoreCache blockStoreCache, ILoggerFactory loggerFactory) :
-            base(chain, blockRepository as Features.BlockStore.IBlockRepository, blockStoreCache as Features.BlockStore.IBlockStoreCache, loggerFactory)
+        public IndexStoreBehavior(ConcurrentChain chain, IIndexRepository indexRepository, IIndexStoreCache indexStoreCache, ILoggerFactory loggerFactory) :
+            base(chain, indexRepository, indexStoreCache, loggerFactory)
         {
         }
     }

--- a/Stratis.Bitcoin.Features.IndexStore/IndexStoreCache.cs
+++ b/Stratis.Bitcoin.Features.IndexStore/IndexStoreCache.cs
@@ -11,7 +11,7 @@ namespace Stratis.Bitcoin.Features.IndexStore
 
     public class IndexStoreCache : BlockStoreCache, IIndexStoreCache
     {
-        public IndexStoreCache(IndexRepository indexRepository, ILoggerFactory loggerFactory) : this(indexRepository, new MemoryCache(new MemoryCacheOptions()), loggerFactory)
+        public IndexStoreCache(IIndexRepository indexRepository, ILoggerFactory loggerFactory) : this(indexRepository, new MemoryCache(new MemoryCacheOptions()), loggerFactory)
         {
         }
 

--- a/Stratis.Bitcoin.Features.IndexStore/IndexStoreFeature.cs
+++ b/Stratis.Bitcoin.Features.IndexStore/IndexStoreFeature.cs
@@ -14,8 +14,8 @@ namespace Stratis.Bitcoin.Features.IndexStore
 {
     public class IndexStoreFeature : BlockStoreFeature
     {
-        public IndexStoreFeature(ConcurrentChain chain, IConnectionManager connectionManager, Signals.Signals signals, IndexRepository indexRepository,
-            IndexStoreCache indexStoreCache, IndexBlockPuller blockPuller, IndexStoreLoop indexStoreLoop, IndexStoreManager indexStoreManager,
+        public IndexStoreFeature(ConcurrentChain chain, IConnectionManager connectionManager, Signals.Signals signals, IIndexRepository indexRepository,
+            IIndexStoreCache indexStoreCache, IndexBlockPuller blockPuller, IndexStoreLoop indexStoreLoop, IndexStoreManager indexStoreManager,
             IndexStoreSignaled indexStoreSignaled, INodeLifetime nodeLifetime, NodeSettings nodeSettings, ILoggerFactory loggerFactory, IndexSettings indexSettings) :
             base(chain, connectionManager, signals, indexRepository, indexStoreCache, blockPuller, indexStoreLoop, indexStoreManager,
                 indexStoreSignaled, nodeLifetime, nodeSettings, loggerFactory, indexSettings, name: "IndexStore")
@@ -24,7 +24,7 @@ namespace Stratis.Bitcoin.Features.IndexStore
 
         public override BlockStoreBehavior BlockStoreBehaviorFactory()
         {
-            return new IndexStoreBehavior(this.chain, this.blockRepository as IndexRepository, this.blockStoreCache as IndexStoreCache, this.loggerFactory);
+            return new IndexStoreBehavior(this.chain, this.blockRepository as IIndexRepository, this.blockStoreCache as IIndexStoreCache, this.loggerFactory);
         }
     }
 
@@ -38,8 +38,8 @@ namespace Stratis.Bitcoin.Features.IndexStore
                 .AddFeature<IndexStoreFeature>()
                 .FeatureServices(services =>
                 {
-                    services.AddSingleton<IndexRepository>();
-                    services.AddSingleton<IndexStoreCache>();
+                    services.AddSingleton<IIndexRepository, IndexRepository>();
+                    services.AddSingleton<IIndexStoreCache, IndexStoreCache>();
                     services.AddSingleton<IndexBlockPuller>();
                     services.AddSingleton<IndexStoreLoop>();
                     services.AddSingleton<IndexStoreManager>();

--- a/Stratis.Bitcoin.Features.IndexStore/IndexStoreLoop.cs
+++ b/Stratis.Bitcoin.Features.IndexStore/IndexStoreLoop.cs
@@ -11,11 +11,11 @@ namespace Stratis.Bitcoin.Features.IndexStore
     public class IndexStoreLoop : BlockStoreLoop
     {        
         public IndexStoreLoop(ConcurrentChain chain,
-            IndexRepository indexRepository,
+            IIndexRepository indexRepository,
             IndexSettings indexSettings,
             ChainState chainState,
             IndexBlockPuller blockPuller,
-            IndexStoreCache cache,
+            IIndexStoreCache cache,
             INodeLifetime nodeLifetime,
             IAsyncLoopFactory asyncLoopFactory,
             ILoggerFactory loggerFactory, 

--- a/Stratis.Bitcoin.Features.IndexStore/IndexStoreManager.cs
+++ b/Stratis.Bitcoin.Features.IndexStore/IndexStoreManager.cs
@@ -8,7 +8,7 @@ namespace Stratis.Bitcoin.Features.IndexStore
 {
     public class IndexStoreManager: BlockStoreManager
     {
-        public IndexStoreManager(ConcurrentChain chain, IConnectionManager connection, IndexRepository indexRepository,
+        public IndexStoreManager(ConcurrentChain chain, IConnectionManager connection, IIndexRepository indexRepository,
             IDateTimeProvider dateTimeProvider, NodeSettings nodeArgs, ChainState chainState, IndexStoreLoop indexStoreLoop):
             base(chain, connection, indexRepository, dateTimeProvider, nodeArgs, chainState, indexStoreLoop)
         {

--- a/Stratis.Bitcoin.Features.IndexStore/IndexStoreSignaled.cs
+++ b/Stratis.Bitcoin.Features.IndexStore/IndexStoreSignaled.cs
@@ -1,10 +1,8 @@
 ﻿using NBitcoin;
 using Stratis.Bitcoin.Base;
-using Stratis.Bitcoin.Configuration;
 using Stratis.Bitcoin.Connection;
 using Stratis.Bitcoin.Utilities;
 using Stratis.Bitcoin.Features.BlockStore;
-using IBlockRepository = Stratis.Bitcoin.Features.BlockStore.IBlockRepository;
 using Microsoft.Extensions.Logging;
 
 namespace Stratis.Bitcoin.Features.IndexStore
@@ -13,8 +11,8 @@ namespace Stratis.Bitcoin.Features.IndexStore
     {
         public IndexStoreSignaled(IndexStoreLoop storeLoop, ConcurrentChain chain, IndexSettings indexSettings,
             ChainState chainState, IConnectionManager connection,
-            INodeLifetime nodeLifetime, IAsyncLoopFactory asyncLoopFactory, IBlockRepository blockRepository, ILoggerFactory loggerFactory) :
-            base(storeLoop, chain, indexSettings, chainState, connection, nodeLifetime, asyncLoopFactory, blockRepository, loggerFactory, "IndexStore")
+            INodeLifetime nodeLifetime, IAsyncLoopFactory asyncLoopFactory, IIndexRepository indexRepository, ILoggerFactory loggerFactory) :
+            base(storeLoop, chain, indexSettings, chainState, connection, nodeLifetime, asyncLoopFactory, indexRepository, loggerFactory, "IndexStore")
         {
         }
     }

--- a/Stratis.Bitcoin.FullNode.sln
+++ b/Stratis.Bitcoin.FullNode.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26430.16
+VisualStudioVersion = 15.0.26430.15
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "global", "global", "{5B331FD3-D493-46A9-928B-B786FC6F3103}"
 	ProjectSection(SolutionItems) = preProject
@@ -67,8 +67,6 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Stratis.Bitcoin.Features.Consensus", "Stratis.Bitcoin.Features.Consensus\Stratis.Bitcoin.Features.Consensus.csproj", "{75C364C1-0785-4EDD-9DB8-B0B21F27573C}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Stratis.Bitcoin.Features.Consensus.Tests", "Stratis.Bitcoin.Features.Consensus.Tests\Stratis.Bitcoin.Features.Consensus.Tests.csproj", "{84433C94-9CB7-4D6F-B2C1-C16B6F7F277C}"
-EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Stratis.Bitcoin.Cli", "Stratis.Bitcoin.Cli\Stratis.Bitcoin.Cli.csproj", "{BCC67768-8333-4723-842D-1A79C084CE3B}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -184,10 +182,6 @@ Global
 		{84433C94-9CB7-4D6F-B2C1-C16B6F7F277C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{84433C94-9CB7-4D6F-B2C1-C16B6F7F277C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{84433C94-9CB7-4D6F-B2C1-C16B6F7F277C}.Release|Any CPU.Build.0 = Release|Any CPU
-		{BCC67768-8333-4723-842D-1A79C084CE3B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{BCC67768-8333-4723-842D-1A79C084CE3B}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{BCC67768-8333-4723-842D-1A79C084CE3B}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{BCC67768-8333-4723-842D-1A79C084CE3B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Stratis.Bitcoin.IntegrationTests/IndexerTests.cs
+++ b/Stratis.Bitcoin.IntegrationTests/IndexerTests.cs
@@ -1,16 +1,20 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
+using DBreeze;
 using NBitcoin;
 using NBitcoin.RPC;
+using Stratis.Bitcoin.Features.Consensus;
+using Stratis.Bitcoin.Features.IndexStore;
+using Stratis.Bitcoin.Features.RPC;
 using Xunit;
 
 namespace Stratis.Bitcoin.IntegrationTests
 {
-    // Disable for now as not to impact NBitcoin.
-    /*
     public class IndexStoreTests
     {
+        // Disable for now as not to impact NBitcoin.
+        /*
         [Fact]
         public void CanCreateIndexFromRPC()
         {
@@ -84,6 +88,70 @@ namespace Stratis.Bitcoin.IntegrationTests
                 Assert.Equal("{\"Name\":\"Output\",\"Table\":\"Index_Output\",\"Builder\":\"(t,b,n) => t.Inputs.Select((i, N) => new object[] { new object[] { i.PrevOut.Hash, i.PrevOut.N }, t.GetHash() })\",\"Many\":false,\"Uses\":[\"System\",\"System.Linq\",\"System.Linq.Expressions\",\"System.Collections.Generic\",\"NBitcoin\"]}", description);
             }
         }
-    }
-    */
+        */
+        [Fact]
+        public void CanRegisterSingleValueIndexFromIndexStoreSettings()
+        {
+            using (NodeBuilder builder = NodeBuilder.Create())
+            {
+                var node = builder.CreateStratisNode(false, fullNodeBuilder =>
+                {
+                    fullNodeBuilder
+                    .UseConsensus()
+                    .UseIndexStore(settings =>
+                    {
+                        settings.RegisterIndex("Output", "(t,b,n) => t.Inputs.Select((i, N) => new object[] { new object[] { i.PrevOut.Hash, i.PrevOut.N }, t.GetHash() })", false);
+                    })
+                    .AddRPC();
+                 });
+
+                builder.StartAll();
+                
+                // Transaction has outputs
+                var block = new Block();
+                var trans = new Transaction();
+                Key key = new Key(); // generate a random private key
+                var scriptPubKeyOut = PayToPubkeyHashTemplate.Instance.GenerateScriptPubKey(key.PubKey);
+                trans.Outputs.Add(new TxOut(100, scriptPubKeyOut));
+                block.Transactions.Add(trans);
+                var hash = trans.GetHash().ToBytes();
+
+                // Transaction has inputs (i.PrevOut)
+                var block2 = new Block();
+                block2.Header.HashPrevBlock = block.GetHash();
+                var trans2 = new Transaction();
+                trans2.Inputs.Add(new TxIn(new OutPoint(trans, 0)));
+                block2.Transactions.Add(trans2);
+                var hash2 = trans2.GetHash().ToBytes();
+
+                var repository = node.FullNode.NodeService<IIndexRepository>() as IndexRepository;
+
+                repository.PutAsync(block.GetHash(), new List<Block> { block, block2 }).GetAwaiter().GetResult();
+
+                var indexTable = repository.Indexes["Output"].Table;
+                var expectedJSON = repository.Indexes["Output"].ToString();
+
+                repository.Dispose();
+
+                using (var engine = new DBreezeEngine(node.FullNode.DataFolder.IndexPath))
+                {
+                    var transaction = engine.GetTransaction();
+
+                    var indexKeyRow = transaction.Select<string, string>("Common", indexTable);
+                    Assert.True(indexKeyRow.Exists && indexKeyRow.Value != null);
+                    Assert.Equal(expectedJSON, indexKeyRow.Value);
+
+                    // Block 2 has been indexed?
+                    var indexKey = new byte[hash.Length + 4];
+                    hash.CopyTo(indexKey, 0);
+                    var IndexedRow = transaction.Select<byte[], byte[]>(indexTable, indexKey);
+                    Assert.True(IndexedRow.Exists);
+                    // Correct value indexed?
+                    var compare = new byte[32];
+                    hash2.CopyTo(compare, 0);
+                    Assert.Equal(compare, IndexedRow.Value);
+                }
+            }
+        }
+    }       
 }

--- a/Stratis.StratisD/Program.cs
+++ b/Stratis.StratisD/Program.cs
@@ -17,7 +17,7 @@ namespace Stratis.StratisD
     {
         public static void Main(string[] args)
         {
-            Network network = args.Contains("-testnet") ? Network.StratisTest : Network.StratisMain;
+            Network network = /*args.Contains("-testnet") ? Network..StratisTest :*/ Network.StratisMain;
             NodeSettings nodeSettings = NodeSettings.FromArguments(args, "stratis", network, ProtocolVersion.ALT_PROTOCOL_VERSION);
 
             // NOTES: running BTC and STRAT side by side is not possible yet as the flags for serialization are static


### PR DESCRIPTION
This change relates to configuring the previously identified indexes for the BlockExplorer end-points.

See https://github.com/stratisproject/StratisBitcoinFullNode/issues/329