### PR TITLE
Added IsPropagated flag to wallet transaction data and changed how SendTransaction works. 

### DIFF
--- a/src/Stratis.Bitcoin.Features.LightWallet.Tests/LightWalletSyncManagerTest.cs
+++ b/src/Stratis.Bitcoin.Features.LightWallet.Tests/LightWalletSyncManagerTest.cs
@@ -4,6 +4,7 @@ using System.Threading;
 using Microsoft.Extensions.Logging;
 using Moq;
 using NBitcoin;
+using Stratis.Bitcoin.Features.Notifications;
 using Stratis.Bitcoin.Features.Notifications.Interfaces;
 using Stratis.Bitcoin.Features.Wallet;
 using Stratis.Bitcoin.Features.Wallet.Interfaces;
@@ -54,7 +55,7 @@ namespace Stratis.Bitcoin.Features.LightWallet.Tests
         }
 
         /// <summary>
-        /// If the <see cref="WalletManager"/> does not contain a single <see cref="Wallet.Wallet"/> the <see cref="LightWalletSyncManager.WalletTip"/>
+        /// If the <see cref="WalletManager"/> does not contain a single <see cref="Wallet"/> the <see cref="LightWalletSyncManager.WalletTip"/>
         /// must be set to the <see cref="ConcurrentChain.Tip"/>.
         /// </summary>
         [Fact]
@@ -72,7 +73,7 @@ namespace Stratis.Bitcoin.Features.LightWallet.Tests
         }
 
         /// <summary>
-        /// If the <see cref="WalletManager"/> contains a <see cref="Wallet.Wallet"/> and the <see cref="WalletManager.WalletTipHash"/> can be found
+        /// If the <see cref="WalletManager"/> contains a <see cref="Wallet"/> and the <see cref="WalletManager.WalletTipHash"/> can be found
         /// on the <see cref="ConcurrentChain"/> request the earliest wallet block height from the WalletManager.
         /// Start syncing from that height and set the <see cref="LightWalletSyncManager.WalletTip"/> to that block.
         /// </summary>
@@ -97,7 +98,7 @@ namespace Stratis.Bitcoin.Features.LightWallet.Tests
         }
 
         /// <summary>
-        /// If the <see cref="WalletManager"/> contains a <see cref="Wallet.Wallet"/> and the <see cref="WalletManager.WalletTipHash"/> can be found
+        /// If the <see cref="WalletManager"/> contains a <see cref="Wallet"/> and the <see cref="WalletManager.WalletTipHash"/> can be found
         /// on the <see cref="ConcurrentChain"/> request the earliest wallet block height from the WalletManager.
         /// Start syncing from that height and set the <see cref="LightWalletSyncManager.WalletTip"/> to that block.
         /// </summary>
@@ -124,7 +125,7 @@ namespace Stratis.Bitcoin.Features.LightWallet.Tests
         }
 
         /// <summary>
-        /// If the <see cref="WalletManager"/> contains a <see cref="Wallet.Wallet"/> and the <see cref="WalletManager.WalletTipHash"/> can not be found
+        /// If the <see cref="WalletManager"/> contains a <see cref="Wallet"/> and the <see cref="WalletManager.WalletTipHash"/> can not be found
         /// on the <see cref="ConcurrentChain"/> we are not on the best chain anymore.
         /// Lookup the point at which the chain forked and remove all blocks after that point.
         /// Start syncing from the earliest wallet height if that is before the fork point and set the <see cref="LightWalletSyncManager.WalletTip"/> to that block.
@@ -158,7 +159,7 @@ namespace Stratis.Bitcoin.Features.LightWallet.Tests
         }
 
         /// <summary>
-        /// If the <see cref="WalletManager"/> contains a <see cref="Wallet.Wallet"/> and the <see cref="WalletManager.WalletTipHash"/> can not be found
+        /// If the <see cref="WalletManager"/> contains a <see cref="Wallet"/> and the <see cref="WalletManager.WalletTipHash"/> can not be found
         /// on the <see cref="ConcurrentChain"/> we are not on the best chain anymore.
         /// Lookup the point at which the chain forked and remove all blocks after that point.
         /// Start syncing from the fork point if that is after the fork point and set the <see cref="LightWalletSyncManager.WalletTip"/> to that block.
@@ -192,7 +193,7 @@ namespace Stratis.Bitcoin.Features.LightWallet.Tests
         }
 
         /// <summary>
-        /// If the <see cref="WalletManager"/> contains a <see cref="Wallet.Wallet"/> and the <see cref="WalletManager.WalletTipHash"/> can not be found
+        /// If the <see cref="WalletManager"/> contains a <see cref="Wallet"/> and the <see cref="WalletManager.WalletTipHash"/> can not be found
         /// on the <see cref="ConcurrentChain"/> we are not on the best chain anymore.
         /// Lookup the point at which the chain forked and remove all blocks after that point.
         /// Start syncing from the oldest wallet creation time if the WalletManager does not have an earliest wallet height.
@@ -230,7 +231,7 @@ namespace Stratis.Bitcoin.Features.LightWallet.Tests
         }
 
         /// <summary>
-        /// If the <see cref="WalletManager"/> contains a <see cref="Wallet.Wallet"/> and the <see cref="WalletManager.WalletTipHash"/> can not be found
+        /// If the <see cref="WalletManager"/> contains a <see cref="Wallet"/> and the <see cref="WalletManager.WalletTipHash"/> can not be found
         /// on the <see cref="ConcurrentChain"/> we are not on the best chain anymore.
         /// Lookup the point at which the chain forked and remove all blocks after that point.
         /// Start syncing from the oldest wallet creation time if the WalletManager does not have an earliest wallet height.
@@ -268,7 +269,7 @@ namespace Stratis.Bitcoin.Features.LightWallet.Tests
         }
 
         /// <summary>
-        /// If the <see cref="WalletManager"/> contains a <see cref="Wallet.Wallet"/> and the <see cref="ConcurrentChain"/> does not contain any blocks
+        /// If the <see cref="WalletManager"/> contains a <see cref="Wallet"/> and the <see cref="ConcurrentChain"/> does not contain any blocks
         /// start the sync from the genesis block and set the <see cref="LightWalletSyncManager.WalletTip"/> to that.
         /// </summary>
         [Fact]

