### PR TITLE
Take puller one block back when syncing

### DIFF
--- a/Stratis.Bitcoin.Features.Notifications.Tests/BlockNotificationFeatureTest.cs
+++ b/Stratis.Bitcoin.Features.Notifications.Tests/BlockNotificationFeatureTest.cs
@@ -24,11 +24,11 @@ namespace Stratis.Bitcoin.Features.Notifications.Tests
                 .Returns(NodeSettings.Default());
             connectionManager.Setup(c => c.Parameters)
                 .Returns(new NodeConnectionParameters());
-            
+
             var chain = new Mock<ConcurrentChain>();
             var chainState = new Mock<ChainState>(new Mock<FullNode>().Object);
             var blockPuller = new Mock<LookaheadBlockPuller>(chain.Object, connectionManager.Object, new LoggerFactory());
-            var blockNotification = new Mock<BlockNotification>(chain.Object, blockPuller.Object, new Bitcoin.Signals.Signals(), new AsyncLoopFactory(new LoggerFactory()), new NodeLifetime());
+            var blockNotification = new Mock<BlockNotification>(this.LoggerFactory.Object, chain.Object, blockPuller.Object, new Bitcoin.Signals.Signals(), new AsyncLoopFactory(new LoggerFactory()), new NodeLifetime());
 
             var blockNotificationFeature = new BlockNotificationFeature(blockNotification.Object, connectionManager.Object, blockPuller.Object, chainState.Object, chain.Object);
             blockNotificationFeature.Start();

--- a/Stratis.Bitcoin.Features.Notifications.Tests/BlockNotificationTest.cs
+++ b/Stratis.Bitcoin.Features.Notifications.Tests/BlockNotificationTest.cs
@@ -1,12 +1,12 @@
-﻿using Microsoft.Extensions.Logging;
+﻿using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using Moq;
 using NBitcoin;
 using Stratis.Bitcoin.BlockPulling;
 using Stratis.Bitcoin.Signals;
 using Stratis.Bitcoin.Tests.Logging;
 using Stratis.Bitcoin.Utilities;
-using System.Threading;
-using System.Threading.Tasks;
 using Xunit;
 
 namespace Stratis.Bitcoin.Features.Notifications.Tests
@@ -21,7 +21,7 @@ namespace Stratis.Bitcoin.Features.Notifications.Tests
             chain.Setup(c => c.GetBlock(startBlockId))
                 .Returns((ChainedBlock)null);
 
-            var notification = new BlockNotification(chain.Object, new Mock<ILookaheadBlockPuller>().Object, new Bitcoin.Signals.Signals(), new AsyncLoopFactory(new LoggerFactory()), new NodeLifetime());
+            var notification = new BlockNotification(this.LoggerFactory.Object, chain.Object, new Mock<ILookaheadBlockPuller>().Object, new Bitcoin.Signals.Signals(), new AsyncLoopFactory(new LoggerFactory()), new NodeLifetime());
 
             notification.Notify();
         }
@@ -40,7 +40,7 @@ namespace Stratis.Bitcoin.Features.Notifications.Tests
             stub.Setup(s => s.NextBlock(lifetime.ApplicationStopping))
                 .Returns((Block)null);
 
-            var notification = new BlockNotification(chain.Object, stub.Object, new Bitcoin.Signals.Signals(), new AsyncLoopFactory(new LoggerFactory()), lifetime);
+            var notification = new BlockNotification(this.LoggerFactory.Object, chain.Object, stub.Object, new Bitcoin.Signals.Signals(), new AsyncLoopFactory(new LoggerFactory()), lifetime);
 
             notification.Notify();
             notification.SyncFrom(startBlockId);
@@ -67,7 +67,7 @@ namespace Stratis.Bitcoin.Features.Notifications.Tests
 
             var signals = new Mock<ISignals>();
 
-            var notification = new BlockNotification(chain.Object, stub.Object, signals.Object, new AsyncLoopFactory(new LoggerFactory()), lifetime);
+            var notification = new BlockNotification(this.LoggerFactory.Object, chain.Object, stub.Object, signals.Object, new AsyncLoopFactory(new LoggerFactory()), lifetime);
 
             await notification.Notify().RunningTask;
 
@@ -94,7 +94,7 @@ namespace Stratis.Bitcoin.Features.Notifications.Tests
 
             var signals = new Mock<ISignals>();
 
-            var notification = new BlockNotification(chain.Object, stub.Object, signals.Object, new AsyncLoopFactory(new LoggerFactory()), lifetime);
+            var notification = new BlockNotification(this.LoggerFactory.Object, chain.Object, stub.Object, signals.Object, new AsyncLoopFactory(new LoggerFactory()), lifetime);
 
             notification.SyncFrom(startBlockId);
             await notification.Notify().RunningTask;

