### PR TITLE
Base DNS server implementation

### DIFF
--- a/src/Stratis.Bitcoin.Features.Dns.Tests/GivenADnsFeature.cs
+++ b/src/Stratis.Bitcoin.Features.Dns.Tests/GivenADnsFeature.cs
@@ -2,7 +2,10 @@
 using FluentAssertions;
 using Microsoft.Extensions.Logging;
 using Moq;
+using NBitcoin.Protocol;
+using Stratis.Bitcoin.Configuration;
 using Stratis.Bitcoin.P2P;
+using Stratis.Bitcoin.Utilities;
 using Xunit;
 
 namespace Stratis.Bitcoin.Features.Dns.Tests
@@ -14,10 +17,53 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
     {
         [Fact]
         [Trait("UnitTest", "UnitTest")]
+        public void WhenConstructorCalled_AndDnsServerIsNull_ThenArgumentNullExceptionIsThrown()
+        {
+            // Arrange.
+            IMasterFile masterFile = new Mock<IMasterFile>().Object;
+            IPeerAddressManager peerAddressManager = new Mock<IPeerAddressManager>().Object;
+            ILoggerFactory loggerFactory = new Mock<ILoggerFactory>().Object;
+            INodeLifetime nodeLifetime = new Mock<INodeLifetime>().Object;
+            NodeSettings nodeSettings = NodeSettings.Default();
+            nodeSettings.DataDir = @"C:\";
+            DataFolder dataFolders = new Mock<DataFolder>(nodeSettings).Object;
+            Action a = () => { new DnsFeature(null, masterFile, peerAddressManager, loggerFactory, nodeLifetime, nodeSettings, dataFolders); };
+
+            // Act and Assert.
+            a.ShouldThrow<ArgumentNullException>().Which.Message.Should().Contain("dnsServer");
+        }
+
+        [Fact]
+        [Trait("UnitTest", "UnitTest")]
+        public void WhenConstructorCalled_AndMasterFileIsNull_ThenArgumentNullExceptionIsThrown()
+        {
+            // Arrange.
+            IDnsServer dnsServer = new Mock<IDnsServer>().Object;
+            IPeerAddressManager peerAddressManager = new Mock<IPeerAddressManager>().Object;
+            ILoggerFactory loggerFactory = new Mock<ILoggerFactory>().Object;
+            INodeLifetime nodeLifetime = new Mock<INodeLifetime>().Object;
+            NodeSettings nodeSettings = NodeSettings.Default();
+            nodeSettings.DataDir = @"C:\";
+            DataFolder dataFolders = new Mock<DataFolder>(nodeSettings).Object;
+            Action a = () => { new DnsFeature(dnsServer, null, peerAddressManager, loggerFactory, nodeLifetime, nodeSettings, dataFolders); };
+
+            // Act and Assert.
+            a.ShouldThrow<ArgumentNullException>().Which.Message.Should().Contain("masterFile");
+        }
+
+        [Fact]
+        [Trait("UnitTest", "UnitTest")]
         public void WhenConstructorCalled_AndPeerAddressManagerIsNull_ThenArgumentNullExceptionIsThrown()
         {
             // Arrange.
-            Action a = () => { new DnsFeature(null, null); };
+            IDnsServer dnsServer = new Mock<IDnsServer>().Object;
+            IMasterFile masterFile = new Mock<IMasterFile>().Object;
+            ILoggerFactory loggerFactory = new Mock<ILoggerFactory>().Object;
+            INodeLifetime nodeLifetime = new Mock<INodeLifetime>().Object;
+            NodeSettings nodeSettings = NodeSettings.Default();
+            nodeSettings.DataDir = @"C:\";
+            DataFolder dataFolders = new Mock<DataFolder>(nodeSettings).Object;
+            Action a = () => { new DnsFeature(dnsServer, masterFile, null, loggerFactory, nodeLifetime, nodeSettings, dataFolders); };
 
             // Act and Assert.
             a.ShouldThrow<ArgumentNullException>().Which.Message.Should().Contain("peerAddressManager");
@@ -28,8 +74,14 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
         public void WhenConstructorCalled_AndLoggerFactoryIsNull_ThenArgumentNullExceptionIsThrown()
         {
             // Arrange.
+            IDnsServer dnsServer = new Mock<IDnsServer>().Object;
+            IMasterFile masterFile = new Mock<IMasterFile>().Object;
             IPeerAddressManager peerAddressManager = new Mock<IPeerAddressManager>().Object;
-            Action a = () => { new DnsFeature(peerAddressManager, null); };
+            INodeLifetime nodeLifetime = new Mock<INodeLifetime>().Object;
+            NodeSettings nodeSettings = NodeSettings.Default();
+            nodeSettings.DataDir = @"C:\";
+            DataFolder dataFolders = new Mock<DataFolder>(nodeSettings).Object;
+            Action a = () => { new DnsFeature(dnsServer, masterFile, peerAddressManager, null, nodeLifetime, nodeSettings, dataFolders); };
 
             // Act and Assert.
             a.ShouldThrow<ArgumentNullException>().Which.Message.Should().Contain("loggerFactory");
@@ -37,14 +89,74 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
 
         [Fact]
         [Trait("UnitTest", "UnitTest")]
+        public void WhenConstructorCalled_AndNodeLifetimeIsNull_ThenArgumentNullExceptionIsThrown()
+        {
+            // Arrange.
+            IDnsServer dnsServer = new Mock<IDnsServer>().Object;
+            IMasterFile masterFile = new Mock<IMasterFile>().Object;
+            IPeerAddressManager peerAddressManager = new Mock<IPeerAddressManager>().Object;
+            ILoggerFactory loggerFactory = new Mock<ILoggerFactory>().Object;
+            NodeSettings nodeSettings = NodeSettings.Default();
+            nodeSettings.DataDir = @"C:\";
+            DataFolder dataFolders = new Mock<DataFolder>(nodeSettings).Object;
+            Action a = () => { new DnsFeature(dnsServer, masterFile, peerAddressManager, loggerFactory, null, nodeSettings, dataFolders); };
+
+            // Act and Assert.
+            a.ShouldThrow<ArgumentNullException>().Which.Message.Should().Contain("nodeLifetime");
+        }
+
+        [Fact]
+        [Trait("UnitTest", "UnitTest")]
+        public void WhenConstructorCalled_AndNodeSettingsIsNull_ThenArgumentNullExceptionIsThrown()
+        {
+            // Arrange.
+            IDnsServer dnsServer = new Mock<IDnsServer>().Object;
+            IMasterFile masterFile = new Mock<IMasterFile>().Object;
+            IPeerAddressManager peerAddressManager = new Mock<IPeerAddressManager>().Object;
+            ILoggerFactory loggerFactory = new Mock<ILoggerFactory>().Object;
+            INodeLifetime nodeLifetime = new Mock<INodeLifetime>().Object;
+            NodeSettings nodeSettings = NodeSettings.Default();
+            nodeSettings.DataDir = @"C:\";
+            DataFolder dataFolders = new Mock<DataFolder>(nodeSettings).Object;
+            Action a = () => { new DnsFeature(dnsServer, masterFile, peerAddressManager, loggerFactory, nodeLifetime, null, dataFolders); };
+
+            // Act and Assert.
+            a.ShouldThrow<ArgumentNullException>().Which.Message.Should().Contain("nodeSettings");
+        }
+
+        [Fact]
+        [Trait("UnitTest", "UnitTest")]
+        public void WhenConstructorCalled_AndDataFoldersIsNull_ThenArgumentNullExceptionIsThrown()
+        {
+            // Arrange.
+            IDnsServer dnsServer = new Mock<IDnsServer>().Object;
+            IMasterFile masterFile = new Mock<IMasterFile>().Object;
+            IPeerAddressManager peerAddressManager = new Mock<IPeerAddressManager>().Object;
+            ILoggerFactory loggerFactory = new Mock<ILoggerFactory>().Object;
+            INodeLifetime nodeLifetime = new Mock<INodeLifetime>().Object;
+            NodeSettings nodeSettings = new Mock<NodeSettings>("bitcoin", null, NodeSettings.SupportedProtocolVersion, "StratisBitcoin").Object;
+            Action a = () => { new DnsFeature(dnsServer, masterFile, peerAddressManager, loggerFactory, nodeLifetime, nodeSettings, null); };
+
+            // Act and Assert.
+            a.ShouldThrow<ArgumentNullException>().Which.Message.Should().Contain("dataFolders");
+        }
+
+        [Fact]
+        [Trait("UnitTest", "UnitTest")]
         public void WhenConstructorCalled_AndAllParametersValid_ThenTypeCreated()
         {
             // Arrange.
+            IDnsServer dnsServer = new Mock<IDnsServer>().Object;
+            IMasterFile masterFile = new Mock<IMasterFile>().Object;
             IPeerAddressManager peerAddressManager = new Mock<IPeerAddressManager>().Object;
+            INodeLifetime nodeLifetime = new Mock<INodeLifetime>().Object;
+            NodeSettings nodeSettings = NodeSettings.Default();
+            nodeSettings.DataDir = @"C:\";
+            DataFolder dataFolders = new Mock<DataFolder>(nodeSettings).Object;
             ILoggerFactory loggerFactory = new Mock<ILoggerFactory>().Object;
 
             // Act.
-            DnsFeature feature = new DnsFeature(peerAddressManager, loggerFactory);
+            DnsFeature feature = new DnsFeature(dnsServer, masterFile, peerAddressManager, loggerFactory, nodeLifetime, nodeSettings, dataFolders);
 
             // Assert.
             feature.Should().NotBeNull();

--- a/src/Stratis.Bitcoin.Features.Dns.Tests/GivenADnsFeature.cs
+++ b/src/Stratis.Bitcoin.Features.Dns.Tests/GivenADnsFeature.cs
@@ -24,35 +24,16 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
         public void WhenConstructorCalled_AndDnsServerIsNull_ThenArgumentNullExceptionIsThrown()
         {
             // Arrange.
-            IMasterFile masterFile = new Mock<IMasterFile>().Object;
             IPeerAddressManager peerAddressManager = new Mock<IPeerAddressManager>().Object;
             ILoggerFactory loggerFactory = new Mock<ILoggerFactory>().Object;
             INodeLifetime nodeLifetime = new Mock<INodeLifetime>().Object;
             NodeSettings nodeSettings = NodeSettings.Default();
             nodeSettings.DataDir = @"C:\";
             DataFolder dataFolders = new Mock<DataFolder>(nodeSettings).Object;
-            Action a = () => { new DnsFeature(null, masterFile, peerAddressManager, loggerFactory, nodeLifetime, nodeSettings, dataFolders); };
+            Action a = () => { new DnsFeature(null, peerAddressManager, loggerFactory, nodeLifetime, nodeSettings, dataFolders); };
 
             // Act and Assert.
             a.ShouldThrow<ArgumentNullException>().Which.Message.Should().Contain("dnsServer");
-        }
-
-        [Fact]
-        [Trait("DNS", "UnitTest")]
-        public void WhenConstructorCalled_AndMasterFileIsNull_ThenArgumentNullExceptionIsThrown()
-        {
-            // Arrange.
-            IDnsServer dnsServer = new Mock<IDnsServer>().Object;
-            IPeerAddressManager peerAddressManager = new Mock<IPeerAddressManager>().Object;
-            ILoggerFactory loggerFactory = new Mock<ILoggerFactory>().Object;
-            INodeLifetime nodeLifetime = new Mock<INodeLifetime>().Object;
-            NodeSettings nodeSettings = NodeSettings.Default();
-            nodeSettings.DataDir = @"C:\";
-            DataFolder dataFolders = new Mock<DataFolder>(nodeSettings).Object;
-            Action a = () => { new DnsFeature(dnsServer, null, peerAddressManager, loggerFactory, nodeLifetime, nodeSettings, dataFolders); };
-
-            // Act and Assert.
-            a.ShouldThrow<ArgumentNullException>().Which.Message.Should().Contain("masterFile");
         }
 
         [Fact]
@@ -61,13 +42,12 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
         {
             // Arrange.
             IDnsServer dnsServer = new Mock<IDnsServer>().Object;
-            IMasterFile masterFile = new Mock<IMasterFile>().Object;
             ILoggerFactory loggerFactory = new Mock<ILoggerFactory>().Object;
             INodeLifetime nodeLifetime = new Mock<INodeLifetime>().Object;
             NodeSettings nodeSettings = NodeSettings.Default();
             nodeSettings.DataDir = @"C:\";
             DataFolder dataFolders = new Mock<DataFolder>(nodeSettings).Object;
-            Action a = () => { new DnsFeature(dnsServer, masterFile, null, loggerFactory, nodeLifetime, nodeSettings, dataFolders); };
+            Action a = () => { new DnsFeature(dnsServer, null, loggerFactory, nodeLifetime, nodeSettings, dataFolders); };
 
             // Act and Assert.
             a.ShouldThrow<ArgumentNullException>().Which.Message.Should().Contain("peerAddressManager");
@@ -79,13 +59,12 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
         {
             // Arrange.
             IDnsServer dnsServer = new Mock<IDnsServer>().Object;
-            IMasterFile masterFile = new Mock<IMasterFile>().Object;
             IPeerAddressManager peerAddressManager = new Mock<IPeerAddressManager>().Object;
             INodeLifetime nodeLifetime = new Mock<INodeLifetime>().Object;
             NodeSettings nodeSettings = NodeSettings.Default();
             nodeSettings.DataDir = @"C:\";
             DataFolder dataFolders = new Mock<DataFolder>(nodeSettings).Object;
-            Action a = () => { new DnsFeature(dnsServer, masterFile, peerAddressManager, null, nodeLifetime, nodeSettings, dataFolders); };
+            Action a = () => { new DnsFeature(dnsServer, peerAddressManager, null, nodeLifetime, nodeSettings, dataFolders); };
 
             // Act and Assert.
             a.ShouldThrow<ArgumentNullException>().Which.Message.Should().Contain("loggerFactory");
@@ -97,13 +76,12 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
         {
             // Arrange.
             IDnsServer dnsServer = new Mock<IDnsServer>().Object;
-            IMasterFile masterFile = new Mock<IMasterFile>().Object;
             IPeerAddressManager peerAddressManager = new Mock<IPeerAddressManager>().Object;
             ILoggerFactory loggerFactory = new Mock<ILoggerFactory>().Object;
             NodeSettings nodeSettings = NodeSettings.Default();
             nodeSettings.DataDir = @"C:\";
             DataFolder dataFolders = new Mock<DataFolder>(nodeSettings).Object;
-            Action a = () => { new DnsFeature(dnsServer, masterFile, peerAddressManager, loggerFactory, null, nodeSettings, dataFolders); };
+            Action a = () => { new DnsFeature(dnsServer, peerAddressManager, loggerFactory, null, nodeSettings, dataFolders); };
 
             // Act and Assert.
             a.ShouldThrow<ArgumentNullException>().Which.Message.Should().Contain("nodeLifetime");
@@ -115,14 +93,13 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
         {
             // Arrange.
             IDnsServer dnsServer = new Mock<IDnsServer>().Object;
-            IMasterFile masterFile = new Mock<IMasterFile>().Object;
             IPeerAddressManager peerAddressManager = new Mock<IPeerAddressManager>().Object;
             ILoggerFactory loggerFactory = new Mock<ILoggerFactory>().Object;
             INodeLifetime nodeLifetime = new Mock<INodeLifetime>().Object;
             NodeSettings nodeSettings = NodeSettings.Default();
             nodeSettings.DataDir = @"C:\";
             DataFolder dataFolders = new Mock<DataFolder>(nodeSettings).Object;
-            Action a = () => { new DnsFeature(dnsServer, masterFile, peerAddressManager, loggerFactory, nodeLifetime, null, dataFolders); };
+            Action a = () => { new DnsFeature(dnsServer, peerAddressManager, loggerFactory, nodeLifetime, null, dataFolders); };
 
             // Act and Assert.
             a.ShouldThrow<ArgumentNullException>().Which.Message.Should().Contain("nodeSettings");
@@ -134,12 +111,11 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
         {
             // Arrange.
             IDnsServer dnsServer = new Mock<IDnsServer>().Object;
-            IMasterFile masterFile = new Mock<IMasterFile>().Object;
             IPeerAddressManager peerAddressManager = new Mock<IPeerAddressManager>().Object;
             ILoggerFactory loggerFactory = new Mock<ILoggerFactory>().Object;
             INodeLifetime nodeLifetime = new Mock<INodeLifetime>().Object;
             NodeSettings nodeSettings = new Mock<NodeSettings>("bitcoin", null, NodeSettings.SupportedProtocolVersion, "StratisBitcoin").Object;
-            Action a = () => { new DnsFeature(dnsServer, masterFile, peerAddressManager, loggerFactory, nodeLifetime, nodeSettings, null); };
+            Action a = () => { new DnsFeature(dnsServer, peerAddressManager, loggerFactory, nodeLifetime, nodeSettings, null); };
 
             // Act and Assert.
             a.ShouldThrow<ArgumentNullException>().Which.Message.Should().Contain("dataFolders");
@@ -151,7 +127,6 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
         {
             // Arrange.
             IDnsServer dnsServer = new Mock<IDnsServer>().Object;
-            IMasterFile masterFile = new Mock<IMasterFile>().Object;
             IPeerAddressManager peerAddressManager = new Mock<IPeerAddressManager>().Object;
             INodeLifetime nodeLifetime = new Mock<INodeLifetime>().Object;
             NodeSettings nodeSettings = NodeSettings.Default();
@@ -160,7 +135,7 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
             ILoggerFactory loggerFactory = new Mock<ILoggerFactory>().Object;
 
             // Act.
-            DnsFeature feature = new DnsFeature(dnsServer, masterFile, peerAddressManager, loggerFactory, nodeLifetime, nodeSettings, dataFolders);
+            DnsFeature feature = new DnsFeature(dnsServer, peerAddressManager, loggerFactory, nodeLifetime, nodeSettings, dataFolders);
 
             // Assert.
             feature.Should().NotBeNull();
@@ -196,7 +171,7 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
             loggerFactory.Setup<ILogger>(f => f.CreateLogger(It.IsAny<string>())).Returns(logger.Object);
 
             // Act.
-            DnsFeature feature = new DnsFeature(dnsServer.Object, masterFile.Object, peerAddressManager, loggerFactory.Object, nodeLifetime.Object, nodeSettings, dataFolders);
+            DnsFeature feature = new DnsFeature(dnsServer.Object, peerAddressManager, loggerFactory.Object, nodeLifetime.Object, nodeSettings, dataFolders);
             feature.Initialize();
             bool waited = waitObject.Wait(5000);
 
@@ -223,9 +198,6 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
             dnsServer.Setup(s => s.ListenAsync(It.IsAny<int>(), It.IsAny<CancellationToken>())).Callback(action);
             dnsServer.Setup(s => s.SwapMasterfile(It.IsAny<IMasterFile>())).Verifiable();
 
-            Mock<IMasterFile> masterFile = new Mock<IMasterFile>();
-            masterFile.Setup(m => m.Load(It.IsAny<Stream>())).Verifiable();
-
             IPeerAddressManager peerAddressManager = new Mock<IPeerAddressManager>().Object;
 
             Mock<INodeLifetime> nodeLifetime = new Mock<INodeLifetime>();
@@ -249,14 +221,13 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
                 }
 
                 // Run feature
-                DnsFeature feature = new DnsFeature(dnsServer.Object, masterFile.Object, peerAddressManager, loggerFactory.Object, nodeLifetime.Object, nodeSettings, dataFolders);
+                DnsFeature feature = new DnsFeature(dnsServer.Object, peerAddressManager, loggerFactory.Object, nodeLifetime.Object, nodeSettings, dataFolders);
                 feature.Initialize();
                 bool waited = waitObject.Wait(5000);
 
                 // Assert.
                 feature.Should().NotBeNull();
                 waited.Should().BeTrue();
-                masterFile.Verify(m => m.Load(It.IsAny<Stream>()), Times.Once);
                 dnsServer.Verify(s => s.SwapMasterfile(It.IsAny<IMasterFile>()), Times.Once);
                 dnsServer.Verify(s => s.ListenAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()), Times.Once);
             }
@@ -287,9 +258,6 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
             dnsServer.Setup(s => s.ListenAsync(It.IsAny<int>(), It.IsAny<CancellationToken>())).Callback(action);
             dnsServer.Setup(s => s.SwapMasterfile(It.IsAny<IMasterFile>())).Verifiable();
 
-            Mock<IMasterFile> masterFile = new Mock<IMasterFile>();
-            masterFile.Setup(m => m.Load(It.IsAny<Stream>())).Verifiable();
-
             IPeerAddressManager peerAddressManager = new Mock<IPeerAddressManager>().Object;
 
             CancellationTokenSource source = new CancellationTokenSource();
@@ -307,7 +275,7 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
             loggerFactory.Setup<ILogger>(f => f.CreateLogger(It.IsAny<string>())).Returns(logger.Object);
 
             // Act.
-            DnsFeature feature = new DnsFeature(dnsServer.Object, masterFile.Object, peerAddressManager, loggerFactory.Object, nodeLifetimeObject, nodeSettings, dataFolders);
+            DnsFeature feature = new DnsFeature(dnsServer.Object, peerAddressManager, loggerFactory.Object, nodeLifetimeObject, nodeSettings, dataFolders);
             feature.Initialize();
             nodeLifetimeObject.StopApplication();
             bool waited = source.Token.WaitHandle.WaitOne(5000);
@@ -315,7 +283,6 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
             // Assert.
             feature.Should().NotBeNull();
             waited.Should().BeTrue();
-            masterFile.Verify(m => m.Load(It.IsAny<Stream>()), Times.Never);
             dnsServer.Verify(s => s.SwapMasterfile(It.IsAny<IMasterFile>()), Times.Never);
             dnsServer.Verify(s => s.ListenAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()), Times.Once);
         }
@@ -332,9 +299,6 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
             };
             dnsServer.Setup(s => s.ListenAsync(It.IsAny<int>(), It.IsAny<CancellationToken>())).Callback(action);
             dnsServer.Setup(s => s.SwapMasterfile(It.IsAny<IMasterFile>())).Verifiable();
-
-            Mock<IMasterFile> masterFile = new Mock<IMasterFile>();
-            masterFile.Setup(m => m.Load(It.IsAny<Stream>())).Verifiable();
 
             IPeerAddressManager peerAddressManager = new Mock<IPeerAddressManager>().Object;
 
@@ -355,14 +319,13 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
             loggerFactory.Setup<ILogger>(f => f.CreateLogger(It.IsAny<string>())).Returns(logger.Object);
 
             // Act.
-            DnsFeature feature = new DnsFeature(dnsServer.Object, masterFile.Object, peerAddressManager, loggerFactory.Object, nodeLifetimeObject, nodeSettings, dataFolders);
+            DnsFeature feature = new DnsFeature(dnsServer.Object, peerAddressManager, loggerFactory.Object, nodeLifetimeObject, nodeSettings, dataFolders);
             feature.Initialize();
             bool waited = source.Token.WaitHandle.WaitOne(5000);
 
             // Assert.
             feature.Should().NotBeNull();
             waited.Should().BeTrue();
-            masterFile.Verify(m => m.Load(It.IsAny<Stream>()), Times.Never);
             dnsServer.Verify(s => s.SwapMasterfile(It.IsAny<IMasterFile>()), Times.Never);
             dnsServer.Verify(s => s.ListenAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()), Times.AtLeastOnce);
             serverError.Should().BeTrue();

--- a/src/Stratis.Bitcoin.Features.Dns.Tests/GivenADnsSeedServer.cs
+++ b/src/Stratis.Bitcoin.Features.Dns.Tests/GivenADnsSeedServer.cs
@@ -1,0 +1,276 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+using DNS.Protocol;
+using DNS.Protocol.ResourceRecords;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Internal;
+using Moq;
+using NBitcoin.Protocol;
+using Stratis.Bitcoin.Configuration;
+using Stratis.Bitcoin.P2P;
+using Stratis.Bitcoin.Utilities;
+using Xunit;
+
+namespace Stratis.Bitcoin.Features.Dns.Tests
+{
+    /// <summary>
+    /// Tests for the <see cref="DnsSeedServer"/> class.
+    /// </summary>
+    public class GivenADnsSeedServer
+    {
+        [Fact]
+        [Trait("DNS", "UnitTest")]
+        public void WhenConstructorCalled_AndUdpClientIsNull_ThenArgumentNullExceptionIsThrown()
+        {
+            // Arrange.
+            IMasterFile masterFile = new Mock<IMasterFile>().Object;
+            ILoggerFactory loggerFactory = new Mock<ILoggerFactory>().Object;
+            Action a = () => { new DnsSeedServer(null, masterFile, loggerFactory); };
+
+            // Act and Assert.
+            a.ShouldThrow<ArgumentNullException>().Which.Message.Should().Contain("client");
+        }
+
+        [Fact]
+        [Trait("DNS", "UnitTest")]
+        public void WhenConstructorCalled_AndMasterFileIsNull_ThenArgumentNullExceptionIsThrown()
+        {
+            // Arrange.
+            IUdpClient udpClient = new Mock<IUdpClient>().Object;
+            ILoggerFactory loggerFactory = new Mock<ILoggerFactory>().Object;
+            Action a = () => { new DnsSeedServer(udpClient, null, loggerFactory); };
+
+            // Act and Assert.
+            a.ShouldThrow<ArgumentNullException>().Which.Message.Should().Contain("masterFile");
+        }
+
+        [Fact]
+        [Trait("DNS", "UnitTest")]
+        public void WhenConstructorCalled_AndLoggerFactoryIsNull_ThenArgumentNullExceptionIsThrown()
+        {
+            // Arrange.
+            IUdpClient udpClient = new Mock<IUdpClient>().Object;
+            IMasterFile masterFile = new Mock<IMasterFile>().Object;
+            Action a = () => { new DnsSeedServer(udpClient, masterFile, null); };
+
+            // Act and Assert.
+            a.ShouldThrow<ArgumentNullException>().Which.Message.Should().Contain("loggerFactory");
+        }
+
+        [Fact]
+        [Trait("DNS", "UnitTest")]
+        public void WhenConstructorCalled_AndAllParametersValid_ThenTypeCreated()
+        {
+            // Arrange.
+            IUdpClient udpClient = new Mock<IUdpClient>().Object;
+            IMasterFile masterFile = new Mock<IMasterFile>().Object;
+            ILoggerFactory loggerFactory = new Mock<ILoggerFactory>().Object;
+
+            // Act.
+            DnsSeedServer server = new DnsSeedServer(udpClient, masterFile, loggerFactory);
+
+            // Assert.
+            server.Should().NotBeNull();
+        }
+
+        [Fact]
+        [Trait("DNS", "UnitTest")]
+        public void WhenDnsServerListening_AndSocketExceptionRaised_ThenDnsServerFailsToStart()
+        {
+            // Arrange.
+            Mock<IUdpClient> udpClient = new Mock<IUdpClient>();
+            udpClient.Setup(c => c.StartListening(It.IsAny<int>())).Throws(new SocketException());
+
+            Mock<IMasterFile> masterFile = new Mock<IMasterFile>();
+
+            Mock<ILogger> logger = new Mock<ILogger>(MockBehavior.Loose);
+            Mock<ILoggerFactory> loggerFactory = new Mock<ILoggerFactory>();
+            loggerFactory.Setup<ILogger>(f => f.CreateLogger(It.IsAny<string>())).Returns(logger.Object);
+
+            // Act.
+            CancellationTokenSource source = new CancellationTokenSource();
+            DnsSeedServer server = new DnsSeedServer(udpClient.Object, masterFile.Object, loggerFactory.Object);
+            Func<Task> func = async () => await server.ListenAsync(53, source.Token);
+
+            // Assert.
+            server.Should().NotBeNull();
+            func.ShouldThrow<SocketException>();
+        }
+
+        [Fact]
+        [Trait("DNS", "UnitTest")]
+        public async Task WhenDnsServerReceiving_AndSocketExceptionRaised_ThenDnsServerFails_Async()
+        {
+            // Arrange.
+            bool startedListening = false;
+            Mock<IUdpClient> udpClient = new Mock<IUdpClient>();
+            udpClient.Setup(c => c.StartListening(It.IsAny<int>())).Callback(() => startedListening = true);
+            udpClient.Setup(c => c.ReceiveAsync()).ThrowsAsync(new SocketException());
+
+            Mock<IMasterFile> masterFile = new Mock<IMasterFile>();
+
+            Mock<ILogger> logger = new Mock<ILogger>(MockBehavior.Loose);
+            bool receivedSocketException = false;
+            logger.Setup(l => l.Log(LogLevel.Error, It.IsAny<EventId>(), It.IsAny<FormattedLogValues>(), It.IsAny<Exception>(), It.IsAny<Func<object, Exception, string>>())).Callback<LogLevel, EventId, object, Exception, Func<object, Exception, string>>((level, id, state, e, f) =>
+            {
+                // Don't reset if we found the error message we were looking for
+                if (!receivedSocketException)
+                {
+                    // Not yet set, check error message
+                    receivedSocketException = state.ToString().StartsWith("Socket exception");
+                }
+            });
+            Mock<ILoggerFactory> loggerFactory = new Mock<ILoggerFactory>();
+            loggerFactory.Setup<ILogger>(f => f.CreateLogger(It.IsAny<string>())).Returns(logger.Object);
+
+            // Act.
+            CancellationTokenSource source = new CancellationTokenSource(2000);
+            DnsSeedServer server = new DnsSeedServer(udpClient.Object, masterFile.Object, loggerFactory.Object);
+
+            try
+            {
+                await server.ListenAsync(53, source.Token);
+            }
+            catch (OperationCanceledException)
+            {
+                // Expected
+            }
+
+            // Assert.
+            server.Should().NotBeNull();
+            startedListening.Should().BeTrue();
+            receivedSocketException.Should().BeTrue();
+        }
+
+        [Fact]
+        [Trait("DNS", "UnitTest")]
+        public async Task WhenDnsServerListening_AndDnsBadRequestReceived_ThenDnsServerFailsToProcessesRequest_Async()
+        {
+            // Arrange.
+            bool startedListening = false;
+            Mock<IUdpClient> udpClient = new Mock<IUdpClient>();
+            udpClient.Setup(c => c.StartListening(It.IsAny<int>())).Callback(() => startedListening = true);
+            udpClient.Setup(c => c.ReceiveAsync()).ReturnsAsync(new Tuple<IPEndPoint, byte[]>(new IPEndPoint(IPAddress.Loopback, 80), this.GetBadDnsRequest()));
+
+            Mock<IMasterFile> masterFile = new Mock<IMasterFile>();
+            masterFile.Setup(m => m.Get(It.IsAny<Question>())).Returns(new List<IResourceRecord>() { new IPAddressResourceRecord(Domain.FromString("google.com"), IPAddress.Loopback) });
+
+            Mock<ILogger> logger = new Mock<ILogger>();
+            bool receivedRequest = false;
+            logger.Setup(l => l.Log(LogLevel.Trace, It.IsAny<EventId>(), It.IsAny<FormattedLogValues>(), It.IsAny<Exception>(), It.IsAny<Func<object, Exception, string>>())).Callback<LogLevel, EventId, object, Exception, Func<object, Exception, string>>((level, id, state, e, f) =>
+            {
+                // Don't reset if we found the trace message we were looking for
+                if (!receivedRequest)
+                {
+                    // Not yet set, check trace message
+                    receivedRequest = state.ToString().StartsWith("DNS request received");
+                }
+            });
+
+            bool receivedBadRequest = false;
+            logger.Setup(l => l.Log(LogLevel.Warning, It.IsAny<EventId>(), It.IsAny<FormattedLogValues>(), It.IsAny<Exception>(), It.IsAny<Func<object, Exception, string>>())).Callback<LogLevel, EventId, object, Exception, Func<object, Exception, string>>((level, id, state, e, f) =>
+            {
+                // Don't reset if we found the warning message we were looking for
+                if (!receivedBadRequest)
+                {
+                    // Not yet set, check warning message
+                    receivedBadRequest = state.ToString().StartsWith("Failed to process DNS request");
+                }
+            });
+            Mock<ILoggerFactory> loggerFactory = new Mock<ILoggerFactory>();
+            loggerFactory.Setup<ILogger>(f => f.CreateLogger(It.IsAny<string>())).Returns(logger.Object);
+
+            // Act.
+            CancellationTokenSource source = new CancellationTokenSource(2000);
+            DnsSeedServer server = new DnsSeedServer(udpClient.Object, masterFile.Object, loggerFactory.Object);
+
+            try
+            {
+                await server.ListenAsync(53, source.Token);
+            }
+            catch (OperationCanceledException)
+            {
+                // Expected
+            }
+
+            // Assert.
+            server.Should().NotBeNull();
+            startedListening.Should().BeTrue();
+            receivedRequest.Should().BeTrue();
+            receivedBadRequest.Should().BeTrue();
+        }
+
+        [Fact]
+        [Trait("DNS", "UnitTest")]
+        public async Task WhenDnsServerListening_AndDnsRequestReceived_ThenDnsServerSuccessfullyProcessesRequest_Async()
+        {
+            // Arrange.
+            bool startedListening = false;
+            bool sentResponse = false;
+            Mock<IUdpClient> udpClient = new Mock<IUdpClient>();
+            udpClient.Setup(c => c.StartListening(It.IsAny<int>())).Callback(() => startedListening = true);
+            udpClient.Setup(c => c.ReceiveAsync()).ReturnsAsync(new Tuple<IPEndPoint, byte[]>(new IPEndPoint(IPAddress.Loopback, 80), this.GetDnsRequest()));
+            udpClient.Setup(c => c.SendAsync(It.IsAny<byte[]>(), It.IsAny<int>(), It.IsAny<IPEndPoint>())).Callback<byte[], int, IPEndPoint>((p, s, ip) => sentResponse = true).ReturnsAsync(1);
+
+            Mock<IMasterFile> masterFile = new Mock<IMasterFile>();
+            masterFile.Setup(m => m.Get(It.IsAny<Question>())).Returns(new List<IResourceRecord>() { new IPAddressResourceRecord(Domain.FromString("google.com"), IPAddress.Loopback) });
+
+            Mock<ILogger> logger = new Mock<ILogger>();
+            bool receivedRequest = false;
+            logger.Setup(l => l.Log(LogLevel.Trace, It.IsAny<EventId>(), It.IsAny<FormattedLogValues>(), It.IsAny<Exception>(), It.IsAny<Func<object, Exception, string>>())).Callback<LogLevel, EventId, object, Exception, Func<object, Exception, string>>((level, id, state, e, f) =>
+            {
+                // Don't reset if we found the trace message we were looking for
+                if (!receivedRequest)
+                {
+                    // Not yet set, check trace message
+                    receivedRequest = state.ToString().StartsWith("DNS request received");
+                }
+            });
+            Mock<ILoggerFactory> loggerFactory = new Mock<ILoggerFactory>();
+            loggerFactory.Setup<ILogger>(f => f.CreateLogger(It.IsAny<string>())).Returns(logger.Object);
+
+            // Act.
+            CancellationTokenSource source = new CancellationTokenSource(2000);
+            DnsSeedServer server = new DnsSeedServer(udpClient.Object, masterFile.Object, loggerFactory.Object);
+
+            try
+            {
+                await server.ListenAsync(53, source.Token);
+            }
+            catch (OperationCanceledException)
+            {
+                // Expected
+            }
+
+            // Assert.
+            server.Should().NotBeNull();
+            startedListening.Should().BeTrue();
+            receivedRequest.Should().BeTrue();
+            sentResponse.Should().BeTrue();
+        }
+
+        /// <summary>
+        /// Sets up a DNS 'A' request for google.com.
+        /// </summary>
+        /// <returns>Returns a test DNS request buffer.</returns>
+        private byte[] GetDnsRequest()
+        {
+            return new byte[] { 236, 17, 1, 32, 0, 1, 0, 0, 0, 0, 0, 1, 6, 103, 111, 111, 103, 108, 101, 3, 99, 111, 109, 0, 0, 1, 0, 1, 0, 0, 41, 16, 0, 0, 0, 0, 0, 0, 0 };
+        }
+
+        /// <summary>
+        /// Sets up a bad DNS 'A' request.
+        /// </summary>
+        /// <returns>Returns a test DNS request buffer.</returns>
+        private byte[] GetBadDnsRequest()
+        {
+            return new byte[] { 255, 2, 255, 3, 0, 1, 0, 0, 0, 0, 0, 1, 6, 103, 111, 111, 103, 108, 101, 3, 99, 111, 109, 0, 0, 1, 0, 1, 0, 0, 41, 16, 0, 0, 0, 0, 0, 0, 0 };
+        }
+    }
+}

--- a/src/Stratis.Bitcoin.Features.Dns/DnsFeature.cs
+++ b/src/Stratis.Bitcoin.Features.Dns/DnsFeature.cs
@@ -31,11 +31,6 @@ namespace Stratis.Bitcoin.Features.Dns
         private readonly IDnsServer dnsServer;
 
         /// <summary>
-        /// Defines the DNS masterfile.
-        /// </summary>
-        private readonly IMasterFile masterFile;
-
-        /// <summary>
         /// Defines the peer address manager.
         /// </summary>
         private readonly IPeerAddressManager peerAddressManager;
@@ -69,16 +64,14 @@ namespace Stratis.Bitcoin.Features.Dns
         /// Initializes a new instance of the <see cref="DnsFeature"/> class.
         /// </summary>
         /// <param name="dnsServer">The DNS server.</param>
-        /// <param name="masterFile">The DNS masterfile.</param>
         /// <param name="peerAddressManager">The peer address manager.</param>
         /// <param name="loggerFactory">The factory to create the logger.</param>
         /// <param name="nodeLifetime">The node lifetime object used for graceful shutdown.</param>
         /// <param name="nodeSettings">The node settings object containing node configuration.</param>
         /// <param name="dataFolders">The data folders of the system.</param>
-        public DnsFeature(IDnsServer dnsServer, IMasterFile masterFile, IPeerAddressManager peerAddressManager, ILoggerFactory loggerFactory, INodeLifetime nodeLifetime, NodeSettings nodeSettings, DataFolder dataFolders)
+        public DnsFeature(IDnsServer dnsServer, IPeerAddressManager peerAddressManager, ILoggerFactory loggerFactory, INodeLifetime nodeLifetime, NodeSettings nodeSettings, DataFolder dataFolders)
         {
             Guard.NotNull(dnsServer, nameof(dnsServer));
-            Guard.NotNull(masterFile, nameof(masterFile));
             Guard.NotNull(peerAddressManager, nameof(peerAddressManager));
             Guard.NotNull(loggerFactory, nameof(loggerFactory));
             Guard.NotNull(nodeLifetime, nameof(nodeLifetime));
@@ -86,7 +79,6 @@ namespace Stratis.Bitcoin.Features.Dns
             Guard.NotNull(dataFolders, nameof(dataFolders));
 
             this.dnsServer = dnsServer;
-            this.masterFile = masterFile;
             this.peerAddressManager = peerAddressManager;
             this.logger = loggerFactory.CreateLogger(this.GetType().FullName);
             this.nodeLifetime = nodeLifetime;
@@ -127,11 +119,12 @@ namespace Stratis.Bitcoin.Features.Dns
 
                         using (FileStream stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read))
                         {
-                            this.masterFile.Load(stream);
-                        }
+                            IMasterFile masterFile = new DnsSeedMasterFile();
+                            masterFile.Load(stream);
 
-                        // Swap in masterfile from disk into DNS server
-                        this.dnsServer.SwapMasterfile(this.masterFile);
+                            // Swap in masterfile from disk into DNS server
+                            this.dnsServer.SwapMasterfile(masterFile);
+                        }
                     }
 
                     this.logger.LogInformation("Starting DNS server on port {0}", this.nodeSettings.DnsListenPort);

--- a/src/Stratis.Bitcoin.Features.Dns/DnsFeature.cs
+++ b/src/Stratis.Bitcoin.Features.Dns/DnsFeature.cs
@@ -1,5 +1,9 @@
-﻿using Microsoft.Extensions.Logging;
+﻿using System;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using Stratis.Bitcoin.Builder.Feature;
+using Stratis.Bitcoin.Configuration;
 using Stratis.Bitcoin.P2P;
 using Stratis.Bitcoin.Utilities;
 
@@ -11,6 +15,21 @@ namespace Stratis.Bitcoin.Features.Dns
     public class DnsFeature : FullNodeFeature
     {
         /// <summary>
+        /// Defines the name of the masterfile on disk.
+        /// </summary>
+        private const string DnsMasterFileName = "masterfile.dat";
+
+        /// <summary>
+        /// Defines the DNS server.
+        /// </summary>
+        private readonly IDnsServer dnsServer;
+
+        /// <summary>
+        /// Defines the DNS masterfile.
+        /// </summary>
+        private readonly IMasterFile masterFile;
+
+        /// <summary>
         /// Defines the peer address manager.
         /// </summary>
         private readonly IPeerAddressManager peerAddressManager;
@@ -21,17 +40,52 @@ namespace Stratis.Bitcoin.Features.Dns
         private readonly ILogger logger;
 
         /// <summary>
+        /// Defines the node lifetime.
+        /// </summary>
+        private readonly INodeLifetime nodeLifetime;
+
+        /// <summary>
+        /// Defines the configuration settings for the node.
+        /// </summary>
+        private readonly NodeSettings nodeSettings;
+
+        /// <summary>
+        /// Defines the data folders of the system.
+        /// </summary>
+        private readonly DataFolder dataFolders;
+
+        /// <summary>
+        /// Defines the long running task used to support the DNS service.
+        /// </summary>
+        private Task dnsTask;
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="DnsFeature"/> class.
         /// </summary>
+        /// <param name="dnsServer">The DNS server.</param>
+        /// <param name="masterFile">The DNS masterfile.</param>
         /// <param name="peerAddressManager">The peer address manager.</param>
         /// <param name="loggerFactory">The factory to create the logger.</param>
-        public DnsFeature(IPeerAddressManager peerAddressManager, ILoggerFactory loggerFactory)
+        /// <param name="nodeLifetime">The node lifetime object used for graceful shutdown.</param>
+        /// <param name="nodeSettings">The node settings object containing node configuration.</param>
+        /// <param name="dataFolders">The data folders of the system.</param>
+        public DnsFeature(IDnsServer dnsServer, IMasterFile masterFile, IPeerAddressManager peerAddressManager, ILoggerFactory loggerFactory, INodeLifetime nodeLifetime, NodeSettings nodeSettings, DataFolder dataFolders)
         {
+            Guard.NotNull(dnsServer, nameof(dnsServer));
+            Guard.NotNull(masterFile, nameof(masterFile));
             Guard.NotNull(peerAddressManager, nameof(peerAddressManager));
             Guard.NotNull(loggerFactory, nameof(loggerFactory));
+            Guard.NotNull(nodeLifetime, nameof(nodeLifetime));
+            Guard.NotNull(nodeSettings, nameof(nodeSettings));
+            Guard.NotNull(dataFolders, nameof(dataFolders));
 
+            this.dnsServer = dnsServer;
+            this.masterFile = masterFile;
             this.peerAddressManager = peerAddressManager;
             this.logger = loggerFactory.CreateLogger(this.GetType().FullName);
+            this.nodeLifetime = nodeLifetime;
+            this.nodeSettings = nodeSettings;
+            this.dataFolders = dataFolders;
         }
 
         /// <summary>
@@ -39,8 +93,49 @@ namespace Stratis.Bitcoin.Features.Dns
         /// </summary>
         public override void Initialize()
         {
-            this.logger.LogInformation("Starting DNS");
-            // TODO: add implementation.            
+            this.logger.LogTrace("()");
+
+            // Create long running task for DNS service
+            this.dnsTask = Task.Factory.StartNew(this.RunDnsServiceAsync, TaskCreationOptions.LongRunning);
+
+            this.logger.LogTrace("(-)");
+        }
+
+        /// <summary>
+        /// Runs the DNS service until the node is stopped.
+        /// </summary>
+        /// <returns>A task used to allow the caller to await the operation.</returns>
+        private async Task RunDnsServiceAsync()
+        {
+            this.logger.LogTrace("()");
+
+            try
+            {
+                // Load masterfile from disk if it exists
+                string path = Path.Combine(this.dataFolders.DnsMasterFilePath + DnsMasterFileName);
+                if (File.Exists(path))
+                {
+                    using (FileStream stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read))
+                    {
+                        this.masterFile.Load(stream);
+                    }
+
+                    // Swap in masterfile from disk into DNS server
+                    this.dnsServer.SwapMasterfile(this.masterFile);
+                }
+
+                this.logger.LogInformation("Starting DNS server on port {0}", this.nodeSettings.DnsListenPort);
+
+                // Start
+                await this.dnsServer.ListenAsync(this.nodeSettings.DnsListenPort, this.nodeLifetime.ApplicationStopping);
+            }
+            catch (OperationCanceledException)
+            {
+                // Node shutting down, expected
+                this.logger.LogInformation("Stopping DNS");
+            }
+
+            this.logger.LogTrace("(-)");
         }
     }
 }

