### PR TITLE
Fix: ConnectionManager gets disposed 3 times.

### DIFF
--- a/src/Stratis.Bitcoin/Base/BaseFeature.cs
+++ b/src/Stratis.Bitcoin/Base/BaseFeature.cs
@@ -175,7 +175,6 @@ namespace Stratis.Bitcoin.Base
 
             this.disposableResources.Add(this.timeSyncBehaviorState);
             this.disposableResources.Add(this.chainRepository);
-            this.disposableResources.Add(this.connectionManager);
             this.disposableResources.Add(this.nodeSettings.LoggerFactory);
 
             this.logger.LogTrace("(-)");

--- a/src/Stratis.Bitcoin/FullNode.cs
+++ b/src/Stratis.Bitcoin/FullNode.cs
@@ -215,8 +215,6 @@ namespace Stratis.Bitcoin
             // Fire INodeLifetime.Stopping.
             this.nodeLifetime.StopApplication();
 
-            this.ConnectionManager.Dispose();
-
             foreach (IDisposable dispo in this.Resources)
                 dispo.Dispose();
 


### PR DESCRIPTION
Tiny PR that prevents 2 unnecessary ConnectionManager.Dispose() calls. 

I've also checked all the classes that inherit IDisposable if they dispose everything correctly. Only FullNode has a problem- it also gets disposed 3 times (2 of them are not intentional, caused by service provider automatically registering disposable objects), but the workaround already included in FullNode.Dispose() implementation, so it's fine. 

Fix #691 