### PR TITLE
Replaced Stop with Dispose for all features and node.

### DIFF
--- a/src/Stratis.Bitcoin.Features.Api/ApiFeature.cs
+++ b/src/Stratis.Bitcoin.Features.Api/ApiFeature.cs
@@ -56,6 +56,7 @@ namespace Stratis.Bitcoin.Features.Api
             this.TryStartKeepaliveMonitor();
         }
 
+        /// <inheritdoc />
         public override void Dispose()
         {
             this.asyncLoop?.Dispose();

--- a/src/Stratis.Bitcoin.Features.Api/ApiFeature.cs
+++ b/src/Stratis.Bitcoin.Features.Api/ApiFeature.cs
@@ -48,7 +48,7 @@ namespace Stratis.Bitcoin.Features.Api
             this.logger = loggerFactory.CreateLogger(this.GetType().FullName);
         }
 
-        public override void Start()
+        public override void Initialize()
         {
             this.logger.LogInformation("API starting on URL '{0}'.", this.fullNode.Settings.ApiUri);
             this.webHost = Program.Initialize(this.fullNodeBuilder.Services, this.fullNode);

--- a/src/Stratis.Bitcoin.Features.Api/ApiFeature.cs
+++ b/src/Stratis.Bitcoin.Features.Api/ApiFeature.cs
@@ -56,7 +56,7 @@ namespace Stratis.Bitcoin.Features.Api
             this.TryStartKeepaliveMonitor();
         }
 
-        public override void Stop()
+        public override void Dispose()
         {
             this.asyncLoop?.Dispose();
 
@@ -85,7 +85,7 @@ namespace Stratis.Bitcoin.Features.Api
 
                     // check the trashold to trigger a shutdown
                     if (monitor.LastBeat.Add(monitor.KeepaliveInterval) < this.fullNode.DateTimeProvider.GetUtcNow())
-                        this.fullNode.Stop();
+                        this.fullNode.Dispose();
 
                     return Task.CompletedTask;
                 },

--- a/src/Stratis.Bitcoin.Features.Api/Controllers/NodeController.cs
+++ b/src/Stratis.Bitcoin.Features.Api/Controllers/NodeController.cs
@@ -35,7 +35,7 @@ namespace Stratis.Bitcoin.Features.Api.Controllers
         public IActionResult Shutdown()
         {
             // start the node shutdown process
-            this.fullNode.Stop();
+            this.fullNode.Dispose();
 
             return this.Ok();
         }

--- a/src/Stratis.Bitcoin.Features.BlockStore/BlockStoreCache.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/BlockStoreCache.cs
@@ -153,6 +153,7 @@ namespace Stratis.Bitcoin.Features.BlockStore
             this.logger.LogTrace("(-)[{0}]", existingBlock != null ? "ALREADY_IN_CACHE" : "ADDED_TO_CACHE");
         }
 
+        /// <inheritdoc />
         public void Dispose()
         {
             this.cache.Dispose();

--- a/src/Stratis.Bitcoin.Features.BlockStore/BlockStoreFeature.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/BlockStoreFeature.cs
@@ -132,6 +132,7 @@ namespace Stratis.Bitcoin.Features.BlockStore
             this.logger.LogTrace("(-)");
         }
 
+        /// <inheritdoc />
         public override void Dispose()
         {
             this.logger.LogInformation("Stopping {0}...", this.name);

--- a/src/Stratis.Bitcoin.Features.BlockStore/BlockStoreFeature.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/BlockStoreFeature.cs
@@ -113,7 +113,7 @@ namespace Stratis.Bitcoin.Features.BlockStore
             return this.blockRepository.GetTrxBlockIdAsync(trxid);
         }
 
-        public override void Start()
+        public override void Initialize()
         {
             this.logger.LogTrace("()");
 

--- a/src/Stratis.Bitcoin.Features.BlockStore/BlockStoreFeature.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/BlockStoreFeature.cs
@@ -132,7 +132,7 @@ namespace Stratis.Bitcoin.Features.BlockStore
             this.logger.LogTrace("(-)");
         }
 
-        public override void Stop()
+        public override void Dispose()
         {
             this.logger.LogInformation("Stopping {0}...", this.name);
 

--- a/src/Stratis.Bitcoin.Features.Consensus/ConsensusFeature.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/ConsensusFeature.cs
@@ -146,7 +146,7 @@ namespace Stratis.Bitcoin.Features.Consensus
         }
 
         /// <inheritdoc />
