### PR TITLE
Allow "=" in config values 

### DIFF
--- a/Stratis.Bitcoin.Tests/NodeConfiguration/TextFileConfigurationTests.cs
+++ b/Stratis.Bitcoin.Tests/NodeConfiguration/TextFileConfigurationTests.cs
@@ -80,5 +80,35 @@ namespace Stratis.Bitcoin.Tests.NodeConfiguration
             Assert.Equal("testValue", result[0]);
             Assert.Equal("testValue2", result[1]);
         }
+
+        /// <summary>
+        /// Assert that we can pass mime-encoded-data as values
+        /// </summary>
+        [Fact]
+        public void GetMimeValueWithFileString()
+        {
+            // Arrange
+            var textFileConfiguration = new TextFileConfiguration("azurekey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==");
+            // Act
+            string[] result = textFileConfiguration.GetAll("azurekey");
+            // Assert
+            Assert.Equal(1, result.Length);
+            Assert.Equal("Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==", result[0]);
+        }
+
+        /// <summary>
+        /// Assert that we can pass mime-encoded-data as values
+        /// </summary>
+        [Fact]
+        public void GetMimeValueWithStringArgs()
+        {
+            // Arrange
+            var textFileConfiguration = new TextFileConfiguration(new string[] { "azurekey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==" });
+            // Act
+            string[] result = textFileConfiguration.GetAll("azurekey");
+            // Assert
+            Assert.Equal(1, result.Length);
+            Assert.Equal("Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==", result[0]);
+        }
     }
 }

--- a/Stratis.Bitcoin/Configuration/TextFileConfiguration.cs
+++ b/Stratis.Bitcoin/Configuration/TextFileConfiguration.cs
@@ -40,8 +40,9 @@ namespace Stratis.Bitcoin.Configuration
             foreach (string arg in args)
             {
                 // Split on the FIRST "=".
+                // This will allow mime-encoded - data strings end in one or more "=" to be parsed.
                 string[] splitted = arg.Split('=');
-                if (splitted.Length > 1)                    
+                if (splitted.Length > 1)
                     this.Add(splitted[0], string.Join("=", splitted.Skip(1)));
                 else
                     this.Add(splitted[0], "1");
@@ -77,6 +78,7 @@ namespace Stratis.Bitcoin.Configuration
                     continue;
 
                 // Split on the FIRST "=".
+                // This will allow mime-encoded - data strings end in one or more "=" to be parsed.
                 string[] split = line.Split('=');
                 if (split.Length == 1)
                     throw new FormatException("Line " + lineNumber + $": \"{l}\" : No value is set");

--- a/Stratis.Bitcoin/Configuration/TextFileConfiguration.cs
+++ b/Stratis.Bitcoin/Configuration/TextFileConfiguration.cs
@@ -39,10 +39,11 @@ namespace Stratis.Bitcoin.Configuration
             this.args = new Dictionary<string, List<string>>();
             foreach (string arg in args)
             {
+                // Split on the FIRST "=".
                 string[] splitted = arg.Split('=');
-                if (splitted.Length == 2)
-                    this.Add(splitted[0], splitted[1]);
-                if (splitted.Length == 1)
+                if (splitted.Length > 1)                    
+                    this.Add(splitted[0], string.Join("=", splitted.Skip(1)));
+                else
                     this.Add(splitted[0], "1");
             }
         }
@@ -75,15 +76,13 @@ namespace Stratis.Bitcoin.Configuration
                 if (string.IsNullOrEmpty(line) || line.StartsWith("#"))
                     continue;
 
-                // Split on '='.
+                // Split on the FIRST "=".
                 string[] split = line.Split('=');
                 if (split.Length == 1)
                     throw new FormatException("Line " + lineNumber + $": \"{l}\" : No value is set");
-                if (split.Length > 2)
-                    throw new FormatException("Line " + lineNumber + $": \"{l}\" : Only one '=' was expected");
 
                 // Add to dictionary. Trim spaces around keys and values.
-                this.Add(split[0].Trim(), split[1].Trim());
+                this.Add(split[0].Trim(), string.Join("=", split.Skip(1)).Trim());
             }
         }
 


### PR DESCRIPTION
After the PR we will be able to pass e.g. Azure keys as command line arguments. 

These mime-encoded-data strings end in one or more "=" - e.g.:

`azurekey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==`