--- a/src/Stratis.Bitcoin.Features.Dns/DnsSeedMasterFile.cs
+++ b/src/Stratis.Bitcoin.Features.Dns/DnsSeedMasterFile.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using DNS.Protocol;
+using DNS.Protocol.ResourceRecords;
+using DNS.Server;
+using Stratis.Bitcoin.P2P.Peer;
+
+namespace Stratis.Bitcoin.Features.Dns
+{
+    /// <summary>
+    /// This class defines a DNS masterfile used to cache the whitelisted peers discovered by the DNS Seed service that supports saving
+    /// and loading from a stream.
+    /// </summary>
+    public class DnsSeedMasterFile : MasterFile, IMasterFile
+    {
+        /// <summary>
+        /// Adds a <see cref="NetworkPeer"/> object to the masterfile.
+        /// </summary>
+        /// <param name="peer">The peer to add to the masterfile so that the IP address of the peer can be returned in a DNS resolve request.</param>
+        public void AddPeer(NetworkPeer peer)
+        {
+            // TODO
+        }
+
+        /// <summary>
+        /// Adds a collection of <see cref="NetworkPeer"/> objects to the masterfile.
+        /// </summary>
+        /// <param name="peers">The peers to add to the masterfile so that the IP address of the peer can be returned in a DNS resolve request.</param>
+        public void AddPeers(IEnumerable<NetworkPeer> peers)
+        {
+            // TODO
+        }
+
+        /// <summary>
+        /// Loads the saved masterfile from the specified stream.
+        /// </summary>
+        /// <param name="stream">The stream containing the masterfile.</param>
+        public void Load(Stream stream)
+        {
+            // TODO
+        }
+
+        /// <summary>
+        /// Saves the cached masterfile to the specified stream.
+        /// </summary>
+        /// <param name="stream">The stream to write the masterfile to.</param>
+        public void Save(Stream stream)
+        {
+            // TODO
+        }
+    }
+}