-        public override void Stop()
+        public override void Dispose()
         {
             // First, we need to wait for the consensus loop to finish.
             // Only then we can flush our coinview safely.

--- a/src/Stratis.Bitcoin.Features.Consensus/ConsensusFeature.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/ConsensusFeature.cs
@@ -128,7 +128,7 @@ namespace Stratis.Bitcoin.Features.Consensus
         }
 
         /// <inheritdoc />
-        public override void Start()
+        public override void Initialize()
         {
             this.dBreezeCoinView.InitializeAsync().GetAwaiter().GetResult();
             this.consensusLoop.StartAsync().GetAwaiter().GetResult();

--- a/src/Stratis.Bitcoin.Features.LightWallet/LightWalletFeature.cs
+++ b/src/Stratis.Bitcoin.Features.LightWallet/LightWalletFeature.cs
@@ -97,7 +97,7 @@ namespace Stratis.Bitcoin.Features.LightWallet
         }
 
         /// <inheritdoc />
-        public override void Start()
+        public override void Initialize()
         {
             this.connectionManager.Parameters.TemplateBehaviors.Add(new DropNodesBehaviour(this.chain, this.connectionManager, this.loggerFactory));
 

--- a/src/Stratis.Bitcoin.Features.LightWallet/LightWalletFeature.cs
+++ b/src/Stratis.Bitcoin.Features.LightWallet/LightWalletFeature.cs
@@ -137,7 +137,7 @@ namespace Stratis.Bitcoin.Features.LightWallet
         }
 
         /// <inheritdoc />
-        public override void Stop()
+        public override void Dispose()
         {
             this.walletFeePolicy.Stop();
             this.asyncLoop.Dispose();

--- a/src/Stratis.Bitcoin.Features.MemoryPool/MempoolFeature.cs
+++ b/src/Stratis.Bitcoin.Features.MemoryPool/MempoolFeature.cs
@@ -95,7 +95,7 @@ namespace Stratis.Bitcoin.Features.MemoryPool
         }
 
         /// <inheritdoc />
-        public override void Stop()
+        public override void Dispose()
         {
             if (this.mempoolManager != null)
             {

--- a/src/Stratis.Bitcoin.Features.MemoryPool/MempoolFeature.cs
+++ b/src/Stratis.Bitcoin.Features.MemoryPool/MempoolFeature.cs
@@ -85,7 +85,7 @@ namespace Stratis.Bitcoin.Features.MemoryPool
         }
 
         /// <inheritdoc />
-        public override void Start()
+        public override void Initialize()
         {
             this.mempoolManager.LoadPoolAsync().GetAwaiter().GetResult();
 

--- a/src/Stratis.Bitcoin.Features.Miner/MiningFeature.cs
+++ b/src/Stratis.Bitcoin.Features.Miner/MiningFeature.cs
@@ -118,7 +118,7 @@ namespace Stratis.Bitcoin.Features.Miner
         }
 
         ///<inheritdoc />
-        public override void Stop()
+        public override void Dispose()
         {
             this.powLoop?.Dispose();
             this.posLoop?.Dispose();

--- a/src/Stratis.Bitcoin.Features.Miner/MiningFeature.cs
+++ b/src/Stratis.Bitcoin.Features.Miner/MiningFeature.cs
@@ -94,7 +94,7 @@ namespace Stratis.Bitcoin.Features.Miner
             }
         }
 
-        ///<inheritdoc />
+        /// <inheritdoc />
         public override void Start()
         {
             if (this.minerSettings.Mine)
@@ -117,14 +117,14 @@ namespace Stratis.Bitcoin.Features.Miner
             }
         }
 
-        ///<inheritdoc />
+        /// <inheritdoc />
         public override void Dispose()
         {
             this.powLoop?.Dispose();
             this.posLoop?.Dispose();
         }
 
-        ///<inheritdoc />
+        /// <inheritdoc />
         public override void ValidateDependencies(IFullNodeServiceProvider services)
         {
             if (services.ServiceProvider.GetService<PosMinting>() != null)

--- a/src/Stratis.Bitcoin.Features.Miner/MiningFeature.cs
+++ b/src/Stratis.Bitcoin.Features.Miner/MiningFeature.cs
@@ -95,7 +95,7 @@ namespace Stratis.Bitcoin.Features.Miner
         }
 
         /// <inheritdoc />
