### PR TITLE
Unit tests for WalletSyncManager

### DIFF
--- a/Stratis.Bitcoin.Features.Wallet.Tests/WalletSyncManagerTest.cs
+++ b/Stratis.Bitcoin.Features.Wallet.Tests/WalletSyncManagerTest.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using NBitcoin;
 using Moq;
 using Stratis.Bitcoin.Features.BlockStore;
+using Stratis.Bitcoin.Features.Wallet.Interfaces;
 using Stratis.Bitcoin.Tests.Logging;
 using Stratis.Bitcoin.Utilities;
 using Xunit;
@@ -240,11 +241,10 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
 
             var walletSyncManager = new WalletSyncManager(this.LoggerFactory.Object, this.walletManager.Object, this.chain, Network.StratisMain,
              this.blockStoreCache.Object, this.storeSettings, this.nodeLifetime.Object);
+            
+            walletSyncManager.SyncFromDate(this.chain.GetBlock(3).Header.BlockTime.DateTime.AddDays(2));
 
-            var block = this.chain.GetBlock(2);
-            walletSyncManager.SyncFromDate(block.Header.BlockTime.DateTime);
-
-            var expectedHash = this.chain.GetBlock(2).HashBlock;
+            var expectedHash = this.chain.GetBlock(3).HashBlock;
             Assert.Equal(walletSyncManager.WalletTip.HashBlock, expectedHash);
             this.walletManager.VerifySet(w => w.WalletTipHash = expectedHash);
         }

--- a/Stratis.Bitcoin.Features.Wallet.Tests/WalletSyncManagerTest.cs
+++ b/Stratis.Bitcoin.Features.Wallet.Tests/WalletSyncManagerTest.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System.Linq;
+using System.Threading.Tasks;
 using NBitcoin;
 using Moq;
 using Stratis.Bitcoin.Features.BlockStore;
@@ -6,6 +7,8 @@ using Stratis.Bitcoin.Tests.Logging;
 using Stratis.Bitcoin.Utilities;
 using Xunit;
 using System.Collections.ObjectModel;
+using Microsoft.Extensions.Logging;
+using System.Collections.Generic;
 
 namespace Stratis.Bitcoin.Features.Wallet.Tests
 {
@@ -45,7 +48,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
         }
 
         [Fact]
-        public void Initialize_BlockOnChain_DoesNotChangeWalletManager()
+        public void Initialize_BlockOnChain_DoesNotReorgWalletManager()
         {
             this.storeSettings.Prune = false;
             this.chain = WalletTestsHelpers.PrepareChainWithBlock();
@@ -62,12 +65,12 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
             this.walletManager.Verify(w => w.RemoveBlocks(It.IsAny<ChainedBlock>()), Times.Exactly(0));
             Assert.True(task.IsCompleted);
         }
-        
+
         [Fact]
