### PR TITLE
Refactor/issue 554

### DIFF
--- a/Stratis.Bitcoin.Features.Consensus/ConsensusFeature.cs
+++ b/Stratis.Bitcoin.Features.Consensus/ConsensusFeature.cs
@@ -280,7 +280,7 @@ namespace Stratis.Bitcoin.Features.Consensus
 
                         if (fullNodeBuilder.NodeSettings.Testnet)
                         {
-                            fullNodeBuilder.Network.Consensus.Option<PosConsensusOptions>().COINBASE_MATURITY = 10;
+                            fullNodeBuilder.Network.Consensus.Option<PosConsensusOptions>().CoinbaseMaturity = 10;
                             fullNodeBuilder.Network.Consensus.Option<PosConsensusOptions>().StakeMinConfirmations = 10;
                         }
 

--- a/Stratis.Bitcoin.Features.Consensus/ConsensusOptions.cs
+++ b/Stratis.Bitcoin.Features.Consensus/ConsensusOptions.cs
@@ -5,26 +5,43 @@ namespace Stratis.Bitcoin.Features.Consensus
     // The default setting of values on the consensus options
     // should be removed in to the initialization of each 
     // network this are network specific values
-
     public class PosConsensusOptions : PowConsensusOptions
     {
+        public new Money ProofOfWorkReward { get; set; }
+
+        public Money ProofOfStakeReward { get; set; }
+
+        public Money PremineReward { get; set; }
+
+        public long PremineHeight { get; set; }
+
+        public long StakeMinConfirmations { get; set; }
+
+        public long StakeMinAge { get; set; }
+
+        /// <summary>Time to elapse before new modifier is computed.</summary>
+        public long StakeModifierInterval { get; set; }
+
+        /// <summary>Maximal length of reorganization that the node is willing to accept.</summary>
+        public uint MaxReorgLength { get; set; }
+
+        /// <summary>
+        /// Initializes the default values.
+        /// </summary>
         public PosConsensusOptions()
         {
-            this.MAX_MONEY = long.MaxValue;
-            this.COINBASE_MATURITY = 50;
+            this.MaxMoney = long.MaxValue;
+            this.CoinbaseMaturity = 50;
+
+            this.ProofOfWorkReward = Money.Coins(4);
+            this.ProofOfStakeReward = Money.COIN;
+            this.PremineReward = Money.Coins(98000000);
+            this.PremineHeight = 2;
+            this.StakeMinConfirmations = 50;
+            this.StakeMinAge = 60;
+            this.StakeModifierInterval = 10 * 60;
+            this.MaxReorgLength = 500;
         }
-        
-        public new Money ProofOfWorkReward { get; set; } = Money.Coins(4);
-
-        public Money ProofOfStakeReward { get; set; } = Money.COIN;
-
-        public Money PremineReward { get; set; } = Money.Coins(98000000);
-
-        public long PremineHeight { get; set; } = 2;
-
-        public long StakeMinConfirmations { get; set; } = 50;
-
-        public long StakeModifierInterval { get; set; } = 10 * 60; // time to elapse before new modifier is computed
     }
 
     /// <summary>