--- a/src/Stratis.Bitcoin.Features.Dns/DnsSeedServer.cs
+++ b/src/Stratis.Bitcoin.Features.Dns/DnsSeedServer.cs
@@ -1,0 +1,239 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using DNS.Client;
+using DNS.Protocol;
+using DNS.Protocol.ResourceRecords;
+using DNS.Protocol.Utils;
+using DNS.Server;
+using Microsoft.Extensions.Logging;
+using Stratis.Bitcoin.Utilities;
+
+namespace Stratis.Bitcoin.Features.Dns
+{
+    /// <summary>
+    /// This class defines a DNS server based on 3rd party library https://github.com/kapetan/dns.
+    /// </summary>
+    public class DnsSeedServer : IDnsServer
+    {
+        /// <summary>
+        /// Sets the timeout at 2 seconds.
+        /// </summary>
+        private const int UdpTimeout = 2000;
+
+        /// <summary>
+        /// Defines a flag used to indicate whether the object has been disposed or not.
+        /// </summary>
+        private bool disposed = false;
+
+        /// <summary>
+        /// Defines the DNS masterfile used to cache IP addresses.
+        /// </summary>
+        private IMasterFile masterFile;
+
+        /// <summary>
+        /// Defines a lock object for the masterfile to use during swapping.
+        /// </summary>
+        private object masterFileLock = new object();
+
+        /// <summary>
+        /// Defines the client used to listen for incoming DNS requests.
+        /// </summary>
+        private UdpClient udpClient;
+
+        /// <summary>
+        /// Defines the logger.
+        /// </summary>
+        private readonly ILogger logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DnsSeedServer"/> class with the port to listen on.
+        /// </summary>
+        /// <param name="masterFile">The initial DNS masterfile.</param>
+        /// <param name="loggerFactory">The logger factory.</param>
+        public DnsSeedServer(IMasterFile masterFile, ILoggerFactory loggerFactory)
+        {
+            Guard.NotNull(masterFile, nameof(masterFile));
+            Guard.NotNull(loggerFactory, nameof(loggerFactory));
+
+            this.masterFile = masterFile;
+            this.logger = loggerFactory.CreateLogger(this.GetType().FullName);
+        }
+
+        /// <summary>
+        /// Gets the current <see cref="IMasterFile"/> instance associated with the <see cref="IDnsServer"/>.
+        /// </summary>
+        public IMasterFile MasterFile
+        {
+            get { return this.masterFile; }
+        }
+
+        /// <summary>
+        /// Starts listening for DNS requests.
+        /// </summary>
+        /// <param name="dnsListenPort">The port to listen on.</param>
+        /// <param name="token">The token used to cancel the listen.</param>
+        /// <returns>A task used to await the listen operation.</returns>
+        public async Task ListenAsync(int dnsListenPort, CancellationToken token)
+        {
+            try
+            {
+                this.udpClient = new UdpClient(dnsListenPort);
+            }
+            catch (SocketException e)
+            {
+                this.logger.LogError(e, "Failed to create UDP client for DNS service.");
+                throw;
+            }
+
+            while (true)
+            {
+                UdpReceiveResult request;
+
+                // Have we been cancelled?
+                if (token.IsCancellationRequested)
+                {
+                    this.logger.LogTrace("Cancellation requested, shutting down DNS listener.");
+                    token.ThrowIfCancellationRequested();
+                }
+
+                try
+                {
+                    request = await this.udpClient.ReceiveAsync();
+
+                    this.logger.LogTrace("DNS request received from {0}.", request.RemoteEndPoint);
+
+                    // Received a request, now handle it
+                    await this.HandleRequestAsync(request);
+                }
+                catch (SocketException e)
+                {
+                    this.logger.LogError(e, "Failed whilst receiving UDP request.");
+                }
+            }
+        }
+
+        /// <summary>
+        /// Swaps in a new version of the cached DNS masterfile used by the DNS server.
+        /// </summary>
+        /// <remarks>
+        /// The <see cref="DnsFeature"/> object is designed to produce a whitelist of peers from the <see cref="P2P.IPeerAddressManager"/>
+        /// object which is then periodically formed into a new masterfile instance and applied to the <see cref="IDnsServer"/> object.  The
+        /// masterfile is swapped for efficiency, rather than applying a merge operation to the existing masterfile, or clearing the existing
+        /// masterfile and re-adding the peer entries (which could cause some interim DNS resolve requests to fail).
+        /// </remarks>
+        /// <param name="masterFile">The new masterfile to swap in.</param>
+        public void SwapMasterfile(IMasterFile masterFile)
+        {
+            Guard.NotNull(masterFile, nameof(masterFile));
+
+            lock (this.masterFileLock)
+            {
+                this.masterFile = masterFile;
+            }
+        }
+
+        /// <summary>
+        /// Disposes of the object.
+        /// </summary>
+        public void Dispose()
+        {
+            this.Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// Disposes of the object.
+        /// </summary>
+        /// <param name="disposing"><c>true</c> if the object is being disposed of deterministically, otherwise <c>false</c>.</param>
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!this.disposed)
+            {
+                if (disposing)
+                {
+                    this.udpClient?.Dispose();
+                }
+
+                this.disposed = true;
+            }
+        }
+
+        /// <summary>
+        /// Resolves the DNS request against the local masterfile.
+        /// </summary>
+        /// <param name="request">The request to resolve against the local masterfile.</param>
+        /// <returns>A DNS response.</returns>
+        private IResponse Resolve(Request request)
+        {
+            Response response = Response.FromRequest(request);
+
+            foreach (Question question in request.Questions)
+            {
+                IList<IResourceRecord> answers = this.masterFile.Get(question);
+                if (answers.Count > 0)
+                {
+                    response.AnswerRecords.Union(answers);
+                }
+            }
+
+            return response;
+        }
+
+        /// <summary>
+        /// Handles a DNS request received by the UDP client.
+        /// </summary>
+        /// <param name="udpRequest">The DNS request received from the UDP client.</param>
+        private async Task HandleRequestAsync(UdpReceiveResult udpRequest)
+        {
+            Request request = null;
+
+            try
+            {
+                // Resolve request against masterfile
+                request = Request.FromArray(udpRequest.Buffer);
+                IResponse response = this.Resolve(request);
+
+                // Send response
+                await this.udpClient.SendAsync(response.ToArray(), response.Size, udpRequest.RemoteEndPoint).WithCancellationTimeout(UdpTimeout);
+            }
+            catch (SocketException e)
+            {
+                this.logger.LogError(e, "Socket error {0} whilst sending DNS response to {1}", e.ErrorCode, udpRequest.RemoteEndPoint);
+            }
+            catch (OperationCanceledException e)
+            {
+                this.logger.LogError(e, "Sending DNS response to {0} timed out.", udpRequest.RemoteEndPoint);
+            }
+            catch (ResponseException e)
+            {
+                this.logger.LogError(e, "Received error {0} when sending DNS response to {1}, trying again.", e.Response.ResponseCode, udpRequest.RemoteEndPoint);
+
+                // Try and send response one more time
+                IResponse response = e.Response;
+                if (response == null)
+                {
+                    response = Response.FromRequest(request);
+                }
+
+                try
+                {
+                    await this.udpClient.SendAsync(response.ToArray(), response.Size, udpRequest.RemoteEndPoint).WithCancellationTimeout(UdpTimeout);
+                }
+                catch (SocketException ex)
+                {
+                    this.logger.LogError(ex, "Socket error {0} whilst sending DNS response to {1}", ex.ErrorCode, udpRequest.RemoteEndPoint);
+                }
+                catch (OperationCanceledException ex)
+                {
+                    this.logger.LogError(ex, "Sending DNS response to {0} timed out.", udpRequest.RemoteEndPoint);
+                }
+            }
+        }
+    }
+}

