### PR TITLE
Reapply walletsyncmanager catchup fix

### DIFF
--- a/Stratis.Bitcoin.Features.Wallet/WalletSyncManager.cs
+++ b/Stratis.Bitcoin.Features.Wallet/WalletSyncManager.cs
@@ -126,13 +126,14 @@ namespace Stratis.Bitcoin.Features.Wallet
                     this.logger.LogTrace("Wallet tip set to '{0}/{1}'.", walletTip.HashBlock, walletTip.Height);
                 }
 
+                // use the temporary wallet tip otherwise we can't detect what we needed to catch up.
                 ChainedBlock incomingBlock = this.chain.GetBlock(block.GetHash());
-                if (incomingBlock.Height > this.walletTip.Height)
+                if (incomingBlock.Height > walletTip.Height)
                 {
                     CancellationToken token = this.nodeLifetime.ApplicationStopping;
 
                     // The wallet is falling behind we need to catch up.
-                    ChainedBlock next = this.walletTip;
+                    ChainedBlock next = walletTip;
                     while (next != incomingBlock)
                     {
                         token.ThrowIfCancellationRequested();


### PR DESCRIPTION
If inbestchain == null in the if statement before we need to check with the wallettip that was set back to block n instead of the current walletsyncmanager wallet tip. Otherwise we won't retrieve the missing blocks and end up with a gap.

The related test ProcessBlock_NewBlock_PreviousHashNotSameAsWalletTip_WalletTipNotOnBestChain_RemovesBlocksAfterForkOnOldChainFromWalletManager_CatchUpWalletManagerUsingBlockStoreCache proves this:
1. wallettip set to block nr 4 of current chain
2. process block nr 5 on other chain
3. rewind to block 2 where fork was caused because inBestChain == null
4. verify block 3,4,5 of the other chain are then processed by the underlying walletmanager

