### PR TITLE
Set content type to fix failing CheckRPCFailures integration test

### DIFF
--- a/Stratis.Bitcoin.Features.RPC/RPCMiddleware.cs
+++ b/Stratis.Bitcoin.Features.RPC/RPCMiddleware.cs
@@ -45,32 +45,36 @@ namespace Stratis.Bitcoin.Features.RPC
 				ex = exx;
 			}
 
-
-			if(ex is ArgumentException || ex is FormatException)
+            if (ex is ArgumentException || ex is FormatException)
 			{
 				JObject response = CreateError(RPCErrorCode.RPC_MISC_ERROR, "Argument error: " + ex.Message);
-				await httpContext.Response.WriteAsync(response.ToString(Formatting.Indented));
+                httpContext.Response.ContentType = "application/json";
+                await httpContext.Response.WriteAsync(response.ToString(Formatting.Indented));
 			}
 			else if(ex is RPCServerException)
 			{
 				var rpcEx = (RPCServerException)ex;
 				JObject response = CreateError(rpcEx.ErrorCode, ex.Message);
-				await httpContext.Response.WriteAsync(response.ToString(Formatting.Indented));
+                httpContext.Response.ContentType = "application/json";
+                await httpContext.Response.WriteAsync(response.ToString(Formatting.Indented));
 			}
 			else if(httpContext.Response?.StatusCode == 404)
 			{
 				JObject response = CreateError(RPCErrorCode.RPC_METHOD_NOT_FOUND, "Method not found");
-				await httpContext.Response.WriteAsync(response.ToString(Formatting.Indented));
+                httpContext.Response.ContentType = "application/json";
+                await httpContext.Response.WriteAsync(response.ToString(Formatting.Indented));
 			}
             else if(this.IsDependencyFailure(ex))
             {
                 JObject response = CreateError(RPCErrorCode.RPC_METHOD_NOT_FOUND, ex.Message);
+                httpContext.Response.ContentType = "application/json";
                 await httpContext.Response.WriteAsync(response.ToString(Formatting.Indented));
             }
 			else if(httpContext.Response?.StatusCode == 500 || ex != null)
 			{
 				JObject response = CreateError(RPCErrorCode.RPC_INTERNAL_ERROR, "Internal error");
-				this.logger.LogError(new EventId(0), ex, "Internal error while calling RPC Method");
+                httpContext.Response.ContentType = "application/json";
+                this.logger.LogError(new EventId(0), ex, "Internal error while calling RPC Method");
 				await httpContext.Response.WriteAsync(response.ToString(Formatting.Indented));
 			}
 		}