-        public override void Start()
+        public override void Initialize()
         {
             if (this.minerSettings.Mine)
             {

--- a/src/Stratis.Bitcoin.Features.Notifications/BlockNotificationFeature.cs
+++ b/src/Stratis.Bitcoin.Features.Notifications/BlockNotificationFeature.cs
@@ -42,7 +42,7 @@ namespace Stratis.Bitcoin.Features.Notifications
             this.loggerFactory = loggerFactory;
         }
 
-        public override void Start()
+        public override void Initialize()
         {
             var connectionParameters = this.connectionManager.Parameters;
             connectionParameters.TemplateBehaviors.Add(new BlockPullerBehavior(this.blockPuller, this.loggerFactory));

--- a/src/Stratis.Bitcoin.Features.Notifications/BlockNotificationFeature.cs
+++ b/src/Stratis.Bitcoin.Features.Notifications/BlockNotificationFeature.cs
@@ -51,7 +51,7 @@ namespace Stratis.Bitcoin.Features.Notifications
             this.chainState.ConsensusTip = this.chain.Tip;
         }
 
-        public override void Stop()
+        public override void Dispose()
         {
             this.blockNotification.Stop();
         }

--- a/src/Stratis.Bitcoin.Features.Notifications/BlockNotificationFeature.cs
+++ b/src/Stratis.Bitcoin.Features.Notifications/BlockNotificationFeature.cs
@@ -51,6 +51,7 @@ namespace Stratis.Bitcoin.Features.Notifications
             this.chainState.ConsensusTip = this.chain.Tip;
         }
 
+        /// <inheritdoc />
         public override void Dispose()
         {
             this.blockNotification.Stop();

--- a/src/Stratis.Bitcoin.Features.Notifications/TransactionNotificationFeature.cs
+++ b/src/Stratis.Bitcoin.Features.Notifications/TransactionNotificationFeature.cs
@@ -21,7 +21,7 @@ namespace Stratis.Bitcoin.Features.Notifications
             this.transactionBehavior = transactionBehavior;
         }
 
-        public override void Start()
+        public override void Initialize()
         {
             this.connectionManager.Parameters.TemplateBehaviors.Add(this.transactionBehavior);
         }

--- a/src/Stratis.Bitcoin.Features.RPC/RPCFeature.cs
+++ b/src/Stratis.Bitcoin.Features.RPC/RPCFeature.cs
@@ -35,7 +35,7 @@ namespace Stratis.Bitcoin.Features.RPC
             this.rpcSettings = rpcSettings;
         }
 
