### PR TITLE
[DNS] Added metrics for output to console

### DIFF
--- a/src/Stratis.Bitcoin.Features.Dns.Tests/GivenADnsSeedServer.cs
+++ b/src/Stratis.Bitcoin.Features.Dns.Tests/GivenADnsSeedServer.cs
@@ -30,8 +30,11 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
         {
             // Arrange.
             IMasterFile masterFile = new Mock<IMasterFile>().Object;
+            IAsyncLoopFactory asyncLoopFactory = new Mock<IAsyncLoopFactory>().Object;
+            INodeLifetime nodeLifetime = new Mock<INodeLifetime>().Object;
             ILoggerFactory loggerFactory = new Mock<ILoggerFactory>().Object;
-            Action a = () => { new DnsSeedServer(null, masterFile, loggerFactory); };
+            IDateTimeProvider dateTimeProvider = new Mock<IDateTimeProvider>().Object;
+            Action a = () => { new DnsSeedServer(null, masterFile, asyncLoopFactory, nodeLifetime, loggerFactory, dateTimeProvider); };
 
             // Act and Assert.
             a.ShouldThrow<ArgumentNullException>().Which.Message.Should().Contain("client");
@@ -43,11 +46,46 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
         {
             // Arrange.
             IUdpClient udpClient = new Mock<IUdpClient>().Object;
+            IAsyncLoopFactory asyncLoopFactory = new Mock<IAsyncLoopFactory>().Object;
+            INodeLifetime nodeLifetime = new Mock<INodeLifetime>().Object;
             ILoggerFactory loggerFactory = new Mock<ILoggerFactory>().Object;
-            Action a = () => { new DnsSeedServer(udpClient, null, loggerFactory); };
+            IDateTimeProvider dateTimeProvider = new Mock<IDateTimeProvider>().Object;
+            Action a = () => { new DnsSeedServer(udpClient, null, asyncLoopFactory, nodeLifetime, loggerFactory, dateTimeProvider); };
 
             // Act and Assert.
             a.ShouldThrow<ArgumentNullException>().Which.Message.Should().Contain("masterFile");
+        }
+
+        [Fact]
+        [Trait("DNS", "UnitTest")]
+        public void WhenConstructorCalled_AndAsyncLoopFactoryIsNull_ThenArgumentNullExceptionIsThrown()
+        {
+            // Arrange.
+            IUdpClient udpClient = new Mock<IUdpClient>().Object;
+            IMasterFile masterFile = new Mock<IMasterFile>().Object;
+            INodeLifetime nodeLifetime = new Mock<INodeLifetime>().Object;
+            ILoggerFactory loggerFactory = new Mock<ILoggerFactory>().Object;
+            IDateTimeProvider dateTimeProvider = new Mock<IDateTimeProvider>().Object;
+            Action a = () => { new DnsSeedServer(udpClient, masterFile, null, nodeLifetime, loggerFactory, dateTimeProvider); };
+
+            // Act and Assert.
+            a.ShouldThrow<ArgumentNullException>().Which.Message.Should().Contain("asyncLoopFactory");
+        }
+
+        [Fact]
+        [Trait("DNS", "UnitTest")]
+        public void WhenConstructorCalled_AndNodeLifetimeIsNull_ThenArgumentNullExceptionIsThrown()
+        {
+            // Arrange.
+            IUdpClient udpClient = new Mock<IUdpClient>().Object;
+            IMasterFile masterFile = new Mock<IMasterFile>().Object;
+            IAsyncLoopFactory asyncLoopFactory = new Mock<IAsyncLoopFactory>().Object;
+            ILoggerFactory loggerFactory = new Mock<ILoggerFactory>().Object;
+            IDateTimeProvider dateTimeProvider = new Mock<IDateTimeProvider>().Object;
+            Action a = () => { new DnsSeedServer(udpClient, masterFile, asyncLoopFactory, null, loggerFactory, dateTimeProvider); };
+
+            // Act and Assert.
+            a.ShouldThrow<ArgumentNullException>().Which.Message.Should().Contain("nodeLifetime");
         }
 
         [Fact]
@@ -57,10 +95,29 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
             // Arrange.
             IUdpClient udpClient = new Mock<IUdpClient>().Object;
             IMasterFile masterFile = new Mock<IMasterFile>().Object;
-            Action a = () => { new DnsSeedServer(udpClient, masterFile, null); };
+            IAsyncLoopFactory asyncLoopFactory = new Mock<IAsyncLoopFactory>().Object;
+            INodeLifetime nodeLifetime = new Mock<INodeLifetime>().Object;
+            IDateTimeProvider dateTimeProvider = new Mock<IDateTimeProvider>().Object;
+            Action a = () => { new DnsSeedServer(udpClient, masterFile, asyncLoopFactory, nodeLifetime, null, dateTimeProvider); };
 
             // Act and Assert.
             a.ShouldThrow<ArgumentNullException>().Which.Message.Should().Contain("loggerFactory");
+        }
+
+        [Fact]
+        [Trait("DNS", "UnitTest")]
+        public void WhenConstructorCalled_AndDateTimeProviderIsNull_ThenArgumentNullExceptionIsThrown()
+        {
+            // Arrange.
+            IUdpClient udpClient = new Mock<IUdpClient>().Object;
+            IMasterFile masterFile = new Mock<IMasterFile>().Object;
+            IAsyncLoopFactory asyncLoopFactory = new Mock<IAsyncLoopFactory>().Object;
+            INodeLifetime nodeLifetime = new Mock<INodeLifetime>().Object;
+            ILoggerFactory loggerFactory = new Mock<ILoggerFactory>().Object;
+            Action a = () => { new DnsSeedServer(udpClient, masterFile, asyncLoopFactory, nodeLifetime, loggerFactory, null); };
+
+            // Act and Assert.
+            a.ShouldThrow<ArgumentNullException>().Which.Message.Should().Contain("dateTimeProvider");
         }
 
         [Fact]
@@ -70,10 +127,13 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
             // Arrange.
             IUdpClient udpClient = new Mock<IUdpClient>().Object;
             IMasterFile masterFile = new Mock<IMasterFile>().Object;
+            IAsyncLoopFactory asyncLoopFactory = new Mock<IAsyncLoopFactory>().Object;
+            INodeLifetime nodeLifetime = new Mock<INodeLifetime>().Object;
             ILoggerFactory loggerFactory = new Mock<ILoggerFactory>().Object;
