### PR TITLE
Move "HighestPersistedBlock" to BlockStore feature

### DIFF
--- a/Stratis.Bitcoin.Features.BlockStore/BlockRepository.cs
+++ b/Stratis.Bitcoin.Features.BlockStore/BlockRepository.cs
@@ -41,6 +41,9 @@
         public uint256 BlockHash { get; private set; }
         public BlockStoreRepositoryPerformanceCounter PerformanceCounter { get; }
         public bool TxIndex { get; private set; }
+        
+        /// <summary>Represents the last block stored to disk.</summary>
+        public ChainedBlock HighestPersistedBlock { get; internal set;}
 
         public BlockRepository(Network network, DataFolder dataFolder, ILoggerFactory loggerFactory)
             : this(network, dataFolder.BlockPath, loggerFactory)

--- a/Stratis.Bitcoin.Features.BlockStore/BlockStoreFeature.cs
+++ b/Stratis.Bitcoin.Features.BlockStore/BlockStoreFeature.cs
@@ -12,13 +12,14 @@ using Stratis.Bitcoin.Interfaces;
 using Stratis.Bitcoin.Utilities;
 using System;
 using System.Runtime.CompilerServices;
+using System.Text;
 using System.Threading.Tasks;
 
 [assembly: InternalsVisibleTo("Stratis.Bitcoin.Features.BlockStore.Tests")]
 
 namespace Stratis.Bitcoin.Features.BlockStore
 {
-    public class BlockStoreFeature : FullNodeFeature, IBlockStore
+    public class BlockStoreFeature : FullNodeFeature, IBlockStore, INodeStats
     {
         protected readonly ConcurrentChain chain;
         protected readonly Signals.Signals signals;
@@ -78,6 +79,17 @@ namespace Stratis.Bitcoin.Features.BlockStore
         public virtual BlockStoreBehavior BlockStoreBehaviorFactory()
         {
             return new BlockStoreBehavior(this.chain, this.blockRepository, this.blockStoreCache, this.loggerFactory);
+        }
+
+        public void AddNodeStats(StringBuilder benchLogs)
+        {
+            var highestBlock = (this.blockRepository as BlockRepository)?.HighestPersistedBlock;
+
+            if (highestBlock != null)
+                benchLogs.AppendLine($"{this.name}.Height: ".PadRight(LoggingConfiguration.ColumnLength + 3) +
+                    highestBlock.Height.ToString().PadRight(8) +
+                    $" {this.name}.Hash: ".PadRight(LoggingConfiguration.ColumnLength + 3) +
+                    highestBlock.HashBlock);
         }
 
         public Task<Transaction> GetTrxAsync(uint256 trxid)

--- a/Stratis.Bitcoin.Features.BlockStore/BlockStoreLoop.cs
+++ b/Stratis.Bitcoin.Features.BlockStore/BlockStoreLoop.cs
@@ -285,7 +285,10 @@ namespace Stratis.Bitcoin.Features.BlockStore
         {
             this.logger.LogTrace("({0}:'{1}')", nameof(block), block?.HashBlock);
 
-            this.ChainState.HighestPersistedBlock = block;
+            var blockRepository = this.BlockRepository as BlockRepository;
+
+            if (blockRepository != null)
+                blockRepository.HighestPersistedBlock = block;
 
             this.logger.LogTrace("(-)");
         }

--- a/Stratis.Bitcoin.Features.IndexStore/IndexStoreLoop.cs
+++ b/Stratis.Bitcoin.Features.IndexStore/IndexStoreLoop.cs
@@ -23,12 +23,7 @@ namespace Stratis.Bitcoin.Features.IndexStore
             base(asyncLoopFactory, blockPuller, indexRepository, cache, chain, chainState, indexSettings, nodeLifetime, loggerFactory, dateTimeProvider)
         {
         }
-        
-        public override string StoreName => GetType().Name;
 
-        protected override void SetHighestPersistedBlock(ChainedBlock block)
-        {
-            this.ChainState.HighestIndexedBlock = block;
-        }
+        public override string StoreName { get { return "IndexStore"; } }
     }
 }