--- a/src/Stratis.Bitcoin.Features.Dns/DnsSeedServer.cs
+++ b/src/Stratis.Bitcoin.Features.Dns/DnsSeedServer.cs
@@ -87,7 +87,7 @@ namespace Stratis.Bitcoin.Features.Dns
             }
             catch (SocketException e)
             {
-                this.logger.LogError(e, "Failed to create UDP client for DNS service.");
+                this.logger.LogError(e, "Socket exception {0} whilst creating UDP client for DNS service.", e.ErrorCode);
                 throw;
             }
 
@@ -113,7 +113,7 @@ namespace Stratis.Bitcoin.Features.Dns
                 }
                 catch (SocketException e)
                 {
-                    this.logger.LogError(e, "Failed whilst receiving UDP request.");
+                    this.logger.LogError(e, "Socket exception {0} whilst receiving UDP request.", e.ErrorCode);
                 }
             }
         }
@@ -180,6 +180,8 @@ namespace Stratis.Bitcoin.Features.Dns
                 {
                     response.AnswerRecords.Union(answers);
                 }
+
+                this.logger.LogTrace("{0} answers to the question: domain = {1}, record type = {2}", answers.Count, question.Name, question.Type);
             }
 
             return response;

--- a/src/Stratis.Bitcoin.Features.Dns/DnsSeedUdpClient.cs
+++ b/src/Stratis.Bitcoin.Features.Dns/DnsSeedUdpClient.cs
@@ -1,0 +1,113 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Stratis.Bitcoin.Features.Dns
+{
+    /// <summary>
+    /// Defines a class for a UDP client that uses the <see cref="UdpClient"/> class as the underlying UDP client.
+    /// </summary>
+    public class DnsSeedUdpClient : IUdpClient, IDisposable
+    {
+        /// <summary>
+        /// Defines a flag that determines if the client is disposed or not.
+        /// </summary>
+        private bool isDisposed = false;
+
+        /// <summary>
+        /// Defines the underlying UDP client.
+        /// </summary>
+        private UdpClient udpClient;
+
+        /// <summary>
+        /// Starts the UDP client to listen for incoming UDP requests.
+        /// </summary>
+        /// <param name="port">The port to listen on.</param>
+        public void StartListening(int port)
+        {
+            // Create client
+            if (this.udpClient != null)
+            {
+                // Already a client, dispose and create a new one
+                this.udpClient.Dispose();
+            }
+
+            this.udpClient = new UdpClient(port);
+        }
+
+        /// <summary>
+        /// Stops the UDP client.
+        /// </summary>
+        public void StopListening()
+        {
+            this.udpClient?.Dispose();
+            this.udpClient = null;
+        }
+
+        /// <summary>
+        /// Receives a UDP message.
+        /// </summary>
+        /// <returns>A task used to await the operation that returns a UDP message.</returns>
+        public async Task<Tuple<IPEndPoint, byte[]>> ReceiveAsync()
+        {
+            this.ThrowIfDisposed();
+            UdpReceiveResult result = await this.udpClient.ReceiveAsync();
+            return new Tuple<IPEndPoint, byte[]>(result.RemoteEndPoint, result.Buffer);
+        }
+
+        /// <summary>
+        /// Sends a UDP message.
+        /// </summary>
+        /// <param name="payload">The payload to send.</param>
+        /// <param name="bytes">The size of the payload.</param>
+        /// <param name="remoteEndpoint">The address to send the payload.</param>
+        /// <returns>A task used to await the operation.</returns>
+        public async Task<int> SendAsync(byte[] payload, int bytes, IPEndPoint remoteEndpoint)
+        {
+            this.ThrowIfDisposed();
+            return await this.udpClient.SendAsync(payload, bytes, remoteEndpoint);
+        }
+
+        /// <summary>
+        /// Disposes of the client.
+        /// </summary>
+        public void Dispose()
+        {
+            this.Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// Disposes of the client.
+        /// </summary>
+        /// <param name="disposing">True if deterministically disposing, otherwise False.</param>
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!this.isDisposed)
+            {
+                if (disposing)
+                {
+                    this.udpClient?.Dispose();
+                    this.udpClient = null;
+                }
+
+                this.isDisposed = true;
+            }
+        }
+
+        /// <summary>
+        /// Throw if object already disposed.
+        /// </summary>
+        private void ThrowIfDisposed()
+        {
+            if (this.isDisposed)
+            {
+                throw new ObjectDisposedException(nameof(DnsSeedUdpClient));
+            }
+        }
+    }
+}

