### PR TITLE
Added a test in order to ensure that every serializable object has a parameterless constructor

### DIFF
--- a/src/Stratis.Bitcoin.IntegrationTests/ConstructorsForSerializableClassesTest.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/ConstructorsForSerializableClassesTest.cs
@@ -31,13 +31,13 @@ namespace Stratis.Bitcoin.IntegrationTests
 
             foreach (var type in types)
             {
+                if (exceptionalTypes.Contains(type))
+                    continue;
+
                 bool parameterlessConstructorExists = type.GetConstructors().Any(x => x.GetParameters().Length == 0);
 
-                if (!exceptionalTypes.Contains(type))
-                {
-                    Assert.True(parameterlessConstructorExists, $"Class {type.FullName} inherits {typeof(IBitcoinSerializable).Name} " +
-                        "but doesn't have a parameterless constructor which is needed for serialization and deserialization process!");
-                }
+                Assert.True(parameterlessConstructorExists, $"Class {type.FullName} inherits {typeof(IBitcoinSerializable).Name} " +
+                    "but doesn't have a parameterless constructor which is needed for serialization and deserialization process!");
             }
         }
 

--- a/src/Stratis.Bitcoin.IntegrationTests/ConstructorsForSerializableClassesTest.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/ConstructorsForSerializableClassesTest.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using NBitcoin;
+using Xunit;
+
+namespace Stratis.Bitcoin.IntegrationTests
+{
+    public class ConstructorsForSerializableClassesTest
+    {
+        [Fact]
+        public void AssureParameterlessConstructorsExistenceForSerializableClasses()
+        {
+            // This list contain types that inherit IBitcoinSerializable but don't have a public
+            // parameterless constructor for a good reason so they should not fail this test.
+            List<Type> exceptionalTypes = new List<Type>()
+            {
+                typeof(NBitcoin.ExtKey),
+                typeof(NBitcoin.ExtPubKey),
+                typeof(NBitcoin.PubKey),
+                typeof(NBitcoin.Protocol.CompactVarInt),
+                typeof(NBitcoin.BitcoinCore.StoredBlock),
+                typeof(NBitcoin.BitcoinCore.StoredItem<>)
+            };
+
+            var assemblies = AppDomain.CurrentDomain.GetAssemblies().Where(x =>
+                x.FullName.Contains("Stratis") || x.FullName.Contains("NBitcoin")).ToList();
+
+            Assert.True(assemblies.Count != 0);
+
+            List<Type> serializableTypes = new List<Type>();
+
+            //collect all types that inherit IBitcoinSerializable
+            foreach (var assembly in assemblies)
+            {
+                foreach (var type in assembly.GetTypes())
+                {
+                    var interfaces = type.GetInterfaces();
+                    if (interfaces.Contains(typeof(IBitcoinSerializable)))
+                        serializableTypes.Add(type);
+                }
+            }
+
+            //ensure each type implements a parameterless constructor.
+            foreach (var type in serializableTypes)
+            {
+                if (!type.IsClass)
+                    continue;
+
+                bool parameterlessConstructorExists = type.GetConstructors().Any(x => x.GetParameters().Length == 0);
+
+                if (!exceptionalTypes.Contains(type))
+                {
+                    Assert.True(parameterlessConstructorExists, $"Class {type.FullName} inherits {typeof(IBitcoinSerializable).Name} " +
+                        "but doesn't have a parameterless constructor which is needed for serialization and deserialization process!");
+                }
+            }
+        }
+
+        /// <summary>
+        /// Serializes input and returns deserialized object.
+        /// </summary>
+        /// <remarks>Needed for troubleshooting this test.</remarks>
+        private T CloneViaSerializeDeserialize<T>(T input) where T : IBitcoinSerializable
+        {
+            MemoryStream ms = new MemoryStream();
+            BitcoinStream bitcoinStream = new BitcoinStream(ms, true);
+
+            input.ReadWrite(bitcoinStream);
+            ms.Position = 0;
+
+            bitcoinStream = new BitcoinStream(bitcoinStream.Inner, false);
+            var obj = Activator.CreateInstance<T>();
+            obj.ReadWrite(bitcoinStream);
+            return obj;
+        }
+    }
+}

--- a/src/Stratis.Bitcoin.IntegrationTests/Stratis.Bitcoin.IntegrationTests.csproj
+++ b/src/Stratis.Bitcoin.IntegrationTests/Stratis.Bitcoin.IntegrationTests.csproj
@@ -28,10 +28,15 @@
   <ItemGroup>
     <ProjectReference Include="..\NBitcoin\NBitcoin.csproj" />
     <ProjectReference Include="..\Stratis.Bitcoin.Features.Api\Stratis.Bitcoin.Features.Api.csproj" />
+    <ProjectReference Include="..\Stratis.Bitcoin.Features.BlockStore\Stratis.Bitcoin.Features.BlockStore.csproj" />
     <ProjectReference Include="..\Stratis.Bitcoin.Features.Consensus\Stratis.Bitcoin.Features.Consensus.csproj" />
+    <ProjectReference Include="..\Stratis.Bitcoin.Features.LightWallet\Stratis.Bitcoin.Features.LightWallet.csproj" />
+    <ProjectReference Include="..\Stratis.Bitcoin.Features.MemoryPool\Stratis.Bitcoin.Features.MemoryPool.csproj" />
     <ProjectReference Include="..\Stratis.Bitcoin.Features.Miner\Stratis.Bitcoin.Features.Miner.csproj" />
+    <ProjectReference Include="..\Stratis.Bitcoin.Features.Notifications\Stratis.Bitcoin.Features.Notifications.csproj" />
     <ProjectReference Include="..\Stratis.Bitcoin.Features.RPC\Stratis.Bitcoin.Features.RPC.csproj" />
     <ProjectReference Include="..\Stratis.Bitcoin.Features.Wallet\Stratis.Bitcoin.Features.Wallet.csproj" />
+    <ProjectReference Include="..\Stratis.Bitcoin.Features.WatchOnlyWallet\Stratis.Bitcoin.Features.WatchOnlyWallet.csproj" />
     <ProjectReference Include="..\Stratis.Bitcoin\Stratis.Bitcoin.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
This test is added in order to prevent scenarios when devs (like me) would delete a parameterless constructor that is never referenced in the codebase thinking that it's useless and then break the node by that. 