### PR TITLE
Bugfix/issue 924b

### DIFF
--- a/src/Stratis.Bitcoin/Connection/ConnectionManager.cs
+++ b/src/Stratis.Bitcoin/Connection/ConnectionManager.cs
@@ -325,8 +325,8 @@ namespace Stratis.Bitcoin.Connection
             foreach (NetworkPeerServer server in this.Servers)
                 server.Dispose();
 
-            foreach (NetworkPeer node in this.connectedNodes.Where(n => n.Behaviors.Find<ConnectionManagerBehavior>().OneTry))
-                node.Disconnect();
+            foreach (NetworkPeer peer in this.connectedNodes.Where(n => n.Behaviors.Find<ConnectionManagerBehavior>().OneTry))
+                peer.Disconnect();
 
             this.logger.LogTrace("(-)");
         }

--- a/src/Stratis.Bitcoin/P2P/Peer/NetworkPeer.cs
+++ b/src/Stratis.Bitcoin/P2P/Peer/NetworkPeer.cs
@@ -524,7 +524,6 @@ namespace Stratis.Bitcoin.P2P.Peer
         private NetworkPeer(bool inbound, NetworkAddress peerAddress, Network network, NetworkPeerConnectionParameters parameters, IDateTimeProvider dateTimeProvider, ILoggerFactory loggerFactory)
         {
             this.loggerFactory = loggerFactory;
-            this.logger = loggerFactory.CreateLogger(this.GetType().FullName, $"[{peerAddress.Endpoint}] ");
             this.dateTimeProvider = dateTimeProvider;
 
             this.MessageProducer = new MessageProducer<IncomingMessage>();
@@ -554,9 +553,10 @@ namespace Stratis.Bitcoin.P2P.Peer
         public NetworkPeer(NetworkAddress peerAddress, Network network, NetworkPeerConnectionParameters parameters, INetworkPeerFactory networkPeerFactory, IDateTimeProvider dateTimeProvider, ILoggerFactory loggerFactory)
             : this(false, peerAddress, network, parameters, dateTimeProvider, loggerFactory)
         {
+            NetworkPeerClient client = networkPeerFactory.CreateNetworkPeerClient(parameters);
+            this.logger = loggerFactory.CreateLogger(this.GetType().FullName, $"[{client.Id}-{peerAddress.Endpoint}] ");
             this.logger.LogTrace("()");
 
-            NetworkPeerClient client = networkPeerFactory.CreateNetworkPeerClient(parameters);
             this.Connection = new NetworkPeerConnection(this, client, this.dateTimeProvider, this.loggerFactory);
 
             this.logger.LogTrace("(-)");
@@ -575,6 +575,7 @@ namespace Stratis.Bitcoin.P2P.Peer
         public NetworkPeer(NetworkAddress peerAddress, Network network, NetworkPeerConnectionParameters parameters, NetworkPeerClient client, VersionPayload peerVersion, IDateTimeProvider dateTimeProvider, ILoggerFactory loggerFactory)
             : this(true, peerAddress, network, parameters, dateTimeProvider, loggerFactory)
         {
+            this.logger = loggerFactory.CreateLogger(this.GetType().FullName, $"[{client.Id}-{peerAddress.Endpoint}] ");
             this.logger.LogTrace("()");
 
             this.RemoteSocketEndpoint = client.RemoteEndPoint;

--- a/src/Stratis.Bitcoin/P2P/Peer/NetworkPeer.cs
+++ b/src/Stratis.Bitcoin/P2P/Peer/NetworkPeer.cs
@@ -132,7 +132,7 @@ namespace Stratis.Bitcoin.P2P.Peer
         public NetworkPeerClient Client { get; private set; }
 
         /// <summary>Event that is set when the connection is closed.</summary>
-        public ManualResetEvent Disconnected { get; private set; }
+        public ManualResetEventSlim Disconnected { get; private set; }
 
         /// <summary>Cancellation to be triggered at shutdown to abort all pending operations on the connection.</summary>
         public CancellationTokenSource CancellationSource { get; private set; }
@@ -159,7 +159,7 @@ namespace Stratis.Bitcoin.P2P.Peer
             this.Client = client;
             this.CancellationSource = new CancellationTokenSource();
             this.cancelRegistration = this.CancellationSource.Token.Register(this.InitiateShutdown);
-            this.Disconnected = new ManualResetEvent(false);
+            this.Disconnected = new ManualResetEventSlim(false);
         }
 
         /// <summary>
@@ -320,6 +320,8 @@ namespace Stratis.Bitcoin.P2P.Peer
                     this.logger.LogError("Error while detaching behavior '{0}': {1}", behavior.GetType().FullName, ex.ToString());
                 }
             }
