### PR TITLE
Remove global.json and fix compiler warnings

### DIFF
--- a/src/Stratis.Bitcoin.Features.Consensus/PosConsensusValidator.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/PosConsensusValidator.cs
@@ -428,7 +428,7 @@ namespace Stratis.Bitcoin.Features.Consensus
                 }
             }
 
-            context.NextWorkRequired = StakeValidator.GetNextTargetRequired(this.stakeChain, context.BlockValidationContext.ChainedBlock.Previous, context.Consensus,
+            context.NextWorkRequired = this.StakeValidator.GetNextTargetRequired(this.stakeChain, context.BlockValidationContext.ChainedBlock.Previous, context.Consensus,
                 context.Stake.BlockStake.IsProofOfStake());
 
             this.logger.LogTrace("(-)[OK]");

--- a/src/Stratis.Bitcoin.Features.Wallet.Tests/WalletControllerTest.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet.Tests/WalletControllerTest.cs
@@ -1724,6 +1724,8 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
 
         public TestReadOnlyNetworkPeerCollection()
         {
+            this.Added = new EventHandler<NetworkPeerEventArgs>((obj, eventArgs) => { });
+            this.Removed = new EventHandler<NetworkPeerEventArgs>((obj, eventArgs) => { });
             this.networkPeers = new List<NetworkPeer>();
             this.networkPeers.Add(null);
         }

--- a/src/Stratis.Bitcoin.FullNode.sln
+++ b/src/Stratis.Bitcoin.FullNode.sln
@@ -1,12 +1,11 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.27004.2010
+VisualStudioVersion = 15.0.27130.2010
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "global", "global", "{5B331FD3-D493-46A9-928B-B786FC6F3103}"
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
-		global.json = global.json
 		Settings.StyleCop = Settings.StyleCop
 	EndProjectSection
 EndProject

--- a/src/Stratis.Bitcoin.IntegrationTests/MinerTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/MinerTests.cs
@@ -159,7 +159,7 @@ namespace Stratis.Bitcoin.IntegrationTests
                 LookaheadBlockPuller blockPuller = new LookaheadBlockPuller(this.chain, connectionManager, new LoggerFactory());
                 PeerBanning peerBanning = new PeerBanning(connectionManager, loggerFactory, dateTimeProvider, nodeSettings);
                 NodeDeployments deployments = new NodeDeployments(this.network, this.chain);
-                ConsensusRules consensusRules = new ConsensusRules(this.network, loggerFactory, dateTimeProvider, chain, deployments, consensusSettings, new Checkpoints()).Register(new FullNodeBuilderConsensusExtension.CoreConsensusRules());
+                ConsensusRules consensusRules = new ConsensusRules(this.network, loggerFactory, dateTimeProvider, this.chain, deployments, consensusSettings, new Checkpoints()).Register(new FullNodeBuilderConsensusExtension.CoreConsensusRules());
                 this.consensus = new ConsensusLoop(new AsyncLoopFactory(loggerFactory), consensusValidator, new NodeLifetime(), this.chain, this.cachedCoinView, blockPuller, new NodeDeployments(this.network, this.chain), loggerFactory, new ChainState(new FullNode(), new InvalidBlockHashStore(dateTimeProvider)), connectionManager, dateTimeProvider, new Signals.Signals(), new Checkpoints(this.network, consensusSettings), consensusSettings, nodeSettings, peerBanning, consensusRules);
                 await this.consensus.StartAsync();
 

--- a/src/global.json
+++ b/src/global.json
@@ -1,8 +1,0 @@
-{
-
-  "sdk": {
-    "version": "2.0.0"
-  },
-
-  "projects": [ "Stratis.Bitcoin", "Stratis.Bitcoin.IntegrationTests", "Stratis.Bitcoin.Tests", "Stratis.BitcoinD", "Stratis.StratisD" ]
-}


### PR DESCRIPTION
Should fix #933 

It appears that global.json was introduced in order to fix a compatibility issue with VS2015 side by side with VS2017 in a pre-release version of core (see https://github.com/stratisproject/StratisBitcoinFullNode/commit/9debb6cd11e4720643f683127ad5d08d28c5b0b8). I no longer think this is an issue. I have both VS2015 and VS2017 installed side by side and I do not require a global.json file in order to build. The removal of the global.json file should allow the project to build on newer tooling sets.

I also cleaned up a couple of compiler warnings I noticed that were present with this build.