### PR TITLE
Unused 'out' optimizations

### DIFF
--- a/src/NBitcoin/Script.cs
+++ b/src/NBitcoin/Script.cs
@@ -1018,14 +1018,12 @@ namespace NBitcoin
 
         public static bool VerifyScript(Script scriptSig, Script scriptPubKey, Transaction tx, int i, ScriptVerify scriptVerify = ScriptVerify.Standard, SigHash sigHash = SigHash.Undefined)
         {
-            ScriptError unused;
-            return VerifyScript(scriptSig, scriptPubKey, tx, i, null, scriptVerify, sigHash, out unused);
+            return VerifyScript(scriptSig, scriptPubKey, tx, i, null, scriptVerify, sigHash, out ScriptError unused);
         }
 
         public static bool VerifyScript(Script scriptSig, Script scriptPubKey, Transaction tx, int i, Money value, ScriptVerify scriptVerify = ScriptVerify.Standard, SigHash sigHash = SigHash.Undefined)
         {
-            ScriptError unused;
-            return VerifyScript(scriptSig, scriptPubKey, tx, i, value, scriptVerify, sigHash, out unused);
+            return VerifyScript(scriptSig, scriptPubKey, tx, i, value, scriptVerify, sigHash, out ScriptError unused);
         }
 
         public static bool VerifyScript(Script scriptSig, Script scriptPubKey, Transaction tx, int i, Money value, out ScriptError error)
@@ -1035,9 +1033,8 @@ namespace NBitcoin
 
         public static bool VerifyScript(Script scriptPubKey, Transaction tx, int i, Money value, ScriptVerify scriptVerify = ScriptVerify.Standard, SigHash sigHash = SigHash.Undefined)
         {
-            ScriptError unused;
             var scriptSig = tx.Inputs[i].ScriptSig;
-            return VerifyScript(scriptSig, scriptPubKey, tx, i, value, scriptVerify, sigHash, out unused);
+            return VerifyScript(scriptSig, scriptPubKey, tx, i, value, scriptVerify, sigHash, out ScriptError unused);
         }
 
         public static bool VerifyScript(Script scriptPubKey, Transaction tx, int i, Money value, out ScriptError error)
@@ -1088,13 +1085,11 @@ namespace NBitcoin
 
         public static bool VerifyScriptConsensus(Script scriptPubKey, Transaction tx, uint nIn, ScriptVerify flags)
         {
-            var err = BitcoinConsensusError.ERR_OK;
-            return VerifyScriptConsensus(scriptPubKey, tx, nIn, flags, out err);
+            return VerifyScriptConsensus(scriptPubKey, tx, nIn, flags, out BitcoinConsensusError unused);
         }
         public static bool VerifyScriptConsensus(Script scriptPubKey, Transaction tx, uint nIn, Money amount, ScriptVerify flags)
         {
-            var err = BitcoinConsensusError.ERR_OK;
-            return VerifyScriptConsensus(scriptPubKey, tx, nIn, amount, flags, out err);
+            return VerifyScriptConsensus(scriptPubKey, tx, nIn, amount, flags, out BitcoinConsensusError unused);
         }
 
         public static bool VerifyScriptConsensus(Script scriptPubKey, Transaction tx, uint nIn, ScriptVerify flags, out BitcoinConsensusError err)

--- a/src/NBitcoin/Transaction.cs
+++ b/src/NBitcoin/Transaction.cs
@@ -696,8 +696,7 @@ namespace NBitcoin
 
         public bool VerifyScript(Script scriptPubKey, ScriptVerify scriptVerify = ScriptVerify.Standard)
         {
-            ScriptError unused;
-            return VerifyScript(scriptPubKey, scriptVerify, out unused);
+            return VerifyScript(scriptPubKey, scriptVerify, out ScriptError unused);
         }
         public bool VerifyScript(Script scriptPubKey, out ScriptError error)
         {
@@ -714,8 +713,7 @@ namespace NBitcoin
 
         public bool VerifyScript(ICoin coin, ScriptVerify scriptVerify = ScriptVerify.Standard)
         {
-            ScriptError error;
-            return VerifyScript(coin, scriptVerify, out error);
+            return VerifyScript(coin, scriptVerify, out ScriptError unused);
         }
 
         public bool VerifyScript(ICoin coin, ScriptVerify scriptVerify, out ScriptError error)

--- a/src/Stratis.Bitcoin.Features.MemoryPool.Tests/MempoolPersistenceTest.cs
+++ b/src/Stratis.Bitcoin.Features.MemoryPool.Tests/MempoolPersistenceTest.cs
@@ -101,8 +101,7 @@ namespace Stratis.Bitcoin.Features.MemoryPool.Tests
             string fileName = "mempool.dat";
             NodeSettings settings = this.CreateSettings("LoadPoolTest_WithBadTransactions");
             IEnumerable<MempoolPersistenceEntry> toSave = this.CreateTestEntries(numTx);
-            TxMempool unused;
-            MempoolManager mempoolManager = CreateTestMempool(settings, out unused);
+            MempoolManager mempoolManager = CreateTestMempool(settings, out TxMempool unused);
 
             MemPoolSaveResult result = (new MempoolPersistence(settings, new LoggerFactory())).Save(toSave, fileName);
             mempoolManager.LoadPoolAsync(fileName).GetAwaiter().GetResult();


### PR DESCRIPTION
Tiny pr that replaces 
```
var unused;
fu(out unused)
```

with 

`fu (out var unused)`