+
+            this.logger.LogTrace("(-)");
         }
 
         /// <inheritdoc />
@@ -331,7 +333,7 @@ namespace Stratis.Bitcoin.P2P.Peer
                 this.CancellationSource.Cancel();
 
             this.receiveMessageTask.Wait();
-            this.Disconnected.WaitOne();
+            this.Disconnected.WaitHandle.WaitOne();
 
             this.Disconnected.Dispose();
             this.CancellationSource.Dispose();
@@ -969,7 +971,7 @@ namespace Stratis.Bitcoin.P2P.Peer
 
             try
             {
-                this.Connection.Disconnected.WaitOne();
+                this.Connection.Disconnected.WaitHandle.WaitOne();
             }
             finally
             {

--- a/src/Stratis.Bitcoin/P2P/Peer/NetworkPeerClient.cs
+++ b/src/Stratis.Bitcoin/P2P/Peer/NetworkPeerClient.cs
@@ -39,8 +39,7 @@ namespace Stratis.Bitcoin.P2P.Peer
         /// <remarks>Write operations on the stream have to be protected by <see cref="writeLock"/>.</remarks>
         public NetworkStream Stream { get; private set; }
 
-        /// <summary>Task that cares about the client once its connection is accepted up until the communication is terminated.</summary>
-        /// <remarks>The client is being processed as long as this task is not complete.</remarks>
+        /// <summary>Task completion that is completed when the client processing is finished.</summary>
         public TaskCompletionSource<bool> ProcessingCompletion { get; private set; }
 
         /// <summary><c>1</c> if the instance of the object has been disposed or disposing is in progress, <c>0</c> otherwise.</summary>

--- a/src/Stratis.Bitcoin/P2P/Peer/NetworkPeerCollection.cs
+++ b/src/Stratis.Bitcoin/P2P/Peer/NetworkPeerCollection.cs
@@ -174,10 +174,10 @@ namespace Stratis.Bitcoin.P2P.Peer
             return this.GetEnumerator();
         }
 
-        public void DisconnectAll(CancellationToken cancellation = default(CancellationToken))
+        public void DisconnectAll(string reason, CancellationToken cancellation = default(CancellationToken))
         {
             foreach (KeyValuePair<NetworkPeer, NetworkPeer> peer in this.networkPeers)
-                peer.Key.DisconnectWithException();
+                peer.Key.DisconnectWithException(reason);
         }
 
         public void Clear()

--- a/src/Stratis.Bitcoin/P2P/Peer/NetworkPeerFactory.cs
+++ b/src/Stratis.Bitcoin/P2P/Peer/NetworkPeerFactory.cs
@@ -89,7 +89,6 @@ namespace Stratis.Bitcoin.P2P.Peer
         /// <param name="tcpClient">Initializes TCP client that may or may not be already connected.</param>
         /// <returns>Newly created network peer client.</returns>
         NetworkPeerClient CreateNetworkPeerClient(TcpClient tcpClient);
-
     }
 
     /// <summary>

--- a/src/Stratis.Bitcoin/P2P/Peer/NetworkPeerServer.cs
+++ b/src/Stratis.Bitcoin/P2P/Peer/NetworkPeerServer.cs
@@ -418,12 +418,15 @@ namespace Stratis.Bitcoin.P2P.Peer
             this.acceptTask.Wait();
 
             ICollection<NetworkPeerClient> connectedClients = this.clientsById.Values;
