### PR TITLE
Serialize/Deserialize NetworkOptions

### DIFF
--- a/src/NBitcoin/BitcoinStream.cs
+++ b/src/NBitcoin/BitcoinStream.cs
@@ -45,6 +45,7 @@ namespace NBitcoin
         }
     }
 
+    // TODO: Make NetworkOptions required in the constructors of this class.
     public partial class BitcoinStream
     {
         int maxArraySize = 1024 * 1024;
@@ -156,7 +157,7 @@ namespace NBitcoin
                 readWriteTyped.MakeGenericMethod(type).Invoke(this, parameters);
                 obj = parameters[0];
             }
-            catch(TargetInvocationException ex)
+            catch (TargetInvocationException ex)
             {
                 throw ex.InnerException;
             }
@@ -196,7 +197,7 @@ namespace NBitcoin
             if (obj == null)
                 obj = Activator.CreateInstance<T>();
             obj.ReadWrite(this);
-            if (!Serializing)
+            if (!this.Serializing)
                 data = obj;
         }
 

--- a/src/NBitcoin/BitcoinStream.cs
+++ b/src/NBitcoin/BitcoinStream.cs
@@ -353,7 +353,7 @@ namespace NBitcoin
         }
 
         NetworkOptions _TransactionSupportedOptions = NetworkOptions.All;
-        public NetworkOptions NetworkOptions
+        public NetworkOptions TransactionOptions
         {
             get
             {
@@ -384,7 +384,7 @@ namespace NBitcoin
 			if(stream == null)
 				throw new ArgumentNullException("stream");
 			ProtocolVersion = stream.ProtocolVersion;
-            NetworkOptions = stream.NetworkOptions.Clone();
+            TransactionOptions = stream.TransactionOptions.Clone();
 			IsBigEndian = stream.IsBigEndian;
 			MaxArraySize = stream.MaxArraySize;
 			Type = stream.Type;

--- a/src/NBitcoin/BitcoinStream.cs
+++ b/src/NBitcoin/BitcoinStream.cs
@@ -13,6 +13,7 @@ namespace NBitcoin
         Network,
         Hash
     }
+
     public class Scope : IDisposable
     {
         Action close;
@@ -43,26 +44,27 @@ namespace NBitcoin
             }
         }
     }
