### PR TITLE
trivial fix to prevent ConsensusStats crash

### DIFF
--- a/Stratis.Bitcoin.Features.Consensus/ConsensusStats.cs
+++ b/Stratis.Bitcoin.Features.Consensus/ConsensusStats.cs
@@ -73,10 +73,11 @@ namespace Stratis.Bitcoin.Features.Consensus
                 benchLogs.AppendLine("Downloaded:".PadRight(LoggingConfiguration.ColumnLength) + this.lookaheadPuller.MedianDownloadCount + " blocks");
                 benchLogs.AppendLine("==========================");
             }
-            benchLogs.AppendLine("Persistent Tip:".PadRight(LoggingConfiguration.ColumnLength) + this.chain.GetBlock(this.bottom.GetBlockHashAsync().Result).Height);
+
+            benchLogs.AppendLine("Persistent Tip:".PadRight(LoggingConfiguration.ColumnLength) + this.chain.GetBlock(this.bottom.GetBlockHashAsync().Result)?.Height);
             if (this.cache != null)
             {
-                benchLogs.AppendLine("Cache Tip".PadRight(LoggingConfiguration.ColumnLength) + this.chain.GetBlock(this.cache.GetBlockHashAsync().Result).Height);
+                benchLogs.AppendLine("Cache Tip".PadRight(LoggingConfiguration.ColumnLength) + this.chain.GetBlock(this.cache.GetBlockHashAsync().Result)?.Height);
                 benchLogs.AppendLine("Cache entries".PadRight(LoggingConfiguration.ColumnLength) + this.cache.CacheEntryCount);
             }
 


### PR DESCRIPTION
GetBlock can return null. The output is not super pretty if that happens, but it is very rare for this to happen, so it should be OK.

Fix #590 