### PR TITLE
Fix Build & Fix 2 miner tests with checkpoint logic

### DIFF
--- a/src/Stratis.Bitcoin.Cli/Program.cs
+++ b/src/Stratis.Bitcoin.Cli/Program.cs
@@ -38,7 +38,7 @@ namespace Stratis.Bitcoin.Cli
                     Console.WriteLine(builder);
                     return;
                 }
-            
+
                 // Determine API port.
                 string blockchain = "bitcoin";
                 int apiPort = 37220;
@@ -61,7 +61,7 @@ namespace Stratis.Bitcoin.Cli
                     // Process RPC call.
                     try
                     {
-                        NodeSettings nodeSettings = NodeSettings.FromArguments(args, blockchain, network);
+                        NodeSettings nodeSettings = new NodeSettings(blockchain, network).LoadArguments(args);
                         var rpcSettings = new RpcSettings();
                         rpcSettings.Load(nodeSettings);
 
@@ -96,7 +96,7 @@ namespace Stratis.Bitcoin.Cli
                             // Get the response.
                             Console.WriteLine($"Sending API command to {url}...");
                             var response = client.GetStringAsync(url).GetAwaiter().GetResult();
-                            
+
                             // Format and return the result as a string to the console.
                             Console.WriteLine(JsonConvert.SerializeObject(JsonConvert.DeserializeObject<object>(response), Formatting.Indented));
                         }

--- a/src/Stratis.Bitcoin.IntegrationTests/MinerTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/MinerTests.cs
@@ -112,9 +112,10 @@ namespace Stratis.Bitcoin.IntegrationTests
             public int baseheight;
             public CachedCoinView cachedCoinView;
 
+            private bool useCheckpoints = true;
+
             public TestContext()
             {
-
             }
 
             public async Task InitializeAsync()
@@ -138,8 +139,13 @@ namespace Stratis.Bitcoin.IntegrationTests
                 this.cachedCoinView = new CachedCoinView(new InMemoryCoinView(this.chain.Tip.HashBlock), dateTimeProvider, new LoggerFactory());
 
                 LoggerFactory loggerFactory = new LoggerFactory();
+
                 var nodeSettings = NodeSettings.Default();
-                ConsensusSettings consensusSettings = new ConsensusSettings(nodeSettings, loggerFactory);
+                var consensusSettings = new ConsensusSettings(nodeSettings, loggerFactory)
+                {
+                    UseCheckpoints = this.useCheckpoints
+                };
+
                 PowConsensusValidator consensusValidator = new PowConsensusValidator(this.network, new Checkpoints(this.network, consensusSettings), dateTimeProvider, loggerFactory);
 
                 ConnectionManager connectionManager = new ConnectionManager(this.network, new NodeConnectionParameters(), nodeSettings, loggerFactory, new NodeLifetime());
@@ -197,6 +203,12 @@ namespace Stratis.Bitcoin.IntegrationTests
                 // Just to make sure we can still make simple blocks
                 this.newBlock = AssemblerForTest(this).CreateNewBlock(this.scriptPubKey);
                 Assert.NotNull(this.newBlock);
+            }
+
+            internal TestContext WithoutCheckpoints()
+            {
+                this.useCheckpoints = false;
+                return this;
             }
         }
 
@@ -320,7 +332,7 @@ namespace Stratis.Bitcoin.IntegrationTests
         public async Task MinerCreateBlockSigopsLimit1000Async()
         {
             var context = new TestContext();
-            await context.InitializeAsync();
+            await context.WithoutCheckpoints().InitializeAsync();
 
             // block sigops > limit: 1000 CHECKMULTISIG + 1
             var tx = new Transaction();
@@ -427,7 +439,7 @@ namespace Stratis.Bitcoin.IntegrationTests
         public async Task MinerCreateBlockCoinbaseMempoolTemplateCreationFailsAsync()
         {
             var context = new TestContext();
-            await context.InitializeAsync();
+            await context.WithoutCheckpoints().InitializeAsync();
             var tx = new Transaction();
             tx.AddInput(new TxIn());
             tx.AddOutput(new TxOut());

--- a/src/Stratis.Bitcoin.IntegrationTests/NodeBuilder.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/NodeBuilder.cs
@@ -209,7 +209,7 @@ namespace Stratis.Bitcoin.IntegrationTests
         /// but all the features required for it are enabled.</remarks>
         public static IFullNode BuildStakingNode(string dir, bool staking = true)
         {
-            NodeSettings nodeSettings = NodeSettings.FromArguments(new string[] { $"-datadir={dir}", $"-stake={(staking ? 1 : 0)}", "-walletname=dummy", "-walletpassword=dummy" });
+            NodeSettings nodeSettings = new NodeSettings().LoadArguments(new string[] { $"-datadir={dir}", $"-stake={(staking ? 1 : 0)}", "-walletname=dummy", "-walletpassword=dummy" });
             var fullNodeBuilder = new FullNodeBuilder(nodeSettings);
             IFullNode fullNode = fullNodeBuilder
                 .UseStratisConsensus()
@@ -560,7 +560,7 @@ namespace Stratis.Bitcoin.IntegrationTests
         private Money fee = Money.Coins(0.0001m);
         private object lockObject = new object();
 
-        public string Folder { get { return this.folder; } }        
+        public string Folder { get { return this.folder; } }
 
         /// <summary>Location of the data directory for the node.</summary>
         public string DataFolder { get { return this.dataDir; } }
@@ -595,10 +595,10 @@ namespace Stratis.Bitcoin.IntegrationTests
         {
             get
             {
-                if(this.runner is StratisBitcoinPosRunner)
-                   return ((StratisBitcoinPosRunner)this.runner).FullNode;
+                if (this.runner is StratisBitcoinPosRunner)
+                    return ((StratisBitcoinPosRunner)this.runner).FullNode;
 
-                return ((StratisBitcoinPowRunner) this.runner).FullNode;
+                return ((StratisBitcoinPowRunner)this.runner).FullNode;
             }
         }
 


### PR DESCRIPTION
Two miner integration tests were failing because consensus uses check points which causes the block validation to be skipped. This causes the test to fail as it expects a exception to be thrown.