### PR TITLE
Adding the Breeze agent to the node version

### DIFF
--- a/Stratis.Bitcoin/Configuration/NodeSettings.cs
+++ b/Stratis.Bitcoin/Configuration/NodeSettings.cs
@@ -81,6 +81,9 @@ namespace Stratis.Bitcoin.Configuration
         /// <summary>Blockchain name. Currently only "bitcoin" and "stratis" are used.</summary>
         public string Name { get; set; }
 
+        /// <summary>The node's user agent that will be shared with peers in the version handshake.</summary>
+        public string Agent { get; set; }
+
         /// <summary>URI to node's API interface.</summary>
         public Uri ApiUri { get; set; }
 
@@ -126,16 +129,18 @@ namespace Stratis.Bitcoin.Configuration
         /// <param name="name">Blockchain name. Currently only "bitcoin" and "stratis" are used.</param>
         /// <param name="innerNetwork">Specification of the network the node runs on - regtest/testnet/mainnet.</param>
         /// <param name="protocolVersion">Supported protocol version for which to create the configuration.</param>
+        /// <param name="agent">The nodes user agent that will be shared with peers.</param>
         /// <returns>Initialized node configuration.</returns>
         /// <exception cref="ConfigurationException">Thrown in case of any problems with the configuration file or command line arguments.</exception>
         public static NodeSettings FromArguments(string[] args, string name = "bitcoin",
             Network innerNetwork = null,
-            ProtocolVersion protocolVersion = SupportedProtocolVersion)
+            ProtocolVersion protocolVersion = SupportedProtocolVersion,
+            string agent = "StratisBitcoin")
         {
             if (string.IsNullOrEmpty(name))
                 throw new ConfigurationException("A network name is mandatory");
 
-            NodeSettings nodeSettings = new NodeSettings { Name = name };
+            NodeSettings nodeSettings = new NodeSettings { Name = name, Agent = agent };
 
             // The logger factory goes in the settings with minimal configuration, 
             // that's so the settings can also log out its progress.

--- a/Stratis.Bitcoin/Connection/ConnectionManager.cs
+++ b/Stratis.Bitcoin/Connection/ConnectionManager.cs
@@ -75,8 +75,8 @@ namespace Stratis.Bitcoin.Connection
             this.logger = loggerFactory.CreateLogger(this.GetType().FullName);
         }
         public void Start()