+            IDateTimeProvider dateTimeProvider = new Mock<IDateTimeProvider>().Object;
 
             // Act.
-            DnsSeedServer server = new DnsSeedServer(udpClient, masterFile, loggerFactory);
+            DnsSeedServer server = new DnsSeedServer(udpClient, masterFile, asyncLoopFactory, nodeLifetime, loggerFactory, dateTimeProvider);
 
             // Assert.
             server.Should().NotBeNull();
@@ -89,18 +149,25 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
 
             Mock<IMasterFile> masterFile = new Mock<IMasterFile>();
 
+            IAsyncLoopFactory asyncLoopFactory = new Mock<IAsyncLoopFactory>().Object;
+            INodeLifetime nodeLifetime = new Mock<INodeLifetime>().Object;
+
             Mock<ILogger> logger = new Mock<ILogger>(MockBehavior.Loose);
             Mock<ILoggerFactory> loggerFactory = new Mock<ILoggerFactory>();
             loggerFactory.Setup<ILogger>(f => f.CreateLogger(It.IsAny<string>())).Returns(logger.Object);
 
+            IDateTimeProvider dateTimeProvider = new Mock<IDateTimeProvider>().Object;
+
             // Act.
             CancellationTokenSource source = new CancellationTokenSource();
-            DnsSeedServer server = new DnsSeedServer(udpClient.Object, masterFile.Object, loggerFactory.Object);
+            DnsSeedServer server = new DnsSeedServer(udpClient.Object, masterFile.Object, asyncLoopFactory, nodeLifetime, loggerFactory.Object, dateTimeProvider);
             Func<Task> func = async () => await server.ListenAsync(53, source.Token);
 
             // Assert.
             server.Should().NotBeNull();
             func.ShouldThrow<SocketException>();
+            server.Metrics.DnsServerFailureCountSinceStart.Should().Be(1);
+            server.Metrics.CurrentSnapshot.DnsServerFailureCountSinceLastPeriod.Should().Be(1);
         }
 
         [Fact]
@@ -114,6 +181,9 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
             udpClient.Setup(c => c.ReceiveAsync()).ThrowsAsync(new SocketException());
 
             Mock<IMasterFile> masterFile = new Mock<IMasterFile>();
+
+            IAsyncLoopFactory asyncLoopFactory = new Mock<IAsyncLoopFactory>().Object;
+            INodeLifetime nodeLifetime = new Mock<INodeLifetime>().Object;
 
             Mock<ILogger> logger = new Mock<ILogger>(MockBehavior.Loose);
             bool receivedSocketException = false;
@@ -129,9 +199,11 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
             Mock<ILoggerFactory> loggerFactory = new Mock<ILoggerFactory>();
             loggerFactory.Setup<ILogger>(f => f.CreateLogger(It.IsAny<string>())).Returns(logger.Object);
 
+            IDateTimeProvider dateTimeProvider = new Mock<IDateTimeProvider>().Object;
+
             // Act.
             CancellationTokenSource source = new CancellationTokenSource(2000);
-            DnsSeedServer server = new DnsSeedServer(udpClient.Object, masterFile.Object, loggerFactory.Object);
+            DnsSeedServer server = new DnsSeedServer(udpClient.Object, masterFile.Object, asyncLoopFactory, nodeLifetime, loggerFactory.Object, dateTimeProvider);
 
             try
             {
@@ -146,6 +218,12 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
             server.Should().NotBeNull();
             startedListening.Should().BeTrue();
             receivedSocketException.Should().BeTrue();
+            server.Metrics.DnsRequestCountSinceStart.Should().BeGreaterThan(0);
+            server.Metrics.DnsRequestFailureCountSinceStart.Should().BeGreaterThan(0);
+            server.Metrics.DnsServerFailureCountSinceStart.Should().Be(0);
+            server.Metrics.CurrentSnapshot.DnsRequestCountSinceLastPeriod.Should().BeGreaterThan(0);
+            server.Metrics.CurrentSnapshot.DnsRequestFailureCountSinceLastPeriod.Should().BeGreaterThan(0);
+            server.Metrics.CurrentSnapshot.DnsServerFailureCountSinceLastPeriod.Should().Be(0);
         }
 
         [Fact]
@@ -160,6 +238,9 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
 
             Mock<IMasterFile> masterFile = new Mock<IMasterFile>();
             masterFile.Setup(m => m.Get(It.IsAny<Question>())).Returns(new List<IResourceRecord>() { new IPAddressResourceRecord(Domain.FromString("google.com"), IPAddress.Loopback) });
+
+            IAsyncLoopFactory asyncLoopFactory = new Mock<IAsyncLoopFactory>().Object;
+            INodeLifetime nodeLifetime = new Mock<INodeLifetime>().Object;
 
             Mock<ILogger> logger = new Mock<ILogger>();
             bool receivedRequest = false;
@@ -186,9 +267,11 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
             Mock<ILoggerFactory> loggerFactory = new Mock<ILoggerFactory>();
             loggerFactory.Setup<ILogger>(f => f.CreateLogger(It.IsAny<string>())).Returns(logger.Object);
 
+            IDateTimeProvider dateTimeProvider = new Mock<IDateTimeProvider>().Object;
+
             // Act.
             CancellationTokenSource source = new CancellationTokenSource(2000);
-            DnsSeedServer server = new DnsSeedServer(udpClient.Object, masterFile.Object, loggerFactory.Object);
+            DnsSeedServer server = new DnsSeedServer(udpClient.Object, masterFile.Object, asyncLoopFactory, nodeLifetime, loggerFactory.Object, dateTimeProvider);
 
             try
             {
@@ -204,6 +287,12 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
             startedListening.Should().BeTrue();
             receivedRequest.Should().BeTrue();
             receivedBadRequest.Should().BeTrue();
+            server.Metrics.DnsRequestCountSinceStart.Should().BeGreaterThan(0);
+            server.Metrics.DnsRequestFailureCountSinceStart.Should().BeGreaterThan(0);
+            server.Metrics.DnsServerFailureCountSinceStart.Should().Be(0);
+            server.Metrics.CurrentSnapshot.DnsRequestCountSinceLastPeriod.Should().BeGreaterThan(0);
+            server.Metrics.CurrentSnapshot.DnsRequestFailureCountSinceLastPeriod.Should().BeGreaterThan(0);
+            server.Metrics.CurrentSnapshot.DnsServerFailureCountSinceLastPeriod.Should().Be(0);
         }
 
         [Fact]
