### PR TITLE
Feature/issue 735

### DIFF
--- a/src/Stratis.Bitcoin.Features.BlockStore.Tests/LoopTests/BlockStoreLoopStepBaseTest.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore.Tests/LoopTests/BlockStoreLoopStepBaseTest.cs
@@ -50,7 +50,7 @@ namespace Stratis.Bitcoin.Features.BlockStore.Tests.LoopTests
             var fullNode = new Mock<FullNode>().Object;
             fullNode.DateTimeProvider = new DateTimeProvider();
 
-            this.chainState = new Mock<ChainState>(fullNode);
+            this.chainState = new Mock<ChainState>(fullNode, new InvalidBlockHashStore(fullNode.DateTimeProvider));
             this.chainState.Object.SetIsInitialBlockDownload(false, DateTime.Today);
 
             this.nodeLifeTime = new Mock<INodeLifetime>();

--- a/src/Stratis.Bitcoin.Features.MemoryPool.Tests/TestChainFactory.cs
+++ b/src/Stratis.Bitcoin.Features.MemoryPool.Tests/TestChainFactory.cs
@@ -77,7 +77,7 @@ namespace Stratis.Bitcoin.Features.MemoryPool.Tests
             ConnectionManager connectionManager = new ConnectionManager(network, new NodeConnectionParameters(), nodeSettings, loggerFactory, new NodeLifetime());
             LookaheadBlockPuller blockPuller = new LookaheadBlockPuller(chain, connectionManager, new LoggerFactory());
 
-            ConsensusLoop consensus = new ConsensusLoop(new AsyncLoopFactory(loggerFactory), consensusValidator, new NodeLifetime(), chain, cachedCoinView, blockPuller, new NodeDeployments(network, chain), loggerFactory, new ChainState(new FullNode()), connectionManager, dateTimeProvider, new Signals.Signals(), new Checkpoints(network, consensusSettings), consensusSettings);
+            ConsensusLoop consensus = new ConsensusLoop(new AsyncLoopFactory(loggerFactory), consensusValidator, new NodeLifetime(), chain, cachedCoinView, blockPuller, new NodeDeployments(network, chain), loggerFactory, new ChainState(new FullNode(), new InvalidBlockHashStore(dateTimeProvider)), connectionManager, dateTimeProvider, new Signals.Signals(), new Checkpoints(network, consensusSettings), consensusSettings);
             await consensus.StartAsync();
 
             BlockPolicyEstimator blockPolicyEstimator = new BlockPolicyEstimator(new MempoolSettings(nodeSettings), loggerFactory, nodeSettings);

--- a/src/Stratis.Bitcoin.IntegrationTests/MinerTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/MinerTests.cs
@@ -151,7 +151,7 @@ namespace Stratis.Bitcoin.IntegrationTests
                 ConnectionManager connectionManager = new ConnectionManager(this.network, new NodeConnectionParameters(), nodeSettings, loggerFactory, new NodeLifetime());
                 LookaheadBlockPuller blockPuller = new LookaheadBlockPuller(this.chain, connectionManager, new LoggerFactory());
 
-                this.consensus = new ConsensusLoop(new AsyncLoopFactory(loggerFactory), consensusValidator, new NodeLifetime(), this.chain, this.cachedCoinView, blockPuller, new NodeDeployments(this.network, this.chain), loggerFactory, new ChainState(new FullNode()), connectionManager, dateTimeProvider, new Signals.Signals(), new Checkpoints(this.network, consensusSettings), consensusSettings);
+                this.consensus = new ConsensusLoop(new AsyncLoopFactory(loggerFactory), consensusValidator, new NodeLifetime(), this.chain, this.cachedCoinView, blockPuller, new NodeDeployments(this.network, this.chain), loggerFactory, new ChainState(new FullNode(), new InvalidBlockHashStore(dateTimeProvider)), connectionManager, dateTimeProvider, new Signals.Signals(), new Checkpoints(this.network, consensusSettings), consensusSettings);
                 await this.consensus.StartAsync();
 
                 this.entry.Fee(11);