@@ -34,28 +51,51 @@ namespace Stratis.Bitcoin.Features.Consensus
     /// </summary>
     public class PowConsensusOptions : NBitcoin.Consensus.ConsensusOptions
     {
-        // The maximum allowed size for a serialized block, in bytes (only for buffer size limits) 
-        public int MAX_BLOCK_SERIALIZED_SIZE = 4000000;
+        /// <summary>The maximum allowed size for a serialized block, in bytes (only for buffer size limits).</summary>
+        public int MaxBlockSerializedSize { get; set; }
 
-        // The maximum allowed weight for a block, see BIP 141 (network rule) 
-        public int MAX_BLOCK_WEIGHT { get; set; } = 4000000;
+        /// <summary>The maximum allowed weight for a block, see BIP 141 (network rule) 
+        public int MaxBlockWeight { get; set; }
 
-        public int WITNESS_SCALE_FACTOR { get; set; } = 4;
-        public int SERIALIZE_TRANSACTION_NO_WITNESS { get; set; } = 0x40000000;
+        public int WitnessScaleFactor { get; set; }
+        public int SerializeTransactionNoWitness { get; set; }
 
-        // Changing the default transaction version requires a two step process: first
-        // adapting relay policy by bumping MAX_STANDARD_VERSION, and then later date
-        // bumping the default CURRENT_VERSION at which point both CURRENT_VERSION and
-        // MAX_STANDARD_VERSION will be equal.
-        public int MAX_STANDARD_VERSION { get; set; } = 2;
-        // The maximum weight for transactions we're willing to relay/mine 
-        public int MAX_STANDARD_TX_WEIGHT { get; set; } = 400000;
-        public int MAX_BLOCK_BASE_SIZE { get; set; } = 1000000;
-        /** The maximum allowed number of signature check operations in a block (network rule) */
-        public int MAX_BLOCK_SIGOPS_COST { get; set; } = 80000;
-        public long MAX_MONEY { get; set; } = 21000000 * Money.COIN;
-        public long COINBASE_MATURITY { get; set; } = 100;
-        public Money ProofOfWorkReward { get; set; } = Money.Coins(50);
+        /// <summary>
+        /// Changing the default transaction version requires a two step process: 
+        /// <list type="bullet">
+        /// <item>Adapting relay policy by bumping <see cref="MaxStandardVersion"/>,</item> 
+        /// <item>and then later date bumping the default CURRENT_VERSION at which point both CURRENT_VERSION and
+        /// <see cref="MaxStandardVersion"/> will be equal.</item>
+        /// </summary>
+        public int MaxStandardVersion { get; set; }
+        
+        /// <summary>The maximum weight for transactions we're willing to relay/mine.</summary>
+        public int MaxStandardTxWeight { get; set; }
+        public int MaxBlockBaseSize { get; set; }
+
+        /// <summary>The maximum allowed number of signature check operations in a block (network rule).</summary>
+        public int MaxBlockSigopsCost { get; set; }
+        public long MaxMoney { get; set; }
+        public long CoinbaseMaturity { get; set; }
+        public Money ProofOfWorkReward { get; set; }
+
+        /// <summary>
+        /// Initializes the default values.
+        /// </summary>
+        public PowConsensusOptions()
+        {
+            this.MaxBlockSerializedSize = 4000000;
+            this.MaxBlockWeight = 4000000;
+            this.WitnessScaleFactor = 4;
+            this.SerializeTransactionNoWitness = 0x40000000;
+            this.MaxStandardVersion = 2;
+            this.MaxStandardTxWeight = 400000;
+            this.MaxBlockBaseSize = 1000000;
+            this.MaxBlockSigopsCost = 80000;
+            this.MaxMoney = 21000000 * Money.COIN;
+            this.CoinbaseMaturity = 100;
+            this.ProofOfWorkReward = Money.Coins(50);
+        }
     }
 
     public static class ConsensusExtentions

