### PR TITLE
For chain searches use skip list method instead of linear searches

### DIFF
--- a/src/NBitcoin.Tests/ChainTests.cs
+++ b/src/NBitcoin.Tests/ChainTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
@@ -194,7 +195,7 @@ namespace NBitcoin.Tests
 
         private void AssertFork(ConcurrentChain chain, ConcurrentChain chain2, ChainedBlock expectedFork)
         {
-            var fork = chain.FindFork(chain2);
+            var fork = this.FindFork(chain, chain2);
             Assert.Equal(expectedFork, fork);
             fork = chain.Tip.FindFork(chain2.Tip);
             Assert.Equal(expectedFork, fork);
@@ -203,7 +204,7 @@ namespace NBitcoin.Tests
             chain = chain2;
             chain2 = temp;
 
-            fork = chain.FindFork(chain2);
+            fork = this.FindFork(chain, chain2);
             Assert.Equal(expectedFork, fork);
             fork = chain.Tip.FindFork(chain2.Tip);
             Assert.Equal(expectedFork, fork);
@@ -573,5 +574,18 @@ namespace NBitcoin.Tests
             return AppendBlock(index, chains);
         }
 
+        /// <summary>
+        /// Returns the first common chained block header between two chains.
+        /// </summary>
+        /// <param name="chainSrc">The source chain.</param>
+        /// <param name="otherChain">The other chain.</param>
+        /// <returns>First common chained block header or <c>null</c>.</returns>
+        private ChainedBlock FindFork(ChainBase chainSrc, ChainBase otherChain)
+        {
+            if (otherChain == null)
+                throw new ArgumentNullException("otherChain");
+
+            return chainSrc.FindFork(otherChain.Tip.EnumerateToGenesis().Select(o => o.HashBlock));
+        }
     }
 }