--- a/Stratis.Bitcoin.Features.Notifications.Tests/BlockNotificationTest.cs
+++ b/Stratis.Bitcoin.Features.Notifications.Tests/BlockNotificationTest.cs
@@ -27,25 +27,36 @@ namespace Stratis.Bitcoin.Features.Notifications.Tests
         }
 
         [Fact]
-        public void NotifySetsPullerLocationToBlockMatchingStartHash()
+        public void NotifySetsPullerLocationToPreviousBlockMatchingStartHash()
         {
-            var startBlockId = new uint256(156);
+            var blockId0 = new uint256(150);
+            var header0 = new BlockHeader();
+
+            var blockId1 = new uint256(151);
+            var header1 = new BlockHeader("00000020e84aee5c9c09f7eb37e0654ba0b3e5a2825c7866bd20409479451a4100000000fe30d12ce0075d539de3d8c15c59767ed9c4299fc93fd5c4919190a72d8dbb9583ffc059ffff001d1140956c");
+
+            var blockId2 = new uint256(152);
+            var header2 = new BlockHeader("00000020cccdc29c36a75b1b4226f218029bac0f3ddd4262ab787419b04b72c600000000b1834fd70f594e0a47d2048a770de5f9eccedb8ea8ff10b1be66c354fd4be28ccdfac059ffff001d07a85047");
+
             var chain = new Mock<ConcurrentChain>();
-            var header = new BlockHeader();
-            chain.Setup(c => c.GetBlock(startBlockId))
-                .Returns(new ChainedBlock(header, 0));
+
+            chain.Setup(c => c.GetBlock(0)).Returns(new ChainedBlock(header0, 0));
+            chain.Setup(c => c.GetBlock(1)).Returns(new ChainedBlock(header1, 1));
+            chain.Setup(c => c.GetBlock(2)).Returns(new ChainedBlock(header2, 2));
+            chain.Setup(c => c.GetBlock(blockId0)).Returns(new ChainedBlock(header0, 0));
+            chain.Setup(c => c.GetBlock(blockId1)).Returns(new ChainedBlock(header1, 1));
+            chain.Setup(c => c.GetBlock(blockId2)).Returns(new ChainedBlock(header2, 2));
 
             var stub = new Mock<ILookaheadBlockPuller>();
             var lifetime = new NodeLifetime();
-            stub.Setup(s => s.NextBlock(lifetime.ApplicationStopping))
-                .Returns((Block)null);
+            stub.Setup(s => s.NextBlock(lifetime.ApplicationStopping)).Returns((Block)null);
 
             var notification = new BlockNotification(this.LoggerFactory.Object, chain.Object, stub.Object, new Bitcoin.Signals.Signals(), new AsyncLoopFactory(new LoggerFactory()), lifetime);
 
             notification.Notify();
-            notification.SyncFrom(startBlockId);
-            notification.SyncFrom(startBlockId);
-            stub.Verify(s => s.SetLocation(It.Is<ChainedBlock>(c => c.Height == 0 && c.Header.GetHash() == header.GetHash())));
+            notification.SyncFrom(blockId1);
+            notification.SyncFrom(blockId1);
+            stub.Verify(s => s.SetLocation(It.Is<ChainedBlock>(c => c.Height == 0 && c.Header.GetHash() == header0.GetHash())));
         }
 
         [Fact]
@@ -100,6 +111,29 @@ namespace Stratis.Bitcoin.Features.Notifications.Tests
             await notification.Notify().RunningTask;
 
             signals.Verify(s => s.SignalBlock(It.IsAny<Block>()), Times.Exactly(2));
+        }
+
+        [Fact]
+        public void CallingSyncFromUpdatesStartHashAccordingly()
+        {
+            var lifetime = new NodeLifetime();
+            var chain = new Mock<ConcurrentChain>();
+            var stub = new Mock<ILookaheadBlockPuller>();
+            var signals = new Mock<ISignals>();
+
+            var notification = new BlockNotification(this.LoggerFactory.Object, chain.Object, stub.Object, signals.Object, new AsyncLoopFactory(new LoggerFactory()), lifetime);
+
+            var blockId1 = new uint256(150);
+            var blockId2 = new uint256(151);
+
+            Assert.Null(notification.StartHash);
+            notification.SyncFrom(blockId1);
+
+            Assert.NotNull(notification.StartHash);
+            Assert.Equal(blockId1, notification.StartHash);
+
+            notification.SyncFrom(blockId2);
+            Assert.Equal(blockId2, notification.StartHash);
         }
     }
 }

--- a/Stratis.Bitcoin.Features.Notifications.Tests/NotificationsControllerTest.cs
+++ b/Stratis.Bitcoin.Features.Notifications.Tests/NotificationsControllerTest.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using System;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Moq;
 using NBitcoin;
