### PR TITLE
Add new endpoint in api for estimating transaction fee

### DIFF
--- a/Stratis.Bitcoin.Features.Wallet/Controllers/WalletController.cs
+++ b/Stratis.Bitcoin.Features.Wallet/Controllers/WalletController.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.Extensions.Logging;
 using NBitcoin;
 using Stratis.Bitcoin.Configuration;
@@ -16,7 +17,6 @@ using System.Linq;
 using System.Net;
 using System.Security;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Mvc.ModelBinding;
 
 namespace Stratis.Bitcoin.Features.Wallet.Controllers
 {
@@ -150,7 +150,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Controllers
                 return ErrorHelpers.BuildErrorResponse(HttpStatusCode.BadRequest, "There was a problem creating a wallet.", e.ToString());
             }
         }
-        
+
         /// <summary>
         /// Loads a wallet previously created by the user.
         /// </summary>
@@ -324,7 +324,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Controllers
 
                         model.TransactionsHistory.Add(receivedItem);
                     }
-                  
+
                     // add outgoing fund transaction details
                     if (transaction.SpendingDetails != null)
                     {
@@ -458,6 +458,45 @@ namespace Stratis.Bitcoin.Features.Wallet.Controllers
                     MaxSpendableAmount = transactionResult.maximumSpendableAmount,
                     Fee = transactionResult.Fee
                 });
