### PR TITLE
Implement transaction input and output shuffling for increased privacy

### DIFF
--- a/Stratis.Bitcoin.Features.Wallet/Controllers/WalletController.cs
+++ b/Stratis.Bitcoin.Features.Wallet/Controllers/WalletController.cs
@@ -495,11 +495,12 @@ namespace Stratis.Bitcoin.Features.Wallet.Controllers
             {
                 var context = new TransactionBuildContext(
                     new WalletAccountReference(request.WalletName, request.AccountName),
-                    new[] {new Recipient {Amount = request.Amount, ScriptPubKey = destination}}.ToList(),
+                    new[] { new Recipient { Amount = request.Amount, ScriptPubKey = destination } }.ToList(),
                     request.Password)
                 {
                     FeeType = FeeParser.Parse(request.FeeType),
-                    MinConfirmations = request.AllowUnconfirmed ? 0 : 1
+                    MinConfirmations = request.AllowUnconfirmed ? 0 : 1,
+                    Shuffle = true
                 };
 
                 var transactionResult = this.walletTransactionHandler.BuildTransaction(context);

--- a/Stratis.Bitcoin.Features.Wallet/WalletTransactionHandler.cs
+++ b/Stratis.Bitcoin.Features.Wallet/WalletTransactionHandler.cs
@@ -58,6 +58,11 @@ namespace Stratis.Bitcoin.Features.Wallet
             this.FindChangeAddress(context);
             this.AddFee(context);
 
+            if(context.Shuffle)
+            {
+                context.TransactionBuilder.Shuffle();
+            }
+
             // build transaction
             context.Transaction = context.TransactionBuilder.BuildTransaction(context.Sign);
 
@@ -69,7 +74,7 @@ namespace Stratis.Bitcoin.Features.Wallet
             }
 
             return context.Transaction;
-        }
+        }        
 
         /// <inheritdoc />
         public void FundTransaction(TransactionBuildContext context, Transaction transaction)
@@ -418,6 +423,11 @@ namespace Stratis.Bitcoin.Features.Wallet
         /// Allows the context to specify a <see cref="FeeRate"/> when building a transaction.
         /// </summary>
         public FeeRate OverrideFeeRate { get; set; }
+
+        /// <summary>
+        /// Shuffles transaction inputs and outputs for increased privacy.
+        /// </summary>
+        public bool Shuffle { get; set; }
     }
 
     /// <summary>


### PR DESCRIPTION
https://github.com/nopara73/ZeroLink/#transaction-output-indexing

#### Transaction Output Indexing
|Basic Post-Mix Wallet Requirement|Post-Mix Wallet Uniformity Requirement|
|---------------------------------|--------------------------------------|
||Post-mix wallet SHOULD index its built transaction outputs randomly.|

A post-mix wallet, due to its design, will only have one input and a maximum of two outputs at all times. Uniform indexing of outputs is necessary in order for multiple post-mix wallet implementations to look the same. A post-mix wallet SHOULD use random indexing of outputs.

Random indexing is not exclusively beneficial for post-mix wallet uniformity, conversely it has another privacy benefit. When a wallet software always generates the change output on the second index, observers always know which output is the change.

It must be mentioned [BIP69](https://github.com/bitcoin/bips/blob/master/bip-0069.mediawiki), Lexicographical Indexing of Outputs was created for the same purpose, however random indexing is slightly more private. If a blockchain observer wants to know if a transaction is in a wallet, using the BIP is a track, because it uses a deterministic algorithm, while random indexing leaves no tracks.