--- a/src/Stratis.Bitcoin.Features.LightWallet.Tests/LightWalletSyncManagerTest.cs
+++ b/src/Stratis.Bitcoin.Features.LightWallet.Tests/LightWalletSyncManagerTest.cs
@@ -473,7 +473,7 @@ namespace Stratis.Bitcoin.Features.LightWallet.Tests
 
             lightWalletSyncManager.ProcessTransaction(transaction);
 
-            this.walletManager.Verify(w => w.ProcessTransaction(transaction, null, null, null));
+            this.walletManager.Verify(w => w.ProcessTransaction(transaction, null, null, true));
         }
 
         /// <summary>

--- a/src/Stratis.Bitcoin.Features.LightWallet.Tests/LightWalletSyncManagerTest.cs
+++ b/src/Stratis.Bitcoin.Features.LightWallet.Tests/LightWalletSyncManagerTest.cs
@@ -35,7 +35,7 @@ namespace Stratis.Bitcoin.Features.LightWallet.Tests
             this.nodeLifetime = new Mock<INodeLifetime>();
             this.asyncLoopFactory = new Mock<IAsyncLoopFactory>();
             this.network = Network.StratisMain;
-            
+
             // Do not assume that the preceding line will set these flags.
             Transaction.TimeStamp = true;
             Block.BlockSignature = true;
@@ -472,7 +472,7 @@ namespace Stratis.Bitcoin.Features.LightWallet.Tests
 
             lightWalletSyncManager.ProcessTransaction(transaction);
 
-            this.walletManager.Verify(w => w.ProcessTransaction(transaction, null, null));
+            this.walletManager.Verify(w => w.ProcessTransaction(transaction, null, null, null));
         }
 
         /// <summary>