@@ -7,7 +8,6 @@ using Stratis.Bitcoin.Features.Notifications.Controllers;
 using Stratis.Bitcoin.Tests.Logging;
 using Stratis.Bitcoin.Utilities;
 using Stratis.Bitcoin.Utilities.JsonErrors;
-using System;
 using Xunit;
 
 namespace Stratis.Bitcoin.Features.Notifications.Tests
@@ -21,7 +21,7 @@ namespace Stratis.Bitcoin.Features.Notifications.Tests
         public void Given_SyncActionIsCalled_When_QueryParameterIsNullOrEmpty_Then_ReturnBadRequest(string from)
         {
             var chain = new Mock<ConcurrentChain>();
-            var blockNotification = new Mock<BlockNotification>(chain.Object, new Mock<ILookaheadBlockPuller>().Object, new Bitcoin.Signals.Signals(), new AsyncLoopFactory(new LoggerFactory()), new NodeLifetime());
+            var blockNotification = new Mock<BlockNotification>(this.LoggerFactory.Object, chain.Object, new Mock<ILookaheadBlockPuller>().Object, new Bitcoin.Signals.Signals(), new AsyncLoopFactory(new LoggerFactory()), new NodeLifetime());
 
             var notificationController = new NotificationsController(blockNotification.Object, chain.Object);
             IActionResult result = notificationController.SyncFrom(from);
@@ -33,7 +33,7 @@ namespace Stratis.Bitcoin.Features.Notifications.Tests
             ErrorModel error = errorResponse.Errors[0];
             Assert.Equal(400, error.Status);
         }
-        
+
         [Fact]
         public void Given_SyncActionIsCalled_When_ABlockHeightIsSpecified_Then_TheChainIsSyncedFromTheHash()
         {
@@ -45,7 +45,7 @@ namespace Stratis.Bitcoin.Features.Notifications.Tests
             ChainedBlock chainedBlock = new ChainedBlock(new BlockHeader(), hash, null);
             var chain = new Mock<ConcurrentChain>();
             chain.Setup(c => c.GetBlock(heightLocation)).Returns(chainedBlock);
-            var blockNotification = new Mock<BlockNotification>(chain.Object, new Mock<ILookaheadBlockPuller>().Object, new Bitcoin.Signals.Signals(), new AsyncLoopFactory(new LoggerFactory()), new NodeLifetime());
+            var blockNotification = new Mock<BlockNotification>(this.LoggerFactory.Object, chain.Object, new Mock<ILookaheadBlockPuller>().Object, new Bitcoin.Signals.Signals(), new AsyncLoopFactory(new LoggerFactory()), new NodeLifetime());
 
             // Act
             var notificationController = new NotificationsController(blockNotification.Object, chain.Object);
@@ -67,7 +67,7 @@ namespace Stratis.Bitcoin.Features.Notifications.Tests
             ChainedBlock chainedBlock = new ChainedBlock(new BlockHeader(), hash, null);
             var chain = new Mock<ConcurrentChain>();
             chain.Setup(c => c.GetBlock(heightLocation)).Returns(chainedBlock);
-            var blockNotification = new Mock<BlockNotification>(chain.Object, new Mock<ILookaheadBlockPuller>().Object, new Bitcoin.Signals.Signals(), new AsyncLoopFactory(new LoggerFactory()), new NodeLifetime());
+            var blockNotification = new Mock<BlockNotification>(this.LoggerFactory.Object, chain.Object, new Mock<ILookaheadBlockPuller>().Object, new Bitcoin.Signals.Signals(), new AsyncLoopFactory(new LoggerFactory()), new NodeLifetime());
 
             // Act
             var notificationController = new NotificationsController(blockNotification.Object, chain.Object);
@@ -84,7 +84,7 @@ namespace Stratis.Bitcoin.Features.Notifications.Tests
             // Set up
             string hashLocation = "notAValidHash";
             var chain = new Mock<ConcurrentChain>();
-            var blockNotification = new Mock<BlockNotification>(chain.Object, new Mock<ILookaheadBlockPuller>().Object, new Bitcoin.Signals.Signals(), new AsyncLoopFactory(new LoggerFactory()), new NodeLifetime());
+            var blockNotification = new Mock<BlockNotification>(this.LoggerFactory.Object, chain.Object, new Mock<ILookaheadBlockPuller>().Object, new Bitcoin.Signals.Signals(), new AsyncLoopFactory(new LoggerFactory()), new NodeLifetime());
 
             // Act
             var notificationController = new NotificationsController(blockNotification.Object, chain.Object);


### PR DESCRIPTION
Fix for a bug that happened when syncing from a height or a hash.
When asked to sync, the block puller was starting to sync from the next block.
Now when it's asked to sync from height h, we move the puller to height h-1 so that the next block is the one we seek to start the syncing from.