### PR TITLE
Feature/coinview flushing issue 525 take two

### DIFF
--- a/Stratis.Bitcoin.Features.Consensus/CoinViews/CachedCoinView.cs
+++ b/Stratis.Bitcoin.Features.Consensus/CoinViews/CachedCoinView.cs
@@ -241,12 +241,12 @@ namespace Stratis.Bitcoin.Features.Consensus.CoinViews
         /// WARNING: This method can only be run from <see cref="ConsensusLoop.Execute(System.Threading.CancellationToken)"/> thread context
         /// or when consensus loop is stopped. Otherwise, there is a risk of race condition when the consensus loop accepts new block.
         /// </remarks>
-        public async Task FlushAsync(bool force)
+        public async Task FlushAsync(bool force = true)
         {
             this.logger.LogTrace("({0}:{1})", nameof(force), force);
 
             DateTime now = this.dateTimeProvider.GetUtcNow();
-            if (!force && (now - this.lastCacheFlushTime).TotalSeconds < CacheFlushTimeIntervalSeconds)
+            if (!force && ((now - this.lastCacheFlushTime).TotalSeconds < CacheFlushTimeIntervalSeconds))
             {
                 this.logger.LogTrace("(-)[NOT_NOW]");
                 return;

--- a/Stratis.Bitcoin.Features.Consensus/CoinViews/CachedCoinView.cs
+++ b/Stratis.Bitcoin.Features.Consensus/CoinViews/CachedCoinView.cs
@@ -227,14 +227,6 @@ namespace Stratis.Bitcoin.Features.Consensus.CoinViews
             {
                 this.logger.LogTrace("Cache is full now with {0} entries, evicting ...", cacheEntryCount);
                 this.Evict();
-
-                cacheEntryCount = this.CacheEntryCount;
-                if (cacheEntryCount > this.MaxItems)
-                {
-                    this.logger.LogTrace("Cache is still full with {0} entries, flusing and evicting ...", cacheEntryCount);
-                    await this.FlushAsync().ConfigureAwait(false);
-                    this.Evict();
-                }
             }
 
             this.logger.LogTrace("(-):*.{0}='{1}',*.{2}.{3}={4}", nameof(result.BlockHash), result.BlockHash, nameof(result.UnspentOutputs), nameof(result.UnspentOutputs.Length), result.UnspentOutputs.Length);

--- a/Stratis.Bitcoin.Features.Consensus/CoinViews/CachedCoinView.cs
+++ b/Stratis.Bitcoin.Features.Consensus/CoinViews/CachedCoinView.cs
@@ -252,8 +252,6 @@ namespace Stratis.Bitcoin.Features.Consensus.CoinViews
                 return;
             }
 
-            this.lastCacheFlushTime = now;
-
             // Before flushing the coinview persist the stake store
             // the stake store depends on the last block hash
             // to be stored after the stake store is persisted.
@@ -294,6 +292,9 @@ namespace Stratis.Bitcoin.Features.Consensus.CoinViews
 
             // Can't await inside a lock.
             await this.flushingTask.ConfigureAwait(false);
+
+            this.lastCacheFlushTime = this.dateTimeProvider.GetUtcNow();
+
             this.logger.LogTrace("(-)");
         }
 

--- a/Stratis.Bitcoin.Features.Consensus/CoinViews/CachedCoinView.cs
+++ b/Stratis.Bitcoin.Features.Consensus/CoinViews/CachedCoinView.cs
@@ -60,7 +60,7 @@ namespace Stratis.Bitcoin.Features.Consensus.CoinViews
 
         /// <summary>Length of the coinview cache flushing interval in seconds.</summary>
         /// <seealso cref="lastCacheFlushTime"/>
-        public const int CacheFlushTimeIntervalSeconds = 3 * 60;
+        public const int CacheFlushTimeIntervalSeconds = 60;
 
         /// <summary>Instance logger.</summary>
         private readonly ILogger logger;