--- a/src/Stratis.Bitcoin.Features.Wallet.Tests/WalletControllerTest.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet.Tests/WalletControllerTest.cs
@@ -1355,11 +1355,8 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
         public void SendTransactionSuccessfulReturnsWalletSendTransactionModelResponse()
         {
             string transactionHex = "010000000189c041f79aac3aa7e7a72804a9a55cd9eceba41a0586640f602eb9823540ce89010000006b483045022100ab9597b37cb8796aefa30b207abb248c8003d4d153076997e375b0daf4f9f7050220546397fee1cefe54c49210ea653e9e61fb88adf51b68d2c04ad6d2b46ddf97a30121035cc9de1f233469dad8a3bbd1e61b699a7dd8e0d8370c6f3b1f2a16167da83546ffffffff02f6400a00000000001976a914accf603142aaa5e22dc82500d3e187caf712f11588ac3cf61700000000001976a91467872601dda216fbf4cab7891a03ebace87d8e7488ac00000000";
-            Transaction transaction = Transaction.Parse(transactionHex);
 
             var mockWalletWrapper = new Mock<IBroadcasterManager>();
-            mockWalletWrapper.Setup(m => m.TryBroadcastAsync(It.IsAny<Transaction>()))
-                .Returns(Task.FromResult(true));
 
             var controller = new WalletController(this.LoggerFactory.Object, new Mock<IWalletManager>().Object, new Mock<IWalletTransactionHandler>().Object, new Mock<IWalletSyncManager>().Object, It.IsAny<ConnectionManager>(), Network.Main, new Mock<ConcurrentChain>().Object, mockWalletWrapper.Object, DateTimeProvider.Default);
             IActionResult result = controller.SendTransactionAsync(new SendTransactionRequest(transactionHex)).GetAwaiter().GetResult();
@@ -1378,8 +1375,6 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
         public void SendTransactionFailedReturnsBadRequest()
         {
             var mockWalletWrapper = new Mock<IBroadcasterManager>();
-            mockWalletWrapper.Setup(m => m.TryBroadcastAsync(It.IsAny<Transaction>()))
-                .Returns(Task.FromResult(false));
 
             var controller = new WalletController(this.LoggerFactory.Object, new Mock<IWalletManager>().Object, new Mock<IWalletTransactionHandler>().Object, new Mock<IWalletSyncManager>().Object, It.IsAny<ConnectionManager>(), Network.Main, new Mock<ConcurrentChain>().Object, mockWalletWrapper.Object, DateTimeProvider.Default);
             IActionResult result = controller.SendTransactionAsync(new SendTransactionRequest(new uint256(15555).ToString())).GetAwaiter().GetResult();
@@ -1415,7 +1410,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
         public void SendTransactionWithExceptionReturnsBadRequest()
         {
             var mockWalletWrapper = new Mock<IBroadcasterManager>();
-            mockWalletWrapper.Setup(m => m.TryBroadcastAsync(It.IsAny<Transaction>()))
+            mockWalletWrapper.Setup(m => m.BroadcastTransaction(It.IsAny<Transaction>()))
                 .Throws(new InvalidOperationException("Issue building transaction."));
 
             var controller = new WalletController(this.LoggerFactory.Object, new Mock<IWalletManager>().Object, new Mock<IWalletTransactionHandler>().Object, new Mock<IWalletSyncManager>().Object, It.IsAny<ConnectionManager>(), Network.Main, new Mock<ConcurrentChain>().Object, mockWalletWrapper.Object, DateTimeProvider.Default);

--- a/src/Stratis.Bitcoin.Features.Wallet.Tests/WalletControllerTest.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet.Tests/WalletControllerTest.cs
@@ -1359,7 +1359,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
             var mockWalletWrapper = new Mock<IBroadcasterManager>();
 
             var controller = new WalletController(this.LoggerFactory.Object, new Mock<IWalletManager>().Object, new Mock<IWalletTransactionHandler>().Object, new Mock<IWalletSyncManager>().Object, It.IsAny<ConnectionManager>(), Network.Main, new Mock<ConcurrentChain>().Object, mockWalletWrapper.Object, DateTimeProvider.Default);
-            IActionResult result = controller.SendTransactionAsync(new SendTransactionRequest(transactionHex)).GetAwaiter().GetResult();
+            IActionResult result = controller.SendTransaction(new SendTransactionRequest(transactionHex));
 
             JsonResult viewResult = Assert.IsType<JsonResult>(result);
             var model = viewResult.Value as WalletSendTransactionModel;
@@ -1377,7 +1377,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
             var mockWalletWrapper = new Mock<IBroadcasterManager>();
 
             var controller = new WalletController(this.LoggerFactory.Object, new Mock<IWalletManager>().Object, new Mock<IWalletTransactionHandler>().Object, new Mock<IWalletSyncManager>().Object, It.IsAny<ConnectionManager>(), Network.Main, new Mock<ConcurrentChain>().Object, mockWalletWrapper.Object, DateTimeProvider.Default);
-            IActionResult result = controller.SendTransactionAsync(new SendTransactionRequest(new uint256(15555).ToString())).GetAwaiter().GetResult();
+            IActionResult result = controller.SendTransaction(new SendTransactionRequest(new uint256(15555).ToString()));
 
             ErrorResult errorResult = Assert.IsType<ErrorResult>(result);
             ErrorResponse errorResponse = Assert.IsType<ErrorResponse>(errorResult.Value);
@@ -1395,7 +1395,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
 
             var controller = new WalletController(this.LoggerFactory.Object, mockWalletWrapper.Object, new Mock<IWalletTransactionHandler>().Object, new Mock<IWalletSyncManager>().Object, It.IsAny<ConnectionManager>(), Network.Main, new Mock<ConcurrentChain>().Object, new Mock<IBroadcasterManager>().Object, DateTimeProvider.Default);
             controller.ModelState.AddModelError("Hex", "Hex required.");
-            IActionResult result = controller.SendTransactionAsync(new SendTransactionRequest("")).GetAwaiter().GetResult();
+            IActionResult result = controller.SendTransaction(new SendTransactionRequest(""));
 
             ErrorResult errorResult = Assert.IsType<ErrorResult>(result);
             ErrorResponse errorResponse = Assert.IsType<ErrorResponse>(errorResult.Value);
@@ -1415,7 +1415,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
 
             var controller = new WalletController(this.LoggerFactory.Object, new Mock<IWalletManager>().Object, new Mock<IWalletTransactionHandler>().Object, new Mock<IWalletSyncManager>().Object, It.IsAny<ConnectionManager>(), Network.Main, new Mock<ConcurrentChain>().Object, mockWalletWrapper.Object, DateTimeProvider.Default);
 
-            IActionResult result = controller.SendTransactionAsync(new SendTransactionRequest(new uint256(15555).ToString())).GetAwaiter().GetResult();
+            IActionResult result = controller.SendTransaction(new SendTransactionRequest(new uint256(15555).ToString()));
 
             ErrorResult errorResult = Assert.IsType<ErrorResult>(result);
             ErrorResponse errorResponse = Assert.IsType<ErrorResponse>(errorResult.Value);

--- a/src/Stratis.Bitcoin.Features.Wallet.Tests/WalletControllerTest.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet.Tests/WalletControllerTest.cs
@@ -1,13 +1,18 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net;
+using System.Net.Sockets;
 using System.Security;
 using System.Threading.Tasks;
+using Castle.Components.DictionaryAdapter;
 using Microsoft.AspNetCore.Mvc;
 using Moq;
 using NBitcoin;
+using NBitcoin.Protocol;
+using Stratis.Bitcoin.Configuration.Logging;
 using Stratis.Bitcoin.Connection;
 using Stratis.Bitcoin.Features.Wallet.Controllers;
 using Stratis.Bitcoin.Features.Wallet.Interfaces;
@@ -1357,8 +1362,11 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
             string transactionHex = "010000000189c041f79aac3aa7e7a72804a9a55cd9eceba41a0586640f602eb9823540ce89010000006b483045022100ab9597b37cb8796aefa30b207abb248c8003d4d153076997e375b0daf4f9f7050220546397fee1cefe54c49210ea653e9e61fb88adf51b68d2c04ad6d2b46ddf97a30121035cc9de1f233469dad8a3bbd1e61b699a7dd8e0d8370c6f3b1f2a16167da83546ffffffff02f6400a00000000001976a914accf603142aaa5e22dc82500d3e187caf712f11588ac3cf61700000000001976a91467872601dda216fbf4cab7891a03ebace87d8e7488ac00000000";
 
             var mockWalletWrapper = new Mock<IBroadcasterManager>();
+            var connectionManagerMock = new Mock<IConnectionManager>();
+            connectionManagerMock.Setup(c => c.ConnectedNodes).Returns(new TestReadOnlyNetworkPeerCollection());
 
-            var controller = new WalletController(this.LoggerFactory.Object, new Mock<IWalletManager>().Object, new Mock<IWalletTransactionHandler>().Object, new Mock<IWalletSyncManager>().Object, It.IsAny<ConnectionManager>(), Network.Main, new Mock<ConcurrentChain>().Object, mockWalletWrapper.Object, DateTimeProvider.Default);
+            var controller = new WalletController(this.LoggerFactory.Object, new Mock<IWalletManager>().Object, new Mock<IWalletTransactionHandler>().Object,
+                new Mock<IWalletSyncManager>().Object, connectionManagerMock.Object, Network.Main, new Mock<ConcurrentChain>().Object, mockWalletWrapper.Object, DateTimeProvider.Default);
             IActionResult result = controller.SendTransaction(new SendTransactionRequest(transactionHex));
 
             JsonResult viewResult = Assert.IsType<JsonResult>(result);
@@ -1372,20 +1380,29 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
         }
 
         [Fact]
-        public void SendTransactionFailedReturnsBadRequest()
+        public void SendTransactionFailedBecauseNoNodesConnected()
         {
             var mockWalletWrapper = new Mock<IBroadcasterManager>();
 
-            var controller = new WalletController(this.LoggerFactory.Object, new Mock<IWalletManager>().Object, new Mock<IWalletTransactionHandler>().Object, new Mock<IWalletSyncManager>().Object, It.IsAny<ConnectionManager>(), Network.Main, new Mock<ConcurrentChain>().Object, mockWalletWrapper.Object, DateTimeProvider.Default);
-            IActionResult result = controller.SendTransaction(new SendTransactionRequest(new uint256(15555).ToString()));
+            var connectionManagerMock = new Mock<IConnectionManager>();
+            connectionManagerMock.Setup(c => c.ConnectedNodes)
+                .Returns(new NetworkPeerCollection());
 
-            ErrorResult errorResult = Assert.IsType<ErrorResult>(result);
-            ErrorResponse errorResponse = Assert.IsType<ErrorResponse>(errorResult.Value);
-            Assert.Single(errorResponse.Errors);
+            WalletController controller = new WalletController(this.LoggerFactory.Object, new Mock<IWalletManager>().Object, new Mock<IWalletTransactionHandler>().Object,
+                new Mock<IWalletSyncManager>().Object, connectionManagerMock.Object, Network.Main, new Mock<ConcurrentChain>().Object, mockWalletWrapper.Object, DateTimeProvider.Default);
 
-            ErrorModel error = errorResponse.Errors[0];
-            Assert.Equal(400, error.Status);
-            Assert.NotNull(error.Message);
+            bool walletExceptionOccurred = false;
+
+            try
+            {
+                controller.SendTransaction(new SendTransactionRequest(new uint256(15555).ToString()));
+            }
+            catch (WalletException)
+            {
+                walletExceptionOccurred = true;
+            }
+
+            Assert.True(walletExceptionOccurred);
         }
 
         [Fact]
@@ -1404,27 +1421,6 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
             ErrorModel error = errorResponse.Errors[0];
             Assert.Equal(400, error.Status);
             Assert.Equal("Hex required.", error.Message);
-        }
-
-        [Fact]
-        public void SendTransactionWithExceptionReturnsBadRequest()
-        {
-            var mockWalletWrapper = new Mock<IBroadcasterManager>();
-            mockWalletWrapper.Setup(m => m.BroadcastTransaction(It.IsAny<Transaction>()))
-                .Throws(new InvalidOperationException("Issue building transaction."));
-
-            var controller = new WalletController(this.LoggerFactory.Object, new Mock<IWalletManager>().Object, new Mock<IWalletTransactionHandler>().Object, new Mock<IWalletSyncManager>().Object, It.IsAny<ConnectionManager>(), Network.Main, new Mock<ConcurrentChain>().Object, mockWalletWrapper.Object, DateTimeProvider.Default);
-
-            IActionResult result = controller.SendTransaction(new SendTransactionRequest(new uint256(15555).ToString()));
-
-            ErrorResult errorResult = Assert.IsType<ErrorResult>(result);
-            ErrorResponse errorResponse = Assert.IsType<ErrorResponse>(errorResult.Value);
-            Assert.Single(errorResponse.Errors);
-
-            ErrorModel error = errorResponse.Errors[0];
-            Assert.Equal(400, error.Status);
-            Assert.StartsWith("System.InvalidOperationException", error.Description);
-            Assert.Equal("Issue building transaction.", error.Message);
         }
 
         [Fact]
@@ -1718,4 +1714,45 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
             Assert.Equal(expectedFee, actualFee);
         }
     }