--- a/Stratis.Bitcoin.Features.RPC/RPCMiddleware.cs
+++ b/Stratis.Bitcoin.Features.RPC/RPCMiddleware.cs
@@ -11,116 +11,116 @@ using Stratis.Bitcoin.Utilities;
 
 namespace Stratis.Bitcoin.Features.RPC
 {
-	public class RPCMiddleware
-	{
-	    private readonly RequestDelegate next;
-	    private readonly IRPCAuthorization authorization;
-	    private readonly ILogger logger;
+    public class RPCMiddleware
+    {
+        private readonly RequestDelegate next;
+        private readonly IRPCAuthorization authorization;
+        private readonly ILogger logger;
         public RPCMiddleware(RequestDelegate next, IRPCAuthorization authorization, ILoggerFactory loggerFactory)
-		{
-			Guard.NotNull(next, nameof(next));
-			Guard.NotNull(authorization, nameof(authorization));
+        {
+            Guard.NotNull(next, nameof(next));
+            Guard.NotNull(authorization, nameof(authorization));
 
-			this.next = next;
-			this.authorization = authorization;
+            this.next = next;
+            this.authorization = authorization;
             this.logger = loggerFactory.CreateLogger(this.GetType().FullName);
         }
 
-		public async Task Invoke(HttpContext httpContext)
-		{
-			Guard.NotNull(httpContext, nameof(httpContext));
+        public async Task Invoke(HttpContext httpContext)
+        {
+            Guard.NotNull(httpContext, nameof(httpContext));
 
-			if(!this.Authorized(httpContext))
-			{
-				httpContext.Response.StatusCode = StatusCodes.Status401Unauthorized;
-				return;
-			}
-			Exception ex = null;
-			try
-			{
-				await this.next.Invoke(httpContext);
-			}
-			catch(Exception exx)
-			{
-				ex = exx;
-			}
+            if(!this.Authorized(httpContext))
+            {
+                httpContext.Response.StatusCode = StatusCodes.Status401Unauthorized;
+                return;
+            }
+            Exception ex = null;
+            try
+            {
+                await this.next.Invoke(httpContext);
+            }
+            catch(Exception exx)
+            {
+                ex = exx;
+            }
 
             if (ex is ArgumentException || ex is FormatException)
-			{
-				JObject response = CreateError(RPCErrorCode.RPC_MISC_ERROR, "Argument error: " + ex.Message);
+            {
+                JObject response = CreateError(RPCErrorCode.RPC_MISC_ERROR, "Argument error: " + ex.Message);
                 httpContext.Response.ContentType = "application/json";
                 await httpContext.Response.WriteAsync(response.ToString(Formatting.Indented));
-			}
-			else if(ex is RPCServerException)
-			{
-				var rpcEx = (RPCServerException)ex;
-				JObject response = CreateError(rpcEx.ErrorCode, ex.Message);
+            }
+            else if(ex is RPCServerException)
+            {
+                var rpcEx = (RPCServerException)ex;
+                JObject response = CreateError(rpcEx.ErrorCode, ex.Message);
                 httpContext.Response.ContentType = "application/json";
                 await httpContext.Response.WriteAsync(response.ToString(Formatting.Indented));
-			}
-			else if(httpContext.Response?.StatusCode == 404)
-			{
-				JObject response = CreateError(RPCErrorCode.RPC_METHOD_NOT_FOUND, "Method not found");
+            }
+            else if(httpContext.Response?.StatusCode == 404)
+            {
+                JObject response = CreateError(RPCErrorCode.RPC_METHOD_NOT_FOUND, "Method not found");
                 httpContext.Response.ContentType = "application/json";
                 await httpContext.Response.WriteAsync(response.ToString(Formatting.Indented));
-			}
+            }
             else if(this.IsDependencyFailure(ex))
             {
                 JObject response = CreateError(RPCErrorCode.RPC_METHOD_NOT_FOUND, ex.Message);
                 httpContext.Response.ContentType = "application/json";
                 await httpContext.Response.WriteAsync(response.ToString(Formatting.Indented));
             }
-			else if(httpContext.Response?.StatusCode == 500 || ex != null)
-			{
-				JObject response = CreateError(RPCErrorCode.RPC_INTERNAL_ERROR, "Internal error");
+            else if(httpContext.Response?.StatusCode == 500 || ex != null)
+            {
+                JObject response = CreateError(RPCErrorCode.RPC_INTERNAL_ERROR, "Internal error");
                 httpContext.Response.ContentType = "application/json";
                 this.logger.LogError(new EventId(0), ex, "Internal error while calling RPC Method");
-				await httpContext.Response.WriteAsync(response.ToString(Formatting.Indented));
-			}
-		}
+                await httpContext.Response.WriteAsync(response.ToString(Formatting.Indented));
+            }
+        }
 
-		private bool IsDependencyFailure(Exception ex)
-		{
-			var invalidOp = ex as InvalidOperationException;
-			if(invalidOp == null)
-				return false;
-			return invalidOp.Source.Equals("Microsoft.Extensions.DependencyInjection.Abstractions", StringComparison.Ordinal);
-		}
+        private bool IsDependencyFailure(Exception ex)
+        {
+            var invalidOp = ex as InvalidOperationException;
+            if(invalidOp == null)
+                return false;
+            return invalidOp.Source.Equals("Microsoft.Extensions.DependencyInjection.Abstractions", StringComparison.Ordinal);
+        }
 
-		private bool Authorized(HttpContext httpContext)
-		{
-			if(!this.authorization.IsAuthorized(httpContext.Connection.RemoteIpAddress))
-				return false;
-			StringValues auth;
-			if(!httpContext.Request.Headers.TryGetValue("Authorization", out auth) || auth.Count != 1)
-				return false;
-			var splittedAuth = auth[0].Split(' ');
-			if(splittedAuth.Length != 2 ||
-			   splittedAuth[0] != "Basic")
-				return false;
+        private bool Authorized(HttpContext httpContext)
+        {
+            if(!this.authorization.IsAuthorized(httpContext.Connection.RemoteIpAddress))
+                return false;
+            StringValues auth;
+            if(!httpContext.Request.Headers.TryGetValue("Authorization", out auth) || auth.Count != 1)
+                return false;
+            var splittedAuth = auth[0].Split(' ');
+            if(splittedAuth.Length != 2 ||
+               splittedAuth[0] != "Basic")
+                return false;
 
-			try
-			{
-				var user = Encoders.ASCII.EncodeData(Encoders.Base64.DecodeData(splittedAuth[1]));
-				if(!this.authorization.IsAuthorized(user))
-					return false;
-			}
-			catch
-			{
-				return false;
-			}
-			return true;
-		}
+            try
+            {
+                var user = Encoders.ASCII.EncodeData(Encoders.Base64.DecodeData(splittedAuth[1]));
+                if(!this.authorization.IsAuthorized(user))
+                    return false;
+            }
+            catch
+            {
+                return false;
+            }
+            return true;
+        }
 
-		private static JObject CreateError(RPCErrorCode code, string message)
-		{
-			JObject response = new JObject();
-			response.Add("result", null);
-			JObject error = new JObject();
-			response.Add("error", error);
-			error.Add("code", (int)code);
-			error.Add("message", message);
-			return response;
-		}
-	}
+        private static JObject CreateError(RPCErrorCode code, string message)
+        {
+            JObject response = new JObject();
+            response.Add("result", null);
+            JObject error = new JObject();
+            response.Add("error", error);
+            error.Add("code", (int)code);
+            error.Add("message", message);
+            return response;
+        }
+    }
 }


### PR DESCRIPTION
The failure presents as an unhandled "WebException" and is being triggered in the RPCClient.cs file:

```
... (line 694)
			catch(WebException ex)
			{
				if(ex.Response == null || ex.Response.ContentLength == 0 ||
					!ex.Response.ContentType.Equals("application/json", StringComparison.Ordinal))
					throw;
				errorResponse = ex.Response;
				response = RPCResponse.Load(await ToMemoryStreamAsync(errorResponse.GetResponseStream()).ConfigureAwait(false));
				if(throwIfRPCError)
					response.ThrowIfError();
			}
...
```

The current situation is that the content type is not being set on JSON formatted error responses (within RPCMiddleware.cs).  As a result the above "throw" gets executed instead of the code that follows. This affects the type of error being produced being "WebException" instead of "RPCException". Consequently the "CheckRPCFailures" test case fails, which is expecting an RPCException (via "response.ThrowIfError()"):

```
        [Fact]
        public void CheckRPCFailures()
        {
            using (NodeBuilder builder = NodeBuilder.Create())
            {
                var node = builder.CreateStratisNode();
                builder.StartAll();
                var client = node.CreateRPCClient();
                var hash = client.GetBestBlockHash();
                try
                {
                    client.SendCommand("lol");
                    Assert.True(false, "should throw");
                }
                catch (RPCException ex)
                {
                    Assert.Equal(RPCErrorCode.RPC_METHOD_NOT_FOUND, ex.RPCCode);
                }
...
```