### PR TITLE
Relate the ConnectionManager's NodeGroups to avoid duplicate connections

### DIFF
--- a/Stratis.Bitcoin/Connection/ConnectionManager.cs
+++ b/Stratis.Bitcoin/Connection/ConnectionManager.cs
@@ -84,7 +84,6 @@ namespace Stratis.Bitcoin.Connection
 				cloneParameters.TemplateBehaviors.Add(new ConnectionManagerBehavior(false, this, this.logger));
 				this.DiscoveredNodeGroup = CreateNodeGroup(cloneParameters, this.discoveredNodeRequiredService);
 				this.DiscoveredNodeGroup.CustomGroupSelector = WellKnownGroupSelectors.ByNetwork; //is the default, but I want to use it
-				this.DiscoveredNodeGroup.Connect();
 			}
 			else
 			{
@@ -100,7 +99,6 @@ namespace Stratis.Bitcoin.Connection
 				this.ConnectNodeGroup = CreateNodeGroup(cloneParameters, NodeServices.Nothing);
 				this.ConnectNodeGroup.MaximumNodeConnection = this.connectionManagerSettings.Connect.Count;
 				this.ConnectNodeGroup.CustomGroupSelector = WellKnownGroupSelectors.ByEndpoint;
-				this.ConnectNodeGroup.Connect();
 			}
 
 			{
@@ -116,10 +114,18 @@ namespace Stratis.Bitcoin.Connection
 				this.AddNodeNodeGroup = CreateNodeGroup(cloneParameters, NodeServices.Nothing);
 				this.AddNodeNodeGroup.MaximumNodeConnection = this.connectionManagerSettings.AddNode.Count;
 				this.AddNodeNodeGroup.CustomGroupSelector = WellKnownGroupSelectors.ByEndpoint;
-				this.AddNodeNodeGroup.Connect();
 			}
 
-			StringBuilder logs = new StringBuilder();
+            // Related the groups to each other to prevent duplicate connections
+            RelatedNodesGroups relGroups = new RelatedNodesGroups();
+            relGroups.Register("Discovered", this.DiscoveredNodeGroup);
+            relGroups.Register("Connect", this.ConnectNodeGroup);
+            relGroups.Register("AddNode", this.AddNodeNodeGroup);
+            this.DiscoveredNodeGroup?.Connect();
+            this.ConnectNodeGroup?.Connect();
+            this.AddNodeNodeGroup?.Connect();
+
+            StringBuilder logs = new StringBuilder();
 			logs.AppendLine("Node listening on:");
 			foreach (NodeServerEndpoint listen in this.connectionManagerSettings.Listen)
 			{


### PR DESCRIPTION
This PR relates ConnectionManager's NodeGroups to avoid duplicate connections