+
+    public class TestReadOnlyNetworkPeerCollection : IReadOnlyNetworkPeerCollection
+    {
+        public event EventHandler<NetworkPeerEventArgs> Added;
+        public event EventHandler<NetworkPeerEventArgs> Removed;
+
+        private List<NetworkPeer> networkPeers;
+
+        public TestReadOnlyNetworkPeerCollection()
+        {
+            this.networkPeers = new List<NetworkPeer>();
+            this.networkPeers.Add(null);
+        }
+
+        public NetworkPeer FindByEndpoint(IPEndPoint endpoint)
+        {
+            return null;
+        }
+
+        public NetworkPeer FindByIp(IPAddress ip)
+        {
+            return null;
+        }
+
+        public NetworkPeer FindLocal()
+        {
+            return null;
+        }
+
+        public IEnumerator<NetworkPeer> GetEnumerator()
+        {
+            return this.networkPeers.GetEnumerator();
+        }
+
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
+        {
+            return this.GetEnumerator();
+        }
+    }
 }
+
+

--- a/src/Stratis.Bitcoin.Features.Wallet.Tests/WalletSyncManagerTest.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet.Tests/WalletSyncManagerTest.cs
@@ -254,7 +254,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
 
             walletSyncManager.ProcessTransaction(transaction);
 
-            this.walletManager.Verify(w => w.ProcessTransaction(transaction, null, null));
+            this.walletManager.Verify(w => w.ProcessTransaction(transaction, null, null, null));
         }
 
         /// <summary>

--- a/src/Stratis.Bitcoin.Features.Wallet.Tests/WalletSyncManagerTest.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet.Tests/WalletSyncManagerTest.cs
@@ -254,7 +254,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
 
             walletSyncManager.ProcessTransaction(transaction);
 
-            this.walletManager.Verify(w => w.ProcessTransaction(transaction, null, null, null));
+            this.walletManager.Verify(w => w.ProcessTransaction(transaction, null, null, true));
         }
 
         /// <summary>

--- a/src/Stratis.Bitcoin.Features.Wallet/Broadcasting/BroadcasterManagerBase.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Broadcasting/BroadcasterManagerBase.cs
@@ -60,14 +60,14 @@ namespace Stratis.Bitcoin.Features.Wallet.Broadcasting
             }
         }
 
-        public abstract void BroadcastTransaction(Transaction transaction);
+        public abstract Task BroadcastTransactionAsync(Transaction transaction);
 
         /// <summary>
         /// Sends transaction to peers.
         /// </summary>
         /// <param name="transaction">Transaction that will be propagated.</param>
         /// <param name="skipHalfOfThePeers">If set to <c>true</c> transaction will be send to all the peers we are connected to. Otherwise it will be sent to half of them.</param>
-        protected void PropagateTransactionToPeers(Transaction transaction, bool skipHalfOfThePeers = false)
+        protected async Task PropagateTransactionToPeersAsync(Transaction transaction, bool skipHalfOfThePeers = false)
         {
             this.AddOrUpdate(transaction, State.ToBroadcast);
 
@@ -77,7 +77,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Broadcasting
             int propagateToCount = skipHalfOfThePeers ? (int)Math.Ceiling(peers.Count / 2.0) : peers.Count;
 
             for (int i = 0; i < propagateToCount; ++i)
-                peers[i].SendMessageAsync(invPayload).GetAwaiter().GetResult();
+                await peers[i].SendMessageAsync(invPayload);
         }
 
         protected bool IsPropagated(Transaction transaction)