+
     public partial class BitcoinStream
     {
-        int _MaxArraySize = 1024 * 1024;
+        int maxArraySize = 1024 * 1024;
         public int MaxArraySize
         {
             get
             {
-                return _MaxArraySize;
+                return this.maxArraySize;
             }
             set
             {
-                _MaxArraySize = value;
+                this.maxArraySize = value;
             }
         }
 
         //ReadWrite<T>(ref T data)
-        static MethodInfo _ReadWriteTyped;
+        static MethodInfo readWriteTyped;
         static BitcoinStream()
         {
-            _ReadWriteTyped = typeof(BitcoinStream)
+            readWriteTyped = typeof(BitcoinStream)
             .GetTypeInfo()
             .DeclaredMethods
             .Where(m => m.Name == "ReadWrite")
@@ -72,28 +74,29 @@ namespace NBitcoin
             .First();
         }
 
-        private readonly Stream _Inner;
+        private readonly Stream inner;
         public Stream Inner
         {
             get
             {
-                return _Inner;
+                return this.inner;
             }
         }
 
-		private readonly bool _Serializing;
-		public bool Serializing
-		{
-			get
-			{
-				return _Serializing;
-			}
-		}
+        private readonly bool serializing;
+        public bool Serializing
+        {
+            get
+            {
+                return this.serializing;
+            }
+        }
+
         public BitcoinStream(Stream inner, bool serializing)
-		{
-			_Serializing = serializing;
-			_Inner = inner;
-		}
+        {
+            this.serializing = serializing;
+            this.inner = inner;
+        }
 
         public BitcoinStream(byte[] bytes)
             : this(new MemoryStream(bytes), false)
@@ -102,9 +105,9 @@ namespace NBitcoin
 
         public Script ReadWrite(Script data)
         {
-            if(Serializing)
+            if (this.Serializing)
             {
-                var bytes = data == null ? Script.Empty.ToBytes(true) : data.ToBytes(true);
+                byte[] bytes = data == null ? Script.Empty.ToBytes(true) : data.ToBytes(true);
                 ReadWriteAsVarString(ref bytes);
                 return data;
             }
@@ -118,7 +121,7 @@ namespace NBitcoin
 
         public void ReadWrite(ref Script script)
         {
-            if(Serializing)
+            if (this.Serializing)
                 ReadWrite(script);
             else
                 script = ReadWrite(script);
@@ -132,7 +135,7 @@ namespace NBitcoin
 
         public void ReadWriteAsVarString(ref byte[] bytes)
         {
-            if(Serializing)
+            if (this.Serializing)
             {
                 VarString str = new VarString(bytes);
                 str.ReadWrite(this);
@@ -150,7 +153,7 @@ namespace NBitcoin
             try
             {
                 var parameters = new object[] { obj };
-                _ReadWriteTyped.MakeGenericMethod(type).Invoke(this, parameters);
+                readWriteTyped.MakeGenericMethod(type).Invoke(this, parameters);
                 obj = parameters[0];
             }
             catch(TargetInvocationException ex)
@@ -163,6 +166,7 @@ namespace NBitcoin
         {
             ReadWriteByte(ref data);
         }
+
         public byte ReadWrite(byte data)
         {
             ReadWrite(ref data);
@@ -180,6 +184,7 @@ namespace NBitcoin
         {
             data.ReadWrite(this);
         }
+
         public void ReadWriteStruct<T>(T data) where T : struct, IBitcoinSerializable
         {
             data.ReadWrite(this);
@@ -188,10 +193,10 @@ namespace NBitcoin
         public void ReadWrite<T>(ref T data) where T : IBitcoinSerializable
         {
             var obj = data;
-            if(obj == null)
+            if (obj == null)
                 obj = Activator.CreateInstance<T>();
             obj.ReadWrite(this);
-            if(!Serializing)
+            if (!Serializing)
                 data = obj;
         }
 
@@ -212,14 +217,17 @@ namespace NBitcoin
             where TItem : IBitcoinSerializable, new()
         {
             var dataArray = data == null ? null : data.ToArray();
-            if(Serializing && dataArray == null)
+
+            if (this.Serializing && dataArray == null)
             {
                 dataArray = new TItem[0];
             }
+
             ReadWriteArray(ref dataArray);
-            if(!Serializing)
+
+            if (!this.Serializing)
             {
-                if(data == null)
+                if (data == null)
                     data = new TList();
                 else
                     data.Clear();
@@ -231,10 +239,12 @@ namespace NBitcoin
         {
             ReadWriteBytes(ref arr);
         }
+
         public void ReadWrite(ref byte[] arr, int offset, int count)
         {
             ReadWriteBytes(ref arr, offset, count);
         }
+
         public void ReadWrite<T>(ref T[] arr) where T : IBitcoinSerializable, new()
         {
             ReadWriteArray<T>(ref arr);
@@ -255,13 +265,13 @@ namespace NBitcoin
             {
                 bytes[i] = (byte)(value >> i * 8);
             }
-            if(IsBigEndian)
+            if (this.IsBigEndian)
                 Array.Reverse(bytes);
             ReadWriteBytes(ref bytes);
-            if(IsBigEndian)
+            if (this.IsBigEndian)
                 Array.Reverse(bytes);
             ulong valueTemp = 0;
-            for(int i = 0; i < bytes.Length; i++)
+            for (int i = 0; i < bytes.Length; i++)
             {
                 var v = (ulong)bytes[i];
                 valueTemp += v << (i * 8);
@@ -271,52 +281,54 @@ namespace NBitcoin
 
         private void ReadWriteBytes(ref byte[] data, int offset = 0, int count = -1)
         {
-            if(data == null) throw new ArgumentNullException("data");
+            if (data == null) throw new ArgumentNullException("data");
 
-            if(data.Length == 0) return;
+            if (data.Length == 0) return;
 
             count = count == -1 ? data.Length : count;
 
-            if(count == 0) return;
+            if (count == 0) return;
 
-            if(Serializing)
+            if (this.Serializing)
             {
-                Inner.Write(data, offset, count);
-                Counter.AddWritten(count);
+                this.Inner.Write(data, offset, count);
+                this.Counter.AddWritten(count);
             }
             else
             {
-                var readen = Inner.ReadEx(data, offset, count, ReadCancellationToken);
-                if(readen == 0)
+                var readen = this.Inner.ReadEx(data, offset, count, this.ReadCancellationToken);
+                if (readen == 0)
                     throw new EndOfStreamException("No more byte to read");
-                Counter.AddRead(readen);
+                this.Counter.AddRead(readen);
 
             }
         }
-        private PerformanceCounter _Counter;
+
+        private PerformanceCounter counter;
         public PerformanceCounter Counter
         {
             get
             {
-                if(_Counter == null)
-                    _Counter = new PerformanceCounter();
-                return _Counter;
+                if (this.counter == null)
+                    this.counter = new PerformanceCounter();
+                return this.counter;
             }
         }
+
         private void ReadWriteByte(ref byte data)
         {
-            if(Serializing)
+            if (this.Serializing)
             {
-                Inner.WriteByte(data);
-                Counter.AddWritten(1);
+                this.Inner.WriteByte(data);
+                this.Counter.AddWritten(1);
             }
             else
             {
-                var readen = Inner.ReadByte();
-                if(readen == -1)
+                var readen = this.Inner.ReadByte();
+                if (readen == -1)
                     throw new EndOfStreamException("No more byte to read");
                 data = (byte)readen;
-                Counter.AddRead(1);
+                this.Counter.AddRead(1);
             }
         }
 
@@ -328,67 +340,66 @@ namespace NBitcoin
 
         public IDisposable BigEndianScope()
         {
-            var old = IsBigEndian;
+            var old = this.IsBigEndian;
             return new Scope(() =>
             {
-                IsBigEndian = true;
+                this.IsBigEndian = true;
             },
             () =>
             {
-                IsBigEndian = old;
+                this.IsBigEndian = old;
             });
         }
 
-        ProtocolVersion _ProtocolVersion = ProtocolVersion.PROTOCOL_VERSION;
+        ProtocolVersion protocolVersion = ProtocolVersion.PROTOCOL_VERSION;
         public ProtocolVersion ProtocolVersion
         {
             get
             {
-                return _ProtocolVersion;
+                return this.protocolVersion;
             }
             set
             {
-                _ProtocolVersion = value;
+                this.protocolVersion = value;
             }
         }
 
-        NetworkOptions _TransactionSupportedOptions = NetworkOptions.All;
+        NetworkOptions transactionSupportedOptions = NetworkOptions.All;
         public NetworkOptions TransactionOptions
         {
             get
             {
-                return _TransactionSupportedOptions;
+                return this.transactionSupportedOptions;
             }
             set
             {
-                _TransactionSupportedOptions = value;
+                this.transactionSupportedOptions = value;
             }
         }
 
-
         public IDisposable ProtocolVersionScope(ProtocolVersion version)
         {
-            var old = ProtocolVersion;
+            var old = this.ProtocolVersion;
             return new Scope(() =>
             {
-                ProtocolVersion = version;
+                this.ProtocolVersion = version;
             },
             () =>
             {
-                ProtocolVersion = old;
+                this.ProtocolVersion = old;
             });
         }
 
-		public void CopyParameters(BitcoinStream stream)
-		{
-			if(stream == null)
-				throw new ArgumentNullException("stream");
-			ProtocolVersion = stream.ProtocolVersion;
-            TransactionOptions = stream.TransactionOptions.Clone();
-			IsBigEndian = stream.IsBigEndian;
-			MaxArraySize = stream.MaxArraySize;
-			Type = stream.Type;
-		}
+        public void CopyParameters(BitcoinStream stream)
+        {
+            if (stream == null)
+                throw new ArgumentNullException("stream");
+            this.ProtocolVersion = stream.ProtocolVersion;
+            this.TransactionOptions = stream.TransactionOptions.Clone();
+            this.IsBigEndian = stream.IsBigEndian;
+            this.MaxArraySize = stream.MaxArraySize;
+            this.Type = stream.Type;
+        }
 
 
         public SerializationType Type
@@ -399,13 +410,13 @@ namespace NBitcoin
 
         public IDisposable SerializationTypeScope(SerializationType value)
         {
-            var old = Type;
+            var old = this.Type;
             return new Scope(() =>
             {
-                Type = value;
+                this.Type = value;
             }, () =>
             {
-                Type = old;
+                this.Type = old;
             });
         }
 
@@ -419,14 +430,15 @@ namespace NBitcoin
         {
             ulong vallong = val;
             ReadWriteAsVarInt(ref vallong);
-            if(!Serializing)
+            if (!this.Serializing)
                 val = (uint)vallong;
         }
+
         public void ReadWriteAsVarInt(ref ulong val)
         {
             var value = new VarInt(val);
             ReadWrite(ref value);
-            if(!Serializing)
+            if (!this.Serializing)
                 val = value.ToLong();
         }
 
@@ -434,14 +446,15 @@ namespace NBitcoin
         {
             var value = new CompactVarInt(val, sizeof(uint));
             ReadWrite(ref value);
-            if(!Serializing)
+            if (!this.Serializing)
                 val = (uint)value.ToLong();
         }
+
         public void ReadWriteAsCompactVarInt(ref ulong val)
         {
             var value = new CompactVarInt(val, sizeof(ulong));
             ReadWrite(ref value);
-            if(!Serializing)
+            if (!this.Serializing)
                 val = value.ToLong();
         }
     }

--- a/src/NBitcoin/BitcoinStream.cs
+++ b/src/NBitcoin/BitcoinStream.cs
@@ -81,19 +81,19 @@ namespace NBitcoin
             }
         }
 
-        private readonly bool _Serializing;
-        public bool Serializing
-        {
-            get
-            {
-                return _Serializing;
-            }
-        }
+		private readonly bool _Serializing;
+		public bool Serializing
+		{
+			get
+			{
+				return _Serializing;
+			}
+		}
         public BitcoinStream(Stream inner, bool serializing)
-        {
-            _Serializing = serializing;
-            _Inner = inner;
-        }
+		{
+			_Serializing = serializing;
+			_Inner = inner;
+		}
 
         public BitcoinStream(byte[] bytes)
             : this(new MemoryStream(bytes), false)
@@ -353,7 +353,7 @@ namespace NBitcoin
         }
 
         NetworkOptions _TransactionSupportedOptions = NetworkOptions.All;
-        public NetworkOptions TransactionOptions
+        public NetworkOptions NetworkOptions
         {
             get
             {
@@ -379,15 +379,16 @@ namespace NBitcoin
             });
         }
 
-        public void CopyParameters(BitcoinStream stream)
-        {
-            if(stream == null)
-                throw new ArgumentNullException("stream");
-            ProtocolVersion = stream.ProtocolVersion;
-            IsBigEndian = stream.IsBigEndian;
-            MaxArraySize = stream.MaxArraySize;
-            Type = stream.Type;
-        }
+		public void CopyParameters(BitcoinStream stream)
+		{
+			if(stream == null)
+				throw new ArgumentNullException("stream");
+			ProtocolVersion = stream.ProtocolVersion;
+            NetworkOptions = stream.NetworkOptions.Clone();
+			IsBigEndian = stream.IsBigEndian;
+			MaxArraySize = stream.MaxArraySize;
+			Type = stream.Type;
+		}
 
 
         public SerializationType Type

--- a/src/NBitcoin/IBitcoinSerializable.cs
+++ b/src/NBitcoin/IBitcoinSerializable.cs
@@ -89,18 +89,17 @@ namespace NBitcoin
         public static byte[] ToBytes(this IBitcoinSerializable serializable, ProtocolVersion version = ProtocolVersion.PROTOCOL_VERSION,
             NetworkOptions options = null)
         {
-            // If no options have been provided then take the options from the serializable
-            if (options == null && serializable is IHaveNetworkOptions)
-                options = (serializable as IHaveNetworkOptions).GetNetworkOptions();
-
-            MemoryStream ms = new MemoryStream();
-            var bms = new BitcoinStream(ms, true)
+            using (MemoryStream ms = new MemoryStream())
             {
-                ProtocolVersion = version,
-                TransactionOptions = options
-            };
-            serializable.ReadWrite(bms);
-            return ToArrayEfficient(ms);
+                var bms = new BitcoinStream(ms, true)
+                {
+                    ProtocolVersion = version,
+                    // If no options have been provided then take the options from the serializable (or default)
+                    TransactionOptions = options ?? ((serializable as IHaveNetworkOptions)?.GetNetworkOptions() ?? NetworkOptions.TemporaryOptions)
+                };
+                serializable.ReadWrite(bms);
+                return ToArrayEfficient(ms);
+            }
         }
 
         public static byte[] ToArrayEfficient(this MemoryStream ms)

--- a/src/NBitcoin/IBitcoinSerializable.cs
+++ b/src/NBitcoin/IBitcoinSerializable.cs
@@ -65,6 +65,7 @@ namespace NBitcoin
         {
             ReadWrite(serializable, new MemoryStream(bytes), false, version, options);
         }
+
         public static void FromBytes(this IBitcoinSerializable serializable, byte[] bytes, ProtocolVersion version = ProtocolVersion.PROTOCOL_VERSION, 
             NetworkOptions options = null)
         {
@@ -80,8 +81,8 @@ namespace NBitcoin
         {
             NetworkOptions options = NetworkOptions.All;
             var instance = new T();
-            if (serializable is IHaveNetworkOptions)
-                options = (serializable as IHaveNetworkOptions).GetNetworkOptions();
+            if (serializable is IHaveNetworkOptions haveNetworkOptions)
+                options = haveNetworkOptions.GetNetworkOptions();
             instance.FromBytes(serializable.ToBytes(version, options), version, options);
             return instance;
         }

--- a/src/NBitcoin/IBitcoinSerializable.cs
+++ b/src/NBitcoin/IBitcoinSerializable.cs
@@ -26,7 +26,7 @@ namespace NBitcoin
             serializable.ReadWrite(new BitcoinStream(stream, serializing)
             {
                 ProtocolVersion = version,
-                NetworkOptions = options
+                TransactionOptions = options
             });
 		}
 		public static int GetSerializedSize(this IBitcoinSerializable serializable, ProtocolVersion version, SerializationType serializationType)
@@ -39,7 +39,7 @@ namespace NBitcoin
 		public static int GetSerializedSize(this IBitcoinSerializable serializable, NetworkOptions options)
 		{
 			var bms = new BitcoinStream(Stream.Null, true);
-			bms.NetworkOptions = options;
+			bms.TransactionOptions = options;
 			serializable.ReadWrite(bms);
 			return (int)bms.Counter.WrittenBytes;
 		}
@@ -72,7 +72,7 @@ namespace NBitcoin
             var bms = new BitcoinStream(bytes)
             {
                 ProtocolVersion = version,
-                NetworkOptions = options
+                TransactionOptions = options
             };
             serializable.ReadWrite(bms);
 		}
@@ -98,7 +98,7 @@ namespace NBitcoin
             var bms = new BitcoinStream(ms, true)
             {
                 ProtocolVersion = version,
-                NetworkOptions = options
+                TransactionOptions = options
             };
 			serializable.ReadWrite(bms);
 			return ToArrayEfficient(ms);

--- a/src/NBitcoin/IBitcoinSerializable.cs
+++ b/src/NBitcoin/IBitcoinSerializable.cs
@@ -9,34 +9,44 @@ namespace NBitcoin
         void ReadWrite(BitcoinStream stream);
     }
 
-    public static class BitcoinSerializableExtensions
+    public interface IHaveNetworkOptions
     {
-        public static void ReadWrite(this IBitcoinSerializable serializable, Stream stream, bool serializing, ProtocolVersion version = ProtocolVersion.PROTOCOL_VERSION)
-        {
-            BitcoinStream s = new BitcoinStream(stream, serializing)
+        NetworkOptions GetNetworkOptions();
+    }
+
+	public static class BitcoinSerializableExtensions
+	{
+		public static void ReadWrite(this IBitcoinSerializable serializable, Stream stream, bool serializing, ProtocolVersion version = ProtocolVersion.PROTOCOL_VERSION, 
+            NetworkOptions options = null)
+		{
+            // If no options have been provided then take the options from the serializable
+            if (options == null && serializing && serializable is IHaveNetworkOptions)
+                options = (serializable as IHaveNetworkOptions).GetNetworkOptions();
+
+            serializable.ReadWrite(new BitcoinStream(stream, serializing)
             {
-                ProtocolVersion = version
-            };
-            serializable.ReadWrite(s);
-        }
-        public static int GetSerializedSize(this IBitcoinSerializable serializable, ProtocolVersion version, SerializationType serializationType)
-        {
+                ProtocolVersion = version,
+                NetworkOptions = options
+            });
+		}
+		public static int GetSerializedSize(this IBitcoinSerializable serializable, ProtocolVersion version, SerializationType serializationType)
+		{
             BitcoinStream s = new BitcoinStream(Stream.Null, true);
-            s.Type = serializationType;
-            s.ReadWrite(serializable);
-            return (int)s.Counter.WrittenBytes;
-        }
-        public static int GetSerializedSize(this IBitcoinSerializable serializable, NetworkOptions options)
-        {
-            var bms = new BitcoinStream(Stream.Null, true);
-            bms.TransactionOptions = options;
-            serializable.ReadWrite(bms);
-            return (int)bms.Counter.WrittenBytes;
-        }
-        public static int GetSerializedSize(this IBitcoinSerializable serializable, ProtocolVersion version = ProtocolVersion.PROTOCOL_VERSION)
-        {
-            return GetSerializedSize(serializable, version, SerializationType.Disk);
-        }
+			s.Type = serializationType;
+			s.ReadWrite(serializable);
+			return (int)s.Counter.WrittenBytes;
+		}
+		public static int GetSerializedSize(this IBitcoinSerializable serializable, NetworkOptions options)
+		{
+			var bms = new BitcoinStream(Stream.Null, true);
+			bms.NetworkOptions = options;
+			serializable.ReadWrite(bms);
+			return (int)bms.Counter.WrittenBytes;
+		}
+		public static int GetSerializedSize(this IBitcoinSerializable serializable, ProtocolVersion version = ProtocolVersion.PROTOCOL_VERSION)
+		{
+			return GetSerializedSize(serializable, version, SerializationType.Disk);
+		}
 
         public static string ToHex(this IBitcoinSerializable serializable, SerializationType serializationType = SerializationType.Disk)
         {
@@ -51,33 +61,48 @@ namespace NBitcoin
             }
         }
 
-        public static void ReadWrite(this IBitcoinSerializable serializable, byte[] bytes, ProtocolVersion version = ProtocolVersion.PROTOCOL_VERSION)
-        {
-            ReadWrite(serializable, new MemoryStream(bytes), false, version);
-        }
-        public static void FromBytes(this IBitcoinSerializable serializable, byte[] bytes, ProtocolVersion version = ProtocolVersion.PROTOCOL_VERSION)
-        {
-            serializable.ReadWrite(new BitcoinStream(bytes)
+		public static void ReadWrite(this IBitcoinSerializable serializable, byte[] bytes, ProtocolVersion version = ProtocolVersion.PROTOCOL_VERSION, 
+            NetworkOptions options = null)
+		{
+			ReadWrite(serializable, new MemoryStream(bytes), false, version, options);
+		}
+		public static void FromBytes(this IBitcoinSerializable serializable, byte[] bytes, ProtocolVersion version = ProtocolVersion.PROTOCOL_VERSION, 
+            NetworkOptions options = null)
+		{
+            var bms = new BitcoinStream(bytes)
             {
-                ProtocolVersion = version
-            });
-        }
+                ProtocolVersion = version,
+                NetworkOptions = options
+            };
+            serializable.ReadWrite(bms);
+		}
 
-        public static T Clone<T>(this T serializable, ProtocolVersion version = ProtocolVersion.PROTOCOL_VERSION) where T : IBitcoinSerializable, new()
-        {
-            var instance = new T();
-            instance.FromBytes(serializable.ToBytes(version), version);
-            return instance;
-        }
-        public static byte[] ToBytes(this IBitcoinSerializable serializable, ProtocolVersion version = ProtocolVersion.PROTOCOL_VERSION)
-        {
+		public static T Clone<T>(this T serializable, ProtocolVersion version = ProtocolVersion.PROTOCOL_VERSION) where T : IBitcoinSerializable, new()
+		{
+            NetworkOptions options = NetworkOptions.All;
+			var instance = new T();
+            if (serializable is IHaveNetworkOptions)
+                options = (serializable as IHaveNetworkOptions).GetNetworkOptions();
+			instance.FromBytes(serializable.ToBytes(version, options), version, options);
+			return instance;
+		}
+        
+		public static byte[] ToBytes(this IBitcoinSerializable serializable, ProtocolVersion version = ProtocolVersion.PROTOCOL_VERSION,
+            NetworkOptions options = null)
+		{
+            // If no options have been provided then take the options from the serializable
+            if (options == null && serializable is IHaveNetworkOptions)
+                options = (serializable as IHaveNetworkOptions).GetNetworkOptions();
+
             MemoryStream ms = new MemoryStream();
-            serializable.ReadWrite(new BitcoinStream(ms, true)
+            var bms = new BitcoinStream(ms, true)
             {
-                ProtocolVersion = version
-            });
-            return ToArrayEfficient(ms);
-        }
+                ProtocolVersion = version,
+                NetworkOptions = options
+            };
+			serializable.ReadWrite(bms);
+			return ToArrayEfficient(ms);
+		}
 
         public static byte[] ToArrayEfficient(this MemoryStream ms)
         {

--- a/src/NBitcoin/IBitcoinSerializable.cs
+++ b/src/NBitcoin/IBitcoinSerializable.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.IO;
+﻿using System.IO;
 using NBitcoin.Protocol;
 
 namespace NBitcoin
@@ -14,11 +13,11 @@ namespace NBitcoin
         NetworkOptions GetNetworkOptions();
     }
 