--- a/src/Stratis.Bitcoin.Features.Dns/IDnsServer.cs
+++ b/src/Stratis.Bitcoin.Features.Dns/IDnsServer.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using DNS.Server;
+
+namespace Stratis.Bitcoin.Features.Dns
+{
+    /// <summary>
+    /// This interface defines a DNS server used by the StratisDnsD daemon to support a DNS Seed service.
+    /// </summary>
+    public interface IDnsServer
+    {
+        /// <summary>
+        /// Gets the current <see cref="IMasterFile"/> instance associated with the <see cref="IDnsServer"/>.
+        /// </summary>
+        IMasterFile MasterFile { get; }
+
+        /// <summary>
+        /// Starts listening for DNS requests.
+        /// </summary>
+        /// <param name="dnsListenPort">The port to listen on.</param>
+        /// <param name="token">The token used to cancel the listen.</param>
+        /// <returns>A task used to await the listen operation.</returns>
+        Task ListenAsync(int dnsListenPort, CancellationToken token);
+
+        /// <summary>
+        /// Swaps in a new version of the cached DNS masterfile used by the DNS server.
+        /// </summary>
+        /// <remarks>
+        /// The <see cref="DnsFeature"/> object is designed to produce a whitelist of peers from the <see cref="P2P.IPeerAddressManager"/>
+        /// object which is then periodically formed into a new masterfile instance and applied to the <see cref="IDnsServer"/> object.  The
+        /// masterfile is swapped for efficiency, rather than applying a merge operation to the existing masterfile, or clearing the existing
+        /// masterfile and re-adding the peer entries (which could cause some interim DNS resolve requests to fail).
+        /// </remarks>
+        /// <param name="masterFile">The new masterfile to swap in.</param>
+        void SwapMasterfile(IMasterFile masterFile);
+    }
+}

