### PR TITLE
Add NetworkOptions to Block and BlockHeader

### DIFF
--- a/src/NBitcoin/BitcoinStream.cs
+++ b/src/NBitcoin/BitcoinStream.cs
@@ -374,7 +374,7 @@ namespace NBitcoin
             }
             set
             {
-                this.transactionSupportedOptions = value;
+                this.transactionSupportedOptions = value ?? throw new ArgumentNullException("A null network options should not be passed here.");
             }
         }
 

--- a/src/NBitcoin/IBitcoinSerializable.cs
+++ b/src/NBitcoin/IBitcoinSerializable.cs
@@ -19,13 +19,13 @@ namespace NBitcoin
             NetworkOptions options = null)
         {
             // If no options have been provided then take the options from the serializable
-            if (options == null && serializing && serializable is IHaveNetworkOptions)
-                options = (serializable as IHaveNetworkOptions).GetNetworkOptions();
+            if (options == null && serializing && serializable is IHaveNetworkOptions haveNetworkOptions)
+                options = haveNetworkOptions.GetNetworkOptions();
 
             serializable.ReadWrite(new BitcoinStream(stream, serializing)
             {
                 ProtocolVersion = version,
-                TransactionOptions = options
+                TransactionOptions = options ?? NetworkOptions.TemporaryOptions
             });
         }
         public static int GetSerializedSize(this IBitcoinSerializable serializable, ProtocolVersion version, SerializationType serializationType)

--- a/src/NBitcoin/IBitcoinSerializable.cs
+++ b/src/NBitcoin/IBitcoinSerializable.cs
@@ -72,7 +72,7 @@ namespace NBitcoin
             var bms = new BitcoinStream(bytes)
             {
                 ProtocolVersion = version,
-                TransactionOptions = options
+                TransactionOptions = options ?? NetworkOptions.TemporaryOptions
             };
             serializable.ReadWrite(bms);
         }


### PR DESCRIPTION
This PR adds NetworkOptions to Block and BlockHeader.

The following files are updated:
- Block.cs
- BlockHeader.cs
- BitcoinStream.cs

See https://github.com/stratisproject/StratisBitcoinFullNode/issues/676