-	public static class BitcoinSerializableExtensions
-	{
-		public static void ReadWrite(this IBitcoinSerializable serializable, Stream stream, bool serializing, ProtocolVersion version = ProtocolVersion.PROTOCOL_VERSION, 
+    public static class BitcoinSerializableExtensions
+    {
+        public static void ReadWrite(this IBitcoinSerializable serializable, Stream stream, bool serializing, ProtocolVersion version = ProtocolVersion.PROTOCOL_VERSION, 
             NetworkOptions options = null)
-		{
+        {
             // If no options have been provided then take the options from the serializable
             if (options == null && serializing && serializable is IHaveNetworkOptions)
                 options = (serializable as IHaveNetworkOptions).GetNetworkOptions();
@@ -28,25 +27,25 @@ namespace NBitcoin
                 ProtocolVersion = version,
                 TransactionOptions = options
             });
-		}
-		public static int GetSerializedSize(this IBitcoinSerializable serializable, ProtocolVersion version, SerializationType serializationType)
-		{
+        }
+        public static int GetSerializedSize(this IBitcoinSerializable serializable, ProtocolVersion version, SerializationType serializationType)
+        {
             BitcoinStream s = new BitcoinStream(Stream.Null, true);
-			s.Type = serializationType;
-			s.ReadWrite(serializable);
-			return (int)s.Counter.WrittenBytes;
-		}
-		public static int GetSerializedSize(this IBitcoinSerializable serializable, NetworkOptions options)
-		{
-			var bms = new BitcoinStream(Stream.Null, true);
-			bms.TransactionOptions = options;
-			serializable.ReadWrite(bms);
-			return (int)bms.Counter.WrittenBytes;
-		}
-		public static int GetSerializedSize(this IBitcoinSerializable serializable, ProtocolVersion version = ProtocolVersion.PROTOCOL_VERSION)
-		{
-			return GetSerializedSize(serializable, version, SerializationType.Disk);
-		}
+            s.Type = serializationType;
+            s.ReadWrite(serializable);
+            return (int)s.Counter.WrittenBytes;
+        }
+        public static int GetSerializedSize(this IBitcoinSerializable serializable, NetworkOptions options)
+        {
+            var bms = new BitcoinStream(Stream.Null, true);
+            bms.TransactionOptions = options;
+            serializable.ReadWrite(bms);
+            return (int)bms.Counter.WrittenBytes;
+        }
+        public static int GetSerializedSize(this IBitcoinSerializable serializable, ProtocolVersion version = ProtocolVersion.PROTOCOL_VERSION)
+        {
+            return GetSerializedSize(serializable, version, SerializationType.Disk);
+        }
 
         public static string ToHex(this IBitcoinSerializable serializable, SerializationType serializationType = SerializationType.Disk)
         {
@@ -61,35 +60,35 @@ namespace NBitcoin
             }
         }
 
