### PR TITLE
Rpc port setting fix

### DIFF
--- a/src/Stratis.Bitcoin.Features.RPC/RpcSettings.cs
+++ b/src/Stratis.Bitcoin.Features.RPC/RpcSettings.cs
@@ -62,13 +62,12 @@ namespace Stratis.Bitcoin.Features.RPC
             var config = nodeSettings.ConfigReader;
 
             this.Server = config.GetOrDefault<bool>("server", false);
-            this.RPCPort = nodeSettings.Network.RPCPort;
+            this.RPCPort = config.GetOrDefault<int>("rpcport", nodeSettings.Network.RPCPort);
 
             if (this.Server)
             {
                 this.RpcUser = config.GetOrDefault<string>("rpcuser", null);
                 this.RpcPassword = config.GetOrDefault<string>("rpcpassword", null);
-                this.RPCPort = config.GetOrDefault<int>("rpcport", nodeSettings.Network.RPCPort);
 
                 try
                 {


### PR DESCRIPTION
This fix allows specifying rpc port without enabling '-server=true'.

This is needed in order to start multiple nodes on the same machine without the need to enable -server.