### PR TITLE
[PeerDiscovery] Adjust asyncloop repeat interval and parallel threads

### DIFF
--- a/src/Stratis.Bitcoin/P2P/PeerDiscoveryLoop.cs
+++ b/src/Stratis.Bitcoin/P2P/PeerDiscoveryLoop.cs
@@ -103,7 +103,7 @@ namespace Stratis.Bitcoin.P2P
                     await this.DiscoverPeersAsync();
             },
             this.nodeLifetime.ApplicationStopping,
-            TimeSpans.Second);
+            TimeSpans.TenSeconds);
         }
 
         /// <summary>
@@ -128,7 +128,7 @@ namespace Stratis.Bitcoin.P2P
 
             Parallel.ForEach(peersToDiscover, new ParallelOptions()
             {
-                MaxDegreeOfParallelism = 5,
+                MaxDegreeOfParallelism = 2,
                 CancellationToken = this.nodeLifetime.ApplicationStopping,
             },
             peer =>


### PR DESCRIPTION
As discussed we have discovered that the peer discovery async loop is currently spamming the network as it doesn't have functionality to check whether or not the peer is connected.