### PR TITLE
Update assumevalid hashes for faster IBD

### DIFF
--- a/src/NBitcoin/Networks.cs
+++ b/src/NBitcoin/Networks.cs
@@ -69,7 +69,7 @@ namespace NBitcoin
 
             consensus.CoinType = 0;
 
-            consensus.DefaultAssumeValid = new uint256("0x0000000000000000003b9ce759c2a087d52abc4266f8f4ebd6d768b89defa50a"); // 477890
+            consensus.DefaultAssumeValid = new uint256("0x00000000000000000086a2362d78ffb4e41dc0b8775ff3c278bd994a5162348a"); // 499610
 
             // The message start string is designed to be unlikely to occur in normal data.
             // The characters are rarely used upper ASCII, not valid as UTF-8, and produce
@@ -161,7 +161,7 @@ namespace NBitcoin
 
             network.consensus.CoinType = 1;
 
-            network.consensus.DefaultAssumeValid = new uint256("0x0000000002e9e7b00e1f6dc5123a04aad68dd0f0968d8c7aa45f6640795c37b1"); // 1135275 
+            network.consensus.DefaultAssumeValid = new uint256("0x000000003ccfe92231efee04df6621e7bb3f7f513588054e19f78d626b951f59"); // 1235126
 
             network.magic = 0x0709110B;
 
@@ -302,7 +302,7 @@ namespace NBitcoin
 
             consensus.CoinType = 105;
 
-            consensus.DefaultAssumeValid = new uint256("0x5acb513b96dcb727fbe85c7d50a1266e6414cdd4c3ae66d01313c34a81b466a2"); // 602240
+            consensus.DefaultAssumeValid = new uint256("0x8c2cf95f9ca72e13c8c4cdf15c2d7cc49993946fb49be4be147e106d502f1869"); // 642930
 
             Block genesis = CreateStratisGenesisBlock(1470467000, 1831645, 0x1e0fffff, 1, Money.Zero);
             consensus.HashGenesisBlock = genesis.GetHash(consensus.NetworkOptions);
@@ -399,7 +399,7 @@ namespace NBitcoin
 
             Assert(consensus.HashGenesisBlock == uint256.Parse("0x00000e246d7b73b88c9ab55f2e5e94d9e22d471def3df5ea448f5576b1d156b9"));
 
-            consensus.DefaultAssumeValid = new uint256("0x74427b2f85b5d9658ee81f7e73526441311122f2b23702b794be557ba43ca43e"); // 184096
+            consensus.DefaultAssumeValid = new uint256("0x12ae16993ce7f0836678f225b2f4b38154fa923bd1888f7490051ddaf4e9b7fa"); // 218810
 
             var builder = new NetworkBuilder()
                 .SetName("StratisTest")


### PR DESCRIPTION
I've updated the hashes to match current chain:

* Mainnet (bitcoin/stratis) picked a block back from the tip that had at least 10 confirmations
* Testnet (bitcoin/stratis) picked a block about 10,000 back from tip

I'm not sure if its necessary to go back so far on strat testnet as I'm not sure the strat testnet is quite as crazy as bitcoins but the bitcoin recommendation is to go back 10,000 blocks because of potential for big reorgs on testnet.

I think these should be safe values however. Using these values my IBD times were as follows:
TSTRAT - 10 mins
STRAT - 35 mins