--- a/Stratis.Bitcoin.Features.Consensus/PosConsensusValidator.cs
+++ b/Stratis.Bitcoin.Features.Consensus/PosConsensusValidator.cs
@@ -210,9 +210,9 @@ namespace Stratis.Bitcoin.Features.Consensus
 
             if (coins.IsCoinstake)
             {
-                if ((nSpendHeight - coins.Height) < this.consensusOptions.COINBASE_MATURITY)
+                if ((nSpendHeight - coins.Height) < this.consensusOptions.CoinbaseMaturity)
                 {
-                    this.logger.LogTrace("Coinstake transaction height {0} spent at height {1}, but maturity is set to {2}.", coins.Height, nSpendHeight, this.consensusOptions.COINBASE_MATURITY);
+                    this.logger.LogTrace("Coinstake transaction height {0} spent at height {1}, but maturity is set to {2}.", coins.Height, nSpendHeight, this.consensusOptions.CoinbaseMaturity);
                     this.logger.LogTrace("(-)[COINSTAKE_PREMATURE_SPENDING]");
                     ConsensusErrors.BadTransactionPrematureCoinstakeSpending.Throw();
                 }

--- a/Stratis.Bitcoin.Features.MemoryPool.Tests/TestChainFactory.cs
+++ b/Stratis.Bitcoin.Features.MemoryPool.Tests/TestChainFactory.cs
@@ -210,8 +210,8 @@ namespace Stratis.Bitcoin.Features.MemoryPool.Tests
         {
             AssemblerOptions options = new AssemblerOptions();
 
-            options.BlockMaxWeight = network.Consensus.Option<PowConsensusOptions>().MAX_BLOCK_WEIGHT;
-            options.BlockMaxSize = network.Consensus.Option<PowConsensusOptions>().MAX_BLOCK_SERIALIZED_SIZE;
+            options.BlockMaxWeight = network.Consensus.Option<PowConsensusOptions>().MaxBlockWeight;
+            options.BlockMaxSize = network.Consensus.Option<PowConsensusOptions>().MaxBlockSerializedSize;
 
             FeeRate blockMinFeeRate = new FeeRate(PowMining.DefaultBlockMinTxFee);
             options.BlockMinFeeRate = blockMinFeeRate;

--- a/Stratis.Bitcoin.Features.MemoryPool/MempoolOrphans.cs
+++ b/Stratis.Bitcoin.Features.MemoryPool/MempoolOrphans.cs
@@ -358,7 +358,7 @@ namespace Stratis.Bitcoin.Features.MemoryPool
                 // 100 orphans, each of which is at most 99,999 bytes big is
                 // at most 10 megabytes of orphans and somewhat more byprev index (in the worst case):
                 int sz = MempoolValidator.GetTransactionWeight(tx, this.Validator.ConsensusOptions);
-                if (sz >= this.consensusValidator.ConsensusOptions.MAX_STANDARD_TX_WEIGHT)
+                if (sz >= this.consensusValidator.ConsensusOptions.MaxStandardTxWeight)
                 {
                     this.mempoolLogger.LogInformation($"ignoring large orphan tx (size: {sz}, hash: {hash})");
                     return false;

--- a/Stratis.Bitcoin.Features.MemoryPool/MempoolValidator.cs
+++ b/Stratis.Bitcoin.Features.MemoryPool/MempoolValidator.cs
@@ -379,8 +379,8 @@ namespace Stratis.Bitcoin.Features.MemoryPool
         {
             return tx.GetSerializedSize(
                        (ProtocolVersion)
-                       ((uint)ProtocolVersion.PROTOCOL_VERSION | consensusOptions.SERIALIZE_TRANSACTION_NO_WITNESS),
-                       SerializationType.Network) * (consensusOptions.WITNESS_SCALE_FACTOR - 1) +
+                       ((uint)ProtocolVersion.PROTOCOL_VERSION | consensusOptions.SerializeTransactionNoWitness),
+                       SerializationType.Network) * (consensusOptions.WitnessScaleFactor - 1) +
                    tx.GetSerializedSize(ProtocolVersion.PROTOCOL_VERSION, SerializationType.Network);
         }
 
@@ -400,7 +400,7 @@ namespace Stratis.Bitcoin.Features.MemoryPool
             // Providing any more cleanup incentive than making additional inputs free would
             // risk encouraging people to create junk outputs to redeem later.
             if (nTxSize == 0)
-                nTxSize = (GetTransactionWeight(trx, consensusOptions) + consensusOptions.WITNESS_SCALE_FACTOR - 1) / consensusOptions.WITNESS_SCALE_FACTOR;
+                nTxSize = (GetTransactionWeight(trx, consensusOptions) + consensusOptions.WitnessScaleFactor - 1) / consensusOptions.WitnessScaleFactor;
 
             foreach (TxIn txInput in trx.Inputs)
             {
@@ -582,7 +582,7 @@ namespace Stratis.Bitcoin.Features.MemoryPool
             // TODO: Implement Witness Code
 
             Transaction tx = context.Transaction;
-            if (tx.Version > this.consensusValidator.ConsensusOptions.MAX_STANDARD_VERSION || tx.Version < 1)
+            if (tx.Version > this.consensusValidator.ConsensusOptions.MaxStandardVersion || tx.Version < 1)
                 context.State.Fail(MempoolErrors.Version).Throw();
 
             // Extremely large transactions with lots of inputs can cost the network
@@ -590,7 +590,7 @@ namespace Stratis.Bitcoin.Features.MemoryPool
             // computing signature hashes is O(ninputs*txsize). Limiting transactions
             // to MAX_STANDARD_TX_WEIGHT mitigates CPU exhaustion attacks.
             int sz = GetTransactionWeight(tx, this.consensusValidator.ConsensusOptions);
-            if (sz >= this.consensusValidator.ConsensusOptions.MAX_STANDARD_TX_WEIGHT)
+            if (sz >= this.consensusValidator.ConsensusOptions.MaxStandardTxWeight)
                 context.State.Fail(MempoolErrors.TxSize).Throw();
 
             foreach (TxIn txin in tx.Inputs)
@@ -709,7 +709,7 @@ namespace Stratis.Bitcoin.Features.MemoryPool
             // itself can contain sigops MAX_STANDARD_TX_SIGOPS is less than
             // MAX_BLOCK_SIGOPS; we still consider this an invalid rather than
             // merely non-standard transaction.
-            if (context.SigOpsCost > this.consensusValidator.ConsensusOptions.MAX_BLOCK_SIGOPS_COST)
+            if (context.SigOpsCost > this.consensusValidator.ConsensusOptions.MaxBlockSigopsCost)
                 context.State.Fail(MempoolErrors.TooManySigops).Throw();
         }
 

--- a/Stratis.Bitcoin.Features.Miner/PosMinting.cs
+++ b/Stratis.Bitcoin.Features.Miner/PosMinting.cs
@@ -1003,6 +1003,7 @@ namespace Stratis.Bitcoin.Features.Miner
             long maturityLimit = this.network.Consensus.Option<PosConsensusOptions>().CoinbaseMaturity;
             long coinAgeLimit = this.network.Consensus.Option<PosConsensusOptions>().StakeMinConfirmations;
             long requiredCoinAgeForStaking = Math.Max(maturityLimit, coinAgeLimit);
+            this.logger.LogTrace("Required coin age for staking is {0}.)", requiredCoinAgeForStaking);
 
             bool res = utxoCount < (requiredCoinAgeForStaking + 1) * CoinstakeSplitLimitMultiplier;
 

--- a/Stratis.Bitcoin.Features.Miner/PosMinting.cs
+++ b/Stratis.Bitcoin.Features.Miner/PosMinting.cs
@@ -59,6 +59,17 @@ namespace Stratis.Bitcoin.Features.Miner
         /** The maximum size for mined blocks */
         public const int MaxBlockSizeGen = MaxBlockSize / 2;
 
+        /// <summary><c>true</c> if coinstake transaction splits the coin and generates extra UTXO 
+        /// to prevent halting chain; <c>false</c> to disable coinstake splitting.</summary>
+        /// <remarks>TODO: It should be configurable option, not constant. See https://github.com/stratisproject/StratisBitcoinFullNode/issues/550 </remarks>
+        public const bool CoinstakeSplitEnabled = true;
+
+        /// <summary>
+        /// If <see cref="CoinstakeSplitEnabled"/> is set, the coinstake will be split if 
+        /// the number of non-empty UTXOs in the wallet is lower than the required coin age for staking plus 1, 
+        /// multiplied by this value. See <see cref="GetSplitStake(int)"/>.</summary>
+        public const int CoinstakeSplitLimitMultiplier = 3;
+
         private readonly ConsensusLoop consensusLoop;
         private readonly ConcurrentChain chain;
         private readonly Network network;
@@ -511,13 +522,14 @@ namespace Stratis.Bitcoin.Features.Miner
         {
             this.logger.LogTrace("({0}.{1}:{2},{3}:'{4}/{5}',{6}:{7},{8}:{9})", nameof(stakeTxes), nameof(stakeTxes.Count), stakeTxes.Count, nameof(chainTip), chainTip.HashBlock, chainTip.Height, nameof(searchInterval), searchInterval, nameof(fees), fees);
 
+            int nonEmptyUtxos = stakeTxes.Count;
             coinstakeTx.Inputs.Clear();
             coinstakeTx.Outputs.Clear();
 
             // Mark coinstake transaction.
             coinstakeTx.Outputs.Add(new TxOut(Money.Zero, new Script()));
 
-            long balance = this.GetBalance(stakeTxes).Satoshi;
+            long balance = this.GetMatureBalance(stakeTxes).Satoshi;
             if (balance <= this.reserveBalance)
             {
                 this.rpcGetStakingInfoModel.Staking = false;
@@ -664,47 +676,6 @@ namespace Stratis.Bitcoin.Features.Miner
                 return false;
             }
 
-            this.logger.LogTrace("Trying to reduce our staking UTXO set by adding additional inputs to coinstake transaction...");
-            foreach (StakeTx stakeTx in setCoins)
-            {
-                // Attempt to add more inputs.
-                // Only add coins of the same key/address as kernel.
-                if ((coinstakeTx.Outputs.Count == 2)
-                    && ((stakeTx.TxOut.ScriptPubKey == scriptPubKeyKernel) || (stakeTx.TxOut.ScriptPubKey == coinstakeTx.Outputs[1].ScriptPubKey))
-                    && (stakeTx.UtxoSet.TransactionId != coinstakeTx.Inputs[0].PrevOut.Hash))
-                {
-                    this.logger.LogTrace("Found candidate UTXO '{0}/{1}' with {2} coins.", stakeTx.OutPoint.Hash, stakeTx.OutPoint.N, stakeTx.TxOut.Value);
-
-                    // Don't add inputs that would violate the reserve limit.
-                    if ((coinstakeInputsValue + stakeTx.TxOut.Value) > (balance - this.reserveBalance))
-                    {
-                        this.logger.LogTrace("UTXO '{0}/{1}' rejected because if it was added, we would not have required reserve anymore. Its value is {2}, we already used {3}, our total balance is {4} and reserve is {5}.", stakeTx.OutPoint.Hash, stakeTx.OutPoint.N, stakeTx.TxOut.Value, coinstakeInputsValue, balance, this.reserveBalance);
-                        continue;
-                    }
-
-                    // Do not add additional significant input.
-                    if (stakeTx.TxOut.Value >= GetStakeCombineThreshold())
-                    {
-                        this.logger.LogTrace("UTXO '{0}/{1}' rejected because its value is too big.", stakeTx.OutPoint.Hash, stakeTx.OutPoint.N);
-                        continue;
-                    }
-
-                    coinstakeTx.Inputs.Add(new TxIn(new OutPoint(stakeTx.UtxoSet.TransactionId, stakeTx.OutputIndex)));
-
-                    coinstakeInputsValue += stakeTx.TxOut.Value;
-                    coinstakeInputs.Add(stakeTx);
-
-                    this.logger.LogTrace("UTXO '{0}/{1}' joined to coinstake transaction.", stakeTx.OutPoint.Hash, stakeTx.OutPoint.N);
-
-                    // Stop adding more inputs if already too many inputs.
-                    if (coinstakeTx.Inputs.Count >= 100)
-                    {
-                        this.logger.LogTrace("Number of coinstake inputs reached the limit of 100.");
-                        break;
-                    }
-                }
-            }
-
             long reward = fees + this.posConsensusValidator.GetProofOfStakeReward(chainTip.Height);
             if (reward <= 0)
             {
@@ -718,7 +689,8 @@ namespace Stratis.Bitcoin.Features.Miner
             coinstakeInputsValue += reward;
 
             // Split stake if above threshold.
-            if (coinstakeInputsValue >= GetStakeSplitThreshold())
+            bool splitStake = GetSplitStake(nonEmptyUtxos);
+            if (splitStake)
             {
                 this.logger.LogTrace("Coinstake UTXO will be split to two.");
                 coinstakeTx.Outputs.Add(new TxOut(0, coinstakeTx.Outputs[1].ScriptPubKey));
@@ -790,17 +762,12 @@ namespace Stratis.Bitcoin.Features.Miner
             return res;
         }
 
-        private static long GetStakeCombineThreshold()
-        {
-            return 100 * Money.COIN;
-        }
-
-        private static long GetStakeSplitThreshold()
-        {
-            return 2 * GetStakeCombineThreshold();
-        }
-
-        public Money GetBalance(List<StakeTx> stakeTxes)
+        /// <summary>
+        /// Calculates the total balance from all UTXOs in the wallet that are mature.
+        /// </summary>
+        /// <param name="stakeTxes">Description of coins in the wallet that will be used for staking.</param>
+        /// <returns>Total balance from all UTXOs in the wallet that are mature.</returns>
+        public Money GetMatureBalance(List<StakeTx> stakeTxes)
         {
             this.logger.LogTrace("({0}.{1}:{2})", nameof(stakeTxes), nameof(stakeTxes.Count), stakeTxes.Count);
 
@@ -890,7 +857,7 @@ namespace Stratis.Bitcoin.Features.Miner
             if (!(stakeTx.UtxoSet.IsCoinbase || stakeTx.UtxoSet.IsCoinstake))
                 return 0;
 
-            return Math.Max(0, (int)this.network.Consensus.Option<PosConsensusOptions>().COINBASE_MATURITY + 1 - this.GetDepthInMainChain(stakeTx));
+            return Math.Max(0, (int)this.network.Consensus.Option<PosConsensusOptions>().CoinbaseMaturity + 1 - this.GetDepthInMainChain(stakeTx));
         }
 
         // Return depth of transaction in blockchain:
@@ -1019,6 +986,28 @@ namespace Stratis.Bitcoin.Features.Miner
         public Miner.Models.GetStakingInfoModel GetGetStakingInfoModel()
         {
             return (Miner.Models.GetStakingInfoModel)this.rpcGetStakingInfoModel.Clone();
+        }
+
+        /// <summary>
+        /// Checks whether the coinstake should be split or not.
+        /// </summary>
+        /// <param name="utxoCount">Number of non-empty UTXOs in the wallet.</param>
+        /// <returns><c>true</c> if the coinstake should be split, <c>false</c> otherwise.</returns>
+        /// <remarks>The coinstake is split if the number of non-empty UTXOs we have in the wallet
+        /// is under the given treshold.</remarks>
+        /// <seealso cref="CoinstakeSplitLimitMultiplier"/>
+        private bool GetSplitStake(int utxoCount)
+        {
+            this.logger.LogTrace("({0}:{1})", nameof(utxoCount), utxoCount);
+
+            long maturityLimit = this.network.Consensus.Option<PosConsensusOptions>().CoinbaseMaturity;
+            long coinAgeLimit = this.network.Consensus.Option<PosConsensusOptions>().StakeMinConfirmations;
+            long requiredCoinAgeForStaking = Math.Max(maturityLimit, coinAgeLimit);
+
+            bool res = utxoCount < (requiredCoinAgeForStaking + 1) * CoinstakeSplitLimitMultiplier;
+
+            this.logger.LogTrace("(-):{0}", res);
+            return res;
         }
     }
 }

--- a/Stratis.Bitcoin.Features.Miner/PosMinting.cs
+++ b/Stratis.Bitcoin.Features.Miner/PosMinting.cs
@@ -1003,7 +1003,7 @@ namespace Stratis.Bitcoin.Features.Miner
             long maturityLimit = this.network.Consensus.Option<PosConsensusOptions>().CoinbaseMaturity;
             long coinAgeLimit = this.network.Consensus.Option<PosConsensusOptions>().StakeMinConfirmations;
             long requiredCoinAgeForStaking = Math.Max(maturityLimit, coinAgeLimit);
-            this.logger.LogTrace("Required coin age for staking is {0}.)", requiredCoinAgeForStaking);
+            this.logger.LogTrace("Required coin age for staking is {0}.", requiredCoinAgeForStaking);
 
             bool res = utxoCount < (requiredCoinAgeForStaking + 1) * CoinstakeSplitLimitMultiplier;
 

--- a/Stratis.Bitcoin.Features.Miner/PosMinting.cs
+++ b/Stratis.Bitcoin.Features.Miner/PosMinting.cs
@@ -579,7 +579,7 @@ namespace Stratis.Bitcoin.Features.Miner
             foreach (StakeTx coin in setCoins)
             {
                 this.logger.LogTrace("Trying UTXO from address '{0}', output amount {1}...", coin.Address.Address, coin.TxOut.Value);
-                bool fKernelFound = false;
+                bool kernelFound = false;
 
                 scriptPubKeyKernel = coin.TxOut.ScriptPubKey;
                 if (!PayToPubkeyTemplate.Instance.CheckScriptPubKey(scriptPubKeyKernel)
@@ -589,7 +589,7 @@ namespace Stratis.Bitcoin.Features.Miner
                     continue;
                 }
 
-                for (uint n = 0; (n < searchInterval) && !fKernelFound; n++)
+                for (uint n = 0; (n < searchInterval) && !kernelFound; n++)
                 {
                     if (this.nodeLifetime.ApplicationStopping.IsCancellationRequested)
                     {
@@ -640,7 +640,7 @@ namespace Stratis.Bitcoin.Features.Miner
                         coinstakeTx.Outputs.Add(new TxOut(0, scriptPubKeyOut));
 
                         this.logger.LogTrace("Kernel accepted, coinstake input is '{0}/{1}'.", prevoutStake.Hash, prevoutStake.N);
-                        fKernelFound = true;
+                        kernelFound = true;
                         break;
                     }
                     catch (ConsensusErrorException cex)
@@ -654,7 +654,7 @@ namespace Stratis.Bitcoin.Features.Miner
                 }
 
                 // If kernel is found stop searching.
-                if (fKernelFound)
+                if (kernelFound)
                     break;
             }
 

--- a/Stratis.Bitcoin.Features.Miner/PowBlockAssembler.cs
+++ b/Stratis.Bitcoin.Features.Miner/PowBlockAssembler.cs
@@ -166,10 +166,10 @@ namespace Stratis.Bitcoin.Features.Miner
             this.blockMaxWeight = (uint)Math.Max(4000, Math.Min(PowMining.DefaultBlockMaxWeight - 4000, options.BlockMaxWeight));
             
             // Limit size to between 1K and MAX_BLOCK_SERIALIZED_SIZE-1K for sanity.
-            this.blockMaxSize = (uint)Math.Max(1000, Math.Min(network.Consensus.Option<PowConsensusOptions>().MAX_BLOCK_SERIALIZED_SIZE - 1000, options.BlockMaxSize));
+            this.blockMaxSize = (uint)Math.Max(1000, Math.Min(network.Consensus.Option<PowConsensusOptions>().MaxBlockSerializedSize - 1000, options.BlockMaxSize));
             
             // Whether we need to account for byte usage (in addition to weight usage).
-            this.needSizeAccounting = (this.blockMaxSize < network.Consensus.Option<PowConsensusOptions>().MAX_BLOCK_SERIALIZED_SIZE - 1000);
+            this.needSizeAccounting = (this.blockMaxSize < network.Consensus.Option<PowConsensusOptions>().MaxBlockSerializedSize - 1000);
 
             this.consensusLoop = consensusLoop;
             this.mempoolLock = mempoolLock;
@@ -553,10 +553,10 @@ namespace Stratis.Bitcoin.Features.Miner
         private bool TestPackage(long packageSize, long packageSigOpsCost)
         {
             // TODO: Switch to weight-based accounting for packages instead of vsize-based accounting.
-            if (this.blockWeight + this.network.Consensus.Option<PowConsensusOptions>().WITNESS_SCALE_FACTOR * packageSize >= this.blockMaxWeight)
+            if (this.blockWeight + this.network.Consensus.Option<PowConsensusOptions>().WitnessScaleFactor * packageSize >= this.blockMaxWeight)
                 return false;
 
-            if (this.blockSigOpsCost + packageSigOpsCost >= this.network.Consensus.Option<PowConsensusOptions>().MAX_BLOCK_SIGOPS_COST)
+            if (this.blockSigOpsCost + packageSigOpsCost >= this.network.Consensus.Option<PowConsensusOptions>().MaxBlockSigopsCost)
                 return false;
 
             return true;

--- a/Stratis.Bitcoin.IntegrationTests/MinerTests.cs
+++ b/Stratis.Bitcoin.IntegrationTests/MinerTests.cs
@@ -28,8 +28,8 @@ namespace Stratis.Bitcoin.IntegrationTests
         {
             AssemblerOptions options = new AssemblerOptions();
 
-            options.BlockMaxWeight = testContext.network.Consensus.Option<PowConsensusOptions>().MAX_BLOCK_WEIGHT;
-            options.BlockMaxSize = testContext.network.Consensus.Option<PowConsensusOptions>().MAX_BLOCK_SERIALIZED_SIZE;
+            options.BlockMaxWeight = testContext.network.Consensus.Option<PowConsensusOptions>().MaxBlockWeight;
+            options.BlockMaxSize = testContext.network.Consensus.Option<PowConsensusOptions>().MaxBlockSerializedSize;
             options.BlockMinFeeRate = blockMinFeeRate;
 
             return new PowBlockAssembler(testContext.consensus, testContext.network, testContext.mempoolLock, testContext.mempool, testContext.date, testContext.chain.Tip, new LoggerFactory(), options);

--- a/Stratis.Bitcoin.IntegrationTests/WalletTests.cs
+++ b/Stratis.Bitcoin.IntegrationTests/WalletTests.cs
@@ -33,7 +33,7 @@ namespace Stratis.Bitcoin.IntegrationTests
                 var key = wallet.GetExtendedPrivateKeyForAddress("123456", addr).PrivateKey;
 
                 stratisSender.SetDummyMinerSecret(new BitcoinSecret(key, stratisSender.FullNode.Network));
-                var maturity = (int)stratisSender.FullNode.Network.Consensus.Option<PowConsensusOptions>().COINBASE_MATURITY;
+                var maturity = (int)stratisSender.FullNode.Network.Consensus.Option<PowConsensusOptions>().CoinbaseMaturity;
                 stratisSender.GenerateStratis(maturity + 5);
                 // wait for block repo for block sync to work
 
@@ -138,7 +138,7 @@ namespace Stratis.Bitcoin.IntegrationTests
                 stratisSender.SetDummyMinerSecret(new BitcoinSecret(key, stratisSender.FullNode.Network));
                 stratisReorg.SetDummyMinerSecret(new BitcoinSecret(key, stratisSender.FullNode.Network));
 
-                var maturity = (int)stratisSender.FullNode.Network.Consensus.Option<PowConsensusOptions>().COINBASE_MATURITY;
+                var maturity = (int)stratisSender.FullNode.Network.Consensus.Option<PowConsensusOptions>().CoinbaseMaturity;
                 stratisSender.GenerateStratisWithMiner(maturity + 15);
 
                 var currentBestHeight = maturity + 15;


### PR DESCRIPTION
Removes coin join mechanism in coinstake and implements coin splitting logic as discussed in #550. Does not complete #550 as the feature is always enabled and can't be set in configuration. It fixes #554 because the buggy code was completely removed.

Some minor cleanups included - code style, comments.

Fix #554