+            }
+            catch (Exception e)
+            {
+                this.logger.LogError("Exception occurred: {0}", e.ToString());
+                return ErrorHelpers.BuildErrorResponse(HttpStatusCode.BadRequest, e.Message, e.ToString());
+            }
+        }
+
+        /// <summary>
+        /// Gets a transaction fee estimate.
+        /// Fee can be estimated by creating a <see cref="TransactionBuildContext"/> with no password
+        /// and then building the transaction and retreiving the fee from the context.
+        /// </summary>
+        /// <param name="request">The transaction parameters.</param>
+        /// <returns>The estimated fee for the transaction.</returns>
+        [Route("estimate-txfee")]
+        [HttpGet]
+        public IActionResult GetTransactionFeeEstimate([FromQuery]TxFeeEstimateRequest request)
+        {
+            Guard.NotNull(request, nameof(request));
+
+            // checks the request is valid
+            if (!this.ModelState.IsValid)
+            {
+                return BuildErrorResponse(this.ModelState);
+            }
+
+            try
+            {
+                var destination = BitcoinAddress.Create(request.DestinationAddress, this.network).ScriptPubKey;
+                var context = new TransactionBuildContext(
+                    new WalletAccountReference(request.WalletName, request.AccountName),
+                    new[] { new Recipient { Amount = request.Amount, ScriptPubKey = destination } }.ToList())
+                {
+                    FeeType = FeeParser.Parse(request.FeeType),
+                    MinConfirmations = request.AllowUnconfirmed ? 0 : 1,
+                };
+
+                return this.Json(this.walletTransactionHandler.EstimateFee(context));
             }
             catch (Exception e)
             {

--- a/Stratis.Bitcoin.Features.Wallet/Interfaces/IWalletTransactionHandler.cs
+++ b/Stratis.Bitcoin.Features.Wallet/Interfaces/IWalletTransactionHandler.cs
@@ -1,7 +1,4 @@
 ﻿using NBitcoin;
-using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace Stratis.Bitcoin.Features.Wallet.Interfaces
 {
@@ -36,5 +33,12 @@ namespace Stratis.Bitcoin.Features.Wallet.Interfaces
         /// <param name="allowUnconfirmed"><c>true</c> to include unconfirmed transactions in the calculation, <c>false</c> otherwise.</param>
         /// <returns>The maximum amount the user can spend in a single transaction, along with the fee required.</returns>
         (Money maximumSpendableAmount, Money Fee) GetMaximumSpendableAmount(WalletAccountReference accountReference, FeeType feeType, bool allowUnconfirmed);
+
+        /// <summary>
+        /// Estimates the fee for the transaction based on information from the <see cref="TransactionBuildContext"/>.
+        /// </summary>
+        /// <param name="context">The context that is used to build a new transaction.</param>
+        /// <returns>The estimated fee.</returns>
+        Money EstimateFee(TransactionBuildContext context);
     }
 }

--- a/Stratis.Bitcoin.Features.Wallet/Models/RequestModels.cs
+++ b/Stratis.Bitcoin.Features.Wallet/Models/RequestModels.cs
@@ -1,8 +1,8 @@
-﻿using System;
-using System.ComponentModel.DataAnnotations;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 using Stratis.Bitcoin.Features.Wallet.Validations;
+using System;
+using System.ComponentModel.DataAnnotations;
 
 namespace Stratis.Bitcoin.Features.Wallet.Models
 {
@@ -104,16 +104,17 @@ namespace Stratis.Bitcoin.Features.Wallet.Models
         public string Name { get; set; }
     }
 
-    public class BuildTransactionRequest : RequestModel
+    /// <summary>
+    /// Model object for <see cref="WalletController.GetTransactionFeeEstimate"> request.
+    /// </summary>
+    /// <seealso cref="Stratis.Bitcoin.Features.Wallet.Models.RequestModel" />
+    public class TxFeeEstimateRequest : RequestModel
     {
         [Required(ErrorMessage = "The name of the wallet is missing.")]
         public string WalletName { get; set; }
-        
+
         [Required(ErrorMessage = "The name of the account is missing.")]
         public string AccountName { get; set; }
-
-        [Required(ErrorMessage = "A password is required.")]
-        public string Password { get; set; }
 
         [Required(ErrorMessage = "A destination address is required.")]
         [IsBitcoinAddress()]
@@ -126,6 +127,12 @@ namespace Stratis.Bitcoin.Features.Wallet.Models
         public string FeeType { get; set; }
 
         public bool AllowUnconfirmed { get; set; }
+    }
+
+    public class BuildTransactionRequest : TxFeeEstimateRequest
+    {
+        [Required(ErrorMessage = "A password is required.")]
+        public string Password { get; set; }
     }
 
     public class SendTransactionRequest : RequestModel

--- a/Stratis.Bitcoin.Features.Wallet/WalletTransactionHandler.cs
+++ b/Stratis.Bitcoin.Features.Wallet/WalletTransactionHandler.cs
@@ -1,12 +1,11 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.Extensions.Logging;
+﻿using Microsoft.Extensions.Logging;
 using NBitcoin;
 using NBitcoin.Policy;
-using Stratis.Bitcoin.Utilities;
-using Stratis.Bitcoin.Interfaces;
 using Stratis.Bitcoin.Features.Wallet.Interfaces;
+using Stratis.Bitcoin.Utilities;
+using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Stratis.Bitcoin.Features.Wallet
 {
@@ -46,17 +45,7 @@ namespace Stratis.Bitcoin.Features.Wallet
         /// <inheritdoc />
         public Transaction BuildTransaction(TransactionBuildContext context)
         {
-            Guard.NotNull(context, nameof(context));
-            Guard.NotNull(context.Recipients, nameof(context.Recipients));
-            Guard.NotNull(context.AccountReference, nameof(context.AccountReference));
-
-            context.TransactionBuilder = new TransactionBuilder();
-
-            this.AddRecipients(context);
-            this.AddCoins(context);
-            this.AddSecrets(context);
-            this.FindChangeAddress(context);
-            this.AddFee(context);
+            this.InitializeTransactionBuilder(context);
 
             if(context.Shuffle)
             {
@@ -172,6 +161,33 @@ namespace Stratis.Bitcoin.Features.Wallet
             }            
 
             return (maxSpendableAmount - fee, fee);
+        }
+
+        /// <inheritdoc />
+        public Money EstimateFee(TransactionBuildContext context)
+        {
+            this.InitializeTransactionBuilder(context);
+
+            return context.TransactionFee;
+        }
+
+        /// <summary>
+        /// Initializes the context transaction builder from information in <see cref="TransactionBuildContext"/>.
+        /// </summary>
+        /// <param name="context">Transaction build context.</param>
+        private void InitializeTransactionBuilder(TransactionBuildContext context)
+        {
+            Guard.NotNull(context, nameof(context));
+            Guard.NotNull(context.Recipients, nameof(context.Recipients));
+            Guard.NotNull(context.AccountReference, nameof(context.AccountReference));
+
+            context.TransactionBuilder = new TransactionBuilder();
+
+            this.AddRecipients(context);
+            this.AddCoins(context);
+            this.AddSecrets(context);
+            this.FindChangeAddress(context);
+            this.AddFee(context);
         }
 
         /// <summary>


### PR DESCRIPTION
This endpoint is so breeze can do a fee estimate without requiring the user to enter a password. Still need to add unit tests for this.