-        public void Initialize_BlockNotChain_RecoversWalletManagerUsingWallet()
+        public void Initialize_BlockNotChain_ReorgsWalletManagerUsingWallet()
         {
             this.storeSettings.Prune = false;
-            this.chain = WalletTestsHelpers.GenerateChainWithHeight(5, Network.StratisMain);            
+            this.chain = WalletTestsHelpers.GenerateChainWithHeight(5, Network.StratisMain);
             this.walletManager.SetupGet(w => w.WalletTipHash)
                 .Returns(new uint256(125)); // try to load non-existing block to get chain to return null.
 
@@ -82,11 +85,164 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
             var task = walletSyncManager.Initialize();
             task.Wait();
 
-            // verify the walletmanager is recovered using the fork block and it's tip is set to it.
-            this.walletManager.Verify(w => w.RemoveBlocks(It.Is<ChainedBlock>(c => c.Header.GetHash() == forkBlockHash)), Times.Exactly(1));
+            // verify the walletmanager is reorged using the fork block and it's tip is set to it.
+            this.walletManager.Verify(w => w.RemoveBlocks(It.Is<ChainedBlock>(c => c.Header.GetHash() == forkBlockHash)));
             this.walletManager.VerifySet(w => w.WalletTipHash = forkBlockHash);
             Assert.Equal(walletSyncManager.WalletTip.HashBlock.ToString(), forkBlock.HashBlock.ToString());
             Assert.True(task.IsCompleted);
+        }
+
+        [Fact]
+        public void ProcessBlock_NewBlock_PreviousHashSameAsWalletTip_PassesBlockToManagerWithoutReorg()
+        {
+            var result = WalletTestsHelpers.GenerateChainAndBlocksWithHeight(5, Network.StratisMain);
+            this.chain = result.Chain;
+            var blocks = result.Blocks;
+            var walletSyncManager = new WalletSyncManagerOverride(this.LoggerFactory.Object, this.walletManager.Object, this.chain, Network.StratisMain,
+                this.blockStoreCache.Object, this.storeSettings, this.nodeLifetime.Object);
+            walletSyncManager.SetWalletTip(this.chain.GetBlock(3));
+
+            var blockToProcess = blocks[3];
+            walletSyncManager.ProcessBlock(blockToProcess); //4th block in the list has same prevhash as which is loaded
+
+            var expectedBlockHash = this.chain.GetBlock(4).Header.GetHash();
+            Assert.Equal(expectedBlockHash, walletSyncManager.WalletTip.Header.GetHash());
+            this.walletManager.Verify(w => w.ProcessBlock(It.Is<Block>(b => b.GetHash() == blockToProcess.GetHash()), It.Is<ChainedBlock>(c => c.Header.GetHash() == expectedBlockHash)));
+        }
+
+        [Fact]
+        public void ProcessBlock_NewBlock_PreviousHashNotSameAsWalletTip_WalletTipNotOnBestChain_RemovesBlocksAfterForkOnOldChainFromWalletManager_CatchUpWalletManagerUsingBlockStoreCache()
+        {
+            var result = WalletTestsHelpers.GenerateForkedChainAndBlocksWithHeight(5, Network.StratisMain, 2);
+            // left side chain containing the 'old' fork.
+            var leftChain = result.LeftChain;
+            // right side chain containing the 'new' fork. Work on this.
+            this.chain = result.RightChain;
+            var walletSyncManager = new WalletSyncManagerOverride(this.LoggerFactory.Object, this.walletManager.Object, this.chain, Network.StratisMain,
+                this.blockStoreCache.Object, this.storeSettings, this.nodeLifetime.Object);
+            // setup blockstorecache to return blocks on the chain.
+            this.blockStoreCache.Setup(b => b.GetBlockAsync(It.IsAny<uint256>()))
+                .ReturnsAsync((uint256 hashblock) =>
+                {
+                    return result.LeftForkBlocks.Union(result.RightForkBlocks).Where(b => b.GetHash() == hashblock).Single();
+                });
+
+            // set 4th block of the old chain as tip. 2 ahead of the fork thus not being on the right chain.
+            walletSyncManager.SetWalletTip(leftChain.GetBlock(result.LeftForkBlocks[3].Header.GetHash()));
+            //process 5th block from the right side of the fork in the list does not have same prevhash as which is loaded.
+            var blockToProcess = result.RightForkBlocks[4];
+            walletSyncManager.ProcessBlock(blockToProcess);
+
+            // walletmanager removes all blocks up to the fork.
+            this.walletManager.Verify(w => w.RemoveBlocks(ExpectChainedBlock(this.chain.GetBlock(2))));
+            var expectedBlockHash = this.chain.GetBlock(5).Header.GetHash();
+            Assert.Equal(expectedBlockHash, walletSyncManager.WalletTip.Header.GetHash());
+
+            //verify manager processes each missing block until caught up.
+            // height 3
+            this.walletManager.Verify(w => w.ProcessBlock(ExpectBlock(result.RightForkBlocks[2]), ExpectChainedBlock(this.chain.GetBlock(3))));
+            // height 4
+            this.walletManager.Verify(w => w.ProcessBlock(ExpectBlock(result.RightForkBlocks[3]), ExpectChainedBlock(this.chain.GetBlock(4))));
+            // height 5
+            this.walletManager.Verify(w => w.ProcessBlock(ExpectBlock(result.RightForkBlocks[4]), ExpectChainedBlock(this.chain.GetBlock(5))), Times.Exactly(2));
+        }
+
+        [Fact]
+        public void ProcessBlock_NewBlock_PreviousHashNotSameAsWalletTip_WalletTipOnBestChain_BlockInBlockStoreCache_CatchUpWalletManagerUsingBlockStoreCache()
+        {
+            var result = WalletTestsHelpers.GenerateChainAndBlocksWithHeight(5, Network.StratisMain);
+            this.chain = result.Chain;
+            var blocks = result.Blocks;
+            var walletSyncManager = new WalletSyncManagerOverride(this.LoggerFactory.Object, this.walletManager.Object, this.chain, Network.StratisMain,
+                this.blockStoreCache.Object, this.storeSettings, this.nodeLifetime.Object);
+            // setup blockstorecache to return blocks on the chain.
+            this.blockStoreCache.Setup(b => b.GetBlockAsync(It.IsAny<uint256>()))
+                .ReturnsAsync((uint256 hashblock) =>
+                {
+                    return blocks.Where(b => b.GetHash() == hashblock).Single();
+                });
+
+            // set 2nd block as tip
+            walletSyncManager.SetWalletTip(this.chain.GetBlock(2));
+            //process 4th block in the list does not have same prevhash as which is loaded
+            var blockToProcess = blocks[3];
+            walletSyncManager.ProcessBlock(blockToProcess); 
+
+            var expectedBlockHash = this.chain.GetBlock(4).Header.GetHash();
+            Assert.Equal(expectedBlockHash, walletSyncManager.WalletTip.Header.GetHash());
+            //verify manager processes each missing block until caught up.
+            // height 3
+            this.walletManager.Verify(w => w.ProcessBlock(ExpectBlock(blocks[2]), ExpectChainedBlock(this.chain.GetBlock(3))));
+            // height 4
+            this.walletManager.Verify(w => w.ProcessBlock(ExpectBlock(blocks[3]), ExpectChainedBlock(this.chain.GetBlock(4))), Times.Exactly(2));
+        }
+
+        [Fact]
+        public void ProcessBlock_NewBlock_PreviousHashNotSameAsWalletTip_WalletTipOnBestChain_BlockArrivesLateInBlockStoreCache_CatchUpWalletManagerUsingBlockStoreCache()
+        {
+            var result = WalletTestsHelpers.GenerateChainAndBlocksWithHeight(5, Network.StratisMain);
+            this.chain = result.Chain;
+            var blocks = result.Blocks;
+            var walletSyncManager = new WalletSyncManagerOverride(this.LoggerFactory.Object, this.walletManager.Object, this.chain, Network.StratisMain,
+                this.blockStoreCache.Object, this.storeSettings, this.nodeLifetime.Object);
+            var blockEmptyCounters = new Dictionary<uint256, int>();
+            // setup blockstorecache to return blocks on the chain but postpone by 3 rounds for each block.
+            this.blockStoreCache.Setup(b => b.GetBlockAsync(It.IsAny<uint256>()))
+                .ReturnsAsync((uint256 hashblock) =>
+                {
+                    if (!blockEmptyCounters.ContainsKey(hashblock))
+                    {
+                        blockEmptyCounters.Add(hashblock, 0);
+                    }
+
+                    if (blockEmptyCounters[hashblock] < 3)
+                    {
+                        blockEmptyCounters[hashblock] += 1;
+                        return null;
+                    }
+                    else
+                    {
+                        return blocks.Where(b => b.GetHash() == hashblock).Single();
+                    }
+                });
+
+            // set 2nd block as tip
+            walletSyncManager.SetWalletTip(this.chain.GetBlock(2)); 
+            //process 4th block in the list  does not have same prevhash as which is loaded
+            var blockToProcess = blocks[3];
+            walletSyncManager.ProcessBlock(blockToProcess);
+
+            var expectedBlockHash = this.chain.GetBlock(4).Header.GetHash();
+            Assert.Equal(expectedBlockHash, walletSyncManager.WalletTip.Header.GetHash());
+            //verify manager processes each missing block until caught up.
+            // height 3
+            this.walletManager.Verify(w => w.ProcessBlock(ExpectBlock(blocks[2]), ExpectChainedBlock(this.chain.GetBlock(3))));
+            // height 4
+            this.walletManager.Verify(w => w.ProcessBlock(ExpectBlock(blocks[3]), ExpectChainedBlock(this.chain.GetBlock(4))), Times.Exactly(2));
+        }
+
+        private static ChainedBlock ExpectChainedBlock(ChainedBlock block)
+        {
+            return It.Is<ChainedBlock>(c => c.Header.GetHash() == block.Header.GetHash());
+        }
+
+        private static Block ExpectBlock(Block block)
+        {
+            return It.Is<Block>(b => b.GetHash() == block.GetHash());
+        }
+
+        private class WalletSyncManagerOverride : WalletSyncManager
+        {
+            public WalletSyncManagerOverride(ILoggerFactory loggerFactory, IWalletManager walletManager, ConcurrentChain chain,
+                Network network, IBlockStoreCache blockStoreCache, StoreSettings storeSettings, INodeLifetime nodeLifetime)
+                : base(loggerFactory, walletManager, chain, network, blockStoreCache, storeSettings, nodeLifetime)
+            {
+            }
+
+            public void SetWalletTip(ChainedBlock tip)
+            {
+                base.walletTip = tip;
+            }
         }
     }
 }

