### PR TITLE
Bugfix/issue 639 lbp after ibd

### DIFF
--- a/Stratis.Bitcoin/BlockPulling/BlockPullerBehavior.cs
+++ b/Stratis.Bitcoin/BlockPulling/BlockPullerBehavior.cs
@@ -149,7 +149,7 @@ namespace Stratis.Bitcoin.BlockPulling
             this.logger.LogTrace("()");
 
             Node attachedNode = this.AttachedNode;
-            if (attachedNode == null || attachedNode.State != NodeState.HandShaked || !this.puller.Requirements.Check(attachedNode.PeerVersion))
+            if ((attachedNode == null) || (attachedNode.State != NodeState.HandShaked) || !this.puller.Requirements.Check(attachedNode.PeerVersion))
             {
                 this.logger.LogTrace("(-)[ATTACHED_NODE]");
                 return;
@@ -172,7 +172,7 @@ namespace Stratis.Bitcoin.BlockPulling
             this.logger.LogTrace("()");
 
             Node attachedNode = this.AttachedNode;
-            if (attachedNode == null || attachedNode.State != NodeState.HandShaked || !this.puller.Requirements.Check(attachedNode.PeerVersion))
+            if ((attachedNode == null) || (attachedNode.State != NodeState.HandShaked) || !this.puller.Requirements.Check(attachedNode.PeerVersion))
             {
                 this.logger.LogTrace("(-)[ATTACHED_NODE]");
                 return;

--- a/Stratis.Bitcoin/BlockPulling/BlockPullerBehavior.cs
+++ b/Stratis.Bitcoin/BlockPulling/BlockPullerBehavior.cs
@@ -105,7 +105,7 @@ namespace Stratis.Bitcoin.BlockPulling
         /// <param name="message">Received message.</param>
         private void Node_MessageReceived(Node node, IncomingMessage message)
         {
-            this.logger.LogTrace("({0}:'{1}')", nameof(node), node?.RemoteSocketEndpoint);
+            this.logger.LogTrace("({0}:'{1}',{2}:'{3}')", nameof(node), node.RemoteSocketEndpoint, nameof(message), message.Message.Command);
 
             message.Message.IfPayloadIs<BlockPayload>((block) =>
             {

--- a/Stratis.Bitcoin/BlockPulling/LookaheadBlockPuller.cs
+++ b/Stratis.Bitcoin/BlockPulling/LookaheadBlockPuller.cs
@@ -372,13 +372,16 @@ namespace Stratis.Bitcoin.BlockPulling
             if (this.location == null)
                 throw new InvalidOperationException("SetLocation should have been called");
 
-            if (this.lookaheadLocation == null && !this.Chain.Contains(this.location))
+            if ((this.lookaheadLocation != null) && (this.location != null) && (this.lookaheadLocation.Height < this.location.Height))
+                this.lookaheadLocation = this.location;
+
+            if ((this.lookaheadLocation == null) && !this.Chain.Contains(this.location.HashBlock))
             {
                 this.logger.LogTrace("(-)[REORG]");
                 return;
             }
 
-            if (this.lookaheadLocation != null && !this.Chain.Contains(this.lookaheadLocation))
+            if ((this.lookaheadLocation != null) && !this.Chain.Contains(this.lookaheadLocation.HashBlock))
                 this.lookaheadLocation = null;
 
             ChainedBlock lookaheadBlock = this.lookaheadLocation ?? this.location;

--- a/Stratis.Bitcoin/BlockPulling/LookaheadBlockPuller.cs
+++ b/Stratis.Bitcoin/BlockPulling/LookaheadBlockPuller.cs
@@ -520,10 +520,7 @@ namespace Stratis.Bitcoin.BlockPulling
                         break;
                     }
 
-                    lock (this.locationLock)
-                    {
-                        this.location = header;
-                    }
+                    this.SetLocation(header);
 
                     lock (this.bufferLock)
                     {


### PR DESCRIPTION
The puller behaved oddly after IBD, it downloaded blocks twice - see the issue for more description.

The problem was that in `NextBlockCore` this line:
```
                        if (!isDownloading) this.AskBlocks(new ChainedBlock[] { header });
```
was using different way than the usual way of asking new blocks. Normally, `LBP.AskBlocks()` is called and it calls `BP.AskBlocks` and it always adjusts `lookaheadLocation`. But when this shortcut was used, `lookaheadLocation` was not properly modified, which then caused many blocks to be downloaded twice when it was not needed. So what we do is that we make an extra checks in `LBP.AskBlocks()` that fixes `lookaheadLocation` if it is find to be in front of `location`. Alternatively, we could adjust `lookaheadLocation` in the shortcut execution path, but the `lookaheadLocation` fixing logic is already placed in `LBP.AskBlocks` and the logic is not trivial. It thus would be a more complex question on how to adjust `lookaheadLocation` correctly in the shortcut execution path. Therefore we chose this very simple fix by extending the fixing logic.

Fix #639 