--- a/Stratis.Bitcoin.IntegrationTests/BlockStoreTests.cs
+++ b/Stratis.Bitcoin.IntegrationTests/BlockStoreTests.cs
@@ -159,7 +159,7 @@ namespace Stratis.Bitcoin.IntegrationTests
                 // wait for block repo for block sync to work
                 TestHelper.WaitLoop(() => stratisNodeSync.FullNode.ConsensusLoop().Tip.HashBlock == stratisNodeSync.FullNode.Chain.Tip.HashBlock);
                 TestHelper.WaitLoop(() => stratisNodeSync.FullNode.ChainBehaviorState.HighestValidatedPoW.HashBlock == stratisNodeSync.FullNode.Chain.Tip.HashBlock);
-                TestHelper.WaitLoop(() => stratisNodeSync.FullNode.ChainBehaviorState.HighestPersistedBlock.HashBlock == stratisNodeSync.FullNode.Chain.Tip.HashBlock);
+                TestHelper.WaitLoop(() => stratisNodeSync.FullNode.HighestPersistedBlock().HashBlock == stratisNodeSync.FullNode.Chain.Tip.HashBlock);
 
                 // sync both nodes
                 stratisNode1.CreateRPCClient().AddNode(stratisNodeSync.Endpoint, true);
@@ -209,7 +209,7 @@ namespace Stratis.Bitcoin.IntegrationTests
                 newNodeInstance.Start();
 
                 // check that store recovered to be the same as the best chain.
-               Assert.Equal(newNodeInstance.FullNode.Chain.Tip.HashBlock, newNodeInstance.FullNode.ChainBehaviorState.HighestPersistedBlock.HashBlock);
+               Assert.Equal(newNodeInstance.FullNode.Chain.Tip.HashBlock, newNodeInstance.FullNode.HighestPersistedBlock().HashBlock);
                 //TestHelper.WaitLoop(() => TestHelper.IsNodeSynced(stratisNodeSync));
             }
         }
@@ -235,10 +235,10 @@ namespace Stratis.Bitcoin.IntegrationTests
                 stratisNodeSync.CreateRPCClient().AddNode(stratisNode2.Endpoint, true);
 
                 stratisNode1.GenerateStratisWithMiner(10);
-                TestHelper.WaitLoop(() => stratisNode1.FullNode.ChainBehaviorState.HighestPersistedBlock.Height == 10);
+                TestHelper.WaitLoop(() => stratisNode1.FullNode.HighestPersistedBlock().Height == 10);
 
-                TestHelper.WaitLoop(() => stratisNode1.FullNode.ChainBehaviorState.HighestPersistedBlock.HashBlock == stratisNodeSync.FullNode.ChainBehaviorState.HighestPersistedBlock.HashBlock);
-                TestHelper.WaitLoop(() => stratisNode2.FullNode.ChainBehaviorState.HighestPersistedBlock.HashBlock == stratisNodeSync.FullNode.ChainBehaviorState.HighestPersistedBlock.HashBlock);
+                TestHelper.WaitLoop(() => stratisNode1.FullNode.HighestPersistedBlock().HashBlock == stratisNodeSync.FullNode.HighestPersistedBlock().HashBlock);
+                TestHelper.WaitLoop(() => stratisNode2.FullNode.HighestPersistedBlock().HashBlock == stratisNodeSync.FullNode.HighestPersistedBlock().HashBlock);
 
                 // remove node 2
                 stratisNodeSync.CreateRPCClient().RemoveNode(stratisNode2.Endpoint);
@@ -247,21 +247,21 @@ namespace Stratis.Bitcoin.IntegrationTests
                 stratisNode1.GenerateStratisWithMiner(10);
 
                 // wait for node 1 to sync