--- a/src/NBitcoin/ChainBase.cs
+++ b/src/NBitcoin/ChainBase.cs
@@ -234,7 +234,7 @@ namespace NBitcoin
 
             while (true)
             {
-                ChainedBlock b = GetBlock(i);
+                ChainedBlock b = this.GetBlock(i);
                 if ((b == null) || (b.Previous != prev))
                     yield break;
 

--- a/src/NBitcoin/ChainBase.cs
+++ b/src/NBitcoin/ChainBase.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace NBitcoin
 {
@@ -142,19 +141,6 @@ namespace NBitcoin
         public Target GetWorkRequired(Network network, int height)
         {
             return this.GetBlock(height).GetWorkRequired(network);
-        }
-
-        /// <summary>
-        /// Returns the first common chained block header between two chains.
-        /// </summary>
-        /// <param name="chain">The other chain.</param>
-        /// <returns>First common chained block header or <c>null</c>.</returns>
-        public ChainedBlock FindFork(ChainBase chain)
-        {
-            if (chain == null)
-                throw new ArgumentNullException("chain");
-
-            return this.FindFork(chain.Tip.EnumerateToGenesis().Select(o => o.HashBlock));
         }
 
         /// <summary>

--- a/src/NBitcoin/ChainedBlock.cs
+++ b/src/NBitcoin/ChainedBlock.cs
@@ -186,7 +186,11 @@ namespace NBitcoin
 
         /// <summary>
         /// Finds the ancestor of this entry in the chain that matches the chained block header specified.
-        /// <remarks>Will first search assuming on existing chain if not then will assume might be a different chain and then will linearly search for the hash.</remarks>
+        /// This can be used when you not sure whether the <paramref name="chainedBlockHeader"/> is on
+        /// the same chain as this block header or not.
+        /// <remarks>Will first search assuming on same chain and looking up height using skiplist, 
+        /// if doesn't match then will assume might be a different chain and then will linearly search 
+        /// for the hash.</remarks>
         /// </summary>
         /// <param name="chainedBlockHeader">The chained block header to search for.</param>
         /// <returns>The chained block header or null if can't be found.</returns>

--- a/src/NBitcoin/ChainedBlock.cs
+++ b/src/NBitcoin/ChainedBlock.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using NBitcoin.BouncyCastle.Math;
 
 namespace NBitcoin
@@ -183,6 +182,20 @@ namespace NBitcoin
         public override string ToString()
         {
             return this.Height + "-" + this.HashBlock;
+        }
+
+        /// <summary>
+        /// Finds the ancestor of this entry in the chain that matches the chained block header specified.
+        /// <remarks>Will first search assuming on existing chain if not then will assume might be a different chain and then will linearly search for the hash.</remarks>
+        /// </summary>
+        /// <param name="chainedBlockHeader">The chained block header to search for.</param>
+        /// <returns>The chained block header or null if can't be found.</returns>
+        public ChainedBlock FindAncestor(ChainedBlock chainedBlockHeader)
+        {
+            ChainedBlock found = this.GetAncestor(chainedBlockHeader.Height);
+            if (found.HashBlock == chainedBlockHeader.HashBlock)
+                return found;
+            return this.FindAncestorOrSelf(chainedBlockHeader.HashBlock);
         }
 
         /// <summary>

--- a/src/NBitcoin/ChainedBlock.cs
+++ b/src/NBitcoin/ChainedBlock.cs
@@ -311,7 +311,7 @@ namespace NBitcoin
                 pastHeight = lastBlock.Height - (consensus.DifficultyAdjustmentInterval - 1);
             }
 
-            ChainedBlock firstChainedBlock = this.EnumerateToGenesis().FirstOrDefault(o => o.Height == pastHeight);
+            ChainedBlock firstChainedBlock = this.GetAncestor((int)pastHeight);
             if (firstChainedBlock == null)
                 throw new NotSupportedException("Can only calculate work of a full chain");
 

--- a/src/NBitcoin/ChainedBlock.cs
+++ b/src/NBitcoin/ChainedBlock.cs
@@ -186,20 +186,17 @@ namespace NBitcoin
 
         /// <summary>
         /// Finds the ancestor of this entry in the chain that matches the chained block header specified.
-        /// This can be used when you not sure whether the <paramref name="chainedBlockHeader"/> is on
-        /// the same chain as this block header or not.
-        /// <remarks>Will first search assuming on same chain and looking up height using skiplist, 
-        /// if doesn't match then will assume might be a different chain and then will linearly search 
-        /// for the hash.</remarks>
+        /// <remarks>It will compare the hash at the same height in the chain to verify the chained block
+        /// header has been found.</remarks>
         /// </summary>
         /// <param name="chainedBlockHeader">The chained block header to search for.</param>
-        /// <returns>The chained block header or null if can't be found.</returns>
-        public ChainedBlock FindAncestor(ChainedBlock chainedBlockHeader)
+        /// <returns>The chained block header or <c>null</c> if can't be found.</returns>
+        public ChainedBlock FindAncestorOrSelf(ChainedBlock chainedBlockHeader)
         {
             ChainedBlock found = this.GetAncestor(chainedBlockHeader.Height);
             if ((found != null) && (found.HashBlock == chainedBlockHeader.HashBlock))
                 return found;
-            return this.FindAncestorOrSelf(chainedBlockHeader.HashBlock);
+            return null;
         }
 
         /// <summary>
@@ -457,6 +454,7 @@ namespace NBitcoin
                     lowChain = lowChain.Previous;
                     highChain = highChain.Previous;
                 }
+
                 if ((lowChain == null) || (highChain == null))
                     return null;
             }

--- a/src/NBitcoin/ChainedBlock.cs
+++ b/src/NBitcoin/ChainedBlock.cs
@@ -197,7 +197,7 @@ namespace NBitcoin
         public ChainedBlock FindAncestor(ChainedBlock chainedBlockHeader)
         {
             ChainedBlock found = this.GetAncestor(chainedBlockHeader.Height);
-            if (found.HashBlock == chainedBlockHeader.HashBlock)
+            if (found != null && (found.HashBlock == chainedBlockHeader.HashBlock))
                 return found;
             return this.FindAncestorOrSelf(chainedBlockHeader.HashBlock);
         }

--- a/src/NBitcoin/ChainedBlock.cs
+++ b/src/NBitcoin/ChainedBlock.cs
@@ -197,7 +197,7 @@ namespace NBitcoin
         public ChainedBlock FindAncestor(ChainedBlock chainedBlockHeader)
         {
             ChainedBlock found = this.GetAncestor(chainedBlockHeader.Height);
-            if (found != null && (found.HashBlock == chainedBlockHeader.HashBlock))
+            if ((found != null) && (found.HashBlock == chainedBlockHeader.HashBlock))
                 return found;
             return this.FindAncestorOrSelf(chainedBlockHeader.HashBlock);
         }