--- a/src/Stratis.Bitcoin.Features.Wallet/Broadcasting/BroadcasterManagerBase.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Broadcasting/BroadcasterManagerBase.cs
@@ -17,17 +17,13 @@ namespace Stratis.Bitcoin.Features.Wallet.Broadcasting
         public event EventHandler<TransactionBroadcastEntry> TransactionStateChanged;
 
         /// <summary> Connection manager for managing node connections.</summary>
-        protected readonly IConnectionManager connectionManager;
+        private readonly IConnectionManager connectionManager;
 
-        /// <summary> Wallet manager.</summary>
-        protected readonly IWalletManager walletManager;
-
-        public BroadcasterManagerBase(IConnectionManager connectionManager, IWalletManager walletManager)
+        public BroadcasterManagerBase(IConnectionManager connectionManager)
         {
             Guard.NotNull(connectionManager, nameof(connectionManager));
 
             this.connectionManager = connectionManager;
-            this.walletManager = walletManager;
             this.Broadcasts = new ConcurrentHashSet<TransactionBroadcastEntry>();
         }
 
@@ -62,8 +58,6 @@ namespace Stratis.Bitcoin.Features.Wallet.Broadcasting
                 broadcastEntry.State = state;
                 this.OnTransactionStateChanged(broadcastEntry);
             }
-
-            this.walletManager.ProcessTransaction(transaction, null, null, state == State.Propagated);
         }
 
         public abstract void BroadcastTransaction(Transaction transaction);

--- a/src/Stratis.Bitcoin.Features.Wallet/Broadcasting/FullNodeBroadcasterManager.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Broadcasting/FullNodeBroadcasterManager.cs
@@ -23,22 +23,18 @@ namespace Stratis.Bitcoin.Features.Wallet.Broadcasting
         }
 
         /// <inheritdoc />
-        public override void BroadcastTransaction(Transaction transaction)
+        public override async Task BroadcastTransactionAsync(Transaction transaction)
         {
-            if (transaction == null)
-                throw new ArgumentNullException(nameof(transaction));
+            Guard.NotNull(transaction, nameof(transaction));
 
             if (this.IsPropagated(transaction))
                 return;
 
             var state = new MempoolValidationState(false);
-            if (!this.mempoolValidator.AcceptToMemoryPool(state, transaction).GetAwaiter().GetResult())
-            {
+            if (!await this.mempoolValidator.AcceptToMemoryPool(state, transaction))
                 this.AddOrUpdate(transaction, State.CantBroadcast);
-                return;
-            }
-
-            this.PropagateTransactionToPeers(transaction, true);
+            else
+                await this.PropagateTransactionToPeersAsync(transaction, true);
         }
     }
 }

--- a/src/Stratis.Bitcoin.Features.Wallet/Broadcasting/FullNodeBroadcasterManager.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Broadcasting/FullNodeBroadcasterManager.cs
@@ -15,7 +15,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Broadcasting
         /// <summary>Memory pool validator for validating transactions.</summary>
         private readonly IMempoolValidator mempoolValidator;
 
-        public FullNodeBroadcasterManager(IConnectionManager connectionManager, IMempoolValidator mempoolValidator, IWalletManager walletManager) : base(connectionManager, walletManager)
+        public FullNodeBroadcasterManager(IConnectionManager connectionManager, IMempoolValidator mempoolValidator) : base(connectionManager)
         {
             Guard.NotNull(mempoolValidator, nameof(mempoolValidator));
 

--- a/src/Stratis.Bitcoin.Features.Wallet/Broadcasting/LightWalletBroadcasterManager.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Broadcasting/LightWalletBroadcasterManager.cs
@@ -11,7 +11,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Broadcasting
     {
         private TimeSpan broadcastMaxTime = TimeSpan.FromSeconds(21);
 
-        public LightWalletBroadcasterManager(IConnectionManager connectionManager, IWalletManager walletManager) : base(connectionManager, walletManager)
+        public LightWalletBroadcasterManager(IConnectionManager connectionManager) : base(connectionManager)
         {
         }
 

--- a/src/Stratis.Bitcoin.Features.Wallet/Broadcasting/LightWalletBroadcasterManager.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Broadcasting/LightWalletBroadcasterManager.cs
@@ -4,6 +4,7 @@ using NBitcoin;
 using Stratis.Bitcoin.Broadcasting;
 using Stratis.Bitcoin.Connection;
 using Stratis.Bitcoin.Features.Wallet.Interfaces;
+using Stratis.Bitcoin.Utilities;
 
 namespace Stratis.Bitcoin.Features.Wallet.Broadcasting
 {
@@ -16,15 +17,14 @@ namespace Stratis.Bitcoin.Features.Wallet.Broadcasting
         }
 
         /// <inheritdoc />
-        public override void BroadcastTransaction(Transaction transaction)
+        public override async Task BroadcastTransactionAsync(Transaction transaction)
         {
-            if (transaction == null)
-                throw new ArgumentNullException(nameof(transaction));
+            Guard.NotNull(transaction, nameof(transaction));
 
             if (this.IsPropagated(transaction))
                 return;
 
-            this.PropagateTransactionToPeers(transaction, true);
+            await this.PropagateTransactionToPeersAsync(transaction, true);
         }
     }
 }

--- a/src/Stratis.Bitcoin.Features.Wallet/Broadcasting/LightWalletBroadcasterManager.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Broadcasting/LightWalletBroadcasterManager.cs
@@ -3,7 +3,7 @@ using System.Threading.Tasks;
 using NBitcoin;
 using Stratis.Bitcoin.Broadcasting;
 using Stratis.Bitcoin.Connection;