--- a/Stratis.Bitcoin.Features.Wallet.Tests/WalletSyncManagerTest.cs
+++ b/Stratis.Bitcoin.Features.Wallet.Tests/WalletSyncManagerTest.cs
@@ -1,0 +1,92 @@
+﻿using System.Threading.Tasks;
+using NBitcoin;
+using Moq;
+using Stratis.Bitcoin.Features.BlockStore;
+using Stratis.Bitcoin.Tests.Logging;
+using Stratis.Bitcoin.Utilities;
+using Xunit;
+using System.Collections.ObjectModel;
+
+namespace Stratis.Bitcoin.Features.Wallet.Tests
+{
+    public class WalletSyncManagerTest : LogsTestBase
+    {
+        private ConcurrentChain chain;
+        private Mock<IWalletManager> walletManager;
+        private Mock<IBlockStoreCache> blockStoreCache;
+        private Mock<INodeLifetime> nodeLifetime;
+        private StoreSettings storeSettings;
+
+        public WalletSyncManagerTest()
+        {
+            this.storeSettings = new StoreSettings()
+            {
+                Prune = false
+            };
+
+            this.chain = new ConcurrentChain(Network.StratisMain);
+            this.walletManager = new Mock<IWalletManager>();
+            this.blockStoreCache = new Mock<IBlockStoreCache>();
+            this.nodeLifetime = new Mock<INodeLifetime>();
+        }
+
+        [Fact]
+        public void Initialize_HavingPrunedStoreSetting_ThrowsWalletException()
+        {
+            this.storeSettings.Prune = true;
+
+            var walletSyncManager = new WalletSyncManager(this.LoggerFactory.Object, this.walletManager.Object, this.chain, Network.StratisMain,
+                this.blockStoreCache.Object, this.storeSettings, this.nodeLifetime.Object);
+
+            Assert.Throws<WalletException>(() =>
+            {
+                walletSyncManager.Initialize().Wait();
+            });
+        }
+
+        [Fact]
+        public void Initialize_BlockOnChain_DoesNotChangeWalletManager()
+        {
+            this.storeSettings.Prune = false;
+            this.chain = WalletTestsHelpers.PrepareChainWithBlock();
+            this.walletManager.Setup(w => w.WalletTipHash)
+                .Returns(this.chain.Tip.Header.GetHash());
+
+            var walletSyncManager = new WalletSyncManager(this.LoggerFactory.Object, this.walletManager.Object, this.chain, Network.StratisMain,
+                this.blockStoreCache.Object, this.storeSettings, this.nodeLifetime.Object);
+
+            var task = walletSyncManager.Initialize();
+            task.Wait();
+
+            this.walletManager.Verify(w => w.GetFirstWalletBlockLocator(), Times.Exactly(0));
+            this.walletManager.Verify(w => w.RemoveBlocks(It.IsAny<ChainedBlock>()), Times.Exactly(0));
+            Assert.True(task.IsCompleted);
+        }
+        
+        [Fact]
+        public void Initialize_BlockNotChain_RecoversWalletManagerUsingWallet()
+        {
+            this.storeSettings.Prune = false;
+            this.chain = WalletTestsHelpers.GenerateChainWithHeight(5, Network.StratisMain);            
+            this.walletManager.SetupGet(w => w.WalletTipHash)
+                .Returns(new uint256(125)); // try to load non-existing block to get chain to return null.
+
+            var forkBlock = this.chain.GetBlock(3); // use a block as the fork to recover to.
+            var forkBlockHash = forkBlock.Header.GetHash();
+            this.walletManager.Setup(w => w.GetFirstWalletBlockLocator())
+                .Returns(new Collection<uint256> { forkBlockHash });
+
+            var walletSyncManager = new WalletSyncManager(this.LoggerFactory.Object, this.walletManager.Object, this.chain, Network.StratisMain,
+                this.blockStoreCache.Object, this.storeSettings, this.nodeLifetime.Object);
+
+            var task = walletSyncManager.Initialize();
+            task.Wait();
+
+            // verify the walletmanager is recovered using the fork block and it's tip is set to it.
+            this.walletManager.Verify(w => w.RemoveBlocks(It.Is<ChainedBlock>(c => c.Header.GetHash() == forkBlockHash)), Times.Exactly(1));
+            this.walletManager.VerifySet(w => w.WalletTipHash = forkBlockHash);
+            Assert.Equal(walletSyncManager.WalletTip.HashBlock.ToString(), forkBlock.HashBlock.ToString());
+            Assert.True(task.IsCompleted);
+        }
+    }
+}