--- a/src/Stratis.Bitcoin.Features.Dns/IFullNodeBuilderExtensions.cs
+++ b/src/Stratis.Bitcoin.Features.Dns/IFullNodeBuilderExtensions.cs
@@ -22,7 +22,12 @@ namespace Stratis.Bitcoin.Features.Dns
             {
                 features
                 .AddFeature<DnsFeature>()
-                .FeatureServices(services => services.AddSingleton(fullNodeBuilder));
+                .FeatureServices(services =>
+                {
+                    services.AddSingleton(fullNodeBuilder);
+                    services.AddSingleton<IMasterFile, DnsSeedMasterFile>();
+                    services.AddSingleton<IDnsServer, DnsSeedServer>();
+                });
             });
            
             return fullNodeBuilder;

--- a/src/Stratis.Bitcoin.Features.Dns/IFullNodeBuilderExtensions.cs
+++ b/src/Stratis.Bitcoin.Features.Dns/IFullNodeBuilderExtensions.cs
@@ -27,6 +27,7 @@ namespace Stratis.Bitcoin.Features.Dns
                     services.AddSingleton(fullNodeBuilder);
                     services.AddSingleton<IMasterFile, DnsSeedMasterFile>();
                     services.AddSingleton<IDnsServer, DnsSeedServer>();