-using Stratis.Bitcoin.P2P.Protocol.Payloads;
+using Stratis.Bitcoin.Features.Wallet.Interfaces;
 
 namespace Stratis.Bitcoin.Features.Wallet.Broadcasting
 {
@@ -11,35 +11,20 @@ namespace Stratis.Bitcoin.Features.Wallet.Broadcasting
     {
         private TimeSpan broadcastMaxTime = TimeSpan.FromSeconds(21);
 
-        public LightWalletBroadcasterManager(IConnectionManager connectionManager) : base(connectionManager)
+        public LightWalletBroadcasterManager(IConnectionManager connectionManager, IWalletManager walletManager) : base(connectionManager, walletManager)
         {
         }
 
         /// <inheritdoc />
-        public override async Task<bool> TryBroadcastAsync(Transaction transaction)
+        public override void BroadcastTransaction(Transaction transaction)
         {
             if (transaction == null)
                 throw new ArgumentNullException(nameof(transaction));
 
             if (this.IsPropagated(transaction))
-                return true;
+                return;
 
             this.PropagateTransactionToPeers(transaction, true);
-
-            var elapsed = TimeSpan.Zero;
-            var checkFrequency = TimeSpan.FromSeconds(1);
-
-            while (elapsed < this.broadcastMaxTime)
-            {
-                var transactionEntry = this.GetTransaction(transaction.GetHash());
-                if (transactionEntry != null && transactionEntry.State == State.Propagated)
-                    return true;
-
-                await Task.Delay(checkFrequency).ConfigureAwait(false);
-                elapsed += checkFrequency;
-            }
-
-            throw new TimeoutException("Transaction propagation has timed out. Lost connection?");
         }
     }
 }

--- a/src/Stratis.Bitcoin.Features.Wallet/Controllers/WalletController.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Controllers/WalletController.cs
@@ -618,7 +618,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Controllers
 
                 this.walletManager.ProcessTransaction(transaction, null, null, false);
 
-                this.broadcasterManager.BroadcastTransaction(transaction);
+                this.broadcasterManager.BroadcastTransactionAsync(transaction).GetAwaiter().GetResult();
 
                 return this.Json(model);
             }

--- a/src/Stratis.Bitcoin.Features.Wallet/Controllers/WalletController.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Controllers/WalletController.cs
@@ -584,7 +584,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Controllers
         /// <returns></returns>
         [Route("send-transaction")]
         [HttpPost]
-        public async Task<IActionResult> SendTransactionAsync([FromBody] SendTransactionRequest request)
+        public IActionResult SendTransaction([FromBody] SendTransactionRequest request)
         {
             Guard.NotNull(request, nameof(request));
 

--- a/src/Stratis.Bitcoin.Features.Wallet/Controllers/WalletController.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Controllers/WalletController.cs
@@ -595,9 +595,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Controllers
             }
 
             if (!this.connectionManager.ConnectedNodes.Any())
-            {
                 throw new WalletException("Can't send transaction: sending transaction requires at least one connection!");
-            }
 
             try
             {
@@ -618,14 +616,11 @@ namespace Stratis.Bitcoin.Features.Wallet.Controllers
                     });
                 }
 
-                bool broadcasted = await this.broadcasterManager.TryBroadcastAsync(transaction).ConfigureAwait(false);
+                this.walletManager.ProcessTransaction(transaction, null, null, false);
 
-                if (broadcasted)
-                    return this.Json(model);
-                else
-                {
-                    throw new Exception(string.Format("Transaction was not sent correctly. Investigate current instance of {0} for more information.", typeof(IBroadcasterManager).Name));
-                }
+                this.broadcasterManager.BroadcastTransaction(transaction);
+
+                return this.Json(model);
             }
             catch (Exception e)
             {

--- a/src/Stratis.Bitcoin.Features.Wallet/Controllers/WalletController.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Controllers/WalletController.cs
@@ -594,6 +594,11 @@ namespace Stratis.Bitcoin.Features.Wallet.Controllers
                 return BuildErrorResponse(this.ModelState);
             }
 