-                TestHelper.WaitLoop(() => stratisNode1.FullNode.ChainBehaviorState.HighestPersistedBlock.Height == 20);
-                TestHelper.WaitLoop(() => stratisNode1.FullNode.ChainBehaviorState.HighestPersistedBlock.HashBlock == stratisNodeSync.FullNode.ChainBehaviorState.HighestPersistedBlock.HashBlock);
+                TestHelper.WaitLoop(() => stratisNode1.FullNode.HighestPersistedBlock().Height == 20);
+                TestHelper.WaitLoop(() => stratisNode1.FullNode.HighestPersistedBlock().HashBlock == stratisNodeSync.FullNode.HighestPersistedBlock().HashBlock);
 
                 // remove node 1
                 stratisNodeSync.CreateRPCClient().RemoveNode(stratisNode1.Endpoint);
 
                 // mine a higher chain with node2
                 stratisNode2.GenerateStratisWithMiner(20);
-                TestHelper.WaitLoop(() => stratisNode2.FullNode.ChainBehaviorState.HighestPersistedBlock.Height == 30);
+                TestHelper.WaitLoop(() => stratisNode2.FullNode.HighestPersistedBlock().Height == 30);
 
                 // add node2 
                 stratisNodeSync.CreateRPCClient().AddNode(stratisNode2.Endpoint, true);
 
                 // node2 should be synced
-                TestHelper.WaitLoop(() => stratisNode2.FullNode.ChainBehaviorState.HighestPersistedBlock.HashBlock == stratisNodeSync.FullNode.ChainBehaviorState.HighestPersistedBlock.HashBlock);
+                TestHelper.WaitLoop(() => stratisNode2.FullNode.HighestPersistedBlock().HashBlock == stratisNodeSync.FullNode.HighestPersistedBlock().HashBlock);
             }
         }
 
@@ -282,8 +282,8 @@ namespace Stratis.Bitcoin.IntegrationTests
                 // sync both nodes
                 stratisNode1.CreateRPCClient().AddNode(stratisNode2.Endpoint, true);
                 stratisNode1.GenerateStratisWithMiner(10);
-                TestHelper.WaitLoop(() => stratisNode1.FullNode.ChainBehaviorState.HighestPersistedBlock.Height == 10);
-                TestHelper.WaitLoop(() => stratisNode1.FullNode.ChainBehaviorState.HighestPersistedBlock.HashBlock == stratisNode2.FullNode.ChainBehaviorState.HighestPersistedBlock.HashBlock);
+                TestHelper.WaitLoop(() => stratisNode1.FullNode.HighestPersistedBlock().Height == 10);
+                TestHelper.WaitLoop(() => stratisNode1.FullNode.HighestPersistedBlock().HashBlock == stratisNode2.FullNode.HighestPersistedBlock().HashBlock);
 
                 var bestBlock1 = stratisNode1.FullNode.BlockStoreManager().BlockRepository.GetAsync(stratisNode1.FullNode.Chain.Tip.HashBlock).Result;
                 Assert.NotNull(bestBlock1);

--- a/Stratis.Bitcoin.IntegrationTests/MemoryPoolTests.cs
+++ b/Stratis.Bitcoin.IntegrationTests/MemoryPoolTests.cs
@@ -568,7 +568,7 @@ namespace Stratis.Bitcoin.IntegrationTests
                 stratisNodeSync.SetDummyMinerSecret(new BitcoinSecret(new Key(), stratisNodeSync.FullNode.Network));
                 stratisNodeSync.GenerateStratis(105); // coinbase maturity = 100
                 TestHelper.WaitLoop(() => stratisNodeSync.FullNode.ConsensusLoop().Tip.HashBlock == stratisNodeSync.FullNode.Chain.Tip.HashBlock);