--- a/Stratis.Bitcoin.Features.Wallet.Tests/WalletTestsHelpers.cs
+++ b/Stratis.Bitcoin.Features.Wallet.Tests/WalletTestsHelpers.cs
@@ -375,7 +375,6 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
             return (chain, blocks);
         }
 
-
         internal static ConcurrentChain PrepareChainWithBlock()
         {
             var chain = new ConcurrentChain(Network.StratisMain);

--- a/Stratis.Bitcoin.Features.Wallet.Tests/WalletTestsHelpers.cs
+++ b/Stratis.Bitcoin.Features.Wallet.Tests/WalletTestsHelpers.cs
@@ -11,9 +11,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
     /// Helper class containing a bunch of methods used for testing the wallet functionality.
     /// </summary>
     public class WalletTestsHelpers
-    {
-        private static ConcurrentChain rightchain;
-
+    {        
         internal static HdAccount CreateAccount(string name)
         {
             return new HdAccount()

--- a/Stratis.Bitcoin.Features.Wallet.Tests/WalletTestsHelpers.cs
+++ b/Stratis.Bitcoin.Features.Wallet.Tests/WalletTestsHelpers.cs
@@ -11,7 +11,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
     /// Helper class containing a bunch of methods used for testing the wallet functionality.
     /// </summary>
     public class WalletTestsHelpers
-    {        
+    {
         internal static HdAccount CreateAccount(string name)
         {
             return new HdAccount()
@@ -52,7 +52,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
             }
 
             return new TransactionData()
-            {                
+            {
                 Amount = amount,
                 Id = id,
                 CreationTime = creationTime.Value,
@@ -96,7 +96,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
             }
             return last;
         }
-        
+
         internal static (ChainedBlock ChainedBlock, Block Block) AppendBlock(ChainedBlock previous, ConcurrentChain chain)
         {
             ChainedBlock last = null;
@@ -195,7 +195,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
 
             return tx;
         }
-        
+
         internal static void AddAddressesToWallet(WalletManager walletManager, int count)
         {
             foreach (var wallet in walletManager.Wallets)
@@ -281,6 +281,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
                 var block = new Block();
                 block.AddTransaction(new Transaction());
                 block.UpdateMerkleRoot();
+                block.Header.BlockTime = new DateTimeOffset(new DateTime(2017, 1, 1).AddDays(i));
                 block.Header.HashPrevBlock = prevBlockHash;
                 block.Header.Nonce = nonce;
                 chain.SetTip(block.Header);
@@ -289,7 +290,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
 
             return chain;
         }
-        
+
         /// <summary>
         /// Creates a set of chains 'forking' at a specific block height. You can see the left chain as the old one and the right as the new chain.
         /// </summary>
@@ -297,7 +298,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
         /// <param name="network">The network to use</param>
         /// <param name="forkBlock">The height at which to put the fork.</param>
         /// <returns></returns>
-        internal static (ConcurrentChain LeftChain, ConcurrentChain RightChain, List<Block> LeftForkBlocks, List<Block> RightForkBlocks) 
+        internal static (ConcurrentChain LeftChain, ConcurrentChain RightChain, List<Block> LeftForkBlocks, List<Block> RightForkBlocks)
             GenerateForkedChainAndBlocksWithHeight(int blockAmount, Network network, int forkBlock)
         {
             var rightchain = new ConcurrentChain(network);
@@ -314,11 +315,11 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
                 block.AddTransaction(new Transaction());
                 block.UpdateMerkleRoot();
                 block.Header.HashPrevBlock = prevBlockHash;
-                block.Header.Nonce = RandomUtils.GetUInt32();               
+                block.Header.Nonce = RandomUtils.GetUInt32();
                 leftchain.SetTip(block.Header);
 
                 if (leftchain.Height == forkBlock)
-                {                    
+                {
                     forkBlockPrevHash = block.GetHash();
                 }
                 prevBlockHash = block.GetHash();
@@ -338,18 +339,18 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
                 block.AddTransaction(new Transaction());
                 block.UpdateMerkleRoot();
                 block.Header.HashPrevBlock = forkBlockPrevHash;
-                block.Header.Nonce = RandomUtils.GetUInt32();                
+                block.Header.Nonce = RandomUtils.GetUInt32();
                 rightchain.SetTip(block.Header);
                 forkBlockPrevHash = block.GetHash();
                 rightForkBlocks.Add(block);
             }
-            
+
             // if all blocks are on both sides the fork fails.
-            if (leftForkBlocks.All(l=> rightForkBlocks.Select(r=> r.GetHash()).Contains(l.GetHash())))
+            if (leftForkBlocks.All(l => rightForkBlocks.Select(r => r.GetHash()).Contains(l.GetHash())))
             {
                 throw new InvalidOperationException("No fork created.");
             }
-            
+
             return (leftchain, rightchain, leftForkBlocks, rightForkBlocks);
         }
 
@@ -440,7 +441,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
 
             return addresses;
         }
-        
+
         internal static TransactionData CreateTransactionDataFromFirstBlock((ConcurrentChain chain, uint256 blockHash, Block block) chainInfo)
         {
             var transaction = chainInfo.block.Transactions[0];

--- a/Stratis.Bitcoin.Features.Wallet/Interfaces/IWalletManager.cs
+++ b/Stratis.Bitcoin.Features.Wallet/Interfaces/IWalletManager.cs
@@ -23,7 +23,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Interfaces
         /// <summary>
         /// The last processed block.
         /// </summary>
-        uint256 WalletTipHash { get; }
+        uint256 WalletTipHash { get; set; }
 
         /// <summary>
         /// Lists all spendable transactions from all accounts in the wallet.
@@ -139,6 +139,11 @@ namespace Stratis.Bitcoin.Features.Wallet.Interfaces
         /// <returns></returns>
         IEnumerable<HdAccount> GetAccounts(string walletName);
 
+        /// <summary>
+        /// Gets the last block height.
+        /// </summary>
+        /// <returns></returns>
+        int LastBlockHeight();
 
         /// <summary>
         /// Remove all the transactions in the wallet that are above this block height
@@ -202,6 +207,13 @@ namespace Stratis.Bitcoin.Features.Wallet.Interfaces
         /// <param name="walletName">The name of the wallet to get.</param>
         /// <returns>A wallet or null if it doesn't exist</returns>
         Wallet GetWalletByName(string walletName);
+
+
+        /// <summary>
+        /// Gets the block locator of the first loaded wallet.
+        /// </summary>
+        /// <returns></returns>
+        ICollection<uint256> GetFirstWalletBlockLocator();
 
         /// <summary>
         /// Gets a change address or create one if all change addresses are used. 

--- a/Stratis.Bitcoin.Features.Wallet/WalletManager.cs
+++ b/Stratis.Bitcoin.Features.Wallet/WalletManager.cs
@@ -501,6 +501,7 @@ namespace Stratis.Bitcoin.Features.Wallet
             }
         }
 
+        /// <inheritdoc />
         public int LastBlockHeight()
         {
             if (!this.Wallets.Any())
@@ -1044,6 +1045,12 @@ namespace Stratis.Bitcoin.Features.Wallet
             }
 
             return wallet;
+        }
+
+        /// <inheritdoc />
+        public ICollection<uint256> GetFirstWalletBlockLocator()
+        {
+            return this.Wallets.First().BlockLocator;
         }
     }
 

--- a/Stratis.Bitcoin.Features.Wallet/WalletSyncManager.cs
+++ b/Stratis.Bitcoin.Features.Wallet/WalletSyncManager.cs
@@ -11,7 +11,7 @@ namespace Stratis.Bitcoin.Features.Wallet
 {
     public class WalletSyncManager : IWalletSyncManager
     {
-        protected readonly WalletManager walletManager;
+        protected readonly IWalletManager walletManager;
         protected readonly ConcurrentChain chain;
         protected readonly CoinType coinType;
         protected readonly ILogger logger;
@@ -26,7 +26,15 @@ namespace Stratis.Bitcoin.Features.Wallet
         public WalletSyncManager(ILoggerFactory loggerFactory, IWalletManager walletManager, ConcurrentChain chain,
             Network network, IBlockStoreCache blockStoreCache, StoreSettings storeSettings, INodeLifetime nodeLifetime)
         {
-            this.walletManager = walletManager as WalletManager;
+            Guard.NotNull(loggerFactory, nameof(loggerFactory));
+            Guard.NotNull(walletManager, nameof(walletManager));
+            Guard.NotNull(chain, nameof(chain));
+            Guard.NotNull(network, nameof(network));
+            Guard.NotNull(blockStoreCache, nameof(blockStoreCache));
+            Guard.NotNull(storeSettings, nameof(storeSettings));
+            Guard.NotNull(nodeLifetime, nameof(nodeLifetime));
+
+            this.walletManager = walletManager;
             this.chain = chain;
             this.blockStoreCache = blockStoreCache;
             this.coinType = (CoinType)network.Consensus.CoinType;
@@ -58,7 +66,7 @@ namespace Stratis.Bitcoin.Features.Wallet
                 // that in the wallet. the block locator will help finding 
                 // a common fork and bringing the wallet back to a good 
                 // state (behind the best chain)
-                var locators = this.walletManager.Wallets.First().BlockLocator;
+                var locators = this.walletManager.GetFirstWalletBlockLocator();
                 BlockLocator blockLocator = new BlockLocator { Blocks = locators.ToList() };
                 var fork = this.chain.FindFork(blockLocator);
                 this.walletManager.RemoveBlocks(fork);


### PR DESCRIPTION
Commits of particular interest:  
4f99028 - Refactoring done to make testing a lot easier to do on this class. Otherwise the walletmanager cast would have made it very difficult. Let me know what you think of it. Doing the same refactor to lightsyncwalletmanager makes it easy to test that as well after this walletmanager refactor from this pull request.
b2a5593 - Ran into and fixed an issue in proceessblock. Already shortly notified dan of the bug that was in it. It has to do with being able to recover using the blockstorecache after the discovery was made earlier that we are not on the best chain anymore.