### PR TITLE
Staking in History

### DIFF
--- a/src/Stratis.Bitcoin.Features.Wallet/Controllers/WalletController.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Controllers/WalletController.cs
@@ -352,7 +352,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Controllers
                             // The staked amount is calculated as the difference between the sum of the outputs and the input and should normally be equal to 1.
                             TransactionItemModel stakingItem = new TransactionItemModel
                             {
-                                Type = TransactionItemType.Mined,
+                                Type = TransactionItemType.Staked,
                                 ToAddress = address.Address,
                                 Amount = relatedOutputs.Sum(o => o.Transaction.Amount) - transaction.Amount,
                                 Id = transaction.SpendingDetails.TransactionId,

--- a/src/Stratis.Bitcoin.Features.Wallet/Controllers/WalletController.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Controllers/WalletController.cs
@@ -342,10 +342,10 @@ namespace Stratis.Bitcoin.Features.Wallet.Controllers
 
                     // First we look for staking transaction as they require special attention.
                     // A staking transaction spends one of our inputs into 2 outputs, paid to the same address.
-                    if (transaction.SpendingDetails != null && transaction.SpendingDetails.IsCoinStake)
+                    if (transaction.SpendingDetails?.IsCoinStake != null && transaction.SpendingDetails.IsCoinStake.Value)
                     {
                         // We look for the 2 outputs related to our spending input.
-                        List<FlatHistory> relatedOutputs = items.Where(h => h.Transaction.Id == transaction.SpendingDetails.TransactionId && h.Transaction.IsCoinStake).ToList();
+                        List<FlatHistory> relatedOutputs = items.Where(h => h.Transaction.Id == transaction.SpendingDetails.TransactionId && h.Transaction.IsCoinStake != null && h.Transaction.IsCoinStake.Value).ToList();
                         if (relatedOutputs.Count == 2)
                         {
                             // Add staking transaction details.

--- a/src/Stratis.Bitcoin.Features.Wallet/Controllers/WalletController.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Controllers/WalletController.cs
@@ -312,7 +312,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Controllers
         {
             Guard.NotNull(request, nameof(request));
 
-            // checks the request is valid
+            // Checks the request is valid.
             if (!this.ModelState.IsValid)
             {
                 return BuildErrorResponse(this.ModelState);
@@ -322,20 +322,28 @@ namespace Stratis.Bitcoin.Features.Wallet.Controllers
             {
                 WalletHistoryModel model = new WalletHistoryModel();
 
-                // get transactions contained in the wallet
-                var items = this.walletManager.GetHistory(request.WalletName).ToList().OrderByDescending(o => o.Transaction.CreationTime).Take(100).ToList();
+                // Get a list of all the transactions, with the addresses associated with them.
+                List<FlatHistory> items = this.walletManager.GetHistory(request.WalletName).ToList().OrderByDescending(o => o.Transaction.CreationTime).Take(100).ToList();
+
+                // Represents a sublist containing only the transactions that have already been spent. 
                 List<FlatHistory> spendingDetails = items.Where(t => t.Transaction.SpendingDetails != null).ToList();
-                List<FlatHistory> filtered = items.Where(t => !t.Address.IsChangeAddress() || (t.Address.IsChangeAddress() && !t.Transaction.IsSpendable())).ToList();
+
+                // Represents a sublist of transactions associated with receive addresses + a sublist of already spent transactions associated with change addresses.
+                // In effect, we filter out 'change' transactions that are not spent, as we don't want to show these in the history.
+                List<FlatHistory> history = items.Where(t => !t.Address.IsChangeAddress() || (t.Address.IsChangeAddress() && !t.Transaction.IsSpendable())).ToList();
+                
+                // Represents a sublist of 'change' transactions.
                 List<FlatHistory> allchange = items.Where(t => t.Address.IsChangeAddress()).ToList();
 
-                foreach (var item in filtered)
+                foreach (var item in history)
                 {
                     var transaction = item.Transaction;
                     var address = item.Address;
 
+                    // Create a record for a 'receive' transaction.
                     if (!address.IsChangeAddress())
                     {
-                        // add incoming fund transaction details
+                        // Add incoming fund transaction details.
                         TransactionItemModel receivedItem = new TransactionItemModel
                         {
                             Type = TransactionItemType.Received,
@@ -349,9 +357,10 @@ namespace Stratis.Bitcoin.Features.Wallet.Controllers
                         model.TransactionsHistory.Add(receivedItem);
                     }
 
-                    // add outgoing fund transaction details
+                    // If this transaction has been spent, add outgoing fund transaction details.
                     if (transaction.SpendingDetails != null)
                     {
+                        // Create a record for a 'send' transaction.
                         var spendingTransactionId = transaction.SpendingDetails.TransactionId;
                         TransactionItemModel sentItem = new TransactionItemModel
                         {
@@ -362,6 +371,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Controllers
                             Amount = Money.Zero
                         };
 
+                        // If this 'send' transaction has made some external payments, i.e the funds were not sent to another address in the wallet.
                         if (transaction.SpendingDetails.Payments != null)
                         {
                             sentItem.Payments = new List<PaymentDetailModel>();
@@ -377,18 +387,18 @@ namespace Stratis.Bitcoin.Features.Wallet.Controllers
                             }
                         }
 
-                        // get the change address for this spending transaction
+                        // Get the change address for this spending transaction.
                         var changeAddress = allchange.FirstOrDefault(a => a.Transaction.Id == spendingTransactionId);
 
-                        // find all the spending details containing the spending transaction id and aggregate the sums.
-                        // this is our best shot at finding the total value of inputs for this transaction.
+                        // Find all the spending details containing the spending transaction id and aggregate the sums.
+                        // This is our best shot at finding the total value of inputs for this transaction.
                         var inputsAmount = new Money(spendingDetails.Where(t => t.Transaction.SpendingDetails.TransactionId == spendingTransactionId).Sum(t => t.Transaction.Amount));
 
-                        // the fee is calculated as follows: funds in utxo - amount spent - amount sent as change
+                        // The fee is calculated as follows: funds in utxo - amount spent - amount sent as change.
                         sentItem.Fee = inputsAmount - sentItem.Amount - (changeAddress == null ? 0 : changeAddress.Transaction.Amount);
 
-                        // mined/staked coins add more coins to the total out
-                        // that makes the fee negative if that's the case ignore the fee
+                        // Mined/staked coins add more coins to the total out.
+                        // That makes the fee negative. If that's the case ignore the fee.
                         if (sentItem.Fee < 0)
                             sentItem.Fee = 0;
 

--- a/src/Stratis.Bitcoin.Features.Wallet/Models/WalletHistoryModel.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Models/WalletHistoryModel.cs
@@ -82,6 +82,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Models
     public enum TransactionItemType
     {
         Received,
-        Send
+        Send,
+        Mined
     }
 }

--- a/src/Stratis.Bitcoin.Features.Wallet/Models/WalletHistoryModel.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Models/WalletHistoryModel.cs
@@ -83,6 +83,6 @@ namespace Stratis.Bitcoin.Features.Wallet.Models
     {
         Received,
         Send,
-        Mined
+        Staked
     }
 }

--- a/src/Stratis.Bitcoin.Features.Wallet/Wallet.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Wallet.cs
@@ -740,8 +740,8 @@ namespace Stratis.Bitcoin.Features.Wallet
         /// <summary>
         /// A value indicating whether this is a coin stake transaction or not.
         /// </summary>
-        [JsonProperty(PropertyName = "isCoinStake")]
-        public bool IsCoinStake { get; set; }
+        [JsonProperty(PropertyName = "isCoinStake", NullValueHandling = NullValueHandling.Ignore)]
+        public bool? IsCoinStake { get; set; }
 
         /// <summary>
         /// A list of payments made out in this transaction.
@@ -907,8 +907,8 @@ namespace Stratis.Bitcoin.Features.Wallet
         /// <summary>
         /// A value indicating whether this is a coin stake transaction or not.
         /// </summary>
-        [JsonProperty(PropertyName = "isCoinStake")]
-        public bool IsCoinStake { get; set; }
+        [JsonProperty(PropertyName = "isCoinStake", NullValueHandling = NullValueHandling.Ignore)]
+        public bool? IsCoinStake { get; set; }
 
         /// <summary>
         /// Gets or sets the creation time.

--- a/src/Stratis.Bitcoin.Features.Wallet/Wallet.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Wallet.cs
@@ -905,6 +905,12 @@ namespace Stratis.Bitcoin.Features.Wallet
         public int? BlockHeight { get; set; }
 
         /// <summary>
+        /// A value indicating whether this is a coin stake transaction or not.
+        /// </summary>
+        [JsonProperty(PropertyName = "isCoinStake")]
+        public bool IsCoinStake { get; set; }
+
+        /// <summary>
         /// Gets or sets the creation time.
         /// </summary>
         [JsonProperty(PropertyName = "creationTime")]

--- a/src/Stratis.Bitcoin.Features.Wallet/WalletManager.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/WalletManager.cs
@@ -518,6 +518,11 @@ namespace Stratis.Bitcoin.Features.Wallet
             return items;
         }
 
+        /// <summary>
+        /// Gets a collection of addresses that have transactions associated with them.
+        /// </summary>
+        /// <param name="wallet">The wallet to get the history from.</param>
+        /// <returns>A collection of addresses that have transactions associated with them.</returns>
         private IEnumerable<HdAddress> GetHistoryInternal(Wallet wallet)
         {
             IEnumerable<HdAccount> accounts = wallet.GetAccountsByCoinType(this.coinType);

--- a/src/Stratis.Bitcoin.Features.Wallet/WalletManager.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/WalletManager.cs
@@ -805,7 +805,7 @@ namespace Stratis.Bitcoin.Features.Wallet
                         return !addr.IsChangeAddress();
                     });
 
-                    this.AddSpendingTransactionToWallet(transaction.ToHex(), hash, transaction.Time, paidOutTo, tTx.Id, tTx.Index, blockHeight, block);
+                    this.AddSpendingTransactionToWallet(transaction.ToHex(), hash, transaction.Time, transaction.IsCoinStake, paidOutTo, tTx.Id, tTx.Index, blockHeight, block);
                 }
             }
 
@@ -906,17 +906,18 @@ namespace Stratis.Bitcoin.Features.Wallet
         /// </summary>
         /// <param name="transactionHash">The transaction hash.</param>
         /// <param name="time">The time.</param>
+        /// <param name="isCoinStake">A value indicating whether this is a coin stake transaction or not.</param>
         /// <param name="paidToOutputs">A list of payments made out</param>
         /// <param name="spendingTransactionId">The id of the transaction containing the output being spent, if this is a spending transaction.</param>
         /// <param name="spendingTransactionIndex">The index of the output in the transaction being referenced, if this is a spending transaction.</param>
         /// <param name="blockHeight">Height of the block.</param>
         /// <param name="block">The block containing the transaction to add.</param>
         /// <param name="transactionHex">The hexadecimal representation of the transaction.</param>
-        private void AddSpendingTransactionToWallet(string transactionHex, uint256 transactionHash, uint time, IEnumerable<TxOut> paidToOutputs,
+        private void AddSpendingTransactionToWallet(string transactionHex, uint256 transactionHash, uint time, bool isCoinStake, IEnumerable<TxOut> paidToOutputs,
             uint256 spendingTransactionId, int? spendingTransactionIndex, int? blockHeight = null, Block block = null)
         {
-            this.logger.LogTrace("({0}:'{1}',{2}:'{3}',{4}:{5},{6}:'{7}',{8}:{9},{10}:{11})", nameof(transactionHex), transactionHex,
-                nameof(transactionHash), transactionHash, nameof(time), time, nameof(spendingTransactionId), spendingTransactionId, nameof(spendingTransactionIndex), spendingTransactionIndex, nameof(blockHeight), blockHeight);
+            this.logger.LogTrace("({0}:'{1}',{2}:'{3}',{4}:{5},{6}:'{7}',{8}:{9},{10}:{11},{12}:{13})", nameof(transactionHex), transactionHex,
+                nameof(transactionHash), transactionHash, nameof(time), time, nameof(isCoinStake), isCoinStake, nameof(spendingTransactionId), spendingTransactionId, nameof(spendingTransactionIndex), spendingTransactionIndex, nameof(blockHeight), blockHeight);
 
             // Get the transaction being spent.
             TransactionData spentTransaction = this.keysLookup.Values.Distinct().SelectMany(v => v.Transactions)
@@ -950,7 +951,8 @@ namespace Stratis.Bitcoin.Features.Wallet
                     Payments = payments,
                     CreationTime = DateTimeOffset.FromUnixTimeSeconds(block?.Header.Time ?? time),
                     BlockHeight = blockHeight,
-                    Hex = transactionHex
+                    Hex = transactionHex,
+                    IsCoinStake = isCoinStake
                 };
 
                 spentTransaction.SpendingDetails = spendingDetails;

--- a/src/Stratis.Bitcoin.Features.Wallet/WalletManager.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/WalletManager.cs
@@ -850,7 +850,7 @@ namespace Stratis.Bitcoin.Features.Wallet
                 var newTransaction = new TransactionData
                 {
                     Amount = amount,
-                    IsCoinStake = isCoinStake,
+                    IsCoinStake = isCoinStake == false ? (bool?)null : true,
                     BlockHeight = blockHeight,
                     BlockHash = block?.GetHash(),
                     Id = transactionHash,
@@ -952,7 +952,7 @@ namespace Stratis.Bitcoin.Features.Wallet
                     CreationTime = DateTimeOffset.FromUnixTimeSeconds(block?.Header.Time ?? time),
                     BlockHeight = blockHeight,
                     Hex = transactionHex,
-                    IsCoinStake = isCoinStake
+                    IsCoinStake = isCoinStake == false ? (bool?)null : true
                 };
 
                 spentTransaction.SpendingDetails = spendingDetails;

--- a/src/Stratis.StratisD/Properties/launchSettings.json
+++ b/src/Stratis.StratisD/Properties/launchSettings.json
@@ -5,7 +5,7 @@
     },
     "Stratis.StratisD Test": {
       "commandName": "Project",
-      "commandLineArgs": "-testnet -checkpoints=0 -assumevalid=0"
+      "commandLineArgs": "-testnet"
     }
   }
 }


### PR DESCRIPTION
In order to be able to show a staking transaction in the History, we look for transactions that are marked as coin stake transaction + that have 1 input from our wallet to 2 outputs to our wallet.

This is better reviewed commit by commit.
Any question, please ask.