-                TestHelper.WaitLoop(() => stratisNodeSync.FullNode.ChainBehaviorState.HighestPersistedBlock.HashBlock == stratisNodeSync.FullNode.Chain.Tip.HashBlock);
+                TestHelper.WaitLoop(() => stratisNodeSync.FullNode.HighestPersistedBlock().HashBlock == stratisNodeSync.FullNode.Chain.Tip.HashBlock);
 
                 var block = stratisNodeSync.FullNode.BlockStoreManager().BlockRepository.GetAsync(stratisNodeSync.FullNode.Chain.GetBlock(4).HashBlock).Result;
                 var prevTrx = block.Transactions.First();
@@ -598,7 +598,7 @@ namespace Stratis.Bitcoin.IntegrationTests
                 stratisNodeSync.SetDummyMinerSecret(new BitcoinSecret(new Key(), stratisNodeSync.FullNode.Network));
                 stratisNodeSync.GenerateStratis(105); // coinbase maturity = 100
                 TestHelper.WaitLoop(() => stratisNodeSync.FullNode.ConsensusLoop().Tip.HashBlock == stratisNodeSync.FullNode.Chain.Tip.HashBlock);
-                TestHelper.WaitLoop(() => stratisNodeSync.FullNode.ChainBehaviorState.HighestPersistedBlock.HashBlock == stratisNodeSync.FullNode.Chain.Tip.HashBlock);
+                TestHelper.WaitLoop(() => stratisNodeSync.FullNode.HighestPersistedBlock().HashBlock == stratisNodeSync.FullNode.Chain.Tip.HashBlock);
 
                 var block = stratisNodeSync.FullNode.BlockStoreManager().BlockRepository.GetAsync(stratisNodeSync.FullNode.Chain.GetBlock(4).HashBlock).Result;
                 var prevTrx = block.Transactions.First();
@@ -641,7 +641,7 @@ namespace Stratis.Bitcoin.IntegrationTests
                 stratisNodeSync.SetDummyMinerSecret(new BitcoinSecret(new Key(), stratisNodeSync.FullNode.Network));
                 stratisNodeSync.GenerateStratis(201); // coinbase maturity = 100
                 TestHelper.WaitLoop(() => stratisNodeSync.FullNode.ConsensusLoop().Tip.HashBlock == stratisNodeSync.FullNode.Chain.Tip.HashBlock);
-                TestHelper.WaitLoop(() => stratisNodeSync.FullNode.ChainBehaviorState.HighestPersistedBlock.HashBlock == stratisNodeSync.FullNode.Chain.Tip.HashBlock);
+                TestHelper.WaitLoop(() => stratisNodeSync.FullNode.HighestPersistedBlock().HashBlock == stratisNodeSync.FullNode.Chain.Tip.HashBlock);
 
                 var trxs = new List<Transaction>();
                 foreach (var index in Enumerable.Range(1, 100))
@@ -680,7 +680,7 @@ namespace Stratis.Bitcoin.IntegrationTests
                 stratisNodeSync.SetDummyMinerSecret(new BitcoinSecret(new Key(), stratisNodeSync.FullNode.Network));
                 stratisNodeSync.GenerateStratis(100); // coinbase maturity = 100
                 TestHelper.WaitLoop(() => stratisNodeSync.FullNode.ConsensusLoop().Tip.HashBlock == stratisNodeSync.FullNode.Chain.Tip.HashBlock);
-                TestHelper.WaitLoop(() => stratisNodeSync.FullNode.ChainBehaviorState.HighestPersistedBlock.HashBlock == stratisNodeSync.FullNode.Chain.Tip.HashBlock);
+                TestHelper.WaitLoop(() => stratisNodeSync.FullNode.HighestPersistedBlock().HashBlock == stratisNodeSync.FullNode.Chain.Tip.HashBlock);
 
                 // Make sure skipping validation of transctions that were
                 // validated going into the memory pool does not allow
@@ -822,7 +822,7 @@ namespace Stratis.Bitcoin.IntegrationTests
                 stratisNodeSync.GenerateStratis(101); // coinbase maturity = 100
                 TestHelper.WaitLoop(() => stratisNodeSync.FullNode.ConsensusLoop().Tip.HashBlock == stratisNodeSync.FullNode.Chain.Tip.HashBlock);
                 TestHelper.WaitLoop(() => stratisNodeSync.FullNode.ChainBehaviorState.HighestValidatedPoW.HashBlock == stratisNodeSync.FullNode.Chain.Tip.HashBlock);