+            if (!this.connectionManager.ConnectedNodes.Any())
+            {
+                throw new WalletException("Can't send transaction: sending transaction requires at least one connection!");
+            }
+
             try
             {
                 var transaction = new Transaction(request.Hex);

--- a/src/Stratis.Bitcoin.Features.Wallet/Interfaces/IWalletManager.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Interfaces/IWalletManager.cs
@@ -156,7 +156,8 @@ namespace Stratis.Bitcoin.Features.Wallet.Interfaces
         /// <param name="transaction">The transaction.</param>
         /// <param name="blockHeight">The height of the block this transaction came from. Null if it was not a transaction included in a block.</param>
         /// <param name="block">The block in which this transaction was included.</param>
-        void ProcessTransaction(Transaction transaction, int? blockHeight = null, Block block = null);
+        /// <param name="isPropagated">Transaction propagation state. Null if unknown.</param>
+        void ProcessTransaction(Transaction transaction, int? blockHeight = null, Block block = null, bool? isPropagated = null);
 
         /// <summary>
         /// Saves the wallet into the file system.

--- a/src/Stratis.Bitcoin.Features.Wallet/Interfaces/IWalletManager.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Interfaces/IWalletManager.cs
@@ -156,7 +156,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Interfaces
         /// <param name="transaction">The transaction.</param>
         /// <param name="blockHeight">The height of the block this transaction came from. Null if it was not a transaction included in a block.</param>
         /// <param name="block">The block in which this transaction was included.</param>
-        /// <param name="isPropagated">Transaction propagation state. Null if unknown.</param>
+        /// <param name="isPropagated">Transaction propagation state.</param>
         void ProcessTransaction(Transaction transaction, int? blockHeight = null, Block block = null, bool isPropagated = true);
 
         /// <summary>

--- a/src/Stratis.Bitcoin.Features.Wallet/Interfaces/IWalletManager.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Interfaces/IWalletManager.cs
@@ -157,7 +157,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Interfaces
         /// <param name="blockHeight">The height of the block this transaction came from. Null if it was not a transaction included in a block.</param>
         /// <param name="block">The block in which this transaction was included.</param>
         /// <param name="isPropagated">Transaction propagation state. Null if unknown.</param>
-        void ProcessTransaction(Transaction transaction, int? blockHeight = null, Block block = null, bool? isPropagated = null);
+        void ProcessTransaction(Transaction transaction, int? blockHeight = null, Block block = null, bool isPropagated = true);
 
         /// <summary>
         /// Saves the wallet into the file system.

--- a/src/Stratis.Bitcoin.Features.Wallet/Wallet.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Wallet.cs
@@ -799,6 +799,12 @@ namespace Stratis.Bitcoin.Features.Wallet
         public string Hex { get; set; }
 
         /// <summary>
+        /// Propagation state of this transaction.
+        /// </summary>
+        [JsonProperty(PropertyName = "isPropagated", NullValueHandling = NullValueHandling.Ignore)]
+        public bool IsPropagated { get; set; }
+
+        /// <summary>
         /// Gets or sets the full transaction object.
         /// </summary>
         [JsonIgnore]

--- a/src/Stratis.Bitcoin.Features.Wallet/Wallet.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Wallet.cs
@@ -801,8 +801,9 @@ namespace Stratis.Bitcoin.Features.Wallet
         /// <summary>
         /// Propagation state of this transaction.
         /// </summary>
+        /// <remarks>Assume it's <c>true</c> if the field is <c>null</c>.</remarks>
         [JsonProperty(PropertyName = "isPropagated", NullValueHandling = NullValueHandling.Ignore)]
-        public bool IsPropagated { get; set; }
+        public bool? IsPropagated { get; set; }
 
         /// <summary>
         /// Gets or sets the full transaction object.

--- a/src/Stratis.Bitcoin.Features.Wallet/WalletManager.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/WalletManager.cs
@@ -99,7 +99,7 @@ namespace Stratis.Bitcoin.Features.Wallet
         // every time we find a trx that credits we need to add it to this lookup
         // private Dictionary<OutPoint, TransactionData> outpointLookup;
         internal Dictionary<Script, HdAddress> keysLookup;
-        
+
         public WalletManager(
             ILoggerFactory loggerFactory,
             Network network,
@@ -145,7 +145,7 @@ namespace Stratis.Bitcoin.Features.Wallet
         {
             if (transactionEntry.State == State.Propagated)
             {
-                this.ProcessTransaction(transactionEntry.Transaction);
+                this.ProcessTransaction(transactionEntry.Transaction, null, null, true);
             }
         }
 
@@ -733,7 +733,7 @@ namespace Stratis.Bitcoin.Features.Wallet
             lock (this.lockObject)
             {
                 foreach (Transaction transaction in block.Transactions)
-                    this.ProcessTransaction(transaction, chainedBlock.Height, block);
+                    this.ProcessTransaction(transaction, chainedBlock.Height, block, true);
 
                 // Update the wallets with the last processed block height.
                 this.UpdateLastBlockSyncedHeight(chainedBlock);
@@ -743,7 +743,7 @@ namespace Stratis.Bitcoin.Features.Wallet
         }
 
         /// <inheritdoc />
-        public void ProcessTransaction(Transaction transaction, int? blockHeight = null, Block block = null)
+        public void ProcessTransaction(Transaction transaction, int? blockHeight = null, Block block = null, bool? isPropagated = null)
         {
             Guard.NotNull(transaction, nameof(transaction));
             uint256 hash = transaction.GetHash();
@@ -763,7 +763,8 @@ namespace Stratis.Bitcoin.Features.Wallet
                     // Check if the outputs contain one of our addresses.
                     if (this.keysLookup.TryGetValue(utxo.ScriptPubKey, out HdAddress pubKey))
                     {
-                        this.AddTransactionToWallet(transaction.ToHex(), hash, transaction.Time, transaction.IsCoinStake, transaction.Outputs.IndexOf(utxo), utxo.Value, utxo.ScriptPubKey, blockHeight, block);
+                        this.AddTransactionToWallet(transaction.ToHex(), hash, transaction.Time, transaction.IsCoinStake, transaction.Outputs.IndexOf(utxo),
+                            utxo.Value, utxo.ScriptPubKey, blockHeight, block, isPropagated ?? block != null);
                         foundTrx.Add(Tuple.Create(utxo.ScriptPubKey, hash));
                     }
                 }
@@ -819,8 +820,9 @@ namespace Stratis.Bitcoin.Features.Wallet
         /// <param name="blockHeight">Height of the block.</param>
         /// <param name="block">The block containing the transaction to add.</param>
         /// <param name="transactionHex">The hexadecimal representation of the transaction.</param>
+        /// <param name="isPropagated">Propagation state of the transaction.</param>
         private void AddTransactionToWallet(string transactionHex, uint256 transactionHash, uint time, bool isCoinStake, int index, Money amount, Script script,
-            int? blockHeight = null, Block block = null)
+            int? blockHeight = null, Block block = null, bool isPropagated = false)
         {
             this.logger.LogTrace("({0}:'{1}',{2}:'{3}',{4}:{5},{6}:{7},{8}:{9},{10}:{11},{12}:{13})", nameof(transactionHex), transactionHex,
                 nameof(transactionHash), transactionHash, nameof(time), time, nameof(isCoinStake), isCoinStake, nameof(index), index, nameof(amount), amount, nameof(blockHeight), blockHeight);
@@ -845,7 +847,8 @@ namespace Stratis.Bitcoin.Features.Wallet
                     CreationTime = DateTimeOffset.FromUnixTimeSeconds(block?.Header.Time ?? time),
                     Index = index,
                     ScriptPubKey = script,
-                    Hex = transactionHex
+                    Hex = transactionHex,
+                    IsPropagated = isPropagated
                 };
 
                 // add the Merkle proof to the (non-spending) transaction
@@ -877,6 +880,11 @@ namespace Stratis.Bitcoin.Features.Wallet
                 if ((block != null) && (foundTransaction.MerkleProof == null))
                 {
                     foundTransaction.MerkleProof = new MerkleBlock(block, new[] { transactionHash }).PartialMerkleTree;
+                }
+
+                if (foundTransaction.IsPropagated != isPropagated)
+                {
+                    foundTransaction.IsPropagated = isPropagated;
                 }
             }
 

--- a/src/Stratis.Bitcoin.Features.Wallet/WalletManager.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/WalletManager.cs
@@ -844,11 +844,9 @@ namespace Stratis.Bitcoin.Features.Wallet
                     CreationTime = DateTimeOffset.FromUnixTimeSeconds(block?.Header.Time ?? time),
                     Index = index,
                     ScriptPubKey = script,
-                    Hex = transactionHex
+                    Hex = transactionHex,
+                    IsPropagated = isPropagated
                 };
-
-                if (!isPropagated)
-                    newTransaction.IsPropagated = false;
 
                 // add the Merkle proof to the (non-spending) transaction
                 if (block != null)
@@ -882,7 +880,7 @@ namespace Stratis.Bitcoin.Features.Wallet
                 }
 
                 if (isPropagated)
-                    foundTransaction.IsPropagated = null;
+                    foundTransaction.IsPropagated = true;
             }
 
             this.TransactionFoundInternal(script);