--- a/src/Stratis.Bitcoin.Tests/Base/ChainStateTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Base/ChainStateTest.cs
@@ -31,7 +31,7 @@ namespace Stratis.Bitcoin.Tests.Base
             fullNode.Setup(f => f.NodeService<IDateTimeProvider>(true))
                 .Returns(DateTimeProvider.Default);
 
-            var chainState = new ChainState(fullNode.Object);
+            var chainState = new ChainState(fullNode.Object, new InvalidBlockHashStore(DateTimeProvider.Default));
 
             // Create some hashes that will be banned forever.
             uint256[] hashesBannedPermanently = new uint256[]

--- a/src/Stratis.Bitcoin.Tests/Base/ChainStateTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Base/ChainStateTest.cs
@@ -1,14 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Text;
-using Stratis.Bitcoin.Base;
-using Xunit;
-using Moq;
-using Stratis.Bitcoin.Builder;
-using Stratis.Bitcoin.Builder.Feature;
-using NBitcoin;
 using System.Threading;
+using Moq;
+using NBitcoin;
+using Stratis.Bitcoin.Base;
 using Stratis.Bitcoin.Utilities;
+using Xunit;
 
 namespace Stratis.Bitcoin.Tests.Base
 {
@@ -21,9 +18,11 @@ namespace Stratis.Bitcoin.Tests.Base
         private static Random rng = new Random();
 
         /// <summary>
-        /// Tests <see cref="ChainState.MarkBlockInvalid(NBitcoin.uint256, DateTime?)"/> and <see cref="ChainState.IsMarkedInvalid(NBitcoin.uint256)"/>
+        /// Tests <see cref="ChainState.MarkBlockInvalid(uint256, DateTime?)"/> and <see cref="ChainState.IsMarkedInvalid(uint256)"/>
         /// for both permantently and temporary bans of blocks.
         /// </summary>
+        /// <remarks>Note that this test is almost identical to <see cref="InvalidBlockHashStoreTest.MarkInvalid_PermanentAndTemporaryBans"/>
+        /// as the <see cref="ChainState"/> is just a middleman between the users of the block hash store and the store itself.</remarks>
         [Fact]
         public void MarkBlockInvalid_PermanentAndTemporaryBans()
         {

--- a/src/Stratis.Bitcoin.Tests/Base/InvalidBlockHashStoreTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Base/InvalidBlockHashStoreTest.cs
@@ -1,0 +1,223 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+using NBitcoin;
+using Stratis.Bitcoin.Base;
+using Stratis.Bitcoin.Utilities;
+using Xunit;
+
+namespace Stratis.Bitcoin.Tests.Base
+{
+    /// <summary>
+    /// Tests of <see cref="InvalidBlockHashStoreTest"/> class.
+    /// </summary>
+    public class InvalidBlockHashStoreTest
+    {
+        /// <summary>Source of randomness.</summary>
+        private static Random rng = new Random();
+
+        /// <summary>
+        /// Tests <see cref="InvalidBlockHashStore.MarkInvalid(uint256, DateTime?)"/> and <see cref="InvalidBlockHashStore.IsInvalid(uint256)"/>
+        /// for both permantently and temporary bans of blocks.
+        /// </summary>
+        [Fact]
+        public void MarkInvalid_PermanentAndTemporaryBans()
+        {
+            var invalidBlockHashStore = new InvalidBlockHashStore(DateTimeProvider.Default);
+
+            // Create some hashes that will be banned forever.
+            uint256[] hashesBannedPermanently = new uint256[]
+            {
+                uint256.Parse("0000000000000000000000000000000000000000000000000000000000000001"),
+                uint256.Parse("0000000000000000000000000000000000000000000000000000000000000002"),
+                uint256.Parse("0000000000000000000000000000000000000000000000000000000000000003"),
+                uint256.Parse("0000000000000000000000000000000000000000000000000000000000000004"),
+            };
+
+            foreach (uint256 hash in hashesBannedPermanently)
+                invalidBlockHashStore.MarkInvalid(hash);
+
+            // Create some hashes that will be banned now, but not in 5 seconds.
+            uint256[] hashesBannedTemporarily1 = new uint256[]
+            {
+                uint256.Parse("0000000000000000000000000000000000000000000000000000000000000011"),
+                uint256.Parse("0000000000000000000000000000000000000000000000000000000000000012"),
+                uint256.Parse("0000000000000000000000000000000000000000000000000000000000000013"),
+                uint256.Parse("0000000000000000000000000000000000000000000000000000000000000014"),
+            };
+
+            foreach (uint256 hash in hashesBannedTemporarily1)
+                invalidBlockHashStore.MarkInvalid(hash, DateTime.UtcNow.AddMilliseconds(rng.Next(2000, 5000)));
+
+            // Create some hashes that will be banned now and also after 5 seconds.
+            uint256[] hashesBannedTemporarily2 = new uint256[]
+            {
+                uint256.Parse("0000000000000000000000000000000000000000000000000000000000000021"),
+                uint256.Parse("0000000000000000000000000000000000000000000000000000000000000022"),
+                uint256.Parse("0000000000000000000000000000000000000000000000000000000000000023"),
+                uint256.Parse("0000000000000000000000000000000000000000000000000000000000000024"),
+            };
+
+            foreach (uint256 hash in hashesBannedTemporarily2)
+                invalidBlockHashStore.MarkInvalid(hash, DateTime.UtcNow.AddMilliseconds(rng.Next(20000, 50000)));
+
+            // Check that all hashes we have generated are banned now.
+            List<uint256> allHashes = new List<uint256>(hashesBannedPermanently);
+            allHashes.AddRange(hashesBannedTemporarily1);
+            allHashes.AddRange(hashesBannedTemporarily2);
+
+            foreach (uint256 hash in allHashes)
+                Assert.True(invalidBlockHashStore.IsInvalid(hash));
+
+            // Wait 5 seconds and then check if hashes from first temporary group are no longer banned and all others still are.
+            Thread.Sleep(5000);
+
+            foreach (uint256 hash in allHashes)
+            {
+                uint num = hash.GetLow32();
+                bool isSecondGroup = (0x10 <= num) && (num < 0x20);
+                Assert.Equal(!isSecondGroup, invalidBlockHashStore.IsInvalid(hash));
+            }
+        }
+
+        /// <summary>
+        /// Tests that the hash store behaves correctly when its capacity is reached.
+        /// Oldest entries should be removed when capacity is reached.
+        /// </summary>
+        [Fact]
+        public void ReachingStoreCapacity_RemovesOldestEntries()
+        {
+            var invalidBlockHashStore = new InvalidBlockHashStore(DateTimeProvider.Default, 10);
+
+            // Create some hashes that will be banned forever.
+            uint256[] hashesBannedPermanently = new uint256[]
+            {
+                uint256.Parse("0000000000000000000000000000000000000000000000000000000000000001"),
+                uint256.Parse("0000000000000000000000000000000000000000000000000000000000000002"),
+                uint256.Parse("0000000000000000000000000000000000000000000000000000000000000003"),
+                uint256.Parse("0000000000000000000000000000000000000000000000000000000000000004"),
+            };
+
+            foreach (uint256 hash in hashesBannedPermanently)
+                invalidBlockHashStore.MarkInvalid(hash);
+
+            // Create some hashes that will be banned.
+            uint256[] hashesBannedTemporarily1 = new uint256[]
+            {
+                uint256.Parse("0000000000000000000000000000000000000000000000000000000000000011"),
+                uint256.Parse("0000000000000000000000000000000000000000000000000000000000000012"),
+                uint256.Parse("0000000000000000000000000000000000000000000000000000000000000013"),
+                uint256.Parse("0000000000000000000000000000000000000000000000000000000000000014"),
+                uint256.Parse("0000000000000000000000000000000000000000000000000000000000000015"),
+                uint256.Parse("0000000000000000000000000000000000000000000000000000000000000016"),
+            };
+
+            foreach (uint256 hash in hashesBannedTemporarily1)
+                invalidBlockHashStore.MarkInvalid(hash, DateTime.UtcNow.AddMilliseconds(rng.Next(2000, 5000)));
+
+            // Check that all hashes we have generated are banned now.
+            List<uint256> allHashes = new List<uint256>(hashesBannedPermanently);
+            allHashes.AddRange(hashesBannedTemporarily1);
+
+            foreach (uint256 hash in allHashes)
+                Assert.True(invalidBlockHashStore.IsInvalid(hash));
+
+            // Add two more hashes that will be banned.
+            uint256[] hashesBannedTemporarily2 = new uint256[]
+            {
+                uint256.Parse("0000000000000000000000000000000000000000000000000000000000000031"),
+                uint256.Parse("0000000000000000000000000000000000000000000000000000000000000032"),
+            };
+
+            foreach (uint256 hash in hashesBannedTemporarily2)
+                invalidBlockHashStore.MarkInvalid(hash, DateTime.UtcNow.AddMilliseconds(rng.Next(20000, 50000)));
+
+            // As the capacity is just 10, the first two hashes should no longer be banned at this point.
+            Assert.False(invalidBlockHashStore.IsInvalid(hashesBannedPermanently[0]));
+            Assert.False(invalidBlockHashStore.IsInvalid(hashesBannedPermanently[1]));
+
+            // And all other hashes are still banned.
+            List<uint256> allBannedHashes = new List<uint256>();
+            allBannedHashes.Add(hashesBannedPermanently[2]);
+            allBannedHashes.Add(hashesBannedPermanently[3]);
+            allBannedHashes.AddRange(hashesBannedTemporarily1);
+            allBannedHashes.AddRange(hashesBannedTemporarily2);
+
+            foreach (uint256 hash in allBannedHashes)
+                Assert.True(invalidBlockHashStore.IsInvalid(hash));
+        }
+
+        /// <summary>
+        /// Another test of behavior of the hash store when its capacity is reached.
+        /// The internal implementation of the block hash store works with a dictionary and a circular array,
+        /// which should skip the entries removed from the dictionary. 
+        /// </summary>
+        [Fact]
+        public void ReachingStoreCapacity_CircularArraySkipsExpiredEntries()
+        {
+            var invalidBlockHashStore = new InvalidBlockHashStore(DateTimeProvider.Default, 10);
+
+            // Create some hashes that will be banned forever.
+            uint256[] hashesBannedPermanently1 = new uint256[]
+            {
+                uint256.Parse("0000000000000000000000000000000000000000000000000000000000000001"),
+                uint256.Parse("0000000000000000000000000000000000000000000000000000000000000002"),
+                uint256.Parse("0000000000000000000000000000000000000000000000000000000000000003"),
+                uint256.Parse("0000000000000000000000000000000000000000000000000000000000000004"),
+            };
+
+            foreach (uint256 hash in hashesBannedPermanently1)
+                invalidBlockHashStore.MarkInvalid(hash);
+
+            // Create some hashes that will be banned temporarily, but not after 5 seconds.
+            uint256[] hashesBannedTemporarily = new uint256[]
+            {
+                uint256.Parse("0000000000000000000000000000000000000000000000000000000000000011"),
+                uint256.Parse("0000000000000000000000000000000000000000000000000000000000000012"),
+                uint256.Parse("0000000000000000000000000000000000000000000000000000000000000013"),
+                uint256.Parse("0000000000000000000000000000000000000000000000000000000000000014"),
+                uint256.Parse("0000000000000000000000000000000000000000000000000000000000000015"),
+                uint256.Parse("0000000000000000000000000000000000000000000000000000000000000016"),
+            };
+
+            foreach (uint256 hash in hashesBannedTemporarily)
+                invalidBlockHashStore.MarkInvalid(hash, DateTime.UtcNow.AddMilliseconds(rng.Next(2000, 5000)));
+
+            // Add more forever bans.
+            uint256[] hashesBannedPermanently2 = new uint256[]
+            {
+                uint256.Parse("0000000000000000000000000000000000000000000000000000000000000021"),
+                uint256.Parse("0000000000000000000000000000000000000000000000000000000000000022"),
+                uint256.Parse("0000000000000000000000000000000000000000000000000000000000000023"),
+                uint256.Parse("0000000000000000000000000000000000000000000000000000000000000024"),
+            };
+
+            foreach (uint256 hash in hashesBannedPermanently2)
+                invalidBlockHashStore.MarkInvalid(hash);
+
+            // Now check that all hashes from the first group are no longer banned and all others still are.
+            List<uint256> allBannedHashes = new List<uint256>(hashesBannedTemporarily);
+            allBannedHashes.AddRange(hashesBannedPermanently2);
+
+            foreach (uint256 hash in hashesBannedPermanently1)
+                Assert.False(invalidBlockHashStore.IsInvalid(hash));
+
+            foreach (uint256 hash in allBannedHashes)
+                Assert.True(invalidBlockHashStore.IsInvalid(hash));
+
+            // Now we wait 5 seconds and touch the first four temporarily banned hashes,
+            // which should remove them from the dictionary. 
+            Thread.Sleep(5000);
+
+            Assert.False(invalidBlockHashStore.IsInvalid(hashesBannedTemporarily[0]));
+            Assert.False(invalidBlockHashStore.IsInvalid(hashesBannedTemporarily[1]));
+            Assert.False(invalidBlockHashStore.IsInvalid(hashesBannedTemporarily[2]));
+            Assert.False(invalidBlockHashStore.IsInvalid(hashesBannedTemporarily[3]));
+
+            // Then we add a new hash, which should remove the four hashes from the circular array as well.
+            invalidBlockHashStore.MarkInvalid(uint256.Parse("0000000000000000000000000000000000000000000000000000000000000031"));
+
+            Assert.Equal(6, invalidBlockHashStore.orderedHashList.Count);
+        }
+    }
+}

--- a/src/Stratis.Bitcoin/Base/BaseFeature.cs
+++ b/src/Stratis.Bitcoin/Base/BaseFeature.cs
@@ -290,6 +290,7 @@ namespace Stratis.Bitcoin.Base
                     services.AddSingleton<FullNode>().AddSingleton((provider) => { return provider.GetService<FullNode>() as IFullNode; });
                     services.AddSingleton<ConcurrentChain>(new ConcurrentChain(fullNodeBuilder.Network));
                     services.AddSingleton<IDateTimeProvider>(DateTimeProvider.Default);
+                    services.AddSingleton<IInvalidBlockHashStore, InvalidBlockHashStore>();
                     services.AddSingleton<ChainState>();
                     services.AddSingleton<ChainRepository>();
                     services.AddSingleton<TimeSyncBehaviorState>();

--- a/src/Stratis.Bitcoin/Base/InvalidBlockHashStore.cs
+++ b/src/Stratis.Bitcoin/Base/InvalidBlockHashStore.cs
@@ -1,0 +1,151 @@
+﻿using System;
+using System.Collections.Generic;
+using NBitcoin;
+using Stratis.Bitcoin.Utilities;
+
+namespace Stratis.Bitcoin.Base
+{
+    /// <summary>
+    /// Contract of a store of block header hashes that are considered invalid.
+    /// </summary>
+    public interface IInvalidBlockHashStore
+    {
+        /// <summary>
+        /// Check if a block is marked as invalid.
+        /// </summary>
+        /// <param name="hashBlock">The block hash to check.</param>
+        /// <returns><c>true</c> if the block is marked as invalid, <c>false</c> otherwise.</returns>
+        bool IsInvalid(uint256 hashBlock);
+
+        /// <summary>
+        /// Marks a block as invalid.
+        /// </summary>
+        /// <param name="hashBlock">The block hash to mark as invalid.</param>
+        /// <param name="rejectedUntil">Time in UTC after which the block is no longer considered as invalid, or <c>null</c> if the block is to be considered invalid forever.</param>
+        void MarkInvalid(uint256 hashBlock, DateTime? rejectedUntil = null);
+    }
+
+    /// <summary>
+    /// In memory store of invalid block header hashes.
+    /// </summary>
+    /// <remarks>
+    /// The store has a limited capacity. When a new block header hash is marked as invalid 
+    /// once the capacity is reached, the oldest entry is removed and no longer considered invalid.
+    /// <para>
+    /// Entries with specified expiration time are either removed just like other entries - i.e. during 
+    /// an add operation when a capacity is reached, or they are removed when they are touched 
+    /// and it is detected that their expiration time is no longer in the future.
+    /// </para>
+    /// </remarks>
+    public class InvalidBlockHashStore : IInvalidBlockHashStore
+    {
+        /// <summary>Default value for the maximal number of hashes we can store.</summary>
+        public const int DefaultCapacity = 1000;
+
+        /// <summary>A provider of the date and time.</summary>
+        private readonly IDateTimeProvider dateTimeProvider;
+
+        /// <summary>Lock object to protect access to <see cref="invalidBlockHashes"/> and <see cref="orderedHashList"/>.</summary>
+        private readonly object lockObject = new object();
+
+        /// <summary>
+        /// Collection of blocks that are to be considered invalid. If the value of the entry is not <c>null</c>, 
+        /// the entry is considered invalid only for a certain amount of time.
+        /// </summary>
+        /// <remarks>All access to this object has to be protected by <see cref="lockObject"/>.</remarks>
+        private readonly Dictionary<uint256, DateTime?> invalidBlockHashes;
+
+        /// <summary>Circular array of block header hash entries to allow quick removal of the oldest entry once the capacity is reached.</summary>
+        /// <remarks>All access to this object has to be protected by <see cref="lockObject"/>.</remarks>
+        private readonly CircularArray<uint256> orderedHashList;
+
+        /// <summary>
+        /// Initializes the instance of the object.
+        /// </summary>
+        /// <param name="capacity">Maximal number of hashes we can store.</param>
+        public InvalidBlockHashStore(IDateTimeProvider dateTimeProvider, int capacity = DefaultCapacity)
+        {
+            this.dateTimeProvider = dateTimeProvider;
+
+            this.invalidBlockHashes = new Dictionary<uint256, DateTime?>(capacity);
+            this.orderedHashList = new CircularArray<uint256>(capacity);
+        }
+
+        /// <inheritdoc />
+        public bool IsInvalid(uint256 hashBlock)
+        {
+            bool res = false;
+
+            lock (this.lockObject)
+            {
+                // First check if the entry exists.
+                DateTime? expirationTime;
+                if (this.invalidBlockHashes.TryGetValue(hashBlock, out expirationTime))
+                {
+                    // The block is banned forever if the expiration date was not set,
+                    // or it is banned temporarily if it was set.
+                    if (expirationTime != null)
+                    {
+                        // The block is still invalid now if the expiration date is still in the future.
+                        res = expirationTime > this.dateTimeProvider.GetUtcNow();
+
+                        // If the expiration date is not in the future anymore, remove the record from the list.
+                        // Note that this will leave entry in the orderedHashList, but that is OK, 
+                        // that entry will be removed later.
+                        if (!res) this.invalidBlockHashes.Remove(hashBlock);
+                    }
+                    else res = true;
+                }
+            }
+
+            return res;
+        }
+
+        /// <inheritdoc />
+        public void MarkInvalid(uint256 hashBlock, DateTime? rejectedUntil = null)
+        {
+            lock (this.lockObject)
+            {
+                DateTime? expirationTime;
+                bool existsAlready = this.invalidBlockHashes.TryGetValue(hashBlock, out expirationTime);
+                if (existsAlready)
+                {
+                    // Entry is existing already, only replace its value if the ban is stronger.
+                    // This happens if the new ban is forever - i.e. rejectedUntil is null,
+                    // or if the existing ban is not forever and the rejectedUntil value is greater 
+                    // than existing expiration time.
+                    bool strongerBan = (rejectedUntil == null) || ((expirationTime != null) && (rejectedUntil.Value > expirationTime.Value));
+                    if (strongerBan) this.invalidBlockHashes[hashBlock] = rejectedUntil;
+                }
+                else
+                {
+                    // No previous entry found, so we add a new ban. This means we can reach 
+                    // the capacity, in which case we first remove the oldest entry.
+                    // Note that there can be entries in the circular array that are no longer in the dictionary.
+                    // We skip all such entries.
+
+                    // We start by adding the new entry to the queue, which will possibly remove the oldest entry if the capacity is reached.
+                    // If capacity has not been reached, there is nothing more to do with the queue.
+                    uint256 oldestEntry;
+                    if (this.orderedHashList.Add(hashBlock, out oldestEntry))
+                    {
+                        // Then we check the dictionary whether it contains the removed entry.
+                        // If not, we remove the next entry from the queue, if there is any,
+                        // and we check the dictionary again. We repeat this until we find 
+                        // an existing entry or until we removed everything from the queue except 
+                        // for the entry we just added.
+                        while (!this.invalidBlockHashes.Remove(oldestEntry))
+                        {
+                            if (this.orderedHashList.Count == 1)
+                                break;
+
+                            this.orderedHashList.RemoveFirst(out oldestEntry);
+                        }
+                    }
+
+                    this.invalidBlockHashes.Add(hashBlock, rejectedUntil);
+                }
+            }
+        }
+    }
+}

--- a/src/Stratis.Bitcoin/Base/InvalidBlockHashStore.cs
+++ b/src/Stratis.Bitcoin/Base/InvalidBlockHashStore.cs
@@ -56,8 +56,11 @@ namespace Stratis.Bitcoin.Base
         private readonly Dictionary<uint256, DateTime?> invalidBlockHashes;
 
         /// <summary>Circular array of block header hash entries to allow quick removal of the oldest entry once the capacity is reached.</summary>
-        /// <remarks>All access to this object has to be protected by <see cref="lockObject"/>.</remarks>
-        private readonly CircularArray<uint256> orderedHashList;
+        /// <remarks>
+        /// All access to this object has to be protected by <see cref="lockObject"/>.
+        /// <para>The field is internal for testing purposes.</para>
+        /// </remarks>
+        internal readonly CircularArray<uint256> orderedHashList;
 
         /// <summary>
         /// Initializes the instance of the object.

--- a/src/Stratis.Bitcoin/Utilities/CircularArray.cs
+++ b/src/Stratis.Bitcoin/Utilities/CircularArray.cs
@@ -76,6 +76,26 @@ namespace Stratis.Bitcoin.Utilities
         }
 
         /// <summary>
+        /// Removes the first item from the circular array, which is the oldest entry in the array.
+        /// </summary>
+        /// <param name="firstItem">If the function returns <c>true</c>, this is filled with the oldest item that was removed.</param>
+        /// <returns><c>true</c> if the oldest item was removed, <c>false</c> if there were no items.</returns>
+        public bool RemoveFirst(out T firstItem)
+        {
+            bool res = false;
+            firstItem = default(T);
+            if (this.Count > 0)
+            {
+                firstItem = this.items[this.Index];
+                this.Index = (this.Index + 1) % this.Capacity;
+                this.Count--;
+                res = true;
+            }
+
+            return res;
+        }
+
+        /// <summary>
         /// Access to an item at specific index.
         /// </summary>
         /// <param name="i">Zero-based index of the item to access. Index must be an integer between 0 and <see cref="Capacity"/> - 1.</param>


### PR DESCRIPTION
The collection of invalid block header hashes has been separated from ChainState into its own class. The store of hashes now has a capacity of 1000 entries and once this is reached, oldest entries are removed. This eliminates the attack vector described in #735.

Tests are included.

Fix #735 