### PR TITLE
Add witness transaction validation to mempool validator

### DIFF
--- a/Stratis.Bitcoin.Features.MemoryPool.Tests/MempoolValidatorTest.cs
+++ b/Stratis.Bitcoin.Features.MemoryPool.Tests/MempoolValidatorTest.cs
@@ -90,9 +90,9 @@ namespace Stratis.Bitcoin.Features.MemoryPool.Tests
         }
 
         [Fact]
-        public async void AcceptToMemoryPool_WithValidP2PKHTxn_IsSuccessfull()
+        public async void AcceptToMemoryPool_WithValidP2PKHTxn_IsSuccessfullAsync()
         {
-            string dataDir = Path.Combine("TestData", nameof(MempoolValidatorTest), nameof(this.AcceptToMemoryPool_WithValidP2PKHTxn_IsSuccessfull));
+            string dataDir = Path.Combine("TestData", nameof(MempoolValidatorTest), nameof(this.AcceptToMemoryPool_WithValidP2PKHTxn_IsSuccessfullAsync));
             Directory.CreateDirectory(dataDir);
 
             BitcoinSecret minerSecret = new BitcoinSecret(new Key(), Network.RegTest);
@@ -119,9 +119,9 @@ namespace Stratis.Bitcoin.Features.MemoryPool.Tests
         /// </summary>
         /// <seealso cref="https://www.codeproject.com/Articles/835098/NBitcoin-Build-Them-All"/>
         [Fact]
-        public async void AcceptToMemoryPool_WithMultiInOutValidTxns_IsSuccessfull()
+        public async void AcceptToMemoryPool_WithMultiInOutValidTxns_IsSuccessfullAsync()
         {
-            string dataDir = Path.Combine("TestData", nameof(MempoolValidatorTest), nameof(this.AcceptToMemoryPool_WithMultiInOutValidTxns_IsSuccessfull));
+            string dataDir = Path.Combine("TestData", nameof(MempoolValidatorTest), nameof(this.AcceptToMemoryPool_WithMultiInOutValidTxns_IsSuccessfullAsync));
             Directory.CreateDirectory(dataDir);
 
             BitcoinSecret miner = new BitcoinSecret(new Key(), Network.RegTest);
@@ -186,9 +186,9 @@ namespace Stratis.Bitcoin.Features.MemoryPool.Tests
         /// </summary>
         /// <seealso cref="https://www.codeproject.com/Articles/835098/NBitcoin-Build-Them-All"/>
         [Fact]
-        public async void AcceptToMemoryPool_WithMultiSigValidTxns_IsSuccessfull()
+        public async void AcceptToMemoryPool_WithMultiSigValidTxns_IsSuccessfullAsync()
         {
-            string dataDir = Path.Combine("TestData", nameof(MempoolValidatorTest), nameof(this.AcceptToMemoryPool_WithMultiSigValidTxns_IsSuccessfull));
+            string dataDir = Path.Combine("TestData", nameof(MempoolValidatorTest), nameof(this.AcceptToMemoryPool_WithMultiSigValidTxns_IsSuccessfullAsync));
             Directory.CreateDirectory(dataDir);
 
             BitcoinSecret miner = new BitcoinSecret(new Key(), Network.RegTest);
@@ -257,9 +257,9 @@ namespace Stratis.Bitcoin.Features.MemoryPool.Tests
         /// </summary>
         /// <seealso cref="https://www.codeproject.com/Articles/835098/NBitcoin-Build-Them-All"/>
         [Fact]
-        public async void AcceptToMemoryPool_WithP2SHValidTxns_IsSuccessfull()
+        public async void AcceptToMemoryPool_WithP2SHValidTxns_IsSuccessfullAsync()
         {
-            string dataDir = Path.Combine("TestData", nameof(MempoolValidatorTest), nameof(this.AcceptToMemoryPool_WithP2SHValidTxns_IsSuccessfull));
+            string dataDir = Path.Combine("TestData", nameof(MempoolValidatorTest), nameof(this.AcceptToMemoryPool_WithP2SHValidTxns_IsSuccessfullAsync));
             Directory.CreateDirectory(dataDir);
 
             BitcoinSecret miner = new BitcoinSecret(new Key(), Network.RegTest);
@@ -320,9 +320,9 @@ namespace Stratis.Bitcoin.Features.MemoryPool.Tests
         /// Validate P2WPKH transaction in memory pool.
         /// </summary>
         [Fact]
-        public async void AcceptToMemoryPool_WithP2WPKHValidTxns_IsSuccessfull()
+        public async void AcceptToMemoryPool_WithP2WPKHValidTxns_IsSuccessfullAsync()
         {
-            string dataDir = Path.Combine("TestData", nameof(MempoolValidatorTest), nameof(this.AcceptToMemoryPool_WithP2WPKHValidTxns_IsSuccessfull));
+            string dataDir = Path.Combine("TestData", nameof(MempoolValidatorTest), nameof(this.AcceptToMemoryPool_WithP2WPKHValidTxns_IsSuccessfullAsync));
             Directory.CreateDirectory(dataDir);
 
             BitcoinSecret miner = new BitcoinSecret(new Key(), Network.RegTest);
@@ -354,9 +354,9 @@ namespace Stratis.Bitcoin.Features.MemoryPool.Tests
         /// Validate P2WSH transaction in memory pool.
         /// </summary>
         [Fact]
-        public async void AcceptToMemoryPool_WithP2WSHValidTxns_IsSuccessfull()
+        public async void AcceptToMemoryPool_WithP2WSHValidTxns_IsSuccessfullAsync()
         {
-            string dataDir = Path.Combine("TestData", nameof(MempoolValidatorTest), nameof(this.AcceptToMemoryPool_WithP2WSHValidTxns_IsSuccessfull));
+            string dataDir = Path.Combine("TestData", nameof(MempoolValidatorTest), nameof(this.AcceptToMemoryPool_WithP2WSHValidTxns_IsSuccessfullAsync));
             Directory.CreateDirectory(dataDir);
 
             BitcoinSecret miner = new BitcoinSecret(new Key(), Network.RegTest);

--- a/Stratis.Bitcoin.Features.MemoryPool.Tests/MempoolValidatorTest.cs
+++ b/Stratis.Bitcoin.Features.MemoryPool.Tests/MempoolValidatorTest.cs
@@ -388,9 +388,9 @@ namespace Stratis.Bitcoin.Features.MemoryPool.Tests
         /// Validate SegWit transaction in memory pool.
         /// </summary>
         [Fact]
-        public async void AcceptToMemoryPool_WithSegWitValidTxns_IsSuccessfull()
+        public async void AcceptToMemoryPool_WithSegWitValidTxns_IsSuccessfullAsync()
         {
-            string dataDir = Path.Combine("TestData", nameof(MempoolValidatorTest), nameof(this.AcceptToMemoryPool_WithSegWitValidTxns_IsSuccessfull));
+            string dataDir = Path.Combine("TestData", nameof(MempoolValidatorTest), nameof(this.AcceptToMemoryPool_WithSegWitValidTxns_IsSuccessfullAsync));
             Directory.CreateDirectory(dataDir);
 
             BitcoinSecret miner = new BitcoinSecret(new Key(), Network.RegTest);

--- a/Stratis.Bitcoin.Features.MemoryPool/MempoolBehavior.cs
+++ b/Stratis.Bitcoin.Features.MemoryPool/MempoolBehavior.cs
@@ -465,7 +465,7 @@ namespace Stratis.Bitcoin.Features.MemoryPool
         private async Task SendAsTxInventory(Node node, IEnumerable<uint256> trxList)
         {
             this.logger.LogTrace("({0}:'{1}',{2}.{3}:{4})", nameof(node), node.RemoteSocketEndpoint, nameof(trxList), "trxList.Count", trxList?.Count());
-            Queue<InventoryVector> queue = new Queue<InventoryVector>(trxList.Select(s => new InventoryVector(InventoryType.MSG_TX, s)));
+            Queue<InventoryVector> queue = new Queue<InventoryVector>(trxList.Select(s => new InventoryVector(node.AddSupportedOptions(InventoryType.MSG_TX), s)));
             while (queue.Count > 0)
             {
                 InventoryVector[] items = queue.TakeAndRemove(ConnectionManager.MAX_INV_SZ).ToArray();

--- a/Stratis.Bitcoin.Features.MemoryPool/MempoolErrors.cs
+++ b/Stratis.Bitcoin.Features.MemoryPool/MempoolErrors.cs
@@ -138,6 +138,9 @@ namespace Stratis.Bitcoin.Features.MemoryPool
         /// <summary>'bad-txns-nonstandard-inputs' error returns a <see cref="RejectNonstandard"/> reject code.</summary>
         public static MempoolError NonstandardInputs = new MempoolError(RejectNonstandard, "bad-txns-nonstandard-inputs");
 
+        /// <summary>'bad-witness-nonstandard' error returns a <see cref="RejectNonstandard"/> reject code.</summary>
+        public static MempoolError NonstandardWitness = new MempoolError(RejectNonstandard, "bad-witness-nonstandard");
+
         /// <summary>'bad-txns-too-many-sigops' error returns a <see cref="RejectNonstandard"/> reject code.</summary>
         public static MempoolError TooManySigops = new MempoolError(RejectNonstandard, "bad-txns-too-many-sigops");
 

--- a/Stratis.Bitcoin.Features.MemoryPool/MempoolValidator.cs
+++ b/Stratis.Bitcoin.Features.MemoryPool/MempoolValidator.cs
@@ -1169,35 +1169,19 @@ namespace Stratis.Bitcoin.Features.MemoryPool
                     // If the scriptPubKey is P2SH, we try to extract the redeemScript casually by converting the scriptSig
                     // into a stack. We do not check IsPushOnly nor compare the hash as these will be done later anyway.
                     // If the check fails at this stage, we know that this txid must be a bad one.
-                    ScriptTemplate p2shTemplate = StandardScripts.GetTemplateFromScriptPubKey(prevScript);
-                    if (p2shTemplate == null)
+                    PayToScriptHashSigParameters sigParams = PayToScriptHashTemplate.Instance.ExtractScriptSigParameters(input.ScriptSig);
+                    if (sigParams == null || sigParams.RedeemScript == null)
                         return false;
 
-                    //todo: extract redeem script, validate and set to prevScript
-
-                    //std::vector < std::vector < unsigned char> > stack;
-                    //// If the scriptPubKey is P2SH, we try to extract the redeemScript casually by converting the scriptSig
-                    //// into a stack. We do not check IsPushOnly nor compare the hash as these will be done later anyway.
-                    //// If the check fails at this stage, we know that this txid must be a bad one.
-                    //if (!EvalScript(stack, tx.vin[i].scriptSig, SCRIPT_VERIFY_NONE, BaseSignatureChecker(), SIGVERSION_BASE))
-                    //    return false;
-                    //if (stack.empty())
-                    //    return false;
-                    //prevScript = CScript(stack.back().begin(), stack.back().end());
+                    prevScript = sigParams.RedeemScript;
                 }
 
                 // Non-witness program must not be associated with any witness
                 if (!prevScript.IsWitness)
                     return false;
 
-                // Check P2WSH standard limits
-                ScriptTemplate template = StandardScripts.GetTemplateFromScriptPubKey(prevScript);
-                if (template == null)
-                    return false;
-
-                // todo: validate the p2sh script - stack script size, max stack items, stack item size
-
-
+                // todo: validate the witness program - stack script size, max stack items, stack item size
+                // Bitcoin logic from here https://github.com/bitcoin/bitcoin/blob/aa624b61c928295c27ffbb4d27be582f5aa31b56/src/policy/policy.cpp#L225-L243
                 //int witnessversion = 0;
                 //std::vector < unsigned char> witnessprogram;
 

--- a/Stratis.Bitcoin.Features.MemoryPool/MempoolValidator.cs
+++ b/Stratis.Bitcoin.Features.MemoryPool/MempoolValidator.cs
@@ -1157,7 +1157,7 @@ namespace Stratis.Bitcoin.Features.MemoryPool
             {
                 // We don't care if witness for this input is empty, since it must not be bloated.
                 // If the script is invalid without witness, it would be caught sooner or later during validation.
-                if (!input.ScriptSig.IsWitness)
+                if (input.WitScript == null)
                     continue;
 
                 TxOut prev = mapInputs.GetOutputFor(input);
@@ -1169,8 +1169,8 @@ namespace Stratis.Bitcoin.Features.MemoryPool
                     // If the scriptPubKey is P2SH, we try to extract the redeemScript casually by converting the scriptSig
                     // into a stack. We do not check IsPushOnly nor compare the hash as these will be done later anyway.
                     // If the check fails at this stage, we know that this txid must be a bad one.
-                    ScriptTemplate template = StandardScripts.GetTemplateFromScriptPubKey(prev.ScriptPubKey);
-                    if (template == null)
+                    ScriptTemplate p2shTemplate = StandardScripts.GetTemplateFromScriptPubKey(prevScript);
+                    if (p2shTemplate == null)
                         return false;
 
                     //todo: extract redeem script, validate and set to prevScript
@@ -1189,6 +1189,14 @@ namespace Stratis.Bitcoin.Features.MemoryPool
                 // Non-witness program must not be associated with any witness
                 if (!prevScript.IsWitness)
                     return false;
+
+                // Check P2WSH standard limits
+                ScriptTemplate template = StandardScripts.GetTemplateFromScriptPubKey(prevScript);
+                if (template == null)
+                    return false;
+
+                // todo: validate the p2sh script - stack script size, max stack items, stack item size
+
 
                 //int witnessversion = 0;
                 //std::vector < unsigned char> witnessprogram;

--- a/Stratis.Bitcoin.Features.MemoryPool/MempoolValidator.cs
+++ b/Stratis.Bitcoin.Features.MemoryPool/MempoolValidator.cs
@@ -551,6 +551,7 @@ namespace Stratis.Bitcoin.Features.MemoryPool
                 context.State.Fail(MempoolErrors.Coinbase).Throw();
 
             // TODO: Implement Witness Code
+            // Bitcoin Ref: https://github.com/bitcoin/bitcoin/blob/ea729d55b4dbd17a53ced474a8457d4759cfb5a5/src/validation.cpp#L463-L467
             //// Reject transactions with witness before segregated witness activates (override with -prematurewitness)
             bool witnessEnabled = false;//IsWitnessEnabled(chainActive.Tip(), Params().GetConsensus());
             //if (!GetBoolArg("-prematurewitness",false) && tx.HasWitness() && !witnessEnabled) {
@@ -574,6 +575,7 @@ namespace Stratis.Bitcoin.Features.MemoryPool
         /// Validate the transaction is a standard transaction.
         /// Checks the version number, transaction size, input signature size,
         /// output script template, single output, & dust outputs.
+        /// <seealso cref="https://github.com/bitcoin/bitcoin/blob/aa624b61c928295c27ffbb4d27be582f5aa31b56/src/policy/policy.cpp##L82-L144"/>
         /// </summary>
         /// <param name="context">Current validation context.</param>
         /// <param name="witnessEnabled">Whether witness is enabled.</param>
@@ -617,7 +619,7 @@ namespace Stratis.Bitcoin.Features.MemoryPool
             foreach (TxOut txout in tx.Outputs)
             {
                 ScriptTemplate script = StandardScripts.GetTemplateFromScriptPubKey(txout.ScriptPubKey);
-                if (script == null) //!::IsStandard(txout.scriptPubKey, whichType, witnessEnabled))
+                if (script == null) //!::IsStandard(txout.scriptPubKey, whichType, witnessEnabled))  https://github.com/bitcoin/bitcoin/blob/aa624b61c928295c27ffbb4d27be582f5aa31b56/src/policy/policy.cpp#L57-L80
                 {
                     context.State.Fail(MempoolErrors.Scriptpubkey).Throw();
                 }


### PR DESCRIPTION
This is basically a C# port of this bitcoin logic sections in the mempool validator: https://github.com/bitcoin/bitcoin/blob/ea729d55b4dbd17a53ced474a8457d4759cfb5a5/src/validation.cpp#L584-#L587
https://github.com/bitcoin/bitcoin/blob/aa624b61c928295c27ffbb4d27be582f5aa31b56/src/policy/policy.cpp#L196

As well as some clean up of some async naming issues with some of the mempool tests.