@@ -221,6 +310,9 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
             Mock<IMasterFile> masterFile = new Mock<IMasterFile>();
             masterFile.Setup(m => m.Get(It.IsAny<Question>())).Returns(new List<IResourceRecord>() { new IPAddressResourceRecord(Domain.FromString("google.com"), IPAddress.Loopback) });
 
+            IAsyncLoopFactory asyncLoopFactory = new Mock<IAsyncLoopFactory>().Object;
+            INodeLifetime nodeLifetime = new Mock<INodeLifetime>().Object;
+
             Mock<ILogger> logger = new Mock<ILogger>();
             bool receivedRequest = false;
             logger.Setup(l => l.Log(LogLevel.Trace, It.IsAny<EventId>(), It.IsAny<FormattedLogValues>(), It.IsAny<Exception>(), It.IsAny<Func<object, Exception, string>>())).Callback<LogLevel, EventId, object, Exception, Func<object, Exception, string>>((level, id, state, e, f) =>
@@ -235,9 +327,11 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
             Mock<ILoggerFactory> loggerFactory = new Mock<ILoggerFactory>();
             loggerFactory.Setup<ILogger>(f => f.CreateLogger(It.IsAny<string>())).Returns(logger.Object);
 
+            IDateTimeProvider dateTimeProvider = new Mock<IDateTimeProvider>().Object;
+
             // Act.
             CancellationTokenSource source = new CancellationTokenSource(2000);
-            DnsSeedServer server = new DnsSeedServer(udpClient.Object, masterFile.Object, loggerFactory.Object);
+            DnsSeedServer server = new DnsSeedServer(udpClient.Object, masterFile.Object, asyncLoopFactory, nodeLifetime, loggerFactory.Object, dateTimeProvider);
 
             try
             {
@@ -253,6 +347,50 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
             startedListening.Should().BeTrue();
             receivedRequest.Should().BeTrue();
             sentResponse.Should().BeTrue();
+            server.Metrics.DnsRequestCountSinceStart.Should().BeGreaterThan(0);
+            server.Metrics.DnsRequestFailureCountSinceStart.Should().Be(0);
+            server.Metrics.DnsServerFailureCountSinceStart.Should().Be(0);
+            server.Metrics.CurrentSnapshot.DnsRequestCountSinceLastPeriod.Should().BeGreaterThan(0);
+            server.Metrics.CurrentSnapshot.DnsRequestFailureCountSinceLastPeriod.Should().Be(0);
+            server.Metrics.CurrentSnapshot.DnsServerFailureCountSinceLastPeriod.Should().Be(0);
+            server.Metrics.CurrentSnapshot.DnsRequestElapsedTicksSinceLastPeriod.Should().BeGreaterThan(0);
+            server.Metrics.CurrentSnapshot.LastDnsRequestElapsedTicks.Should().BeGreaterThan(0);
+        }
+
+        [Fact]
+        [Trait("DNS", "UnitTest")]
+        public void WhenDnsServerInitialized_ThenMetricsLoopStarted()
+        {
+            // Arrange.
+            Mock<IUdpClient> udpClient = new Mock<IUdpClient>();
+            Mock<IMasterFile> masterFile = new Mock<IMasterFile>();
+
+            CancellationTokenSource source = new CancellationTokenSource(5000);
+            Mock<INodeLifetime> nodeLifetime = new Mock<INodeLifetime>();
+            nodeLifetime.Setup(n => n.ApplicationStopping).Returns(source.Token);
+
+            Mock<ILogger> logger = new Mock<ILogger>();
+            bool startedLoop = false;
+            logger.Setup(l => l.Log(LogLevel.Information, It.IsAny<EventId>(), It.IsAny<FormattedLogValues>(), It.IsAny<Exception>(), It.IsAny<Func<object, Exception, string>>())).Callback<LogLevel, EventId, object, Exception, Func<object, Exception, string>>((level, id, state, e, f) =>
+            {
+                startedLoop = state.ToString().Contains("DNS Metrics");
+            });
+            Mock<ILoggerFactory> loggerFactory = new Mock<ILoggerFactory>();
+            loggerFactory.Setup<ILogger>(f => f.CreateLogger(It.IsAny<string>())).Returns(logger.Object);
+
+            IAsyncLoopFactory asyncLoopFactory = new AsyncLoopFactory(loggerFactory.Object);
+
+            IDateTimeProvider dateTimeProvider = new Mock<IDateTimeProvider>().Object;
+
+            // Act.
+            DnsSeedServer server = new DnsSeedServer(udpClient.Object, masterFile.Object, asyncLoopFactory, nodeLifetime.Object, loggerFactory.Object, dateTimeProvider);
+            server.Initialize();
+            bool waited = source.Token.WaitHandle.WaitOne();
+
+            // Assert.
+            server.Should().NotBeNull();
+            waited.Should().BeTrue();
+            startedLoop.Should().BeTrue();
         }
 
         /// <summary>

--- a/src/Stratis.Bitcoin.Features.Dns/DnsFeature.cs
+++ b/src/Stratis.Bitcoin.Features.Dns/DnsFeature.cs
@@ -93,7 +93,7 @@ namespace Stratis.Bitcoin.Features.Dns
         {
             this.logger.LogTrace("()");
 
-            // Create long running task for DNS service
+            // Create long running task for DNS service.
             this.dnsTask = Task.Factory.StartNew(this.RunDnsService, TaskCreationOptions.LongRunning);
 
             this.logger.LogTrace("(-)");
@@ -107,7 +107,7 @@ namespace Stratis.Bitcoin.Features.Dns
         {
             this.logger.LogTrace("()");
 
-            // Initialize DNS server
+            // Initialize DNS server.
             this.dnsServer.Initialize();
 
             bool restarted = false;
@@ -116,10 +116,10 @@ namespace Stratis.Bitcoin.Features.Dns
             {
                 try
                 {
-                    // Only load if we are starting up for the first time
+                    // Only load if we are starting up for the first time.
                     if (!restarted)
                     {
-                        // Load masterfile from disk if it exists
+                        // Load masterfile from disk if it exists.
                         string path = Path.Combine(this.dataFolders.DnsMasterFilePath, DnsMasterFileName);
                         if (File.Exists(path))
                         {
@@ -130,7 +130,7 @@ namespace Stratis.Bitcoin.Features.Dns
                                 IMasterFile masterFile = new DnsSeedMasterFile();
                                 masterFile.Load(stream);
 
-                                // Swap in masterfile from disk into DNS server
+                                // Swap in masterfile from disk into DNS server.
                                 this.dnsServer.SwapMasterfile(masterFile);
                             }
                         }
@@ -138,12 +138,12 @@ namespace Stratis.Bitcoin.Features.Dns
 
                     this.logger.LogInformation("Starting DNS server on port {0}", this.nodeSettings.DnsListenPort);
 
-                    // Start
+                    // Start.
                     this.dnsServer.ListenAsync(this.nodeSettings.DnsListenPort, this.nodeLifetime.ApplicationStopping).GetAwaiter().GetResult();
                 }
                 catch (OperationCanceledException)
                 {
-                    // Node shutting down, expected
+                    // Node shutting down, expected.
                     this.logger.LogInformation("Stopping DNS");
                     break;
                 }
@@ -153,12 +153,12 @@ namespace Stratis.Bitcoin.Features.Dns
 
                     try
                     {
-                        // Back-off before restart
+                        // Back-off before restart.
                         Task.Delay(DnsServerBackoffInterval, this.nodeLifetime.ApplicationStopping).GetAwaiter().GetResult();
                     }
                     catch (OperationCanceledException)
                     {
-                        // Node shutting down, expected
+                        // Node shutting down, expected.
                         this.logger.LogInformation("Stopping DNS");
                         break;
                     }

--- a/src/Stratis.Bitcoin.Features.Dns/DnsMetric.cs
+++ b/src/Stratis.Bitcoin.Features.Dns/DnsMetric.cs
@@ -1,0 +1,108 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+
+namespace Stratis.Bitcoin.Features.Dns
+{
+    /// <summary>
+    /// Stores metric values for the <see cref="DnsSeedServer"/> object.
+    /// </summary>
+    public class DnsMetric
+    {
+        /// <summary>
+        /// Defines the DNS request count.
+        /// </summary>
+        private long requestCount;
+
+        /// <summary>
+        /// Defines the maximum count of peers seen since the server started.
+        /// </summary>
+        private long maxPeerCount;
+
+        /// <summary>
+        /// Defines the server failure count.
+        /// </summary>
+        private int serverFailureCount;
+
+        /// <summary>
+        /// Defines the request failure count.
+        /// </summary>
+        private int requestFailureCount;
+
+        /// <summary>
+        /// Defines the current snapshot.
+        /// </summary>
+        private DnsMetricSnapshot snapshot = new DnsMetricSnapshot();
+
+        /// <summary>
+        /// Gets the total number of DNS requests issued to the DNS server since the start of the application.
+        /// </summary>
+        public long DnsRequestCountSinceStart { get { return this.requestCount; } }
+
+        /// <summary>
+        /// Gets the maximum count of peers seen since the start of the application.
+        /// </summary>
+        public long MaxPeerCountSinceStart { get { return this.maxPeerCount; } }
+
+        /// <summary>
+        /// Gets the number of failures of the server since the start of the application (server failures are restarted).
+        /// </summary>
+        public int DnsServerFailureCountSinceStart { get { return this.serverFailureCount; } }
+
+        /// <summary>
+        /// Gets the number of failures processing DNS requests since the start of the application.
+        /// </summary>
+        public int DnsRequestFailureCountSinceStart { get { return this.requestFailureCount; } }
+
+        /// <summary>
+        /// Gets the current snapshot.
+        /// </summary>
+        public DnsMetricSnapshot CurrentSnapshot { get { return this.snapshot; } }
+
+        /// <summary>
+        /// Captures the metrics for the last request.
+        /// </summary>
+        /// <param name="peerCount">The last measured count of peers available.</param>
+        /// <param name="elapsedTicks">The last measured elapsed ticks taken to process the request.</param>
+        /// <param name="requestFailed">True if the request failed, otherwise False.</param>
+        public void CaptureRequestMetrics(int peerCount, long elapsedTicks, bool requestFailed)
+        {
+            // Utmost accuracy isn't important, but useful to do this with as few instructions as possible
+            Interlocked.Increment(ref this.requestCount);
+            
+            if (peerCount > this.maxPeerCount)
+            {
+                this.maxPeerCount = peerCount;
+            }
+
+            if (requestFailed)
+            {
+                Interlocked.Increment(ref this.requestFailureCount);
+            }
+
+            // Capture at snapshot level
+            this.snapshot.CaptureRequestMetrics(peerCount, elapsedTicks, requestFailed);
+        }
+
+        /// <summary>
+        /// Increments the server failed count.
+        /// </summary>
+        public void CaptureServerFailedMetric()
+        {
+            Interlocked.Increment(ref this.serverFailureCount);
+            this.snapshot.CaptureServerFailedMetric();
+        }
+
+        /// <summary>
+        /// Resets the current snapshot and returns the previous one as the result.
+        /// </summary>
+        /// <returns>Returns the previous snapshot.</returns>
+        public DnsMetricSnapshot ResetSnapshot()
+        {
+            DnsMetricSnapshot previousSnapshot = this.snapshot;
+            Interlocked.Exchange(ref this.snapshot, new DnsMetricSnapshot());
+            return previousSnapshot;
+        }
+    }
+}

--- a/src/Stratis.Bitcoin.Features.Dns/DnsMetric.cs
+++ b/src/Stratis.Bitcoin.Features.Dns/DnsMetric.cs
@@ -68,7 +68,7 @@ namespace Stratis.Bitcoin.Features.Dns
         /// <param name="requestFailed">True if the request failed, otherwise False.</param>
         public void CaptureRequestMetrics(int peerCount, long elapsedTicks, bool requestFailed)
         {
-            // Utmost accuracy isn't important, but useful to do this with as few instructions as possible
+            // Utmost accuracy isn't important, but useful to do this with as few instructions as possible.
             Interlocked.Increment(ref this.requestCount);
             
             if (peerCount > this.maxPeerCount)
@@ -81,7 +81,7 @@ namespace Stratis.Bitcoin.Features.Dns
                 Interlocked.Increment(ref this.requestFailureCount);
             }
 
-            // Capture at snapshot level
+            // Capture at snapshot level.
             this.snapshot.CaptureRequestMetrics(peerCount, elapsedTicks, requestFailed);
         }
 

--- a/src/Stratis.Bitcoin.Features.Dns/DnsMetricSnapshot.cs
+++ b/src/Stratis.Bitcoin.Features.Dns/DnsMetricSnapshot.cs
@@ -1,0 +1,112 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+
+namespace Stratis.Bitcoin.Features.Dns
+{
+    /// <summary>
+    /// Stores snapshot metric values for the <see cref="DnsSeedServer"/> object.
+    /// </summary>
+    public class DnsMetricSnapshot
+    {
+        /// <summary>
+        /// Defines the DNS request count.
+        /// </summary>
+        private long requestCount;
+
+        /// <summary>
+        /// Defines the count of elapsed ticks for this period.
+        /// </summary>
+        private long elapsedTicks;
+
+        /// <summary>
+        /// Defines the count of peers.
+        /// </summary>
+        private long peerCount;
+
+        /// <summary>
+        /// Defines the last measured elapsed ticks when processing DNS request.
+        /// </summary>
+        private long lastElapsedTicks;
+
+        /// <summary>
+        /// Defines the last count of peers.
+        /// </summary>
+        private int lastPeerCount;
+
+        /// <summary>
+        /// Defines the server failure count.
+        /// </summary>
+        private int serverFailureCount;
+
+        /// <summary>
+        /// Defines the request failure count.
+        /// </summary>
+        private int requestFailureCount;
+
+        /// <summary>
+        /// Gets the number of DNS requests issued to the DNS server since the last metrics period.
+        /// </summary>
+        public long DnsRequestCountSinceLastPeriod { get { return this.requestCount; } }
+
+        /// <summary>
+        /// Gets the total number of elasped ticks processing DNS requests since the last metrics period.
+        /// </summary>
+        public long DnsRequestElapsedTicksSinceLastPeriod { get { return this.elapsedTicks; } }
+
+        /// <summary>
+        /// Gets the total number of peers available to DNS responses since the last metrics period.
+        /// </summary>
+        public long PeerCountSinceLastPeriod { get { return this.peerCount; } }
+
+        /// <summary>
+        /// Gets the number of elapsed ticks processing the most recent DNS request.
+        /// </summary>
+        public long LastDnsRequestElapsedTicks { get { return this.lastElapsedTicks; } }
+
+        /// <summary>
+        /// Gets the last number of peers available.
+        /// </summary>
+        public int LastPeerCount { get { return this.lastPeerCount; } }
+
+        /// <summary>
+        /// Gets the number of failures of the server since the last metrics period (server failures are restarted).
+        /// </summary>
+        public int DnsServerFailureCountSinceLastPeriod { get { return this.serverFailureCount; } }
+
+        /// <summary>
+        /// Gets the number of failures processing DNS requests since the last metrics period.
+        /// </summary>
+        public int DnsRequestFailureCountSinceLastPeriod { get { return this.requestFailureCount; } }
+
+        /// <summary>
+        /// Captures the metrics for the last request.
+        /// </summary>
+        /// <param name="peerCount">The last measured count of peers available.</param>
+        /// <param name="elapsedTicks">The last measured elapsed ticks taken to process the request.</param>
+        /// <param name="requestFailed">True if the request failed, otherwise False.</param>
+        public void CaptureRequestMetrics(int peerCount, long elapsedTicks, bool requestFailed)
+        {
+            // Utmost accuracy isn't important, but useful to do this with as few instructions as possible
+            Interlocked.Increment(ref this.requestCount);
+            Interlocked.Add(ref this.peerCount, peerCount);
+            Interlocked.Add(ref this.elapsedTicks, elapsedTicks);
+            Interlocked.Exchange(ref this.lastPeerCount, peerCount);
+            Interlocked.Exchange(ref this.lastElapsedTicks, elapsedTicks);
+            
+            if (requestFailed)
+            {
+                Interlocked.Increment(ref this.requestFailureCount);
+            }
+        }
+
+        /// <summary>
+        /// Increments the server failed count.
+        /// </summary>
+        public void CaptureServerFailedMetric()
+        {
+            Interlocked.Increment(ref this.serverFailureCount);
+        }
+    }
+}

--- a/src/Stratis.Bitcoin.Features.Dns/DnsMetricSnapshot.cs
+++ b/src/Stratis.Bitcoin.Features.Dns/DnsMetricSnapshot.cs
@@ -88,7 +88,7 @@ namespace Stratis.Bitcoin.Features.Dns
         /// <param name="requestFailed">True if the request failed, otherwise False.</param>
         public void CaptureRequestMetrics(int peerCount, long elapsedTicks, bool requestFailed)
         {
-            // Utmost accuracy isn't important, but useful to do this with as few instructions as possible
+            // Utmost accuracy isn't important, but useful to do this with as few instructions as possible.
             Interlocked.Increment(ref this.requestCount);
             Interlocked.Add(ref this.peerCount, peerCount);
             Interlocked.Add(ref this.elapsedTicks, elapsedTicks);

--- a/src/Stratis.Bitcoin.Features.Dns/DnsSeedServer.cs
+++ b/src/Stratis.Bitcoin.Features.Dns/DnsSeedServer.cs
@@ -138,7 +138,7 @@ namespace Stratis.Bitcoin.Features.Dns
         {
             this.logger.LogTrace("()");
 
-            // Create async loop for outputting metrics
+            // Create async loop for outputting metrics.
             this.metricsLoop = this.asyncLoopFactory.Run(nameof(this.LogMetrics), async (token) => await Task.Run(() => this.LogMetrics()), this.nodeLifetime.ApplicationStopping, repeatEvery: TimeSpan.FromSeconds(MetricsLogRate));
 
             this.logger.LogTrace("(-)");
@@ -156,7 +156,7 @@ namespace Stratis.Bitcoin.Features.Dns
 
             try
             {
-                // Start listening on UDP port
+                // Start listening on UDP port.
                 this.udpClient.StartListening(dnsListenPort);
 
                 while (!token.IsCancellationRequested)
@@ -167,7 +167,7 @@ namespace Stratis.Bitcoin.Features.Dns
 
                         this.logger.LogTrace("DNS request received of size {0} from endpoint {1}.", request.Item2.Length, request.Item1);
 
-                        // Received a request, now handle it
+                        // Received a request, now handle it.
                         Stopwatch stopWatch = new Stopwatch();
                         stopWatch.Start();
 
@@ -175,7 +175,7 @@ namespace Stratis.Bitcoin.Features.Dns
 
                         stopWatch.Stop();
 
-                        // TODO - get list of peers from masterfile
+                        // TODO - get list of peers from masterfile.
                         this.metrics.CaptureRequestMetrics(0, stopWatch.ElapsedTicks, false);
                     }
                     catch (ArgumentException e)
@@ -190,7 +190,7 @@ namespace Stratis.Bitcoin.Features.Dns
                     }
                 }
 
-                // We've been cancelled
+                // We've been cancelled.
                 this.logger.LogTrace("Cancellation requested, shutting down DNS listener.");
                 token.ThrowIfCancellationRequested();
             }
@@ -320,11 +320,11 @@ namespace Stratis.Bitcoin.Features.Dns
                     throw new ArgumentException($"Request message contains a non-error response code of {header.ResponseCode}.");
                 }
 
-                // Resolve request against masterfile
+                // Resolve request against masterfile.
                 request = new Request(header, Question.GetAllFromArray(udpRequest.Item2, header.Size, header.QuestionCount));
                 IResponse response = this.Resolve(request);
 
-                // Send response
+                // Send response.
                 await this.udpClient.SendAsync(response.ToArray(), response.Size, udpRequest.Item1).WithCancellationTimeout(UdpTimeout);
             }
             catch (SocketException e)