--- a/src/Stratis.Bitcoin.IntegrationTests/WalletTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/WalletTests.cs
@@ -56,7 +56,7 @@ namespace Stratis.Bitcoin.IntegrationTests
                     new WalletAccountReference("mywallet", "account 0"), "123456", sendto.ScriptPubKey, Money.COIN * 100, FeeType.Medium, 101));
 
                 // broadcast to the other node
-                stratisSender.FullNode.NodeService<WalletController>().SendTransactionAsync(new SendTransactionRequest(trx.ToHex())).GetAwaiter().GetResult();
+                stratisSender.FullNode.NodeService<WalletController>().SendTransaction(new SendTransactionRequest(trx.ToHex()));
 
                 // wait for the trx to arrive
                 TestHelper.WaitLoop(() => stratisReceiver.CreateRPCClient().GetRawMempool().Length > 0);
@@ -154,7 +154,7 @@ namespace Stratis.Bitcoin.IntegrationTests
                 var transaction1 = stratisSender.FullNode.WalletTransactionHandler().BuildTransaction(CreateContext(new WalletAccountReference("mywallet", "account 0"), "123456", sendto.ScriptPubKey, Money.COIN * 100, FeeType.Medium, 101));
 
                 // broadcast to the other node
-                stratisSender.FullNode.NodeService<WalletController>().SendTransactionAsync(new SendTransactionRequest(transaction1.ToHex())).GetAwaiter().GetResult();
+                stratisSender.FullNode.NodeService<WalletController>().SendTransaction(new SendTransactionRequest(transaction1.ToHex()));
 
                 // wait for the trx to arrive
                 TestHelper.WaitLoop(() => stratisReceiver.CreateRPCClient().GetRawMempool().Length > 0);
@@ -188,7 +188,7 @@ namespace Stratis.Bitcoin.IntegrationTests
                 // send more coins to the wallet
                 sendto = stratisReceiver.FullNode.WalletManager().GetUnusedAddress(new WalletAccountReference("mywallet", "account 0"));
                 var transaction2 = stratisSender.FullNode.WalletTransactionHandler().BuildTransaction(CreateContext(new WalletAccountReference("mywallet", "account 0"), "123456", sendto.ScriptPubKey, Money.COIN * 10, FeeType.Medium, 101));
-                stratisSender.FullNode.NodeService<WalletController>().SendTransactionAsync(new SendTransactionRequest(transaction2.ToHex())).GetAwaiter().GetResult();
+                stratisSender.FullNode.NodeService<WalletController>().SendTransaction(new SendTransactionRequest(transaction2.ToHex()));
                 // wait for the trx to arrive
                 TestHelper.WaitLoop(() => stratisReceiver.CreateRPCClient().GetRawMempool().Length > 0);
                 Assert.NotNull(stratisReceiver.CreateRPCClient().GetRawTransaction(transaction2.GetHash(), false));
@@ -235,7 +235,7 @@ namespace Stratis.Bitcoin.IntegrationTests
                 // ReBuild Transaction 2
                 // ====================
                 // After the reorg transaction2 was returned back to mempool
-                stratisSender.FullNode.NodeService<WalletController>().SendTransactionAsync(new SendTransactionRequest(transaction2.ToHex())).GetAwaiter().GetResult();
+                stratisSender.FullNode.NodeService<WalletController>().SendTransaction(new SendTransactionRequest(transaction2.ToHex()));
 
                 TestHelper.WaitLoop(() => stratisReceiver.CreateRPCClient().GetRawMempool().Length > 0);
                 // mine the transaction again

--- a/src/Stratis.Bitcoin/Interfaces/IBroadcasterManager.cs
+++ b/src/Stratis.Bitcoin/Interfaces/IBroadcasterManager.cs
@@ -7,7 +7,7 @@ namespace Stratis.Bitcoin.Interfaces
 {
     public interface IBroadcasterManager
     {
-        Task<bool> TryBroadcastAsync(Transaction transaction);
+        void BroadcastTransaction(Transaction transaction);
 
         event EventHandler<TransactionBroadcastEntry> TransactionStateChanged;
 

--- a/src/Stratis.Bitcoin/Interfaces/IBroadcasterManager.cs
+++ b/src/Stratis.Bitcoin/Interfaces/IBroadcasterManager.cs
@@ -7,7 +7,7 @@ namespace Stratis.Bitcoin.Interfaces
 {
     public interface IBroadcasterManager
     {
-        void BroadcastTransaction(Transaction transaction);
+        Task BroadcastTransactionAsync(Transaction transaction);
 
         event EventHandler<TransactionBroadcastEntry> TransactionStateChanged;
 

--- a/src/Stratis.Bitcoin/Stratis.Bitcoin.csproj
+++ b/src/Stratis.Bitcoin/Stratis.Bitcoin.csproj
@@ -17,10 +17,6 @@
     <Version>1.0.6-alpha</Version>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
   </PropertyGroup>
-
-  <ItemGroup>
-    <Compile Remove="Broadcasting\BroadcasterManagerBase.cs" />
-  </ItemGroup>
   <ItemGroup>
     <PackageReference Include="ConcurrentHashSet" Version="1.0.2" />
     <PackageReference Include="DBreeze" Version="1.89.0" />

--- a/src/Stratis.Bitcoin/Stratis.Bitcoin.csproj
+++ b/src/Stratis.Bitcoin/Stratis.Bitcoin.csproj
@@ -17,6 +17,10 @@
     <Version>1.0.6-alpha</Version>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
   </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="Broadcasting\BroadcasterManagerBase.cs" />
+  </ItemGroup>
   <ItemGroup>
     <PackageReference Include="ConcurrentHashSet" Version="1.0.2" />
     <PackageReference Include="DBreeze" Version="1.89.0" />


### PR DESCRIPTION
Changes: 

1) Added requirement of having at least 1 connection in order to send a tx.
2) Removed waiting for propagation before returning result of SendTransaction.
3) Now it's possible to check propagation state of the transaction by looking it up in the wallet and using IsPropagated flag. 
4) Changed SendTransactionAsync to SendTransaction because now this method do not use any awaitable methods. 

Those changes were discussed in [issue 597](https://github.com/stratisproject/StratisBitcoinFullNode/issues/597) so for more info about the logic behind this changes take a look at the discussion. 

Fix: #579