+                    services.AddSingleton<IUdpClient, DnsSeedUdpClient>();
                 });
             });
            

--- a/src/Stratis.Bitcoin.Features.Dns/IMasterFile.cs
+++ b/src/Stratis.Bitcoin.Features.Dns/IMasterFile.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using DNS.Protocol;
+using DNS.Protocol.ResourceRecords;
+using DNS.Server;
+using Stratis.Bitcoin.P2P.Peer;
+
+namespace Stratis.Bitcoin.Features.Dns
+{
+    /// <summary>
+    /// This interface defines a DNS masterfile used to cache the whitelisted peers discovered by the DNS Seed service.
+    /// </summary>
+    public interface IMasterFile
+    {
+        /// <summary>
+        /// Adds a <see cref="NetworkPeer"/> object to the masterfile.
+        /// </summary>
+        /// <param name="peer">The peer to add to the masterfile so that the IP address of the peer can be returned in a DNS resolve request.</param>
+        void AddPeer(NetworkPeer peer);
+
+        /// <summary>
+        /// Adds a collection of <see cref="NetworkPeer"/> objects to the masterfile.
+        /// </summary>
+        /// <param name="peers">The peers to add to the masterfile so that the IP address of the peer can be returned in a DNS resolve request.</param>
+        void AddPeers(IEnumerable<NetworkPeer> peers);
+
+        /// <summary>
+        /// Gets a list of resource records that match the question.
+        /// </summary>
+        /// <param name="question">The question to ask of the masterfile.</param>
+        /// <returns>A list of resource records.</returns>
+        IList<IResourceRecord> Get(Question question);
+
+        /// <summary>
+        /// Loads the saved masterfile from the specified stream.
+        /// </summary>
+        /// <param name="stream">The stream containing the masterfile.</param>
+        void Load(Stream stream);
+
+        /// <summary>
+        /// Saves the cached masterfile to the specified stream.
+        /// </summary>
+        /// <param name="stream">The stream to write the masterfile to.</param>
+        void Save(Stream stream);
+    }
+}