@@ -339,7 +339,7 @@ namespace Stratis.Bitcoin.Features.Dns
             {
                 this.logger.LogError(e, "Received error {0} when sending DNS response to {1}, trying again.", e.Response.ResponseCode, udpRequest.Item1);
 
-                // Try and send response one more time
+                // Try and send response one more time.
                 IResponse response = e.Response;
                 if (response == null)
                 {
@@ -372,14 +372,14 @@ namespace Stratis.Bitcoin.Features.Dns
 
             try
             {
-                // Print out total and period values
+                // Print out total and period values.
                 StringBuilder metricOutput = new StringBuilder();
                 metricOutput.AppendLine("==========DNS Metrics==========");
                 metricOutput.AppendLine();
                 metricOutput.AppendFormat(this.MetricsOutputFormat, "Snapshot Time", this.dateTimeProvider.GetAdjustedTime());
                 metricOutput.AppendLine();
 
-                // Metrics since start
+                // Metrics since start.
                 metricOutput.AppendLine(">>> Metrics since start");
                 metricOutput.AppendFormat(this.MetricsOutputFormat, "Total DNS Requests", this.metrics.DnsRequestCountSinceStart);
                 metricOutput.AppendFormat(this.MetricsOutputFormat, "Total DNS Server Failures (Restarted)", this.metrics.DnsServerFailureCountSinceStart);
@@ -387,14 +387,14 @@ namespace Stratis.Bitcoin.Features.Dns
                 metricOutput.AppendFormat(this.MetricsOutputFormat, "Maximum Peer Count in DNS Response", this.metrics.DnsRequestFailureCountSinceStart);
                 metricOutput.AppendLine();
 
-                // Reset period values
+                // Reset period values.
                 DnsMetricSnapshot snapshot = this.metrics.ResetSnapshot();
 
-                // Calculate averages
+                // Calculate averages.
                 double averagePeerCount = snapshot.DnsRequestCountSinceLastPeriod == 0 ? 0 : snapshot.PeerCountSinceLastPeriod / snapshot.DnsRequestCountSinceLastPeriod;
                 double averageElapsedTicks = snapshot.DnsRequestCountSinceLastPeriod == 0 ? 0 : snapshot.DnsRequestElapsedTicksSinceLastPeriod / snapshot.DnsRequestCountSinceLastPeriod;
 
-                // Metrics since last period
+                // Metrics since last period.
                 metricOutput.AppendLine($">>> Metrics for last period ({MetricsLogRate} secs)");
                 metricOutput.AppendFormat(this.MetricsOutputFormat, "DNS Requests", snapshot.DnsRequestCountSinceLastPeriod);
                 metricOutput.AppendFormat(this.MetricsOutputFormat, "DNS Server Failures (Restarted)", snapshot.DnsServerFailureCountSinceLastPeriod);
@@ -405,12 +405,12 @@ namespace Stratis.Bitcoin.Features.Dns
                 metricOutput.AppendFormat(this.MetricsOutputFormat, "Last Elapsed Time Processing DNS Requests (ms)", new TimeSpan(snapshot.LastDnsRequestElapsedTicks).TotalMilliseconds);
                 metricOutput.AppendLine();
 
-                // Output
+                // Output.
                 this.logger.LogInformation(metricOutput.ToString());
             }
             catch (Exception e)
             {
-                // If metrics fail, just log
+                // If metrics fail, just log.
                 this.logger.LogWarning(e, "Failed to output DNS metrics.");
             }
 

--- a/src/Stratis.Bitcoin.Features.Dns/DnsSeedServer.cs
+++ b/src/Stratis.Bitcoin.Features.Dns/DnsSeedServer.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Net;
@@ -13,6 +14,7 @@ using DNS.Protocol.ResourceRecords;
 using DNS.Protocol.Utils;
 using DNS.Server;
 using Microsoft.Extensions.Logging;
+using Stratis.Bitcoin.Configuration.Logging;
 using Stratis.Bitcoin.Utilities;
 
 namespace Stratis.Bitcoin.Features.Dns
@@ -26,6 +28,16 @@ namespace Stratis.Bitcoin.Features.Dns
         /// Sets the timeout at 2 seconds.
         /// </summary>
         private const int UdpTimeout = 2000;
+
+        /// <summary>
+        /// Sets the period by which metrics are logged (secs).
+        /// </summary>
+        private const int MetricsLogRate = 20;
+
+        /// <summary>
+        /// Defines the output format for a metric row.
+        /// </summary>
+        private readonly string MetricsOutputFormat = "{0,-60}: {1,20}" + Environment.NewLine;
 
         /// <summary>
         /// Defines a flag used to indicate whether the object has been disposed or not.
@@ -45,7 +57,17 @@ namespace Stratis.Bitcoin.Features.Dns
         /// <summary>
         /// Defines the client used to listen for incoming DNS requests.
         /// </summary>
-        private IUdpClient udpClient;
+        private readonly IUdpClient udpClient;
+
+        /// <summary>
+        /// Defines a factory for creating async loops.
+        /// </summary>
+        private readonly IAsyncLoopFactory asyncLoopFactory;
+
+        /// <summary>
+        /// Defines a node lifetime object.
+        /// </summary>
+        private readonly INodeLifetime nodeLifetime;
 
         /// <summary>
         /// Defines the logger.
@@ -53,20 +75,44 @@ namespace Stratis.Bitcoin.Features.Dns
         private readonly ILogger logger;
 
         /// <summary>
+        /// Defines the date-time provider.
+        /// </summary>
+        private readonly IDateTimeProvider dateTimeProvider;
+
+        /// <summary>
+        /// Defines a metrics async loop.
+        /// </summary>
+        private IAsyncLoop metricsLoop;
+
+        /// <summary>
+        /// Defines an entity that holds the metrics for the DNS server.
+        /// </summary>
+        private DnsMetric metrics;
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="DnsSeedServer"/> class with the port to listen on.
         /// </summary>
         /// <param name="client">The UDP client to use to receive DNS requests and send DNS responses.</param>
         /// <param name="masterFile">The initial DNS masterfile.</param>
+        /// <param name="asyncLoopFactory">The async loop factory.</param>
         /// <param name="loggerFactory">The logger factory.</param>
-        public DnsSeedServer(IUdpClient client, IMasterFile masterFile, ILoggerFactory loggerFactory)
+        /// <param name="dateTimeProvider">The <see cref="DateTime"/> provider.</param>
+        public DnsSeedServer(IUdpClient client, IMasterFile masterFile, IAsyncLoopFactory asyncLoopFactory, INodeLifetime nodeLifetime, ILoggerFactory loggerFactory, IDateTimeProvider dateTimeProvider)
         {
             Guard.NotNull(client, nameof(client));
             Guard.NotNull(masterFile, nameof(masterFile));
+            Guard.NotNull(asyncLoopFactory, nameof(asyncLoopFactory));
+            Guard.NotNull(nodeLifetime, nameof(nodeLifetime));
             Guard.NotNull(loggerFactory, nameof(loggerFactory));
+            Guard.NotNull(dateTimeProvider, nameof(dateTimeProvider));
 
             this.udpClient = client;
             this.masterFile = masterFile;
+            this.asyncLoopFactory = asyncLoopFactory;
+            this.nodeLifetime = nodeLifetime;
             this.logger = loggerFactory.CreateLogger(this.GetType().FullName);
+            this.dateTimeProvider = dateTimeProvider;
+            this.metrics = new DnsMetric();
         }
 
         /// <summary>
@@ -78,6 +124,27 @@ namespace Stratis.Bitcoin.Features.Dns
         }
 
         /// <summary>
+        /// Gets the metrics for the DNS server.
+        /// </summary>
+        public DnsMetric Metrics
+        {
+            get { return this.metrics; }
+        }
+
+        /// <summary>
+        /// Initializes the DNS Server.
+        /// </summary>
+        public void Initialize()
+        {
+            this.logger.LogTrace("()");
+
+            // Create async loop for outputting metrics
+            this.metricsLoop = this.asyncLoopFactory.Run(nameof(this.LogMetrics), async (token) => await Task.Run(() => this.LogMetrics()), this.nodeLifetime.ApplicationStopping, repeatEvery: TimeSpan.FromSeconds(MetricsLogRate));
+
+            this.logger.LogTrace("(-)");
+        }
+
+        /// <summary>
         /// Starts listening for DNS requests.
         /// </summary>
         /// <param name="dnsListenPort">The port to listen on.</param>
@@ -85,51 +152,58 @@ namespace Stratis.Bitcoin.Features.Dns
         /// <returns>A task used to await the listen operation.</returns>
         public async Task ListenAsync(int dnsListenPort, CancellationToken token)
         {
+            this.logger.LogTrace("()");
+
             try
             {
+                // Start listening on UDP port
                 this.udpClient.StartListening(dnsListenPort);
-            }
-            catch (SocketException e)
-            {
-                this.logger.LogError(e, "Socket exception {0} whilst creating UDP client for DNS service.", e.ErrorCode);
-                throw;
-            }
 
-            try
-            {
-                while (true)
+                while (!token.IsCancellationRequested)
                 {
-                    Tuple<IPEndPoint, byte[]> request;
-
-                    // Have we been cancelled?
-                    if (token.IsCancellationRequested)
-                    {
-                        this.logger.LogTrace("Cancellation requested, shutting down DNS listener.");
-                        token.ThrowIfCancellationRequested();
-                    }
-
                     try
                     {
-                        request = await this.udpClient.ReceiveAsync();
+                        Tuple<IPEndPoint, byte[]> request = await this.udpClient.ReceiveAsync();
 
                         this.logger.LogTrace("DNS request received of size {0} from endpoint {1}.", request.Item2.Length, request.Item1);
 
                         // Received a request, now handle it
+                        Stopwatch stopWatch = new Stopwatch();
+                        stopWatch.Start();
+
                         await this.HandleRequestAsync(request);
+
+                        stopWatch.Stop();
+
+                        // TODO - get list of peers from masterfile
+                        this.metrics.CaptureRequestMetrics(0, stopWatch.ElapsedTicks, false);
                     }
                     catch (ArgumentException e)
                     {
+                        this.metrics.CaptureRequestMetrics(0, 0, true);
                         this.logger.LogWarning(e, "Failed to process DNS request.");
                     }
                     catch (SocketException e)
                     {
+                        this.metrics.CaptureRequestMetrics(0, 0, true);
                         this.logger.LogError(e, "Socket exception {0} whilst receiving UDP request.", e.ErrorCode);
                     }
                 }
+
+                // We've been cancelled
+                this.logger.LogTrace("Cancellation requested, shutting down DNS listener.");
+                token.ThrowIfCancellationRequested();
+            }
+            catch (Exception e) when (!(e is OperationCanceledException))
+            {
+                this.metrics.CaptureServerFailedMetric();
+                throw;
             }
             finally
             {
                 this.udpClient.StopListening();
+
+                this.logger.LogTrace("(-)");
             }
         }
 
@@ -145,12 +219,16 @@ namespace Stratis.Bitcoin.Features.Dns
         /// <param name="masterFile">The new masterfile to swap in.</param>
         public void SwapMasterfile(IMasterFile masterFile)
         {
+            this.logger.LogTrace("()");
+
             Guard.NotNull(masterFile, nameof(masterFile));
 
             lock (this.masterFileLock)
             {
                 this.masterFile = masterFile;
             }
+
+            this.logger.LogTrace("(-)");
         }
 
         /// <summary>
@@ -174,6 +252,8 @@ namespace Stratis.Bitcoin.Features.Dns
                 {
                     IDisposable disposableClient = this.udpClient as IDisposable;
                     disposableClient?.Dispose();
+
+                    this.metricsLoop?.Dispose();
                 }
 
                 this.disposed = true;
@@ -187,6 +267,8 @@ namespace Stratis.Bitcoin.Features.Dns
         /// <returns>A DNS response.</returns>
         private IResponse Resolve(Request request)
         {
+            this.logger.LogTrace("()");
+
             Response response = Response.FromRequest(request);
 
             foreach (Question question in request.Questions)
@@ -203,6 +285,8 @@ namespace Stratis.Bitcoin.Features.Dns
                 this.logger.LogTrace("{0} answers to the question: domain = {1}, record type = {2}", answers.Count, question.Name, question.Type);
             }
 
+            this.logger.LogTrace("(-)");
+
             return response;
         }
 