-                TestHelper.WaitLoop(() => stratisNodeSync.FullNode.ChainBehaviorState.HighestPersistedBlock.HashBlock == stratisNodeSync.FullNode.Chain.Tip.HashBlock);
+                TestHelper.WaitLoop(() => stratisNodeSync.FullNode.HighestPersistedBlock().HashBlock == stratisNodeSync.FullNode.Chain.Tip.HashBlock);
 
                 var block = stratisNodeSync.FullNode.BlockStoreManager().BlockRepository.GetAsync(stratisNodeSync.FullNode.Chain.GetBlock(1).HashBlock).Result;
                 var prevTrx = block.Transactions.First();

--- a/Stratis.Bitcoin.IntegrationTests/NodeBuilder.cs
+++ b/Stratis.Bitcoin.IntegrationTests/NodeBuilder.cs
@@ -61,6 +61,11 @@ namespace Stratis.Bitcoin.IntegrationTests
         {
             return fullNode.NodeService<BlockStoreManager>();
         }
+
+        public static ChainedBlock HighestPersistedBlock(this FullNode fullNode)
+        {
+            return (fullNode.NodeService<Features.BlockStore.IBlockRepository>() as BlockRepository).HighestPersistedBlock;
+        }
     }
 
     public enum CoreNodeState

--- a/Stratis.Bitcoin.IntegrationTests/NodeSync.cs
+++ b/Stratis.Bitcoin.IntegrationTests/NodeSync.cs
@@ -114,7 +114,7 @@ namespace Stratis.Bitcoin.IntegrationTests
                 var tip = coreCreateNode.FindBlock(5).Last();
                 stratisNode.CreateRPCClient().AddNode(coreCreateNode.Endpoint, true);
                 TestHelper.WaitLoop(() => stratisNode.CreateRPCClient().GetBestBlockHash() == coreCreateNode.CreateRPCClient().GetBestBlockHash());
-                TestHelper.WaitLoop(() => stratisNode.FullNode.ChainBehaviorState.HighestPersistedBlock.HashBlock == stratisNode.FullNode.Chain.Tip.HashBlock);
+                TestHelper.WaitLoop(() => stratisNode.FullNode.HighestPersistedBlock().HashBlock == stratisNode.FullNode.Chain.Tip.HashBlock);
 
                 var bestBlockHash = stratisNode.CreateRPCClient().GetBestBlockHash();
                 Assert.Equal(tip.GetHash(), bestBlockHash);

--- a/Stratis.Bitcoin.IntegrationTests/TestHelper.cs
+++ b/Stratis.Bitcoin.IntegrationTests/TestHelper.cs
@@ -22,7 +22,7 @@ namespace Stratis.Bitcoin.IntegrationTests
         {
             if (node1.FullNode.Chain.Tip.HashBlock != node2.FullNode.Chain.Tip.HashBlock) return false;
             if (node1.FullNode.ChainBehaviorState.HighestValidatedPoW.HashBlock != node2.FullNode.ChainBehaviorState.HighestValidatedPoW.HashBlock) return false;
-            if (node1.FullNode.ChainBehaviorState.HighestPersistedBlock.HashBlock != node2.FullNode.ChainBehaviorState.HighestPersistedBlock.HashBlock) return false;
+            if (node1.FullNode.HighestPersistedBlock().HashBlock != node2.FullNode.HighestPersistedBlock().HashBlock) return false;
             if (node1.FullNode.MempoolManager().InfoAll().Count != node2.FullNode.MempoolManager().InfoAll().Count) return false;
             if (node1.FullNode.WalletManager().WalletTipHash != node2.FullNode.WalletManager().WalletTipHash) return false;
             if (node1.CreateRPCClient().GetBestBlockHash() != node2.CreateRPCClient().GetBestBlockHash()) return false;
@@ -32,7 +32,7 @@ namespace Stratis.Bitcoin.IntegrationTests
         public static bool IsNodeSynced(CoreNode node)
         {
             if (node.FullNode.Chain.Tip.HashBlock != node.FullNode.ChainBehaviorState.HighestValidatedPoW.HashBlock) return false;
-            if (node.FullNode.Chain.Tip.HashBlock != node.FullNode.ChainBehaviorState.HighestPersistedBlock.HashBlock) return false;
+            if (node.FullNode.Chain.Tip.HashBlock != node.FullNode.HighestPersistedBlock().HashBlock) return false;
             if (node.FullNode.Chain.Tip.HashBlock != node.FullNode.WalletManager().WalletTipHash) return false;
             return true;
         }

--- a/Stratis.Bitcoin/Base/ChainState.cs
+++ b/Stratis.Bitcoin/Base/ChainState.cs
@@ -78,20 +78,6 @@ namespace Stratis.Bitcoin.Base
             get; set;
         }
 