--- a/src/NBitcoin/ChainedBlock.cs
+++ b/src/NBitcoin/ChainedBlock.cs
@@ -443,8 +443,16 @@ namespace NBitcoin
 
             while (highChain.HashBlock != lowChain.HashBlock)
             {
-                lowChain = lowChain.Previous;
-                highChain = highChain.Previous;
+                if (highChain.Skip != lowChain.Skip)
+                {
+                    highChain = highChain.Skip;
+                    lowChain = lowChain.Skip;
+                }
+                else
+                {
+                    lowChain = lowChain.Previous;
+                    highChain = highChain.Previous;
+                }
                 if ((lowChain == null) || (highChain == null))
                     return null;
             }

--- a/src/NBitcoin/ChainedBlock.cs
+++ b/src/NBitcoin/ChainedBlock.cs
@@ -186,16 +186,17 @@ namespace NBitcoin
 
         /// <summary>
         /// Finds the ancestor of this entry in the chain that matches the chained block header specified.
-        /// <remarks>It will compare the hash at the same height in the chain to verify the chained block
-        /// header has been found.</remarks>
         /// </summary>
         /// <param name="chainedBlockHeader">The chained block header to search for.</param>
         /// <returns>The chained block header or <c>null</c> if can't be found.</returns>
+        /// <remarks>This method compares the hash of the block header at the same height in the current chain 
+        /// to verify the correct chained block header has been found.</remarks>
         public ChainedBlock FindAncestorOrSelf(ChainedBlock chainedBlockHeader)
         {
             ChainedBlock found = this.GetAncestor(chainedBlockHeader.Height);
             if ((found != null) && (found.HashBlock == chainedBlockHeader.HashBlock))
                 return found;
+
             return null;
         }
 

