### PR TITLE
Rephrase exception thrown when non-valid mnemonic is entered

### DIFF
--- a/Stratis.Bitcoin.Features.Wallet/WalletManager.cs
+++ b/Stratis.Bitcoin.Features.Wallet/WalletManager.cs
@@ -210,7 +210,21 @@ namespace Stratis.Bitcoin.Features.Wallet
             }
 
             // generate the root seed used to generate keys
-            ExtKey extendedKey = HdOperations.GetHdPrivateKey(mnemonic, passphrase);
+            ExtKey extendedKey;
+            try
+            {
+                extendedKey = HdOperations.GetHdPrivateKey(mnemonic, passphrase);
+            }
+            catch (NotSupportedException ex)
+            {
+                if (ex.Message == "Unknown")
+                {
+                    throw new WalletException("Please make sure you enter valid mnemonic words.");
+                }
+
+                throw;
+            }
+
 
             // create a wallet file 
             string encryptedSeed = extendedKey.PrivateKey.GetEncryptedBitcoinSecret(password, this.network).ToWif();


### PR DESCRIPTION
When a string like "sdsa" is entered as a mnemonic, a NotSupportedException is thrown from NBitcoin with "Unknown" as the message.
This PR changes the message to "Please make sure you enter valid mnemonic words.", making it less confusing to users.