--- a/src/Stratis.Bitcoin.Features.Dns/IUdpClient.cs
+++ b/src/Stratis.Bitcoin.Features.Dns/IUdpClient.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Stratis.Bitcoin.Features.Dns
+{
+    /// <summary>
+    /// Defines an interface for a UDP client used to send and receive UDP messages.
+    /// </summary>
+    public interface IUdpClient
+    {
+        /// <summary>
+        /// Starts the UDP client to listen for incoming UDP requests.
+        /// </summary>
+        /// <param name="port">The port to listen on.</param>
+        /// <returns>A task used to await the operation.</returns>
+        void StartListening(int port);
+
+        /// <summary>
+        /// Stops the UDP client.
+        /// </summary>
+        /// <returns>A task used to await the operation.</returns>
+        void StopListening();
+
+        /// <summary>
+        /// Receives a UDP message.
+        /// </summary>
+        /// <returns>A task used to await the operation that returns a UDP message.</returns>
+        Task<Tuple<IPEndPoint, byte[]>> ReceiveAsync();
+
+        /// <summary>
+        /// Sends a UDP message.
+        /// </summary>
+        /// <param name="payload">The payload to send.</param>
+        /// <param name="bytes">The size of the payload.</param>
+        /// <param name="remoteEndpoint">The address to send the payload.</param>
+        /// <returns>A task used to await the operation.</returns>
+        Task<int> SendAsync(byte[] payload, int bytes, IPEndPoint remoteEndpoint);
+    }
+}

--- a/src/Stratis.Bitcoin/Configuration/DataFolder.cs
+++ b/src/Stratis.Bitcoin/Configuration/DataFolder.cs
@@ -28,6 +28,7 @@ namespace Stratis.Bitcoin.Configuration
             this.RpcCookieFile = Path.Combine(path, ".cookie");
             this.WalletPath = Path.Combine(path);
             this.LogPath = Path.Combine(path, "Logs");
+            this.DnsMasterFilePath = path;
         }
 
         /// <summary>Address manager's database of peers.</summary>
@@ -61,5 +62,9 @@ namespace Stratis.Bitcoin.Configuration
         /// <summary>Path to log files.</summary>
         /// <seealso cref="Logging.LoggingConfiguration"/>
         public string LogPath { get; internal set; }
+
+        /// <summary>Path to DNS masterfile.</summary>
+        /// <seealso cref="Features.Dns.IMasterFile.Save"/>
+        public string DnsMasterFilePath { get; internal set; }
     }
 }

--- a/src/Stratis.Bitcoin/Configuration/NodeSettings.cs
+++ b/src/Stratis.Bitcoin/Configuration/NodeSettings.cs
@@ -125,6 +125,12 @@ namespace Stratis.Bitcoin.Configuration
         /// <summary><c>true</c> to sync time with other peers and calculate adjusted time, <c>false</c> to use our system clock only.</summary>
         public bool SyncTimeEnabled { get; set; }
 
+        /// <summary><c>true</c> if the DNS Seed service should also run as a full node, otherwise <c>false</c>.</summary>
+        public bool DnsFullNode { get; set; }
+
+        /// <summary>Defines the port that the DNS server will listen on, by default this is 53.</summary>
+        public int DnsListenPort { get; set; }
+
         /// <summary>
         /// Initializes default configuration.
         /// </summary>
@@ -225,6 +231,15 @@ namespace Stratis.Bitcoin.Configuration
 
             this.SyncTimeEnabled = config.GetOrDefault<bool>("synctime", true);
             this.Logger.LogDebug("Time synchronization with peers is {0}.", this.SyncTimeEnabled ? "enabled" : "disabled");
+
+            if (args.Contains("-dnsfullnode", StringComparer.CurrentCultureIgnoreCase))
+            {
+                this.DnsFullNode = true;
+                this.Logger.LogDebug("DNS Seed Service is set to run as a full node, if running as DNS Seed.", this.DnsListenPort);
+            }
+
+            this.DnsListenPort = config.GetOrDefault<int>("dnslistenport", 53);
+            this.Logger.LogDebug("DNS Seed Service listen port is {0}, if running as DNS Seed.", this.DnsListenPort);
 
             try
             {

--- a/src/Stratis.StratisDnsD/Properties/launchSettings.json
+++ b/src/Stratis.StratisDnsD/Properties/launchSettings.json
@@ -5,7 +5,7 @@
     },
     "Stratis.StratisDnsD Test": {
       "commandName": "Project",
-      "commandLineArgs": "-testnet"
+      "commandLineArgs": "-testnet -dnslistenport=5399"
     }
   }
 }


### PR DESCRIPTION
- For trello backlog item: https://trello.com/c/DrlOCEm9
- Uses 3rd party library from https://github.com/kapetan/dns (nuget package)
- Given some deficiencies in the library, the DnsServer class has been rewritten to allow a custom master file and to support dig DNS requests (which it failed with during integration testing).
-  Updates DnsFeature to start the DNS server and restart it if it fails, also responds to the cancellation token ApplicationStopping in the INodeLifetime object.
- Updates to NodeSettings to support dnslistenport and dnsfullnode options
- Updates to DataFolders to support a location for the cached DNS masterfile
- Added DnsSeedServer class (and interfaces) that implements DNS request resolver using 3rd party library
- Added DnsSeedUdpClient class (and interfaces) to wrap the .NET UdpClient class to make the DnsSeedServer class unit testable
- Added unit tests
- Added code to register services for the DnsFeature when building the full node