### PR TITLE
initialize network once and then use it consistently

### DIFF
--- a/src/Stratis.Bitcoin.IntegrationTests/P2P/PeerConnectionTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/P2P/PeerConnectionTests.cs
@@ -18,6 +18,12 @@ namespace Stratis.Bitcoin.IntegrationTests.P2P
         private INodeLifetime nodeLifetime;
         private NodeSettings nodeSettings;
         private IPeerAddressManager peerAddressManager;
+        private readonly Network network;
+
+        public PeerConnectionTests()
+        {
+            this.network = Network.Main;
+        }
 
         /// <summary>
         /// This tests the fact that we can't find and connect to a
@@ -28,14 +34,14 @@ namespace Stratis.Bitcoin.IntegrationTests.P2P
         {
             this.CreateTestContext("PeerConnectorAddNode_PeerAlreadyConnected_Scenario1");
 
-            var peerConnectorAddNode = new PeerConnectorAddNode(new AsyncLoopFactory(this.loggerFactory), DateTimeProvider.Default, this.loggerFactory, Network.StratisMain, this.networkPeerFactory, this.nodeLifetime, this.nodeSettings, this.peerAddressManager);
-            var peerDiscovery = new PeerDiscovery(new AsyncLoopFactory(this.loggerFactory), this.loggerFactory, Network.StratisMain, this.networkPeerFactory, this.nodeLifetime, this.nodeSettings, this.peerAddressManager);
+            var peerConnectorAddNode = new PeerConnectorAddNode(new AsyncLoopFactory(this.loggerFactory), DateTimeProvider.Default, this.loggerFactory, this.network, this.networkPeerFactory, this.nodeLifetime, this.nodeSettings, this.peerAddressManager);
+            var peerDiscovery = new PeerDiscovery(new AsyncLoopFactory(this.loggerFactory), this.loggerFactory, this.network, this.networkPeerFactory, this.nodeLifetime, this.nodeSettings, this.peerAddressManager);
 
             IConnectionManager connectionManager = new ConnectionManager(
                 new AsyncLoopFactory(this.loggerFactory),
                 DateTimeProvider.Default,
                 this.loggerFactory,
-                Network.StratisTest,
+                this.network,
                 this.networkPeerFactory,
                 this.nodeSettings,
                 this.nodeLifetime,

--- a/src/Stratis.Bitcoin.Tests/P2P/PeerConnectorTests.cs
+++ b/src/Stratis.Bitcoin.Tests/P2P/PeerConnectorTests.cs
@@ -14,11 +14,11 @@ namespace Stratis.Bitcoin.Tests.P2P
     public sealed class PeerConnectorTests
     {
         private readonly IAsyncLoopFactory asyncLoopFactory;
-        private readonly IConnectionManager connectionManager;
         private readonly ExtendedLoggerFactory loggerFactory;
         private readonly NetworkPeerFactory networkPeerFactory;
         private readonly NetworkPeerConnectionParameters networkPeerParameters;
         private readonly NodeLifetime nodeLifetime;
+        private readonly Network network;
 
         public PeerConnectorTests()
         {
@@ -29,6 +29,7 @@ namespace Stratis.Bitcoin.Tests.P2P
             this.networkPeerFactory = new NetworkPeerFactory(DateTimeProvider.Default, this.loggerFactory);
             this.networkPeerParameters = new NetworkPeerConnectionParameters();
             this.nodeLifetime = new NodeLifetime();
+            this.network = Network.Main;
         }
 
         [Fact]
@@ -197,7 +198,7 @@ namespace Stratis.Bitcoin.Tests.P2P
 
         private PeerConnectorAddNode CreatePeerConnecterAddNode(NodeSettings nodeSettings, IPeerAddressManager peerAddressManager)
         {
-            var peerConnector = new PeerConnectorAddNode(this.asyncLoopFactory, DateTimeProvider.Default, this.loggerFactory, Network.StratisTest, this.networkPeerFactory, this.nodeLifetime, nodeSettings, peerAddressManager);
+            var peerConnector = new PeerConnectorAddNode(this.asyncLoopFactory, DateTimeProvider.Default, this.loggerFactory, this.network, this.networkPeerFactory, this.nodeLifetime, nodeSettings, peerAddressManager);
             var connectionManager = CreateConnectionManager(nodeSettings, peerAddressManager, peerConnector);
             peerConnector.Initialize(connectionManager);
             return peerConnector;
@@ -205,7 +206,7 @@ namespace Stratis.Bitcoin.Tests.P2P
 
         private PeerConnectorConnectNode CreatePeerConnectorConnectNode(NodeSettings nodeSettings, IPeerAddressManager peerAddressManager)
         {
-            var peerConnector = new PeerConnectorConnectNode(this.asyncLoopFactory, DateTimeProvider.Default, this.loggerFactory, Network.StratisTest, this.networkPeerFactory, this.nodeLifetime, nodeSettings, peerAddressManager);
+            var peerConnector = new PeerConnectorConnectNode(this.asyncLoopFactory, DateTimeProvider.Default, this.loggerFactory, this.network, this.networkPeerFactory, this.nodeLifetime, nodeSettings, peerAddressManager);
             var connectionManager = CreateConnectionManager(nodeSettings, peerAddressManager, peerConnector);
             peerConnector.Initialize(connectionManager);
             return peerConnector;
@@ -213,7 +214,7 @@ namespace Stratis.Bitcoin.Tests.P2P
 
         private PeerConnectorDiscovery CreatePeerConnectorDiscovery(NodeSettings nodeSettings, IPeerAddressManager peerAddressManager)
         {
-            var peerConnector = new PeerConnectorDiscovery(this.asyncLoopFactory, DateTimeProvider.Default, this.loggerFactory, Network.StratisTest, this.networkPeerFactory, this.nodeLifetime, nodeSettings, peerAddressManager);
+            var peerConnector = new PeerConnectorDiscovery(this.asyncLoopFactory, DateTimeProvider.Default, this.loggerFactory, this.network, this.networkPeerFactory, this.nodeLifetime, nodeSettings, peerAddressManager);
             var connectionManager = CreateConnectionManager(nodeSettings, peerAddressManager, peerConnector);
             peerConnector.Initialize(connectionManager);
             return peerConnector;
@@ -225,7 +226,7 @@ namespace Stratis.Bitcoin.Tests.P2P
                 new AsyncLoopFactory(this.loggerFactory),
                 DateTimeProvider.Default,
                 this.loggerFactory,
-                Network.StratisTest,
+                this.network,
                 this.networkPeerFactory,
                 nodeSettings,
                 this.nodeLifetime,


### PR DESCRIPTION
in one method two different networks were used, i think this was bug, 
so instead i'm suggesting that we decide on the network in test class constructor and then we can't be inconsistent