-        /// <summary>
-        /// Represents the last block stored to disk
-        /// </summary>
-        public ChainedBlock HighestPersistedBlock
-        {
-            get; set;
-        }
 
-        /// <summary>
-        /// Represents the last block stored to the index repository
-        /// </summary>
-        public ChainedBlock HighestIndexedBlock
-        {
-            get; set;
-        }
     }
 }

--- a/Stratis.Bitcoin/FullNode.cs
+++ b/Stratis.Bitcoin/FullNode.cs
@@ -250,31 +250,13 @@ namespace Stratis.Bitcoin
                                      this.Chain.Tip.Height.ToString().PadRight(8) +
                                      " Headers.Hash: ".PadRight(LoggingConfiguration.ColumnLength + 3) + this.Chain.Tip.HashBlock);
 
-                // TODO
+                // TODO: Why are three features all setting the HighestValidatedPoW (Consensus, Mining and Notifications)?
                 if (this?.ChainBehaviorState?.HighestValidatedPoW != null)
                 {
                     benchLogs.AppendLine("Consensus.Height: ".PadRight(LoggingConfiguration.ColumnLength + 3) +
                                          this.ChainBehaviorState.HighestValidatedPoW.Height.ToString().PadRight(8) +
                                          " Consensus.Hash: ".PadRight(LoggingConfiguration.ColumnLength + 3) +
                                          this.ChainBehaviorState.HighestValidatedPoW.HashBlock);
-                }
-
-                // TODO
-                if (this.ChainBehaviorState.HighestPersistedBlock != null)
-                {
-                    benchLogs.AppendLine("Store.Height: ".PadRight(LoggingConfiguration.ColumnLength + 3) +
-                                         this.ChainBehaviorState.HighestPersistedBlock.Height.ToString().PadRight(8) +
-                                         " Store.Hash: ".PadRight(LoggingConfiguration.ColumnLength + 3) +
-                                         this.ChainBehaviorState.HighestPersistedBlock.HashBlock);
-                }
-
-                // TODO
-                if (this.ChainBehaviorState.HighestIndexedBlock != null)
-                {
-                    benchLogs.AppendLine("Index.Height: ".PadRight(LoggingConfiguration.ColumnLength + 3) +
-                                         this.ChainBehaviorState.HighestIndexedBlock.Height.ToString().PadRight(8) +
-                                         " Index.Hash: ".PadRight(LoggingConfiguration.ColumnLength + 3) +
-                                         this.ChainBehaviorState.HighestIndexedBlock.HashBlock);
                 }
 
                 // Display node stats grouped together


### PR DESCRIPTION
This PR addresses 2 TODO's relating to BlockStore and IndexStore in FullNode.cs. It includes:

- Moving "HighestPersistedBlock" from ChainState to the BlockRepository
- Moving the logging code relating to the above value to the Blockstore feature
- It also addresses a bug in the new StoreName method override in the Index Repository