### PR TITLE
Corrected Node Building Instructions

### DIFF
--- a/Documentation/getting-started.md
+++ b/Documentation/getting-started.md
@@ -23,8 +23,7 @@ To install and run the node, you need
 ```
 git clone https://github.com/stratisproject/StratisBitcoinFullNode.git  
 cd StratisBitcoinFullNode
-git checkout master
-git submodule updated --init --recursive
+git submodule update --init --recursive
 ```
 
 ### Build and run the code
@@ -34,7 +33,6 @@ So you have 4 options:
 1. To run a <b>Stratis</b> node on <b>MainNet</b>, do
 ```
 cd Stratis.StratisD
-dotnet restore
 dotnet run
 ```  
 

--- a/Documentation/getting-started.md
+++ b/Documentation/getting-started.md
@@ -34,7 +34,7 @@ So you have 4 options:
 1. To run a <b>Stratis</b> node on <b>MainNet</b>, do
 ```
 cd Stratis.StratisD
-dotnet build
+dotnet restore
 dotnet run
 ```  
 

--- a/Documentation/getting-started.md
+++ b/Documentation/getting-started.md
@@ -24,7 +24,7 @@ To install and run the node, you need
 git clone https://github.com/stratisproject/StratisBitcoinFullNode.git  
 cd StratisBitcoinFullNode
 git checkout master
-git submodule init --init --recursive
+git submodule updated --init --recursive
 ```
 
 ### Build and run the code


### PR DESCRIPTION
Corrected missing step for building node, changing `dotnet build` to `dotnet restore` (Restores the dependencies and tools of a project.). dotnet build is redundant as it is already incorporated into `dotnet run`, however it does not display logging, but dotnet run will report any build issues anyway.