### PR TITLE
Change name of command line parameter "listen" to "bind"

### DIFF
--- a/Stratis.Bitcoin/Configuration/NodeSettings.cs
+++ b/Stratis.Bitcoin/Configuration/NodeSettings.cs
@@ -221,12 +221,12 @@ namespace Stratis.Bitcoin.Configuration
             var port = config.GetOrDefault<int>("port", nodeSettings.Network.DefaultPort);
             try
             {
-                nodeSettings.ConnectionManager.Listen.AddRange(config.GetAll("listen")
+                nodeSettings.ConnectionManager.Listen.AddRange(config.GetAll("bind")
                         .Select(c => new NodeServerEndpoint(ConvertToEndpoint(c, port), false)));
             }
             catch (FormatException)
             {
-                throw new ConfigurationException("Invalid listen parameter");
+                throw new ConfigurationException("Invalid bind parameter");
             }
 
             try


### PR DESCRIPTION
"Stratis node uses -listen for what Bitcoin Core uses -bind. Bitcoin Core also defines -listen, but uses it for different thing. This is probably not an intention and the parameters should be compatible." - Aprogiena

See https://github.com/stratisproject/StratisBitcoinFullNode/issues/259

This PR changes the name of the "listen" parameter to "bind".