--- a/src/Stratis.Bitcoin.Features.Consensus/Extensions.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/Extensions.cs
@@ -12,10 +12,8 @@ namespace Stratis.Bitcoin.Features.Consensus
         {
             ChainedBlock highest = newTip.Height > tip.Height ? newTip : tip;
             ChainedBlock lowest = highest == newTip ? tip : newTip;
-            while (lowest.Height != highest.Height)
-            {
-                highest = highest.Previous;
-            }
+
+            highest = highest.GetAncestor(lowest.Height);
 
             while (lowest.HashBlock != highest.HashBlock)
             {

--- a/src/Stratis.Bitcoin.Features.Consensus/Extensions.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/Extensions.cs
@@ -8,22 +8,6 @@ namespace Stratis.Bitcoin.Features.Consensus
 {
     public static class Extensions
     {
-        public static ChainedBlock FindFork(this ChainedBlock newTip, ChainedBlock tip)
-        {
-            ChainedBlock highest = newTip.Height > tip.Height ? newTip : tip;
-            ChainedBlock lowest = highest == newTip ? tip : newTip;
-
-            highest = highest.GetAncestor(lowest.Height);
-
-            while (lowest.HashBlock != highest.HashBlock)
-            {
-                lowest = lowest.Previous;
-                highest = highest.Previous;
-            }
-
-            return highest;
-        }
-
         public static async Task<bool> IfPayloadIsAsync<TPayload>(this Message message, Func<TPayload, Task> action) where TPayload : Payload
         {
             TPayload payload = message.Payload as TPayload;

--- a/src/Stratis.Bitcoin.Features.LightWallet/LightWalletSyncManager.cs
+++ b/src/Stratis.Bitcoin.Features.LightWallet/LightWalletSyncManager.cs
@@ -200,7 +200,7 @@ namespace Stratis.Bitcoin.Features.LightWallet
 
                 if (newTip.Height > this.walletTip.Height)
                 {
-                    ChainedBlock findTip = newTip.FindAncestorOrSelf(this.walletTip.HashBlock);
+                    ChainedBlock findTip = newTip.FindAncestorOrSelf(this.walletTip);
                     if (findTip == null)
                     {
                         this.logger.LogTrace("(-)[NEW_TIP_AHEAD_NOT_IN_WALLET]");
@@ -216,7 +216,7 @@ namespace Stratis.Bitcoin.Features.LightWallet
                 }
                 else
                 {
-                    ChainedBlock findTip = this.walletTip.FindAncestorOrSelf(newTip.HashBlock);
+                    ChainedBlock findTip = this.walletTip.FindAncestorOrSelf(newTip);
                     if (findTip == null)
                     {
                         this.logger.LogTrace("(-)[NEW_TIP_BEHIND_NOT_IN_WALLET]");

--- a/src/Stratis.Bitcoin.Features.Wallet/WalletSyncManager.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/WalletSyncManager.cs
@@ -139,7 +139,7 @@ namespace Stratis.Bitcoin.Features.Wallet
 
                 if (newTip.Height > this.walletTip.Height)
                 {
-                    ChainedBlock findTip = newTip.FindAncestor(this.walletTip);
+                    ChainedBlock findTip = newTip.FindAncestorOrSelf(this.walletTip);
                     if (findTip == null)
                     {
                         this.logger.LogTrace("(-)[NEW_TIP_AHEAD_NOT_IN_WALLET]");
@@ -197,7 +197,7 @@ namespace Stratis.Bitcoin.Features.Wallet
                 }
                 else
                 {
-                    ChainedBlock findTip = this.walletTip.FindAncestor(newTip);
+                    ChainedBlock findTip = this.walletTip.FindAncestorOrSelf(newTip);
                     if (findTip == null)
                     {
                         this.logger.LogTrace("(-)[NEW_TIP_BEHIND_NOT_IN_WALLET]");

--- a/src/Stratis.Bitcoin.Features.Wallet/WalletSyncManager.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/WalletSyncManager.cs
@@ -197,7 +197,7 @@ namespace Stratis.Bitcoin.Features.Wallet
                 }
                 else
                 {
-                    ChainedBlock findTip = this.walletTip.GetAncestor(newTip.Height);
+                    ChainedBlock findTip = this.walletTip.FindAncestor(newTip);
                     if (findTip == null)
                     {
                         this.logger.LogTrace("(-)[NEW_TIP_BEHIND_NOT_IN_WALLET]");

--- a/src/Stratis.Bitcoin.Features.Wallet/WalletSyncManager.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/WalletSyncManager.cs
@@ -139,7 +139,7 @@ namespace Stratis.Bitcoin.Features.Wallet
 
                 if (newTip.Height > this.walletTip.Height)
                 {
-                    ChainedBlock findTip = newTip.GetAncestor(this.walletTip.Height);
+                    ChainedBlock findTip = newTip.FindAncestor(this.walletTip);
                     if (findTip == null)
                     {
                         this.logger.LogTrace("(-)[NEW_TIP_AHEAD_NOT_IN_WALLET]");

--- a/src/Stratis.Bitcoin.Features.Wallet/WalletSyncManager.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/WalletSyncManager.cs
@@ -139,7 +139,7 @@ namespace Stratis.Bitcoin.Features.Wallet
 
                 if (newTip.Height > this.walletTip.Height)
                 {
-                    ChainedBlock findTip = newTip.FindAncestorOrSelf(this.walletTip.HashBlock);
+                    ChainedBlock findTip = newTip.GetAncestor(this.walletTip.Height);
                     if (findTip == null)
                     {
                         this.logger.LogTrace("(-)[NEW_TIP_AHEAD_NOT_IN_WALLET]");
@@ -197,7 +197,7 @@ namespace Stratis.Bitcoin.Features.Wallet
                 }
                 else
                 {
-                    ChainedBlock findTip = this.walletTip.FindAncestorOrSelf(newTip.HashBlock);
+                    ChainedBlock findTip = this.walletTip.GetAncestor(newTip.Height);
                     if (findTip == null)
                     {
                         this.logger.LogTrace("(-)[NEW_TIP_BEHIND_NOT_IN_WALLET]");


### PR DESCRIPTION
This PR 
* Replaces linear searches on chain headers with GetAncestor which uses skip list to search for block heights which will improve performance
* Move FindFork method that was only used by tests into tests

Issue #659 
