### PR TITLE
Update coding-style.md

### DIFF
--- a/Documentation/coding-style.md
+++ b/Documentation/coding-style.md
@@ -32,7 +32,10 @@ The general rules:
 `public int X { get; private set; }`  
 17. Avoid initializing instance properties outside of constructor.  
 `public int MaxItems { get; set; } = 100000;`  
-18. Always provide a blank line after a curly brace that is not followed by another curly brace.  
+18. - Always provide a blank line after a curly brace that is not followed by another curly brace.  
+    - Opening curly brackets must not be preceded or followed by blank line
+    - Closing curly brackets must not be preceded by blank line
+    - Code must not contain multiple blank lines in a row
 
    Therefore this is correct:
    ```

--- a/Documentation/coding-style.md
+++ b/Documentation/coding-style.md
@@ -32,6 +32,30 @@ The general rules:
 `public int X { get; private set; }`  
 17. Avoid initializing instance properties outside of constructor.  
 `public int MaxItems { get; set; } = 100000;`  
+18. Always provide a blank line after a curly brace that is not followed by a another curly brace.  
+
+   Therefore this is correct:
+   ```
+      if ()
+      {
+          block
+      }
+      [EMPTY LINE HERE]
+      //more code here...
+   ```   
+
+   And this is correct:
+   ```
+      if ()
+      {
+         foreach ()
+         {
+           block
+         }      
+      }
+      [EMPTY LINE HERE]
+      //more code here...
+   ```   
 
 We have provided a Visual Studio 2017 EditorConfig file (`.editorconfig`) at the root of the full node repository, enabling C# auto-formatting and warnings conforming to some of the above guidelines.
 

--- a/Documentation/coding-style.md
+++ b/Documentation/coding-style.md
@@ -32,7 +32,7 @@ The general rules:
 `public int X { get; private set; }`  
 17. Avoid initializing instance properties outside of constructor.  
 `public int MaxItems { get; set; } = 100000;`  
-18. Always provide a blank line after a curly brace that is not followed by a another curly brace.  
+18. Always provide a blank line after a curly brace that is not followed by another curly brace.  
 
    Therefore this is correct:
    ```


### PR DESCRIPTION
I have added rule #18 which is Aprogenia's "Blank Line After Curly Brace" rule.

Note: I did not have to modify the sample code as it already observed that rule.