@@ -212,6 +296,8 @@ namespace Stratis.Bitcoin.Features.Dns
         /// <param name="udpRequest">The DNS request received from the UDP client.</param>
         private async Task HandleRequestAsync(Tuple<IPEndPoint, byte[]> udpRequest)
         {
+            this.logger.LogTrace("()");
+
             Request request = null;
 
             try
@@ -273,6 +359,62 @@ namespace Stratis.Bitcoin.Features.Dns
                     this.logger.LogError(ex, "Sending DNS response to {0} timed out.", udpRequest.Item1);
                 }
             }
+
+            this.logger.LogTrace("(-)");
+        }
+
+        /// <summary>
+        /// Logs metrics periodically to the console.
+        /// </summary>
+        private void LogMetrics()
+        {
+            this.logger.LogTrace("()");
+
+            try
+            {
+                // Print out total and period values
+                StringBuilder metricOutput = new StringBuilder();
+                metricOutput.AppendLine("==========DNS Metrics==========");
+                metricOutput.AppendLine();
+                metricOutput.AppendFormat(this.MetricsOutputFormat, "Snapshot Time", this.dateTimeProvider.GetAdjustedTime());
+                metricOutput.AppendLine();
+
+                // Metrics since start
+                metricOutput.AppendLine(">>> Metrics since start");
+                metricOutput.AppendFormat(this.MetricsOutputFormat, "Total DNS Requests", this.metrics.DnsRequestCountSinceStart);
+                metricOutput.AppendFormat(this.MetricsOutputFormat, "Total DNS Server Failures (Restarted)", this.metrics.DnsServerFailureCountSinceStart);
+                metricOutput.AppendFormat(this.MetricsOutputFormat, "Total DNS Request Failures", this.metrics.DnsRequestFailureCountSinceStart);
+                metricOutput.AppendFormat(this.MetricsOutputFormat, "Maximum Peer Count in DNS Response", this.metrics.DnsRequestFailureCountSinceStart);
+                metricOutput.AppendLine();
+
+                // Reset period values
+                DnsMetricSnapshot snapshot = this.metrics.ResetSnapshot();
+
+                // Calculate averages
+                double averagePeerCount = snapshot.DnsRequestCountSinceLastPeriod == 0 ? 0 : snapshot.PeerCountSinceLastPeriod / snapshot.DnsRequestCountSinceLastPeriod;
+                double averageElapsedTicks = snapshot.DnsRequestCountSinceLastPeriod == 0 ? 0 : snapshot.DnsRequestElapsedTicksSinceLastPeriod / snapshot.DnsRequestCountSinceLastPeriod;
+
+                // Metrics since last period
+                metricOutput.AppendLine($">>> Metrics for last period ({MetricsLogRate} secs)");
+                metricOutput.AppendFormat(this.MetricsOutputFormat, "DNS Requests", snapshot.DnsRequestCountSinceLastPeriod);
+                metricOutput.AppendFormat(this.MetricsOutputFormat, "DNS Server Failures (Restarted)", snapshot.DnsServerFailureCountSinceLastPeriod);
+                metricOutput.AppendFormat(this.MetricsOutputFormat, "DNS Request Failures", snapshot.DnsRequestFailureCountSinceLastPeriod);
+                metricOutput.AppendFormat(this.MetricsOutputFormat, "Average Peer Count in DNS Response", averagePeerCount);
+                metricOutput.AppendFormat(this.MetricsOutputFormat, "Last Peer Count in DNS Response", snapshot.LastPeerCount);
+                metricOutput.AppendFormat(this.MetricsOutputFormat, "Average Elapsed Time Processing DNS Requests (ms)", new TimeSpan((long)averageElapsedTicks).TotalMilliseconds);
+                metricOutput.AppendFormat(this.MetricsOutputFormat, "Last Elapsed Time Processing DNS Requests (ms)", new TimeSpan(snapshot.LastDnsRequestElapsedTicks).TotalMilliseconds);
+                metricOutput.AppendLine();
+
+                // Output
+                this.logger.LogInformation(metricOutput.ToString());
+            }
+            catch (Exception e)
+            {
+                // If metrics fail, just log
+                this.logger.LogWarning(e, "Failed to output DNS metrics.");
+            }
+
+            this.logger.LogTrace("(-)");
         }
     }
 }

--- a/src/Stratis.Bitcoin.Features.Dns/IDnsServer.cs
+++ b/src/Stratis.Bitcoin.Features.Dns/IDnsServer.cs
@@ -18,6 +18,16 @@ namespace Stratis.Bitcoin.Features.Dns
         IMasterFile MasterFile { get; }
 
         /// <summary>
+        /// Gets the metrics for the DNS server.
+        /// </summary>
+        DnsMetric Metrics { get; }
+
+        /// <summary>
+        /// Initializes the DNS Server.
+        /// </summary>
+        void Initialize();
+
+        /// <summary>
         /// Starts listening for DNS requests.
         /// </summary>
         /// <param name="dnsListenPort">The port to listen on.</param>


### PR DESCRIPTION
- For Trello item: https://trello.com/c/rX5dYdQL
- Added new tests for metric output and updated existing tests
- Changed main DNS loop in feature to not load masterfile on restart of DNS server
- Added DNS metric types for totals and snapshot values
- Updated DNS server to capture metric values in main receive request loop and output metrics periodically using an async loop
- Fixed full stops at end of comments as per previous PR