-        public override void Start()
+        public override void Initialize()
         {
             if (this.rpcSettings.Server)
             {

--- a/src/Stratis.Bitcoin.Features.Wallet/WalletFeature.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/WalletFeature.cs
@@ -116,7 +116,7 @@ namespace Stratis.Bitcoin.Features.Wallet
         }
 
         /// <inheritdoc />
-        public override void Stop()
+        public override void Dispose()
         {
             this.blockSubscriberDisposable.Dispose();
             this.transactionSubscriberDisposable.Dispose();

--- a/src/Stratis.Bitcoin.Features.Wallet/WalletFeature.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/WalletFeature.cs
@@ -103,7 +103,7 @@ namespace Stratis.Bitcoin.Features.Wallet
         }
 
         /// <inheritdoc />
-        public override void Start()
+        public override void Initialize()
         {
             // subscribe to receiving blocks and transactions
             this.blockSubscriberDisposable = this.signals.SubscribeForBlocks(new BlockObserver(this.walletSyncManager));

--- a/src/Stratis.Bitcoin.Features.WatchOnlyWallet/WatchOnlyWalletFeature.cs
+++ b/src/Stratis.Bitcoin.Features.WatchOnlyWallet/WatchOnlyWalletFeature.cs
@@ -43,7 +43,7 @@ namespace Stratis.Bitcoin.Features.WatchOnlyWallet
         }
 
         /// <inheritdoc />
-        public override void Stop()
+        public override void Dispose()
         {
             this.blockSubscriberdDisposable.Dispose();
             this.transactionSubscriberdDisposable.Dispose();

--- a/src/Stratis.Bitcoin.Features.WatchOnlyWallet/WatchOnlyWalletFeature.cs
+++ b/src/Stratis.Bitcoin.Features.WatchOnlyWallet/WatchOnlyWalletFeature.cs
@@ -33,7 +33,7 @@ namespace Stratis.Bitcoin.Features.WatchOnlyWallet
         }
 
         /// <inheritdoc />
-        public override void Start()
+        public override void Initialize()
         {
             // subscribe to receiving blocks and transactions
             this.blockSubscriberdDisposable = this.signals.SubscribeForBlocks(new BlockObserver(this.walletManager));

--- a/src/Stratis.Bitcoin.IntegrationTests/BlockStoreTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/BlockStoreTests.cs
@@ -203,7 +203,7 @@ namespace Stratis.Bitcoin.IntegrationTests
                 stratisNodeSync.FullNode.Chain.SetTip(stratisNodeSync.FullNode.Chain.GetBlock(stratisNodeSync.FullNode.Chain.Height - 5));
 
                 // stop the node it will persist the chain with the reset tip
-                stratisNodeSync.FullNode.Stop();
+                stratisNodeSync.FullNode.Dispose();
 
                 var newNodeInstance = builder.CloneStratisNode(stratisNodeSync);
 

--- a/src/Stratis.Bitcoin.IntegrationTests/WalletTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/WalletTests.cs
@@ -441,7 +441,7 @@ namespace Stratis.Bitcoin.IntegrationTests
                 stratisNodeSync.FullNode.Chain.SetTip(stratisNodeSync.FullNode.Chain.GetBlock(stratisNodeSync.FullNode.Chain.Height - 5));
 
                 // stop the node it will persist the chain with the reset tip
-                stratisNodeSync.FullNode.Stop();
+                stratisNodeSync.FullNode.Dispose();
 
                 var newNodeInstance = builder.CloneStratisNode(stratisNodeSync);
 

--- a/src/Stratis.Bitcoin.Tests/Builder/Feature/FeatureCollectionTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Builder/Feature/FeatureCollectionTest.cs
@@ -37,7 +37,7 @@ namespace Stratis.Bitcoin.Tests.Builder.Feature
                 throw new NotImplementedException();
             }
 
-            public void Stop()
+            public void Dispose()
             {
                 throw new NotImplementedException();
             }

--- a/src/Stratis.Bitcoin.Tests/Builder/Feature/FeatureCollectionTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Builder/Feature/FeatureCollectionTest.cs
@@ -32,7 +32,7 @@ namespace Stratis.Bitcoin.Tests.Builder.Feature
 
         private class FeatureCollectionFullNodeFeature : IFullNodeFeature
         {
-            public void Start()
+            public void Initialize()
             {
                 throw new NotImplementedException();
             }

--- a/src/Stratis.Bitcoin.Tests/Builder/Feature/FeatureRegistrationTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Builder/Feature/FeatureRegistrationTest.cs
@@ -104,7 +104,7 @@ namespace Stratis.Bitcoin.Tests.Builder.Feature
 
         private class FeatureRegistrationFullNodeFeature : IFullNodeFeature
         {
-            public void Start()
+            public void Initialize()
             {
                 throw new NotImplementedException();
             }

--- a/src/Stratis.Bitcoin.Tests/Builder/Feature/FeatureRegistrationTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Builder/Feature/FeatureRegistrationTest.cs
@@ -109,7 +109,7 @@ namespace Stratis.Bitcoin.Tests.Builder.Feature
                 throw new NotImplementedException();
             }
 
-            public void Stop()
+            public void Dispose()
             {
                 throw new NotImplementedException();
             }

--- a/src/Stratis.Bitcoin.Tests/Builder/Feature/FeaturesDependencyCheckingTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Builder/Feature/FeaturesDependencyCheckingTest.cs
@@ -19,7 +19,7 @@ namespace Stratis.Bitcoin.Tests.Builder.Feature
         private class FeatureA : IFullNodeFeature
         {
             /// <inheritdoc />
-            public void Start()
+            public void Initialize()
             {
                 throw new NotImplementedException();
             }

--- a/src/Stratis.Bitcoin.Tests/Builder/Feature/FeaturesDependencyCheckingTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Builder/Feature/FeaturesDependencyCheckingTest.cs
@@ -25,7 +25,7 @@ namespace Stratis.Bitcoin.Tests.Builder.Feature
             }
 
             /// <inheritdoc />
-            public void Stop()
+            public void Dispose()
             {
                 throw new NotImplementedException();
             }

--- a/src/Stratis.Bitcoin.Tests/Builder/Feature/FeaturesExtensionsTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Builder/Feature/FeaturesExtensionsTest.cs
@@ -19,7 +19,7 @@ namespace Stratis.Bitcoin.Tests.Builder.Feature
         private class FeatureA : IFullNodeFeature
         {
             /// <inheritdoc />
-            public void Start()
+            public void Initialize()
             {
                 throw new NotImplementedException();
             }
@@ -42,7 +42,7 @@ namespace Stratis.Bitcoin.Tests.Builder.Feature
         private class FeatureB : IFullNodeFeature
         {
             /// <inheritdoc />
-            public void Start()
+            public void Initialize()
             {
                 throw new NotImplementedException();
             }

--- a/src/Stratis.Bitcoin.Tests/Builder/Feature/FeaturesExtensionsTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Builder/Feature/FeaturesExtensionsTest.cs
@@ -25,7 +25,7 @@ namespace Stratis.Bitcoin.Tests.Builder.Feature
             }
 
             /// <inheritdoc />
-            public void Stop()
+            public void Dispose()
             {
                 throw new NotImplementedException();
             }
@@ -48,7 +48,7 @@ namespace Stratis.Bitcoin.Tests.Builder.Feature
             }
 
             /// <inheritdoc />
-            public void Stop()
+            public void Dispose()
             {
                 throw new NotImplementedException();
             }

--- a/src/Stratis.Bitcoin.Tests/Builder/FullNodeBuilderTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Builder/FullNodeBuilderTest.cs
@@ -13,7 +13,7 @@ namespace Stratis.Bitcoin.Tests.Builder
     {
         public class DummyFeature : FullNodeFeature
         {
-            public override void Start()
+            public override void Initialize()
             {
                 // nothing.
             }

--- a/src/Stratis.Bitcoin.Tests/Builder/FullNodeFeatureExecutorTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Builder/FullNodeFeatureExecutorTest.cs
@@ -82,7 +82,7 @@ namespace Stratis.Bitcoin.Tests.Builder
         [Fact]
         public void StopCallsStopOnEachFeatureRegisterdWithFullNode()
         {
-            this.executor.Stop();
+            this.executor.Dispose();
 
             this.feature.Verify(f => f.Stop(), Times.Exactly(1));
             this.feature2.Verify(f => f.Stop(), Times.Exactly(1));
@@ -98,7 +98,7 @@ namespace Stratis.Bitcoin.Tests.Builder
                 this.feature2.Setup(f => f.Stop())
                     .Throws(new ArgumentNullException());
 
-                this.executor.Stop();
+                this.executor.Dispose();
             });
         }
 

--- a/src/Stratis.Bitcoin.Tests/Builder/FullNodeFeatureExecutorTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Builder/FullNodeFeatureExecutorTest.cs
@@ -84,8 +84,8 @@ namespace Stratis.Bitcoin.Tests.Builder
         {
             this.executor.Dispose();
 
-            this.feature.Verify(f => f.Stop(), Times.Exactly(1));
-            this.feature2.Verify(f => f.Stop(), Times.Exactly(1));
+            this.feature.Verify(f => f.Dispose(), Times.Exactly(1));
+            this.feature2.Verify(f => f.Dispose(), Times.Exactly(1));
         }
 
         [Fact]
@@ -93,9 +93,9 @@ namespace Stratis.Bitcoin.Tests.Builder
         {
             Assert.Throws<AggregateException>(() =>
             {
-                this.feature.Setup(f => f.Stop())
+                this.feature.Setup(f => f.Dispose())
                     .Throws(new ArgumentNullException());
-                this.feature2.Setup(f => f.Stop())
+                this.feature2.Setup(f => f.Dispose())
                     .Throws(new ArgumentNullException());
 
                 this.executor.Dispose();

--- a/src/Stratis.Bitcoin.Tests/Builder/FullNodeFeatureExecutorTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Builder/FullNodeFeatureExecutorTest.cs
@@ -59,10 +59,10 @@ namespace Stratis.Bitcoin.Tests.Builder
         [Fact]
         public void StartCallsStartOnEachFeatureRegisterdWithFullNode()
         {
-            this.executor.Start();
+            this.executor.Initialize();
 
-            this.feature.Verify(f => f.Start(), Times.Exactly(1));
-            this.feature2.Verify(f => f.Start(), Times.Exactly(1));
+            this.feature.Verify(f => f.Initialize(), Times.Exactly(1));
+            this.feature2.Verify(f => f.Initialize(), Times.Exactly(1));
         }
 
         [Fact]
@@ -70,12 +70,12 @@ namespace Stratis.Bitcoin.Tests.Builder
         {
             Assert.Throws<AggregateException>(() =>
             {
-                this.feature.Setup(f => f.Start())
+                this.feature.Setup(f => f.Initialize())
                     .Throws(new ArgumentNullException());
-                this.feature2.Setup(f => f.Start())
+                this.feature2.Setup(f => f.Initialize())
                     .Throws(new ArgumentNullException());
 
-                this.executor.Start();
+                this.executor.Initialize();
             });
         }
 
@@ -108,7 +108,7 @@ namespace Stratis.Bitcoin.Tests.Builder
         [Fact]
         public void TestMissingDependencyThrowsException()
         {
-            Assert.Throws<AggregateException>(() => this.MissingFeatureExecutor.Start());
+            Assert.Throws<AggregateException>(() => this.MissingFeatureExecutor.Initialize());
         }
     }
 }

--- a/src/Stratis.Bitcoin.Tests/Builder/FullNodeServiceProviderTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Builder/FullNodeServiceProviderTest.cs
@@ -56,7 +56,7 @@ namespace Stratis.Bitcoin.Tests.Builder
         private class TestFeatureStub : IFullNodeFeature
         {
             /// <inheritdoc />
-            public void Start()
+            public void Initialize()
             {
                 throw new NotImplementedException();
             }
@@ -76,7 +76,7 @@ namespace Stratis.Bitcoin.Tests.Builder
         private class TestFeatureStub2 : IFullNodeFeature
         {
             /// <inheritdoc />
-            public void Start()
+            public void Initialize()
             {
                 throw new NotImplementedException();
             }

--- a/src/Stratis.Bitcoin.Tests/Builder/FullNodeServiceProviderTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Builder/FullNodeServiceProviderTest.cs
@@ -62,7 +62,7 @@ namespace Stratis.Bitcoin.Tests.Builder
             }
 
             /// <inheritdoc />
-            public void Stop()
+            public void Dispose()
             {
                 throw new NotImplementedException();
             }
@@ -82,7 +82,7 @@ namespace Stratis.Bitcoin.Tests.Builder
             }
 
             /// <inheritdoc />
-            public void Stop()
+            public void Dispose()
             {
                 throw new NotImplementedException();
             }

--- a/src/Stratis.Bitcoin/Base/BaseFeature.cs
+++ b/src/Stratis.Bitcoin/Base/BaseFeature.cs
@@ -161,7 +161,7 @@ namespace Stratis.Bitcoin.Base
         }
 
         /// <inheritdoc />
-        public override void Start()
+        public override void Initialize()
         {
             this.logger.LogTrace("()");
 

--- a/src/Stratis.Bitcoin/Base/BaseFeature.cs
+++ b/src/Stratis.Bitcoin/Base/BaseFeature.cs
@@ -246,7 +246,7 @@ namespace Stratis.Bitcoin.Base
         }
 
         /// <inheritdoc />
-        public override void Stop()
+        public override void Dispose()
         {
             this.logger.LogInformation("Flushing peers...");
             this.flushAddressManagerLoop.Dispose();

--- a/src/Stratis.Bitcoin/Base/ChainRepository.cs
+++ b/src/Stratis.Bitcoin/Base/ChainRepository.cs
@@ -111,6 +111,7 @@ namespace Stratis.Bitcoin.Base
             return task;
         }
 
+        /// <inheritdoc />
         public void Dispose()
         {
             this.dbreeze.Dispose();

--- a/src/Stratis.Bitcoin/Builder/Feature/FullNodeFeature.cs
+++ b/src/Stratis.Bitcoin/Builder/Feature/FullNodeFeature.cs
@@ -10,7 +10,7 @@ namespace Stratis.Bitcoin.Builder.Feature
         /// <summary>
         /// Triggered when the FullNode host has fully started.
         /// </summary>
-        void Start();
+        void Initialize();
 
         /// <summary>
         /// Validates the feature's required dependencies are all present.
@@ -33,7 +33,7 @@ namespace Stratis.Bitcoin.Builder.Feature
     public abstract class FullNodeFeature : IFullNodeFeature
     {
         /// <inheritdoc />
-        public abstract void Start();
+        public abstract void Initialize();
 
         /// <inheritdoc />
         public virtual void Dispose()

--- a/src/Stratis.Bitcoin/Builder/Feature/FullNodeFeature.cs
+++ b/src/Stratis.Bitcoin/Builder/Feature/FullNodeFeature.cs
@@ -1,20 +1,16 @@
-﻿namespace Stratis.Bitcoin.Builder.Feature
+﻿using System;
+
+namespace Stratis.Bitcoin.Builder.Feature
 {
     /// <summary>
     /// Defines methods for features that are managed by the FullNode.
     /// </summary>
-    public interface IFullNodeFeature
+    public interface IFullNodeFeature : IDisposable
     {
         /// <summary>
         /// Triggered when the FullNode host has fully started.
         /// </summary>
         void Start();
-
-        /// <summary>
-        /// Triggered when the FullNode is performing a graceful shutdown.
-        /// Requests may still be in flight. Shutdown will block until this event completes.
-        /// </summary>
-        void Stop();
 
         /// <summary>
         /// Validates the feature's required dependencies are all present.
@@ -40,7 +36,7 @@
         public abstract void Start();
 
         /// <inheritdoc />
-        public virtual void Stop()
+        public virtual void Dispose()
         {
         }
 

--- a/src/Stratis.Bitcoin/Builder/FullNodeFeatureExecutor.cs
+++ b/src/Stratis.Bitcoin/Builder/FullNodeFeatureExecutor.cs
@@ -20,7 +20,7 @@ namespace Stratis.Bitcoin.Builder
         /// <summary>
         /// Stops all registered features of the associated full node.
         /// </summary>
-        void Stop();
+        void Dispose();
     }
 
     /// <summary>
@@ -64,11 +64,11 @@ namespace Stratis.Bitcoin.Builder
         }
 
         /// <inheritdoc />
-        public void Stop()
+        public void Dispose()
         {
             try
             {
-                this.Execute(service => service.Stop(), true);
+                this.Execute(feature => feature.Dispose(), true);
             }
             catch (Exception ex)
             {

--- a/src/Stratis.Bitcoin/Builder/FullNodeFeatureExecutor.cs
+++ b/src/Stratis.Bitcoin/Builder/FullNodeFeatureExecutor.cs
@@ -15,7 +15,7 @@ namespace Stratis.Bitcoin.Builder
         /// <summary>
         /// Starts all registered features of the associated full node.
         /// </summary>
-        void Start();
+        void Initialize();
 
         /// <summary>
         /// Stops all registered features of the associated full node.
@@ -49,12 +49,12 @@ namespace Stratis.Bitcoin.Builder
         }
 
         /// <inheritdoc />
-        public void Start()
+        public void Initialize()
         {
             try
             {
                 this.Execute(service => service.ValidateDependencies(this.node.Services));
-                this.Execute(service => service.Start());
+                this.Execute(service => service.Initialize());
             }
             catch (Exception ex)
             {

--- a/src/Stratis.Bitcoin/Connection/ConnectionManager.cs
+++ b/src/Stratis.Bitcoin/Connection/ConnectionManager.cs
@@ -368,6 +368,7 @@ namespace Stratis.Bitcoin.Connection
             return match.Groups[1].Value;
         }
 
+        /// <inheritdoc />
         public void Dispose()
         {
             this.logger.LogTrace("()");

--- a/src/Stratis.Bitcoin/FullNode.cs
+++ b/src/Stratis.Bitcoin/FullNode.cs
@@ -187,8 +187,8 @@ namespace Stratis.Bitcoin
 
             this.logger.LogInformation("Starting node...");
 
-            // Start all registered features.
-            this.fullNodeFeatureExecutor.Start();
+            // Initialize all registered features.
+            this.fullNodeFeatureExecutor.Initialize();
 
             // Start connecting to peers.
             this.ConnectionManager.Start();

--- a/src/Stratis.Bitcoin/FullNode.cs
+++ b/src/Stratis.Bitcoin/FullNode.cs
@@ -29,9 +29,6 @@ namespace Stratis.Bitcoin
         /// <summary>Component responsible for starting and stopping all the node's features.</summary>
         private FullNodeFeatureExecutor fullNodeFeatureExecutor;
 
-        /// <summary>Indicates whether the node has been stopped or is currently being stopped.</summary>
-        internal bool Stopped;
-
         /// <summary>Indicates whether the node's instance has been disposed or is currently being disposed.</summary>
         public bool IsDisposed { get; private set; }
 
@@ -202,32 +199,6 @@ namespace Stratis.Bitcoin
             this.StartPeriodicLog();
         }
 
-        /// <inheritdoc />
-        public void Stop()
-        {
-            if (this.Stopped)
-                return;
-
-            this.Stopped = true;
-
-            this.logger.LogInformation("Closing node pending...");
-
-            // Fire INodeLifetime.Stopping.
-            this.nodeLifetime.StopApplication();
-
-            this.ConnectionManager.Dispose();
-
-            foreach (IDisposable dispo in this.Resources)
-                dispo.Dispose();
-
-            // Fire the NodeFeatureExecutor.Stop.
-            this.fullNodeFeatureExecutor.Stop();
-            (this.Services.ServiceProvider as IDisposable)?.Dispose();
-
-            // Fire INodeLifetime.Stopped.
-            this.nodeLifetime.NotifyStopped();
-        }
-
         /// <summary>
         /// Starts a loop to periodically log statistics about node's status very couple of seconds.
         /// <para>
@@ -272,17 +243,21 @@ namespace Stratis.Bitcoin
 
             this.IsDisposed = true;
 
-            if (!this.Stopped)
-            {
-                try
-                {
-                    this.Stop();
-                }
-                catch (Exception ex)
-                {
-                    this.logger?.LogError(ex.Message);
-                }
-            }
+            this.logger.LogInformation("Closing node pending...");
+
+            // Fire INodeLifetime.Stopping.
+            this.nodeLifetime.StopApplication();
+
+            this.ConnectionManager.Dispose();
+
+            foreach (IDisposable disposable in this.Resources)
+                disposable.Dispose();
+
+            // Fire the NodeFeatureExecutor.Stop.
+            this.fullNodeFeatureExecutor.Dispose();
+
+            // Fire INodeLifetime.Stopped.
+            this.nodeLifetime.NotifyStopped();
 
             this.HasExited = true;
         }

--- a/src/Stratis.Bitcoin/IFullNode.cs
+++ b/src/Stratis.Bitcoin/IFullNode.cs
@@ -30,11 +30,6 @@ namespace Stratis.Bitcoin
         void Start();
 
         /// <summary>
-        /// Stops the full node and all its features.
-        /// </summary>
-        void Stop();
-
-        /// <summary>
         /// Find a service of a particular type
         /// </summary>
         /// <typeparam name="T">Class of type</typeparam>

--- a/src/Stratis.Bitcoin/P2P/Peer/NetworkPeer.cs
+++ b/src/Stratis.Bitcoin/P2P/Peer/NetworkPeer.cs
@@ -1335,6 +1335,7 @@ namespace Stratis.Bitcoin.P2P.Peer
             return inventoryType;
         }
 
+        /// <inheritdoc />
         public void Dispose()
         {
             Disconnect("Node disposed");

--- a/src/Stratis.Bitcoin/P2P/Peer/NetworkPeerListener.cs
+++ b/src/Stratis.Bitcoin/P2P/Peer/NetworkPeerListener.cs
@@ -66,6 +66,7 @@ namespace Stratis.Bitcoin.P2P.Peer
             }
         }
 
+        /// <inheritdoc />
         public void Dispose()
         {
             this.subscription?.Dispose();

--- a/src/Stratis.Bitcoin/P2P/Peer/NetworkPeerServer.cs
+++ b/src/Stratis.Bitcoin/P2P/Peer/NetworkPeerServer.cs
@@ -397,6 +397,7 @@ namespace Stratis.Bitcoin.P2P.Peer
             });
         }
 
+        /// <inheritdoc />
         public void Dispose()
         {
             if (!this.cancel.IsCancellationRequested)

--- a/src/Stratis.Bitcoin/P2P/PeerDiscoveryLoop.cs
+++ b/src/Stratis.Bitcoin/P2P/PeerDiscoveryLoop.cs
@@ -153,6 +153,7 @@ namespace Stratis.Bitcoin.P2P
             peers.AddRange(this.network.SeedNodes);
         }
 
+        /// <inheritdoc />
         public void Dispose()
         {
             this.asyncLoop?.Dispose();


### PR DESCRIPTION
Replaced Stop with Dispose for all features and FullNode.
The reason for that is that all Stop() calls actually dispose stuff instead of stopping the feature.  

And in case of node there were Stop() and Dispose():  Stop() would do the disposing (leaving IsDisposed flag false), Dispose() would call Stop() which is a very counter-intuitive behavior. 

This is discussed in #799