### PR TITLE
Attempt to fix stopwatch test

### DIFF
--- a/src/Stratis.Bitcoin.Tests/Utilities/StopwatchTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Utilities/StopwatchTest.cs
@@ -37,6 +37,9 @@ namespace Stratis.Bitcoin.Tests.Utilities
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
                 return;
 
+            // Give the testing environment a chance to settle down a little bit.
+            Thread.Sleep(5000);
+
             int epsilonMs = 100;
             int expectedElapsedMs = 0;
             long elapsedTicksByDispStopwatch = 0;

--- a/src/Stratis.Bitcoin.Tests/Utilities/StopwatchTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Utilities/StopwatchTest.cs
@@ -37,7 +37,7 @@ namespace Stratis.Bitcoin.Tests.Utilities
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
                 return;
 
-            int epsilonMs = 50;
+            int epsilonMs = 100;
             int expectedElapsedMs = 0;
             long elapsedTicksByDispStopwatch = 0;
 


### PR DESCRIPTION
It seems that the testing environment is quite unreliable. We thus try to
- increase the epsilon to accept slightly worse results than before
- wait a bit before the test starts in case some post processing is still going on (like GC or whatever) from previous tests