--- a/Stratis.Bitcoin.Features.Consensus/ConsensusFeature.cs
+++ b/Stratis.Bitcoin.Features.Consensus/ConsensusFeature.cs
@@ -201,8 +201,11 @@ namespace Stratis.Bitcoin.Features.Consensus
                     if (block.Error == null)
                     {
                         this.chainState.HighestValidatedPoW = this.consensusLoop.Tip;
-                        if (this.chain.Tip.HashBlock == block.ChainedBlock?.HashBlock)
-                            this.consensusLoop.FlushAsync().GetAwaiter().GetResult();
+
+                        // We really want to flush if we are at the top of the chain.
+                        // Otherwise, we just allow the flush to happen if it is needed.
+                        bool mustFlush = this.chain.Tip.HashBlock == block.ChainedBlock?.HashBlock;
+                        this.consensusLoop.FlushAsync(mustFlush).GetAwaiter().GetResult();
 
                         this.signals.SignalBlock(block.Block);
                     }

--- a/Stratis.Bitcoin.Features.Consensus/ConsensusFeature.cs
+++ b/Stratis.Bitcoin.Features.Consensus/ConsensusFeature.cs
@@ -204,8 +204,8 @@ namespace Stratis.Bitcoin.Features.Consensus
 
                         // We really want to flush if we are at the top of the chain.
                         // Otherwise, we just allow the flush to happen if it is needed.
-                        bool mustFlush = this.chain.Tip.HashBlock == block.ChainedBlock?.HashBlock;
-                        this.consensusLoop.FlushAsync(mustFlush).GetAwaiter().GetResult();
+                        bool forceFlush = this.chain.Tip.HashBlock == block.ChainedBlock?.HashBlock;
+                        this.consensusLoop.FlushAsync(forceFlush).GetAwaiter().GetResult();
 
                         this.signals.SignalBlock(block.Block);
                     }

--- a/Stratis.Bitcoin.Features.Consensus/ConsensusLoop.cs
+++ b/Stratis.Bitcoin.Features.Consensus/ConsensusLoop.cs
@@ -202,14 +202,17 @@ namespace Stratis.Bitcoin.Features.Consensus
             this.logger.LogTrace("(-)[OK]");
         }
 
-        public Task FlushAsync()
+        /// <summary>
+        /// Flushes changes in the cached coinview to the disk.
+        /// </summary>
+        /// <param name="force"><c>true</c> to enforce flush, <c>false</c> to flush only if the cached coinview itself wants to be flushed.</param>
+        public async Task FlushAsync(bool force)
         {
-            this.logger.LogTrace("()");
+            this.logger.LogTrace("({0}:{1})", nameof(force), force);
 
-            Task res = (this.UTXOSet as CachedCoinView)?.FlushAsync();
+            await (this.UTXOSet as CachedCoinView)?.FlushAsync(force);
 
             this.logger.LogTrace("(-)");
-            return res;
         }
 
         private Task TryPrefetchAsync(DeploymentFlags flags)

--- a/Stratis.Bitcoin.Features.MemoryPool.Tests/TestChainFactory.cs
+++ b/Stratis.Bitcoin.Features.MemoryPool.Tests/TestChainFactory.cs
@@ -70,7 +70,7 @@ namespace Stratis.Bitcoin.Features.MemoryPool.Tests
             network.Consensus.Options = new PowConsensusOptions();
             PowConsensusValidator consensusValidator = new PowConsensusValidator(network, new Checkpoints(network), loggerFactory);
             ConcurrentChain chain = new ConcurrentChain(network);
-            CachedCoinView cachedCoinView = new CachedCoinView(new InMemoryCoinView(chain.Tip.HashBlock), loggerFactory);
+            CachedCoinView cachedCoinView = new CachedCoinView(new InMemoryCoinView(chain.Tip.HashBlock), DateTimeProvider.Default, loggerFactory);
 
             ConnectionManager connectionManager = new ConnectionManager(network, new NodeConnectionParameters(), nodeSettings, loggerFactory, new NodeLifetime());
             LookaheadBlockPuller blockPuller = new LookaheadBlockPuller(chain, connectionManager, new LoggerFactory());

--- a/Stratis.Bitcoin.Features.Miner/PosMinting.cs
+++ b/Stratis.Bitcoin.Features.Miner/PosMinting.cs
@@ -303,7 +303,7 @@ namespace Stratis.Bitcoin.Features.Miner
                     this.logger.LogDebug("Consensus error exception occurred in miner loop: {0}", cee.ToString());
                     this.rpcGetStakingInfoModel.Errors = cee.Message;
                 }
