### PR TITLE
Excepton thrown if no LastBlockSyncHeight

### DIFF
--- a/src/Stratis.Bitcoin.Features.Wallet.Tests/WalletManagerTest.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet.Tests/WalletManagerTest.cs
@@ -1241,18 +1241,17 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
         }
 
         [Fact]
-        public void LastReceivedBlockHashWithoutAnyWalletOfCoinTypeThrowsException()
+        public void NoLastReceivedBlockHashInWalletReturnsChainTip()
         {
-            Assert.Throws<Exception>(() =>
-            {
-                var walletManager = new WalletManager(this.LoggerFactory.Object, Network.Main, new Mock<ConcurrentChain>().Object, NodeSettings.Default(),
-                    CreateDataFolder(this), new Mock<IWalletFeePolicy>().Object, new Mock<IAsyncLoopFactory>().Object, new NodeLifetime(), DateTimeProvider.Default);
-                var wallet = this.walletFixture.GenerateBlankWallet("myWallet", "password");
-                wallet.AccountsRoot.ElementAt(0).CoinType = CoinType.Stratis;
-                walletManager.Wallets.Add(wallet);
+            var chain = WalletTestsHelpers.GenerateChainWithHeight(2, Network.Main);
+            var walletManager = new WalletManager(this.LoggerFactory.Object, Network.Main, chain, NodeSettings.Default(),
+                CreateDataFolder(this), new Mock<IWalletFeePolicy>().Object, new Mock<IAsyncLoopFactory>().Object, new NodeLifetime(), DateTimeProvider.Default);
+            var wallet = this.walletFixture.GenerateBlankWallet("myWallet", "password");
+            wallet.AccountsRoot.ElementAt(0).CoinType = CoinType.Stratis;
+            walletManager.Wallets.Add(wallet);
 
-                var result = walletManager.LastReceivedBlockHash();
-            });
+            var result = walletManager.LastReceivedBlockHash();
+            Assert.Equal(chain.Tip.HashBlock, result);
         }
 
         [Fact]


### PR DESCRIPTION
There was a bug who's repro steps are the following:
In a normal situation:
1. user starts off with new installation (no folder, no blocks, and **no chain**)
2. user starts the node
3. user creates a wallet, before the chain is downloaded
4. wallet is created but LastBlockSyncHeight and LastBlockSyncHash are not yet populated (as per design, we don't know anything about the chain yet)
5. when chain is downloaded, LastBlockSyncHeight and LastBlockSyncHash are updated

If between 4. and 5., the node is stopped, the wallet won't have LastBlockSyncHeight and LastBlockSyncHash on restart, leading to an exception.
The fix presented here waits for the chain to be downloaded in the background before updating the LastBlockSyncHeight and LastBlockSyncHash in the wallets.