### PR TITLE
Api and RPC integration Test fixtures

### DIFF
--- a/src/Stratis.Bitcoin.IntegrationTests/Program.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/Program.cs
@@ -4,7 +4,7 @@
     {
         public static void Main(string[] args)
         {
-            new WalletTests().CanSendToAddress();
+            new WalletTests().CanMineAndSendToAddress();
         }
     }
 }

--- a/src/Stratis.Bitcoin.IntegrationTests/WalletTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/WalletTests.cs
@@ -78,7 +78,7 @@ namespace Stratis.Bitcoin.IntegrationTests
         }
 
         [Fact]
-        public void CanMineBlocks()
+        public void CanMineAndSendToAddress()
         {
             using (NodeBuilder builder = NodeBuilder.Create())
             {
@@ -88,19 +88,7 @@ namespace Stratis.Bitcoin.IntegrationTests
                 var rpc = stratisNodeSync.CreateRPCClient();
                 rpc.SendCommand(NBitcoin.RPC.RPCOperations.generate, 10);
                 Assert.Equal(10, rpc.GetBlockCount());
-            }
-        }
 
-        [Fact]
-        public void CanSendToAddress()
-        {
-            using (NodeBuilder builder = NodeBuilder.Create())
-            {
-                CoreNode stratisNodeSync = builder.CreateStratisPowNode();
-                this.InitializeTestWallet(stratisNodeSync);
-                builder.StartAll();
-                var rpc = stratisNodeSync.CreateRPCClient();
-                rpc.SendCommand(NBitcoin.RPC.RPCOperations.generate, 101);
                 var address = new Key().PubKey.GetAddress(rpc.Network);
                 var tx = rpc.SendToAddress(address, Money.Coins(1.0m));
                 Assert.NotNull(tx);


### PR DESCRIPTION
I've created separate fixtures for the api and rpc integration tests. This will speed them up tremendously from 1-2 seconds per test to 10-300miliseconds per test. 
I've also merged two of the integration tests because one was just an additional action after the other. Integration tests are expensive and this saves another 4 seconds locally for me.