-                catch (Exception e)
+                catch
                 {
                     this.logger.LogTrace("(-)[UNHANDLED_EXCEPTION]");
                     throw;

--- a/Stratis.Bitcoin.IntegrationTests/CoinViewTests.cs
+++ b/Stratis.Bitcoin.IntegrationTests/CoinViewTests.cs
@@ -63,7 +63,7 @@ namespace Stratis.Bitcoin.IntegrationTests
                 var genesis = ctx.Network.GetGenesis();
                 var genesisChainedBlock = new ChainedBlock(genesis.Header, 0);
                 var chained = MakeNext(genesisChainedBlock);
-                var cacheCoinView = new CachedCoinView(ctx.PersistentCoinView, loggerFactory);
+                var cacheCoinView = new CachedCoinView(ctx.PersistentCoinView, DateTimeProvider.Default, loggerFactory);
 
                 cacheCoinView.SaveChangesAsync(new UnspentOutputs[] { new UnspentOutputs(genesis.Transactions[0].GetHash(), new Coins(genesis.Transactions[0], 0)) }, null, genesisChainedBlock.HashBlock, chained.HashBlock).Wait();
                 Assert.NotNull(cacheCoinView.FetchCoinsAsync(new[] { genesis.Transactions[0].GetHash() }).Result.UnspentOutputs[0]);
@@ -95,7 +95,7 @@ namespace Stratis.Bitcoin.IntegrationTests
         {
             using(NodeContext ctx = NodeContext.Create())
             {
-                var cacheCoinView = new CachedCoinView(ctx.PersistentCoinView, this.loggerFactory);
+                var cacheCoinView = new CachedCoinView(ctx.PersistentCoinView, DateTimeProvider.Default, this.loggerFactory);
                 var tester = new CoinViewTester(cacheCoinView);
 
                 var coins = tester.CreateCoins(5);

--- a/Stratis.Bitcoin.IntegrationTests/MinerTests.cs
+++ b/Stratis.Bitcoin.IntegrationTests/MinerTests.cs
@@ -127,7 +127,7 @@ namespace Stratis.Bitcoin.IntegrationTests
                 this.entry = new TestMemPoolEntryHelper();
                 this.chain = new ConcurrentChain(this.network);
                 this.network.Consensus.Options = new PowConsensusOptions();
-                this.cachedCoinView = new CachedCoinView(new InMemoryCoinView(this.chain.Tip.HashBlock), new LoggerFactory());
+                this.cachedCoinView = new CachedCoinView(new InMemoryCoinView(this.chain.Tip.HashBlock), DateTimeProvider.Default, new LoggerFactory());
                 this.consensus = new ConsensusLoop(new PowConsensusValidator(this.network, new Checkpoints(this.network), new LoggerFactory()), this.chain, this.cachedCoinView, new LookaheadBlockPuller(this.chain, new ConnectionManager(this.network, new NodeConnectionParameters(), new NodeSettings(), new LoggerFactory(), new NodeLifetime()), new LoggerFactory()), new NodeDeployments(this.network), new LoggerFactory());
                 this.consensus.Initialize();
 


### PR DESCRIPTION
Before, during IBD, coinview did not flush. Flushing was implemented to be done in consensus loop in case our consensus chain processed a block that is at the tip of the best chain (i.e. not in IBD). Second flushing was implemented in `FetchCoinsAsync` method if the number of items in the cache reached certain (very high limit). Third flushing execution path was during shutdown. 

Before, we fixed #426, which was a race condition between consensus loop accepting of a new block and the shutdown flushing thread. We solved it by first stopping the consensus loop and only then doing the flush. Naturally this problem is not present in the first flush way because it is done from consensus loop, but we did not fix the second way from `FetchCoinsAsync`. 

So we have now removed flushing possibility from FCA and we kept the already fixed shutdown flushing and we changed flushing from consensus loop thread in a way it would flush more often (not just when we are at the tip). Now it is normal that this consensus loop flush does the flush in the middle of IBD and it does so if the last flush is more than 1 minute old.

This prevents the negative effect of #525, which was that due to no flushing for very long time, there were even hundreds of thousands blocks of data unflushed and when user invoked shutdown of the node, the waiting time for the flush to finish was even in hours. This should not happen anymore since we flush every minute during IBD.

Fix #525 