### PR TITLE
rename IBlockRepository in NBitcoin to avoid conflicts

### DIFF
--- a/src/NBitcoin/BitcoinCore/BlockRepository.cs
+++ b/src/NBitcoin/BitcoinCore/BlockRepository.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 
 namespace NBitcoin.BitcoinCore
 {
-	public class BlockRepository : IBlockRepository
+	public class BlockRepository : INBitcoinBlockRepository
 	{
 		IndexedBlockStore _BlockStore;
 		IndexedBlockStore _HeaderStore;

--- a/src/NBitcoin/BlockValidator.cs
+++ b/src/NBitcoin/BlockValidator.cs
@@ -277,7 +277,7 @@ namespace NBitcoin
 		}
 
 		// Check kernel hash target and coinstake signature
-		public static bool CheckProofOfStake(IBlockRepository blockStore, ITransactionRepository trasnactionStore, IBlockTransactionMapStore mapStore,
+		public static bool CheckProofOfStake(INBitcoinBlockRepository blockStore, ITransactionRepository trasnactionStore, IBlockTransactionMapStore mapStore,
 			ChainedBlock pindexPrev, BlockStake prevBlockStake, Transaction tx, uint nBits, out uint256 hashProofOfStake, out uint256 targetProofOfStake)
 		{
 			targetProofOfStake = null; hashProofOfStake = null;
@@ -331,7 +331,7 @@ namespace NBitcoin
 		public const uint StakeMinAge = 60; // 8 hours
 		public const uint ModifierInterval = 10 * 60; // time to elapse before new modifier is computed
 
-		public static bool CheckAndComputeStake(IBlockRepository blockStore, ITransactionRepository trasnactionStore, IBlockTransactionMapStore mapStore, StakeChain stakeChain,
+		public static bool CheckAndComputeStake(INBitcoinBlockRepository blockStore, ITransactionRepository trasnactionStore, IBlockTransactionMapStore mapStore, StakeChain stakeChain,
 			ChainBase chainIndex, ChainedBlock pindex, Block block, out BlockStake blockStake)
 		{
 			if (block.GetHash() != pindex.HashBlock)
@@ -376,7 +376,7 @@ namespace NBitcoin
 			return ComputeStakeModifier(chainIndex, pindex, blockStake, stakeChain);
 		}
 
-		private static bool IsConfirmedInNPrevBlocks(IBlockRepository blockStore, Transaction txPrev, ChainedBlock pindexFrom, int maxDepth, ref int actualDepth)
+		private static bool IsConfirmedInNPrevBlocks(INBitcoinBlockRepository blockStore, Transaction txPrev, ChainedBlock pindexFrom, int maxDepth, ref int actualDepth)
 		{
 			// note: this method can be optimized by ensuring that blockstore keeps 
 			// in memory at least maxDepth blocks twards genesis
@@ -570,7 +570,7 @@ namespace NBitcoin
 				return (nTimeBlock == nTimeTx);
 		}
 
-		public static bool CheckKernel(IBlockRepository blockStore, ITransactionRepository trasnactionStore,
+		public static bool CheckKernel(INBitcoinBlockRepository blockStore, ITransactionRepository trasnactionStore,
 			IBlockTransactionMapStore mapStore, StakeChain stakeChain,
 			ChainedBlock pindexPrev, uint nBits, long nTime, OutPoint prevout, ref long pBlockTime)
 		{
@@ -864,7 +864,7 @@ namespace NBitcoin
 		// guaranteed to be in main chain by sync-checkpoint. This rule is
 		// introduced to help nodes establish a consistent view of the coin
 		// age (trust score) of competing branches.
-		public static bool GetCoinAge(IBlockRepository blockStore, ITransactionRepository trasnactionStore, IBlockTransactionMapStore mapStore,
+		public static bool GetCoinAge(INBitcoinBlockRepository blockStore, ITransactionRepository trasnactionStore, IBlockTransactionMapStore mapStore,
 			Transaction trx, ChainedBlock pindexPrev, out ulong nCoinAge)
 		{
 

--- a/src/NBitcoin/IBlockRepository.cs
+++ b/src/NBitcoin/IBlockRepository.cs
@@ -2,7 +2,7 @@
 
 namespace NBitcoin
 {
-	public interface IBlockRepository
+	public interface INBitcoinBlockRepository
 	{
 		Task<Block> GetBlockAsync(uint256 blockId);
 	}

--- a/src/NBitcoin/NoSqlBlockRepository.cs
+++ b/src/NBitcoin/NoSqlBlockRepository.cs
@@ -5,7 +5,7 @@ using System.Threading.Tasks;
 
 namespace NBitcoin
 {
-	public class NoSqlBlockRepository : IBlockRepository
+	public class NoSqlBlockRepository : INBitcoinBlockRepository
 	{
 		readonly NoSqlRepository repository;
 

--- a/src/NBitcoin/RPC/RPCClient.cs
+++ b/src/NBitcoin/RPC/RPCClient.cs
@@ -129,7 +129,7 @@ namespace NBitcoin.RPC
 		wallet			 walletpassphrasechange
 		wallet			 walletpassphrase			yes
 	*/
-	public partial class RPCClient : IBlockRepository
+	public partial class RPCClient : INBitcoinBlockRepository
 	{
 		private string _Authentication;
 		private readonly Uri _address;

--- a/src/NBitcoin/RPC/RestClient.cs
+++ b/src/NBitcoin/RPC/RestClient.cs
@@ -25,7 +25,7 @@ namespace NBitcoin.RPC
 	/// <summary>
 	/// Client class for the unauthenticated REST Interface
 	/// </summary>
-	public class RestClient : IBlockRepository
+	public class RestClient : INBitcoinBlockRepository
 	{
 		private readonly Uri _address;
 

--- a/src/NBitcoin/Utils.cs
+++ b/src/NBitcoin/Utils.cs
@@ -24,7 +24,7 @@ namespace NBitcoin
 {
 	public static class Extensions
 	{
-		public static Block GetBlock(this IBlockRepository repository, uint256 blockId)
+		public static Block GetBlock(this INBitcoinBlockRepository repository, uint256 blockId)
 		{
 			try
 			{

--- a/src/Stratis.Bitcoin.Features.BlockStore.Tests/BlockRepositoryInMemory.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore.Tests/BlockRepositoryInMemory.cs
@@ -7,7 +7,7 @@ using Stratis.Bitcoin.Utilities;
 
 namespace Stratis.Bitcoin.Features.BlockStore.Tests
 {
-    public class BlockRepositoryInMemory : BlockStore.IBlockRepository
+    public class BlockRepositoryInMemory : IBlockRepository
     {
         private ConcurrentDictionary<uint256, Block> store;
         public uint256 BlockHash { get; private set; }

--- a/src/Stratis.Bitcoin.Features.BlockStore.Tests/BlockRepositoryTest.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore.Tests/BlockRepositoryTest.cs
@@ -428,7 +428,7 @@ namespace Stratis.Bitcoin.Features.BlockStore.Tests
             }
         }
 
-        private BlockStore.IBlockRepository SetupRepository(Network main, string dir)
+        private IBlockRepository SetupRepository(Network main, string dir)
         {
             var repository = new BlockRepository(main, dir, DateTimeProvider.Default, this.loggerFactory);
             repository.InitializeAsync().GetAwaiter().GetResult();

--- a/src/Stratis.Bitcoin.Features.BlockStore.Tests/LoopTests/BlockStoreLoopStepBaseTest.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore.Tests/LoopTests/BlockStoreLoopStepBaseTest.cs
@@ -29,7 +29,7 @@ namespace Stratis.Bitcoin.Features.BlockStore.Tests.LoopTests
     {
         private IAsyncLoopFactory asyncLoopFactory;
         private StoreBlockPuller blockPuller;
-        internal BlockStore.IBlockRepository BlockRepository { get; private set; }
+        internal IBlockRepository BlockRepository { get; private set; }
         private Mock<ChainState> chainState;
         private Mock<IConnectionManager> connectionManager;
         private DataFolder dataFolder;

--- a/src/Stratis.Bitcoin.Features.Miner/PosMinting.cs
+++ b/src/Stratis.Bitcoin.Features.Miner/PosMinting.cs
@@ -8,6 +8,7 @@ using NBitcoin;
 using NBitcoin.Crypto;
 using NBitcoin.Protocol;
 using Stratis.Bitcoin.Base;
+using Stratis.Bitcoin.Features.BlockStore;
 using Stratis.Bitcoin.Configuration;
 using Stratis.Bitcoin.Connection;
 using Stratis.Bitcoin.Features.Consensus;
@@ -16,7 +17,6 @@ using Stratis.Bitcoin.Features.MemoryPool;
 using Stratis.Bitcoin.Features.Wallet;
 using Stratis.Bitcoin.Features.Wallet.Interfaces;
 using Stratis.Bitcoin.Utilities;
-using IBlockRepository = Stratis.Bitcoin.Features.BlockStore.IBlockRepository;
 
 namespace Stratis.Bitcoin.Features.Miner
 {

--- a/src/Stratis.Bitcoin.Features.Miner/PowMining.cs
+++ b/src/Stratis.Bitcoin.Features.Miner/PowMining.cs
@@ -4,9 +4,9 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using NBitcoin;
 using Stratis.Bitcoin.Base;
+using Stratis.Bitcoin.Features.BlockStore;
 using Stratis.Bitcoin.Features.Consensus;
 using Stratis.Bitcoin.Utilities;
-using IBlockRepository = Stratis.Bitcoin.Features.BlockStore.IBlockRepository;
 
 namespace Stratis.Bitcoin.Features.Miner
 {

--- a/src/Stratis.Bitcoin.IntegrationTests/NodeBuilder.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/NodeBuilder.cs
@@ -66,7 +66,7 @@ namespace Stratis.Bitcoin.IntegrationTests
 
         public static ChainedBlock HighestPersistedBlock(this FullNode fullNode)
         {
-            return (fullNode.NodeService<Features.BlockStore.IBlockRepository>() as BlockRepository).HighestPersistedBlock;
+            return (fullNode.NodeService<IBlockRepository>() as BlockRepository).HighestPersistedBlock;
         }
     }
 


### PR DESCRIPTION
before there were two different interfaces called IBlockRepository
this PR renames the one in NBitcoin and cleans the usage of our IBlockRepository in FN files