-		public static void ReadWrite(this IBitcoinSerializable serializable, byte[] bytes, ProtocolVersion version = ProtocolVersion.PROTOCOL_VERSION, 
+        public static void ReadWrite(this IBitcoinSerializable serializable, byte[] bytes, ProtocolVersion version = ProtocolVersion.PROTOCOL_VERSION, 
             NetworkOptions options = null)
-		{
-			ReadWrite(serializable, new MemoryStream(bytes), false, version, options);
-		}
-		public static void FromBytes(this IBitcoinSerializable serializable, byte[] bytes, ProtocolVersion version = ProtocolVersion.PROTOCOL_VERSION, 
+        {
+            ReadWrite(serializable, new MemoryStream(bytes), false, version, options);
+        }
+        public static void FromBytes(this IBitcoinSerializable serializable, byte[] bytes, ProtocolVersion version = ProtocolVersion.PROTOCOL_VERSION, 
             NetworkOptions options = null)
-		{
+        {
             var bms = new BitcoinStream(bytes)
             {
                 ProtocolVersion = version,
                 TransactionOptions = options
             };
             serializable.ReadWrite(bms);
-		}
+        }
 
-		public static T Clone<T>(this T serializable, ProtocolVersion version = ProtocolVersion.PROTOCOL_VERSION) where T : IBitcoinSerializable, new()
-		{
+        public static T Clone<T>(this T serializable, ProtocolVersion version = ProtocolVersion.PROTOCOL_VERSION) where T : IBitcoinSerializable, new()
+        {
             NetworkOptions options = NetworkOptions.All;
-			var instance = new T();
+            var instance = new T();
             if (serializable is IHaveNetworkOptions)
                 options = (serializable as IHaveNetworkOptions).GetNetworkOptions();
-			instance.FromBytes(serializable.ToBytes(version, options), version, options);
-			return instance;
-		}
+            instance.FromBytes(serializable.ToBytes(version, options), version, options);
+            return instance;
+        }
         
-		public static byte[] ToBytes(this IBitcoinSerializable serializable, ProtocolVersion version = ProtocolVersion.PROTOCOL_VERSION,
+        public static byte[] ToBytes(this IBitcoinSerializable serializable, ProtocolVersion version = ProtocolVersion.PROTOCOL_VERSION,
             NetworkOptions options = null)
-		{
+        {
             // If no options have been provided then take the options from the serializable
             if (options == null && serializable is IHaveNetworkOptions)
                 options = (serializable as IHaveNetworkOptions).GetNetworkOptions();
@@ -100,9 +99,9 @@ namespace NBitcoin
                 ProtocolVersion = version,
                 TransactionOptions = options
             };
-			serializable.ReadWrite(bms);
-			return ToArrayEfficient(ms);
-		}
+            serializable.ReadWrite(bms);
+            return ToArrayEfficient(ms);
+        }
 
         public static byte[] ToArrayEfficient(this MemoryStream ms)
         {

--- a/src/NBitcoin/InMemoryNoSqlRepository.cs
+++ b/src/NBitcoin/InMemoryNoSqlRepository.cs
@@ -6,31 +6,31 @@ namespace NBitcoin
 {
     public class InMemoryNoSqlRepository : NoSqlRepository
     {
-        Dictionary<string, byte[]> _Table = new Dictionary<string, byte[]>();
+        Dictionary<string, byte[]> table = new Dictionary<string, byte[]>();
 
         public InMemoryNoSqlRepository(NetworkOptions options = null)
             :base(options)
         {
         }
 
-		protected override Task PutBytesBatch(IEnumerable<Tuple<string, byte[]>> enumerable)
-		{
-			foreach(var data in enumerable)
-			{
-				if(data.Item2 == null)
-				{
-					_Table.Remove(data.Item1);
-				}
-				else
-					_Table.AddOrReplace(data.Item1, data.Item2);
-			}
-			return Task.FromResult(true);
-		}
+        protected override Task PutBytesBatch(IEnumerable<Tuple<string, byte[]>> enumerable)
+        {
+            foreach(var data in enumerable)
+            {
+                if(data.Item2 == null)
+                {
+                    this.table.Remove(data.Item1);
+                }
+                else
+                    this.table.AddOrReplace(data.Item1, data.Item2);
+            }
+            return Task.FromResult(true);
+        }
 
         protected override Task<byte[]> GetBytes(string key)
         {
             byte[] result = null;
-            _Table.TryGetValue(key, out result);
+            this.table.TryGetValue(key, out result);
             return Task.FromResult(result);
         }
     }

--- a/src/NBitcoin/InMemoryNoSqlRepository.cs
+++ b/src/NBitcoin/InMemoryNoSqlRepository.cs
@@ -8,19 +8,24 @@ namespace NBitcoin
     {
         Dictionary<string, byte[]> _Table = new Dictionary<string, byte[]>();
 
-        protected override Task PutBytesBatch(IEnumerable<Tuple<string, byte[]>> enumerable)
+        public InMemoryNoSqlRepository(NetworkOptions options = null)
+            :base(options)
         {
-            foreach(var data in enumerable)
-            {
-                if(data.Item2 == null)
-                {
-                    _Table.Remove(data.Item1);
-                }
-                else
-                    _Table.AddOrReplace(data.Item1, data.Item2);
-            }
-            return Task.FromResult(true);
         }
+
+		protected override Task PutBytesBatch(IEnumerable<Tuple<string, byte[]>> enumerable)
+		{
+			foreach(var data in enumerable)
+			{
+				if(data.Item2 == null)
+				{
+					_Table.Remove(data.Item1);
+				}
+				else
+					_Table.AddOrReplace(data.Item1, data.Item2);
+			}
+			return Task.FromResult(true);
+		}
 
         protected override Task<byte[]> GetBytes(string key)
         {

--- a/src/NBitcoin/NetworkOptions.cs
+++ b/src/NBitcoin/NetworkOptions.cs
@@ -6,12 +6,12 @@ namespace NBitcoin
     /// The current use-case for this class is to provide option-dependent serialization.
     /// It is a drop-in replacement for the legacy TransactionOptions enumeration.
     /// </summary>
-    /// <description>
+    /// <remarks>
     /// The NetworkOptions instance is intended to be relayed from the Network object to 
     /// the child objects: Network => Block => Transaction => TxIn/TxOut => Coin => ...
     /// It can also be used on repository or stream objects that need to deserialize the 
     /// above objects or passed as a parameter futher down the call-hierarchy as needed.
-    /// </description>
+    /// </remarks>
     public class NetworkOptions
     {
         public const uint None = 0x00000000;

--- a/src/NBitcoin/NetworkOptions.cs
+++ b/src/NBitcoin/NetworkOptions.cs
@@ -27,7 +27,7 @@ namespace NBitcoin
 
         private uint flags = All;
 
-        /// <summary>To be used as placeholder until static flags have been completely removed - i.e. from the tests as well...</summary>
+        /// <summary>TODO: To be used as placeholder until static flags have been completely removed - i.e. from the tests as well...</summary>
         public static NetworkOptions TemporaryOptions
         {
             get
@@ -53,19 +53,18 @@ namespace NBitcoin
             get
             {
                 bool isPOS = (this.flags & POS) != 0;
-                // This sanity check will be removed once the static flags are removed
+                // TODO: This sanity check will be removed once the static flags are removed
                 if (isPOS != Block.BlockSignature)
                 {
-                    throw new ArgumentException($"Block.BlockSignature { Block.BlockSignature} mismatches cross-check value: { isPOS }");
+                    throw new ArgumentException($"Block.BlockSignature {Block.BlockSignature} mismatches cross-check value: {isPOS}");
                 }
-                // This sanity check will be removed once the static flags are removed
+                // TODO: This sanity check will be removed once the static flags are removed
                 if (isPOS != Transaction.TimeStamp)
                 {
-                    throw new ArgumentException($"Transaction.TimeStamp {Transaction.TimeStamp} mismatches cross-check value: { isPOS }");
+                    throw new ArgumentException($"Transaction.TimeStamp {Transaction.TimeStamp} mismatches cross-check value: {isPOS}");
                 }
                 return isPOS;
             }
-
             set
             {
                 this.flags = value ? (this.flags | POS) : (this.flags & ~POS);
@@ -81,7 +80,6 @@ namespace NBitcoin
             {
                 return (this.flags & Witness) != 0;
             }
-
             set
             {
                 this.flags = value ? (this.flags | Witness) : (this.flags & ~Witness);

--- a/src/NBitcoin/NoSqlBlockRepository.cs
+++ b/src/NBitcoin/NoSqlBlockRepository.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 
 namespace NBitcoin
@@ -16,9 +15,9 @@ namespace NBitcoin
             this.repository = repository;
         }
 
-		public NoSqlBlockRepository(NetworkOptions options = null)
-			: this(new InMemoryNoSqlRepository(options))
-		{
+        public NoSqlBlockRepository(NetworkOptions options = null)
+            : this(new InMemoryNoSqlRepository(options))
+        {
 
         }
 
@@ -26,7 +25,7 @@ namespace NBitcoin
 
         public Task<Block> GetBlockAsync(uint256 blockId)
         {
-            return repository.GetAsync<Block>(blockId.ToString());
+            return this.repository.GetAsync<Block>(blockId.ToString());
         }
 
         #endregion
@@ -37,7 +36,7 @@ namespace NBitcoin
         }
         public Task PutAsync(uint256 blockId, Block block)
         {
-            return repository.PutAsync(blockId.ToString(), block);
+            return this.repository.PutAsync(blockId.ToString(), block);
         }
     }
 
@@ -55,9 +54,9 @@ namespace NBitcoin
             this.repository = repository;
         }
 
-		public BlockTransactionMapStore(NetworkOptions options = null)
-			: this(new InMemoryNoSqlRepository(options))
-		{
+        public BlockTransactionMapStore(NetworkOptions options = null)
+            : this(new InMemoryNoSqlRepository(options))
+        {
 
         }
 

--- a/src/NBitcoin/NoSqlBlockRepository.cs
+++ b/src/NBitcoin/NoSqlBlockRepository.cs
@@ -16,9 +16,9 @@ namespace NBitcoin
             this.repository = repository;
         }
 
-        public NoSqlBlockRepository()
-            : this(new InMemoryNoSqlRepository())
-        {
+		public NoSqlBlockRepository(NetworkOptions options = null)
+			: this(new InMemoryNoSqlRepository(options))
+		{
 
         }
 
@@ -55,9 +55,9 @@ namespace NBitcoin
             this.repository = repository;
         }
 
-        public BlockTransactionMapStore()
-            : this(new InMemoryNoSqlRepository())
-        {
+		public BlockTransactionMapStore(NetworkOptions options = null)
+			: this(new InMemoryNoSqlRepository(options))
+		{
 
         }
 

--- a/src/NBitcoin/NoSqlRepository.cs
+++ b/src/NBitcoin/NoSqlRepository.cs
@@ -6,8 +6,8 @@ using System.Threading.Tasks;
 
 namespace NBitcoin
 {
-	public abstract class NoSqlRepository
-	{
+    public abstract class NoSqlRepository
+    {
         public NetworkOptions TransactionOptions { get; private set; }
 
         public NoSqlRepository(NetworkOptions options = null)
@@ -15,10 +15,10 @@ namespace NBitcoin
             this.TransactionOptions = options ?? NetworkOptions.TemporaryOptions;
         }
 
-		public Task PutAsync(string key, IBitcoinSerializable obj)
-		{
-			return PutBytes(key, obj == null ? null : obj.ToBytes(options:this.TransactionOptions));
-		}
+        public Task PutAsync(string key, IBitcoinSerializable obj)
+        {
+            return PutBytes(key, obj == null ? null : obj.ToBytes(options:this.TransactionOptions));
+        }
 
         public void Put(string key, IBitcoinSerializable obj)
         {
@@ -32,15 +32,15 @@ namespace NBitcoin
             }
         }
 
-		public async Task<T> GetAsync<T>(string key) where T : IBitcoinSerializable, new()
-		{
-			var data = await GetBytes(key).ConfigureAwait(false);
-			if(data == null)
-				return default(T);
-			T obj = new T();
-			obj.ReadWrite(data, options:this.TransactionOptions);
-			return obj;
-		}
+        public async Task<T> GetAsync<T>(string key) where T : IBitcoinSerializable, new()
+        {
+            var data = await GetBytes(key).ConfigureAwait(false);
+            if(data == null)
+                return default(T);
+            T obj = new T();
+            obj.ReadWrite(data, options:this.TransactionOptions);
+            return obj;
+        }
 
         public T Get<T>(string key) where T : IBitcoinSerializable, new()
         {

--- a/src/NBitcoin/NoSqlTransactionRepository.cs
+++ b/src/NBitcoin/NoSqlTransactionRepository.cs
@@ -10,7 +10,7 @@ namespace NBitcoin
         {
             get
             {
-                return repository;
+                return this.repository;
             }
         }
 
@@ -29,7 +29,7 @@ namespace NBitcoin
 
         public Task<Transaction> GetAsync(uint256 txId)
         {
-            return repository.GetAsync<Transaction>(GetId(txId));
+            return this.repository.GetAsync<Transaction>(GetId(txId));
         }
 
         private string GetId(uint256 txId)
@@ -39,7 +39,7 @@ namespace NBitcoin
 
         public Task PutAsync(uint256 txId, Transaction tx)
         {
-            return repository.PutAsync(GetId(txId), tx);
+            return this.repository.PutAsync(GetId(txId), tx);
         }
 
         #endregion

--- a/src/NBitcoin/NoSqlTransactionRepository.cs
+++ b/src/NBitcoin/NoSqlTransactionRepository.cs
@@ -5,31 +5,31 @@ namespace NBitcoin
 {
     public class NoSqlTransactionRepository : ITransactionRepository
     {
-        private readonly NoSqlRepository _Repository;
+        private readonly NoSqlRepository repository;
         public NoSqlRepository Repository
         {
             get
             {
-                return _Repository;
+                return repository;
             }
         }
 
-		public NoSqlTransactionRepository(NetworkOptions options = null)
+        public NoSqlTransactionRepository(NetworkOptions options = null)
             :this(new InMemoryNoSqlRepository(options))
-		{
+        {
 
         }
         public NoSqlTransactionRepository(NoSqlRepository repository)
         {
             if(repository == null)
                 throw new ArgumentNullException("repository");
-            _Repository = repository;
+            this.repository = repository;
         }
         #region ITransactionRepository Members
 
         public Task<Transaction> GetAsync(uint256 txId)
         {
-            return _Repository.GetAsync<Transaction>(GetId(txId));
+            return repository.GetAsync<Transaction>(GetId(txId));
         }
 
         private string GetId(uint256 txId)
@@ -39,7 +39,7 @@ namespace NBitcoin
 
         public Task PutAsync(uint256 txId, Transaction tx)
         {
-            return _Repository.PutAsync(GetId(txId), tx);
+            return repository.PutAsync(GetId(txId), tx);
         }
 
         #endregion

--- a/src/NBitcoin/NoSqlTransactionRepository.cs
+++ b/src/NBitcoin/NoSqlTransactionRepository.cs
@@ -14,8 +14,9 @@ namespace NBitcoin
             }
         }
 
-        public NoSqlTransactionRepository() : this(new InMemoryNoSqlRepository())
-        {
+		public NoSqlTransactionRepository(NetworkOptions options = null)
+            :this(new InMemoryNoSqlRepository(options))
+		{
 
         }
         public NoSqlTransactionRepository(NoSqlRepository repository)

--- a/src/Stratis.Bitcoin/Utilities/DBreezeSerializer.cs
+++ b/src/Stratis.Bitcoin/Utilities/DBreezeSerializer.cs
@@ -16,7 +16,7 @@ namespace Stratis.Bitcoin.Utilities
         /// <summary>
         /// Initializes custom serializers for DBreeze engine.
         /// </summary>
-        public void Initialize(NetworkOptions networkOptions = null)
+        public void Initialize(NetworkOptions networkOptions = null) // TODO: Make the NetworkOptions required
         {
             this.NetworkOptions = networkOptions;
             CustomSerializator.ByteArraySerializator = this.Serializer;

--- a/src/Stratis.Bitcoin/Utilities/DBreezeSerializer.cs
+++ b/src/Stratis.Bitcoin/Utilities/DBreezeSerializer.cs
@@ -114,7 +114,7 @@ namespace Stratis.Bitcoin.Utilities
                 return new uint256(bytes);
 
             if (type == typeof(Block))
-                return new Block(bytes, options:this.NetworkOptions);
+                return new Block(bytes/*, options:this.NetworkOptions*/);
 
             if (type == typeof(BlockStake))
                 return new BlockStake(bytes);

--- a/src/Stratis.Bitcoin/Utilities/DBreezeSerializer.cs
+++ b/src/Stratis.Bitcoin/Utilities/DBreezeSerializer.cs
@@ -11,11 +11,14 @@ namespace Stratis.Bitcoin.Utilities
     /// </summary>
     public class DBreezeSerializer
     {
+        public NetworkOptions NetworkOptions { get; private set; }
+
         /// <summary>
         /// Initializes custom serializers for DBreeze engine.
         /// </summary>
-        public void Initialize()
+        public void Initialize(NetworkOptions networkOptions = null)
         {
+            this.NetworkOptions = networkOptions;
             CustomSerializator.ByteArraySerializator = this.Serializer;
             CustomSerializator.ByteArrayDeSerializator = this.Deserializer;
         }
@@ -29,7 +32,7 @@ namespace Stratis.Bitcoin.Utilities
         {
             IBitcoinSerializable serializable = obj as IBitcoinSerializable;
             if (serializable != null)
-                return serializable.ToBytes();
+                return serializable.ToBytes(options: this.NetworkOptions);
 
             uint256 u256 = obj as uint256;
             if (u256 != null)
@@ -89,21 +92,21 @@ namespace Stratis.Bitcoin.Utilities
             if (type == typeof(Coins))
             {
                 Coins coin = new Coins();
-                coin.ReadWrite(bytes);
+                coin.ReadWrite(bytes, options:this.NetworkOptions);
                 return coin;
             }
 
             if (type == typeof(BlockHeader))
             {
                 BlockHeader header = new BlockHeader();
-                header.ReadWrite(bytes);
+                header.ReadWrite(bytes, options: this.NetworkOptions);
                 return header;
             }
 
             if (type == typeof(RewindData))
             {
                 RewindData rewind = new RewindData();
-                rewind.ReadWrite(bytes);
+                rewind.ReadWrite(bytes, options: this.NetworkOptions);
                 return rewind;
             }
 
@@ -111,7 +114,7 @@ namespace Stratis.Bitcoin.Utilities
                 return new uint256(bytes);
 
             if (type == typeof(Block))
-                return new Block(bytes);
+                return new Block(bytes, options:this.NetworkOptions);
 
             if (type == typeof(BlockStake))
                 return new BlockStake(bytes);


### PR DESCRIPTION
This PR:
1. Allows BitcoinSerializable entities to deal properly with the NetworkOptions member variable during serialization/deserialization. 
2. Injects the NetworkOptions into any new BitcoinStream created during serialization. This makes the NetworkOptions available to any child object being reconstructed from the stream.

See https://github.com/stratisproject/StratisBitcoinFullNode/issues/676