-		{
-			this.parameters.UserAgent = "StratisBitcoin:" + GetVersion();
+        {
+            this.parameters.UserAgent = $"{this.NodeSettings.Agent}:{this.GetVersion()}";
 			this.parameters.Version = this.NodeSettings.ProtocolVersion;
 			if (this.connectionManagerSettings.Connect.Count == 0)
 			{

--- a/Stratis.Bitcoin/Connection/ConnectionManager.cs
+++ b/Stratis.Bitcoin/Connection/ConnectionManager.cs
@@ -42,27 +42,27 @@ namespace Stratis.Bitcoin.Connection
 
     public class ConnectionManager : IConnectionManager
     {
-		// The maximum number of entries in an 'inv' protocol message
-		public const int MAX_INV_SZ = 50000;
+        // The maximum number of entries in an 'inv' protocol message
+        public const int MAX_INV_SZ = 50000;
 
-		private readonly NodesCollection connectedNodes = new NodesCollection();
-		private readonly Dictionary<Node, PerformanceSnapshot> downloads = new Dictionary<Node, PerformanceSnapshot>();
-		private NodeServices discoveredNodeRequiredService = NodeServices.Network;
-		private readonly ConnectionManagerSettings connectionManagerSettings;
-		private readonly Network network;
-		private readonly NodeConnectionParameters parameters;
-		private readonly NodeSettings nodeSettings;
+        private readonly NodesCollection connectedNodes = new NodesCollection();
+        private readonly Dictionary<Node, PerformanceSnapshot> downloads = new Dictionary<Node, PerformanceSnapshot>();
+        private NodeServices discoveredNodeRequiredService = NodeServices.Network;
+        private readonly ConnectionManagerSettings connectionManagerSettings;
+        private readonly Network network;
+        private readonly NodeConnectionParameters parameters;
+        private readonly NodeSettings nodeSettings;
         private readonly ILogger logger;
         private readonly INodeLifetime nodeLifetime;
 
         public Network Network { get { return this.network; } }
-		public NodeConnectionParameters Parameters { get { return this.parameters; } }
-		public NodeSettings NodeSettings { get { return this.nodeSettings; } }
-		public IReadOnlyNodesCollection ConnectedNodes { get { return this.connectedNodes; } }
-		public List<NodeServer> Servers { get; } = new List<NodeServer>();
-		public NodesGroup ConnectNodeGroup { get; private set; }
-		public NodesGroup AddNodeNodeGroup { get; private set; }
-		public NodesGroup DiscoveredNodeGroup { get; set; }
+        public NodeConnectionParameters Parameters { get { return this.parameters; } }
+        public NodeSettings NodeSettings { get { return this.nodeSettings; } }
+        public IReadOnlyNodesCollection ConnectedNodes { get { return this.connectedNodes; } }
+        public List<NodeServer> Servers { get; } = new List<NodeServer>();
+        public NodesGroup ConnectNodeGroup { get; private set; }
+        public NodesGroup AddNodeNodeGroup { get; private set; }
+        public NodesGroup DiscoveredNodeGroup { get; set; }
 
         public ConnectionManager(Network network, NodeConnectionParameters parameters, NodeSettings nodeSettings, ILoggerFactory loggerFactory, INodeLifetime nodeLifetime)
         {
@@ -77,44 +77,44 @@ namespace Stratis.Bitcoin.Connection
         public void Start()
         {
             this.parameters.UserAgent = $"{this.NodeSettings.Agent}:{this.GetVersion()}";
-			this.parameters.Version = this.NodeSettings.ProtocolVersion;
-			if (this.connectionManagerSettings.Connect.Count == 0)
-			{
-				NodeConnectionParameters cloneParameters = this.parameters.Clone();
-				cloneParameters.TemplateBehaviors.Add(new ConnectionManagerBehavior(false, this, this.logger));
-				this.DiscoveredNodeGroup = CreateNodeGroup(cloneParameters, this.discoveredNodeRequiredService);
-				this.DiscoveredNodeGroup.CustomGroupSelector = WellKnownGroupSelectors.ByNetwork; //is the default, but I want to use it
-			}
-			else
-			{
-				NodeConnectionParameters cloneParameters = this.parameters.Clone();
-				cloneParameters.TemplateBehaviors.Add(new ConnectionManagerBehavior(false, this, this.logger));
-				cloneParameters.TemplateBehaviors.Remove<AddressManagerBehavior>();
-				var addrman = new AddressManager();
-				addrman.Add(this.connectionManagerSettings.Connect.Select(c => new NetworkAddress(c)).ToArray(), IPAddress.Loopback);
-				var addrmanBehavior = new AddressManagerBehavior(addrman);
-				addrmanBehavior.Mode = AddressManagerBehaviorMode.None;
-				cloneParameters.TemplateBehaviors.Add(addrmanBehavior);
+            this.parameters.Version = this.NodeSettings.ProtocolVersion;
+            if (this.connectionManagerSettings.Connect.Count == 0)
+            {
+                NodeConnectionParameters cloneParameters = this.parameters.Clone();
+                cloneParameters.TemplateBehaviors.Add(new ConnectionManagerBehavior(false, this, this.logger));
+                this.DiscoveredNodeGroup = CreateNodeGroup(cloneParameters, this.discoveredNodeRequiredService);
+                this.DiscoveredNodeGroup.CustomGroupSelector = WellKnownGroupSelectors.ByNetwork; //is the default, but I want to use it
+            }
+            else
+            {
+                NodeConnectionParameters cloneParameters = this.parameters.Clone();
+                cloneParameters.TemplateBehaviors.Add(new ConnectionManagerBehavior(false, this, this.logger));
+                cloneParameters.TemplateBehaviors.Remove<AddressManagerBehavior>();
+                var addrman = new AddressManager();
+                addrman.Add(this.connectionManagerSettings.Connect.Select(c => new NetworkAddress(c)).ToArray(), IPAddress.Loopback);
+                var addrmanBehavior = new AddressManagerBehavior(addrman);
+                addrmanBehavior.Mode = AddressManagerBehaviorMode.None;
+                cloneParameters.TemplateBehaviors.Add(addrmanBehavior);
 
-				this.ConnectNodeGroup = CreateNodeGroup(cloneParameters, NodeServices.Nothing);
-				this.ConnectNodeGroup.MaximumNodeConnection = this.connectionManagerSettings.Connect.Count;
-				this.ConnectNodeGroup.CustomGroupSelector = WellKnownGroupSelectors.ByEndpoint;
-			}
+                this.ConnectNodeGroup = CreateNodeGroup(cloneParameters, NodeServices.Nothing);
+                this.ConnectNodeGroup.MaximumNodeConnection = this.connectionManagerSettings.Connect.Count;
+                this.ConnectNodeGroup.CustomGroupSelector = WellKnownGroupSelectors.ByEndpoint;
+            }
 
-			{
-				NodeConnectionParameters cloneParameters = this.parameters.Clone();
-				cloneParameters.TemplateBehaviors.Add(new ConnectionManagerBehavior(false, this, this.logger));
-				cloneParameters.TemplateBehaviors.Remove<AddressManagerBehavior>();
-				var addrman = new AddressManager();
-				addrman.Add(this.connectionManagerSettings.AddNode.Select(c => new NetworkAddress(c)).ToArray(), IPAddress.Loopback);
-				var addrmanBehavior = new AddressManagerBehavior(addrman);
-				addrmanBehavior.Mode = AddressManagerBehaviorMode.AdvertizeDiscover;
-				cloneParameters.TemplateBehaviors.Add(addrmanBehavior);
+            {
+                NodeConnectionParameters cloneParameters = this.parameters.Clone();
+                cloneParameters.TemplateBehaviors.Add(new ConnectionManagerBehavior(false, this, this.logger));
+                cloneParameters.TemplateBehaviors.Remove<AddressManagerBehavior>();
+                var addrman = new AddressManager();
+                addrman.Add(this.connectionManagerSettings.AddNode.Select(c => new NetworkAddress(c)).ToArray(), IPAddress.Loopback);
+                var addrmanBehavior = new AddressManagerBehavior(addrman);
+                addrmanBehavior.Mode = AddressManagerBehaviorMode.AdvertizeDiscover;
+                cloneParameters.TemplateBehaviors.Add(addrmanBehavior);
 
-				this.AddNodeNodeGroup = CreateNodeGroup(cloneParameters, NodeServices.Nothing);
-				this.AddNodeNodeGroup.MaximumNodeConnection = this.connectionManagerSettings.AddNode.Count;
-				this.AddNodeNodeGroup.CustomGroupSelector = WellKnownGroupSelectors.ByEndpoint;
-			}
+                this.AddNodeNodeGroup = CreateNodeGroup(cloneParameters, NodeServices.Nothing);
+                this.AddNodeNodeGroup.MaximumNodeConnection = this.connectionManagerSettings.AddNode.Count;
+                this.AddNodeNodeGroup.CustomGroupSelector = WellKnownGroupSelectors.ByEndpoint;
+            }
 
             // Related the groups to each other to prevent duplicate connections
             RelatedNodesGroups relGroups = new RelatedNodesGroups();
@@ -126,183 +126,183 @@ namespace Stratis.Bitcoin.Connection
             this.AddNodeNodeGroup?.Connect();
 
             StringBuilder logs = new StringBuilder();
-			logs.AppendLine("Node listening on:");
-			foreach (NodeServerEndpoint listen in this.connectionManagerSettings.Listen)
-			{
-				NodeConnectionParameters cloneParameters = this.parameters.Clone();
-				var server = new NodeServer(this.Network);
-				server.LocalEndpoint = listen.Endpoint;
-				server.ExternalEndpoint = this.connectionManagerSettings.ExternalEndpoint;
-				this.Servers.Add(server);
-				cloneParameters.TemplateBehaviors.Add(new ConnectionManagerBehavior(true, this, this.logger)
-				{
-					Whitelisted = listen.Whitelisted
-				});
-				server.InboundNodeConnectionParameters = cloneParameters;
-				server.Listen();
-				logs.Append(listen.Endpoint.Address + ":" + listen.Endpoint.Port);
-				if (listen.Whitelisted)
-					logs.Append(" (whitelisted)");
-				logs.AppendLine();
-			}
-		    this.logger.LogInformation(logs.ToString());
-		}
+            logs.AppendLine("Node listening on:");
+            foreach (NodeServerEndpoint listen in this.connectionManagerSettings.Listen)
+            {
+                NodeConnectionParameters cloneParameters = this.parameters.Clone();
+                var server = new NodeServer(this.Network);
+                server.LocalEndpoint = listen.Endpoint;
+                server.ExternalEndpoint = this.connectionManagerSettings.ExternalEndpoint;
+                this.Servers.Add(server);
+                cloneParameters.TemplateBehaviors.Add(new ConnectionManagerBehavior(true, this, this.logger)
+                {
+                    Whitelisted = listen.Whitelisted
+                });
+                server.InboundNodeConnectionParameters = cloneParameters;
+                server.Listen();
+                logs.Append(listen.Endpoint.Address + ":" + listen.Endpoint.Port);
+                if (listen.Whitelisted)
+                    logs.Append(" (whitelisted)");
+                logs.AppendLine();
+            }
+            this.logger.LogInformation(logs.ToString());
+        }
 
-		public void AddDiscoveredNodesRequirement(NodeServices services)
-		{
-			this.discoveredNodeRequiredService |= services;
-			NodesGroup group = this.DiscoveredNodeGroup;
-			if (group != null &&
-			   !group.Requirements.RequiredServices.HasFlag(services))
-			{
-				group.Requirements.RequiredServices |= NodeServices.NODE_WITNESS;
-				foreach (Node node in group.ConnectedNodes)
-				{
-					if (!node.PeerVersion.Services.HasFlag(services))
-						node.DisconnectAsync("The peer does not support the required services requirement");
-				}
-			}
-		}
+        public void AddDiscoveredNodesRequirement(NodeServices services)
+        {
+            this.discoveredNodeRequiredService |= services;
+            NodesGroup group = this.DiscoveredNodeGroup;
+            if (group != null &&
+               !group.Requirements.RequiredServices.HasFlag(services))
+            {
+                group.Requirements.RequiredServices |= NodeServices.NODE_WITNESS;
+                foreach (Node node in group.ConnectedNodes)
+                {
+                    if (!node.PeerVersion.Services.HasFlag(services))
+                        node.DisconnectAsync("The peer does not support the required services requirement");
+                }
+            }
+        }
 
-		public string GetStats()
-		{
-			StringBuilder builder = new StringBuilder();
-			lock (this.downloads)
-			{
-				PerformanceSnapshot diffTotal = new PerformanceSnapshot(0, 0);
-				builder.AppendLine("=======Connections=======");
-				foreach (Node node in this.ConnectedNodes)
-				{
-					PerformanceSnapshot newSnapshot = node.Counter.Snapshot();
-					PerformanceSnapshot lastSnapshot = null;
-					if (this.downloads.TryGetValue(node, out lastSnapshot))
-					{
-						BlockPullerBehavior behavior = node.Behaviors.OfType<BlockPullerBehavior>()
-																	.FirstOrDefault(b => b.Puller.GetType() == typeof(LookaheadBlockPuller));
-						PerformanceSnapshot diff = newSnapshot - lastSnapshot;
-						diffTotal = new PerformanceSnapshot(diff.TotalReadenBytes + diffTotal.TotalReadenBytes, diff.TotalWrittenBytes + diffTotal.TotalWrittenBytes) { Start = diff.Start, Taken = diff.Taken };
-						builder.Append((node.RemoteSocketAddress + ":" + node.RemoteSocketPort).PadRight(LoggingConfiguration.ColumnLength * 2) + "R:" + ToKBSec(diff.ReadenBytesPerSecond) + "\tW:" + ToKBSec(diff.WrittenBytesPerSecond));
-						if (behavior != null)
-						{
+        public string GetStats()
+        {
+            StringBuilder builder = new StringBuilder();
+            lock (this.downloads)
+            {
+                PerformanceSnapshot diffTotal = new PerformanceSnapshot(0, 0);
+                builder.AppendLine("=======Connections=======");
+                foreach (Node node in this.ConnectedNodes)
+                {
+                    PerformanceSnapshot newSnapshot = node.Counter.Snapshot();
+                    PerformanceSnapshot lastSnapshot = null;
+                    if (this.downloads.TryGetValue(node, out lastSnapshot))
+                    {
+                        BlockPullerBehavior behavior = node.Behaviors.OfType<BlockPullerBehavior>()
+                                                                    .FirstOrDefault(b => b.Puller.GetType() == typeof(LookaheadBlockPuller));
+                        PerformanceSnapshot diff = newSnapshot - lastSnapshot;
+                        diffTotal = new PerformanceSnapshot(diff.TotalReadenBytes + diffTotal.TotalReadenBytes, diff.TotalWrittenBytes + diffTotal.TotalWrittenBytes) { Start = diff.Start, Taken = diff.Taken };
+                        builder.Append((node.RemoteSocketAddress + ":" + node.RemoteSocketPort).PadRight(LoggingConfiguration.ColumnLength * 2) + "R:" + ToKBSec(diff.ReadenBytesPerSecond) + "\tW:" + ToKBSec(diff.WrittenBytesPerSecond));
+                        if (behavior != null)
+                        {
                             int intQuality = (int)behavior.QualityScore;
                             builder.Append("\tQualityScore: " + intQuality + (intQuality < 10 ? "\t" : "") + "\tPendingBlocks: " + behavior.PendingDownloadsCount);
-						}
-						builder.AppendLine();
-					}
-					this.downloads.AddOrReplace(node, newSnapshot);
-				}
-				builder.AppendLine("=================");
-				builder.AppendLine("Total".PadRight(LoggingConfiguration.ColumnLength * 2) + "R:" + ToKBSec(diffTotal.ReadenBytesPerSecond) + "\tW:" + ToKBSec(diffTotal.WrittenBytesPerSecond));
-				builder.AppendLine("==========================");
+                        }
+                        builder.AppendLine();
+                    }
+                    this.downloads.AddOrReplace(node, newSnapshot);
+                }
+                builder.AppendLine("=================");
+                builder.AppendLine("Total".PadRight(LoggingConfiguration.ColumnLength * 2) + "R:" + ToKBSec(diffTotal.ReadenBytesPerSecond) + "\tW:" + ToKBSec(diffTotal.WrittenBytesPerSecond));
+                builder.AppendLine("==========================");
 
-				//TODO: Hack, we should just clean nodes that are not connect anymore
-				if (this.downloads.Count > 1000)
-					this.downloads.Clear();
-			}
-			return builder.ToString();
-		}
+                //TODO: Hack, we should just clean nodes that are not connect anymore
+                if (this.downloads.Count > 1000)
+                    this.downloads.Clear();
+            }
+            return builder.ToString();
+        }
 
-		public string GetNodeStats()
-		{
-			var builder = new StringBuilder();
+        public string GetNodeStats()
+        {
+            var builder = new StringBuilder();
 
-			foreach (Node node in this.ConnectedNodes)
-			{
-				ConnectionManagerBehavior connectionManagerBehavior = node.Behavior<ConnectionManagerBehavior>();
-				ChainHeadersBehavior chainHeadersBehavior = node.Behavior<ChainHeadersBehavior>();
-				builder.AppendLine(
-					"Node:" + (node.RemoteInfo() + ", ").PadRight(LoggingConfiguration.ColumnLength + 15) +
-					(" connected" + " (" + (connectionManagerBehavior.Inbound ? "inbound" : "outbound") + "),").PadRight(LoggingConfiguration.ColumnLength + 7) +
-					(" agent " + node.PeerVersion.UserAgent + ", ").PadRight(LoggingConfiguration.ColumnLength + 2) +
-					" height=" + chainHeadersBehavior.PendingTip.Height);
-			}
-			return builder.ToString();
-		}
+            foreach (Node node in this.ConnectedNodes)
+            {
+                ConnectionManagerBehavior connectionManagerBehavior = node.Behavior<ConnectionManagerBehavior>();
+                ChainHeadersBehavior chainHeadersBehavior = node.Behavior<ChainHeadersBehavior>();
+                builder.AppendLine(
+                    "Node:" + (node.RemoteInfo() + ", ").PadRight(LoggingConfiguration.ColumnLength + 15) +
+                    (" connected" + " (" + (connectionManagerBehavior.Inbound ? "inbound" : "outbound") + "),").PadRight(LoggingConfiguration.ColumnLength + 7) +
+                    (" agent " + node.PeerVersion.UserAgent + ", ").PadRight(LoggingConfiguration.ColumnLength + 2) +
+                    " height=" + chainHeadersBehavior.PendingTip.Height);
+            }
+            return builder.ToString();
+        }
 
-		private string ToKBSec(ulong bytesPerSec)
-		{
-			double speed = ((double)bytesPerSec / 1024.0);
-			return speed.ToString("0.00") + " KB/S";
-		}
+        private string ToKBSec(ulong bytesPerSec)
+        {
+            double speed = ((double)bytesPerSec / 1024.0);
+            return speed.ToString("0.00") + " KB/S";
+        }
 
-		private NodesGroup CreateNodeGroup(NodeConnectionParameters cloneParameters, NodeServices requiredServices)
-		{
-			return new NodesGroup(this.Network, cloneParameters, new NodeRequirement
-			{
-				MinVersion = this.NodeSettings.ProtocolVersion,
-				RequiredServices = requiredServices,
-			});
-		}
+        private NodesGroup CreateNodeGroup(NodeConnectionParameters cloneParameters, NodeServices requiredServices)
+        {
+            return new NodesGroup(this.Network, cloneParameters, new NodeRequirement
+            {
+                MinVersion = this.NodeSettings.ProtocolVersion,
+                RequiredServices = requiredServices,
+            });
+        }
 
-		private string GetVersion()
-		{
-			Match match = Regex.Match(this.GetType().AssemblyQualifiedName, "Version=([0-9]+\\.[0-9]+\\.[0-9]+)\\.");
-			return match.Groups[1].Value;
-		}
+        private string GetVersion()
+        {
+            Match match = Regex.Match(this.GetType().AssemblyQualifiedName, "Version=([0-9]+\\.[0-9]+\\.[0-9]+)\\.");
+            return match.Groups[1].Value;
+        }
 
-		public void Dispose()
-		{
-			if (this.DiscoveredNodeGroup != null)
-				this.DiscoveredNodeGroup.Dispose();
-			if (this.ConnectNodeGroup != null)
-				this.ConnectNodeGroup.Dispose();
-			if (this.AddNodeNodeGroup != null)
-				this.AddNodeNodeGroup.Dispose();
-			foreach (NodeServer server in this.Servers)
-				server.Dispose();
-			foreach (Node node in this.connectedNodes.Where(n => n.Behaviors.Find<ConnectionManagerBehavior>().OneTry))
-				node.Disconnect();
-		}
+        public void Dispose()
+        {
+            if (this.DiscoveredNodeGroup != null)
+                this.DiscoveredNodeGroup.Dispose();
+            if (this.ConnectNodeGroup != null)
+                this.ConnectNodeGroup.Dispose();
+            if (this.AddNodeNodeGroup != null)
+                this.AddNodeNodeGroup.Dispose();
+            foreach (NodeServer server in this.Servers)
+                server.Dispose();
+            foreach (Node node in this.connectedNodes.Where(n => n.Behaviors.Find<ConnectionManagerBehavior>().OneTry))
+                node.Disconnect();
+        }
 
-		internal void AddConnectedNode(Node node)
-		{
-			this.connectedNodes.Add(node);
-		}
+        internal void AddConnectedNode(Node node)
+        {
+            this.connectedNodes.Add(node);
+        }
 
-		internal void RemoveConnectedNode(Node node)
-		{
-			this.connectedNodes.Remove(node);
-		}
+        internal void RemoveConnectedNode(Node node)
+        {
+            this.connectedNodes.Remove(node);
+        }
 
-		public Node FindNodeByEndpoint(IPEndPoint endpoint)
-		{
-			return this.connectedNodes.FindByEndpoint(endpoint);
-		}
+        public Node FindNodeByEndpoint(IPEndPoint endpoint)
+        {
+            return this.connectedNodes.FindByEndpoint(endpoint);
+        }
 
-		public Node FindNodeByIp(IPAddress ip)
-		{
-			return this.connectedNodes.FindByIp(ip);
-		}
+        public Node FindNodeByIp(IPAddress ip)
+        {
+            return this.connectedNodes.FindByIp(ip);
+        }
 
-		public Node FindLocalNode()
-		{
-			return this.connectedNodes.FindLocal();
-		}
+        public Node FindLocalNode()
+        {
+            return this.connectedNodes.FindLocal();
+        }
 
-		public void AddNodeAddress(IPEndPoint endpoint)
-		{
-			AddressManager addrman = AddressManagerBehavior.GetAddrman(this.AddNodeNodeGroup.NodeConnectionParameters);
-			addrman.Add(new NetworkAddress(endpoint));
-			this.AddNodeNodeGroup.MaximumNodeConnection++;
-		}
+        public void AddNodeAddress(IPEndPoint endpoint)
+        {
+            AddressManager addrman = AddressManagerBehavior.GetAddrman(this.AddNodeNodeGroup.NodeConnectionParameters);
+            addrman.Add(new NetworkAddress(endpoint));
+            this.AddNodeNodeGroup.MaximumNodeConnection++;
+        }
 
-		public void RemoveNodeAddress(IPEndPoint endpoint)
-		{
-			Node node = this.connectedNodes.FindByEndpoint(endpoint);
-			if (node != null)
-				node.DisconnectAsync("Requested by user");
-		}
+        public void RemoveNodeAddress(IPEndPoint endpoint)
+        {
+            Node node = this.connectedNodes.FindByEndpoint(endpoint);
+            if (node != null)
+                node.DisconnectAsync("Requested by user");
+        }
 
-		public Node Connect(IPEndPoint endpoint)
-		{
-			NodeConnectionParameters cloneParameters = this.parameters.Clone();
-			cloneParameters.TemplateBehaviors.Add(new ConnectionManagerBehavior(false, this, this.logger)
-			{
-				OneTry = true
-			});
-			var node = Node.Connect(this.Network, endpoint, cloneParameters);
-			node.VersionHandshake();
-			return node;
-		}
-	}
+        public Node Connect(IPEndPoint endpoint)
+        {
+            NodeConnectionParameters cloneParameters = this.parameters.Clone();
+            cloneParameters.TemplateBehaviors.Add(new ConnectionManagerBehavior(false, this, this.logger)
+            {
+                OneTry = true
+            });
+            var node = Node.Connect(this.Network, endpoint, cloneParameters);
+            node.VersionHandshake();
+            return node;
+        }
+    }
 }

--- a/Stratis.BreezeD/Program.cs
+++ b/Stratis.BreezeD/Program.cs
@@ -26,7 +26,7 @@ namespace Stratis.BreezeD
             var apiUri = args.GetValueOf("apiuri");
             var isTestNet = args.Contains("-testnet");
             var isStratis = args.Contains("stratis");
-            var agent = "Breeze(spv)";
+            var agent = "Breeze";
 
             NodeSettings nodeSettings;
             if (isStratis)

--- a/Stratis.BreezeD/Program.cs
+++ b/Stratis.BreezeD/Program.cs
@@ -26,6 +26,7 @@ namespace Stratis.BreezeD
             var apiUri = args.GetValueOf("apiuri");
             var isTestNet = args.Contains("-testnet");
             var isStratis = args.Contains("stratis");
+            var agent = "Breeze(spv)";
 
             NodeSettings nodeSettings;
             if (isStratis)
@@ -37,12 +38,12 @@ namespace Stratis.BreezeD
                 if (isTestNet)
                     args = args.Append("-addnode=51.141.28.47").ToArray(); // TODO: fix this temp hack 
 
-                nodeSettings = NodeSettings.FromArguments(args, "stratis", network, ProtocolVersion.ALT_PROTOCOL_VERSION);
+                nodeSettings = NodeSettings.FromArguments(args, "stratis", network, ProtocolVersion.ALT_PROTOCOL_VERSION, agent);
                 nodeSettings.ApiUri = new Uri(string.IsNullOrEmpty(apiUri) ? DefaultStratisUri : apiUri);
             }
             else
             {
-                nodeSettings = NodeSettings.FromArguments(args);
+                nodeSettings = NodeSettings.FromArguments(args, agent: agent);
                 nodeSettings.ApiUri = new Uri(string.IsNullOrEmpty(apiUri) ? DefaultBitcoinUri : apiUri);
             }
 


### PR DESCRIPTION
I am considering we should change the default agent from `StratisBitcoin` to be `StratisNode`.  

Alternatively we can also enforce a certain structure in the agent name to `stratis:[node-description]:version`.
Then for the fullnode it will be `stratis:fullnode:1.0.2` and for breeze it will be `stratis:breeze:1.0.2`

We could also put macros to for example for the version, Breeze has its own version this will allow to override version.