-            this.logger.LogInformation("Waiting for {0} connected clients to finish.", connectedClients.Count);
-            foreach (NetworkPeerClient client in connectedClients)
+            if (connectedClients.Count > 0)
             {
-                TaskCompletionSource<bool> completion = client.ProcessingCompletion;
-                client.Dispose();
-                completion.Task.Wait();
+                this.logger.LogInformation("Waiting for {0} connected clients to finish.", connectedClients.Count);
+                foreach (NetworkPeerClient client in connectedClients)
+                {
+                    TaskCompletionSource<bool> completion = client.ProcessingCompletion;
+                    client.Dispose();
+                    completion.Task.Wait();
+                }
             }
 
             this.logger.LogTrace("(-)");

--- a/src/Stratis.Bitcoin/P2P/Peer/NetworkPeerServer.cs
+++ b/src/Stratis.Bitcoin/P2P/Peer/NetworkPeerServer.cs
@@ -423,6 +423,7 @@ namespace Stratis.Bitcoin.P2P.Peer
                 this.logger.LogInformation("Waiting for {0} connected clients to finish.", connectedClients.Count);
                 foreach (NetworkPeerClient client in connectedClients)
                 {
+                    this.logger.LogTrace("Disposing and waiting for client ID {0}.", client.Id);
                     TaskCompletionSource<bool> completion = client.ProcessingCompletion;
                     client.Dispose();
                     completion.Task.Wait();

--- a/src/Stratis.Bitcoin/P2P/Peer/NetworkPeerServer.cs
+++ b/src/Stratis.Bitcoin/P2P/Peer/NetworkPeerServer.cs
@@ -404,7 +404,7 @@ namespace Stratis.Bitcoin.P2P.Peer
 
             try
             {
-                this.ConnectedNetworkPeers.DisconnectAll();
+                this.ConnectedNetworkPeers.DisconnectAll("Node shutdown");
             }
             catch (Exception e)
             {

--- a/src/Stratis.Bitcoin/P2P/PeerConnector.cs
+++ b/src/Stratis.Bitcoin/P2P/PeerConnector.cs
@@ -241,7 +241,7 @@ namespace Stratis.Bitcoin.P2P
         /// <summary>Disconnects all the peers in <see cref="ConnectedPeers"/>.</summary>
         private void Disconnect()
         {
-            this.ConnectedPeers.DisconnectAll("Node shutdown.");
+            this.ConnectedPeers.DisconnectAll("Node shutdown");
         }
 
         /// <inheritdoc/>

--- a/src/Stratis.Bitcoin/P2P/PeerConnector.cs
+++ b/src/Stratis.Bitcoin/P2P/PeerConnector.cs
@@ -241,7 +241,7 @@ namespace Stratis.Bitcoin.P2P
         /// <summary>Disconnects all the peers in <see cref="ConnectedPeers"/>.</summary>
         private void Disconnect()
         {
-            this.ConnectedPeers.DisconnectAll();
+            this.ConnectedPeers.DisconnectAll("Node shutdown.");
         }
 
         /// <inheritdoc/>


### PR DESCRIPTION
This is technical part 16 of the node job, but never mind :-)

This does not really fixes #924 because since the node job PR part 15 was merged such behavior has not been seen, but I've revealed what I mentioned in a comment of #924, which is leaking unfinished clients. 

This had to do with incomplete shutdown and cleanup sequence of the client.



So in this PR we 
- make couple of minor improvements in comments, logs, renaming etc.
- change the shutdown sequence of the peer clients
- and thus fix the connected client leak
- replace disconnected event with slim version
- network peer loggers are prefixed with network client ID which is very handy while debugging issues like those we fixed in this PR

We do not yet document this as the end goal is to merge NPConnection class with NPClient class into one class and outside of NP.cs file. So it will change again, but should now be done correctly.