### PR TITLE
Bugfix/block propagation

### DIFF
--- a/src/NBitcoin/OpenAsset/ColoredTransaction.cs
+++ b/src/NBitcoin/OpenAsset/ColoredTransaction.cs
@@ -1,5 +1,4 @@
 ﻿#if !NOJSONNET
-using System.Threading.Tasks;
 using System.Linq;
 using Newtonsoft.Json.Linq;
 #endif

--- a/src/Stratis.Bitcoin.Features.BlockStore.Tests/BlockStoreBehaviorTest.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore.Tests/BlockStoreBehaviorTest.cs
@@ -30,7 +30,7 @@ namespace Stratis.Bitcoin.Features.BlockStore.Tests
         {
             List<ChainedBlock> blocks = new List<ChainedBlock>();
 
-            var task = this.behavior.AnnounceBlocks(blocks);
+            var task = this.behavior.AnnounceBlocksAsync(blocks);
 
             Assert.Equal(TaskStatus.RanToCompletion, task.Status);
             Assert.Null(this.behavior.AttachedPeer);

--- a/src/Stratis.Bitcoin.Features.BlockStore/BlockStoreBehavior.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/BlockStoreBehavior.cs
@@ -252,7 +252,7 @@ namespace Stratis.Bitcoin.Features.BlockStore
 
                     if (!foundStartingHeader)
                     {
-                        this.logger.LogTrace("Checking is the peer can connect header '{0}'.", chainedBlock);
+                        this.logger.LogTrace("Checking is the peer '{0}' can connect header '{1}'.", peer.RemoteSocketEndpoint, chainedBlock);
 
                         // Peer doesn't have a block at the height of our block and with the same hash?
                         if (chainBehavior.PendingTip.FindAncestorOrSelf(chainedBlock) != null)

--- a/src/Stratis.Bitcoin.Features.BlockStore/BlockStoreBehavior.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/BlockStoreBehavior.cs
@@ -256,9 +256,10 @@ namespace Stratis.Bitcoin.Features.BlockStore
 
                         // Peer doesn't have a block at the height of our block and with the same hash?
                         if (chainBehavior.PendingTip.FindAncestorOrSelf(chainedBlock) != null)
+                        {
+                            this.logger.LogTrace("Peer '{0}' does not have header '{1}'.", peer.RemoteSocketEndpoint, chainedBlock.Previous);
                             continue;
-
-                        this.logger.LogTrace("Checking is the peer can connect previous header '{0}'.", chainedBlock.Previous);
+                        }
 
                         // Peer doesn't have a block at the height of our block.Previous and with the same hash?
                         if (chainBehavior.PendingTip.FindAncestorOrSelf(chainedBlock.Previous) == null)
@@ -269,6 +270,7 @@ namespace Stratis.Bitcoin.Features.BlockStore
                             break;
                         }
 
+                        this.logger.LogTrace("Peer '{0}' can connect header '{1}'.", peer.RemoteSocketEndpoint, chainedBlock.Previous);
                         foundStartingHeader = true;
                     }
 

--- a/src/Stratis.Bitcoin.Features.BlockStore/BlockStoreBehavior.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/BlockStoreBehavior.cs
@@ -255,7 +255,7 @@ namespace Stratis.Bitcoin.Features.BlockStore
                         this.logger.LogTrace("Checking is the peer can connect header '{0}'.", chainedBlock);
 
                         // Peer doesn't have a block at the height of our block and with the same hash?
-                        if (chainBehavior.PendingTip.FindAncestorOrSelf(chainedBlock) == null)
+                        if (chainBehavior.PendingTip.FindAncestorOrSelf(chainedBlock) != null)
                             continue;
 
                         this.logger.LogTrace("Checking is the peer can connect previous header '{0}'.", chainedBlock.Previous);

--- a/src/Stratis.Bitcoin.Features.BlockStore/BlockStoreBehavior.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/BlockStoreBehavior.cs
@@ -193,18 +193,18 @@ namespace Stratis.Bitcoin.Features.BlockStore
             this.logger.LogTrace("(-)");
         }
 
-        private async Task SendAsBlockInventoryAsync(NetworkPeer node, IEnumerable<uint256> blocks)
+        private async Task SendAsBlockInventoryAsync(NetworkPeer peer, IEnumerable<uint256> blocks)
         {
-            this.logger.LogTrace("({0}:'{1}',{2}.Count:{3})", nameof(node), node?.RemoteSocketEndpoint, nameof(blocks), blocks.Count());
+            this.logger.LogTrace("({0}:'{1}',{2}.Count:{3})", nameof(peer), peer?.RemoteSocketEndpoint, nameof(blocks), blocks.Count());
 
             var queue = new Queue<InventoryVector>(blocks.Select(s => new InventoryVector(InventoryType.MSG_BLOCK, s)));
             while (queue.Count > 0)
             {
                 var items = queue.TakeAndRemove(ConnectionManager.MaxInventorySize).ToArray();
-                if (node.IsConnected)
+                if (peer.IsConnected)
                 {
-                    this.logger.LogTrace("Sending inventory message to peer '{0}'.", node.RemoteSocketEndpoint);
-                    await node.SendMessageAsync(new InvPayload(items));
+                    this.logger.LogTrace("Sending inventory message to peer '{0}'.", peer.RemoteSocketEndpoint);
+                    await peer.SendMessageAsync(new InvPayload(items));
                 }
             }
 
@@ -288,7 +288,7 @@ namespace Stratis.Bitcoin.Features.BlockStore
                 else if (this.PreferHeaders)
                 {
                     if (headers.Count > 1) this.logger.LogDebug("Sending {0} headers, range {1} - {2}, to peer '{3}'.", headers.Count, headers.First(), headers.Last(), peer.RemoteSocketEndpoint);
-                    else this.logger.LogDebug("Sending header {0} to peer '{1}'.", headers.First(), peer.RemoteSocketEndpoint);
+                    else this.logger.LogDebug("Sending header '{0}' to peer '{1}'.", headers.First(), peer.RemoteSocketEndpoint);
 
                     chainBehavior.SetPendingTip(bestIndex);
                     Task res = peer.SendMessageAsync(new HeadersPayload(headers.ToArray()));

--- a/src/Stratis.Bitcoin.Features.BlockStore/BlockStoreSignaled.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/BlockStoreSignaled.cs
@@ -197,7 +197,7 @@ namespace Stratis.Bitcoin.Features.BlockStore
 
                 this.logger.LogTrace("{0} blocks will be sent to {1} peers.", broadcastItems.Count, behaviours.Count());
                 foreach (BlockStoreBehavior behaviour in behaviours)
-                    await behaviour.AnnounceBlocks(broadcastItems).ConfigureAwait(false);
+                    await behaviour.AnnounceBlocksAsync(broadcastItems).ConfigureAwait(false);
             },
             this.nodeLifetime.ApplicationStopping,
             repeatEvery: TimeSpans.Second,

--- a/src/Stratis.Bitcoin/Base/ChainHeadersBehavior.cs
+++ b/src/Stratis.Bitcoin/Base/ChainHeadersBehavior.cs
@@ -178,7 +178,7 @@ namespace Stratis.Bitcoin.Base
 
                         // Ignoring "getheaders" from peers because node is in initial block download.
                         // If not in IBD whitelisted won't be checked.
-                        if (this.chainState.IsInitialBlockDownload && !this.AttachedPeer.Behavior<ConnectionManagerBehavior>().Whitelisted) break;
+                        if (this.chainState.IsInitialBlockDownload && !peer.Behavior<ConnectionManagerBehavior>().Whitelisted) break;
 
                         HeadersPayload headers = new HeadersPayload();
                         ChainedBlock consensusTip = this.chainState.ConsensusTip;
@@ -207,7 +207,7 @@ namespace Stratis.Bitcoin.Base
                             }
                         }
 
-                        this.AttachedPeer.SendMessageVoidAsync(headers);
+                        peer.SendMessageVoidAsync(headers);
                         break;
                     }
 
@@ -264,8 +264,8 @@ namespace Stratis.Bitcoin.Base
                                 // Now we know the previous block header and thus we can connect the new header.
                             }
 
-                            tip = new ChainedBlock(header, header.GetHash(this.AttachedPeer.Network.NetworkOptions), prev);
-                            bool validated = this.Chain.GetBlock(tip.HashBlock) != null || tip.Validate(this.AttachedPeer.Network);
+                            tip = new ChainedBlock(header, header.GetHash(peer.Network.NetworkOptions), prev);
+                            bool validated = this.Chain.GetBlock(tip.HashBlock) != null || tip.Validate(peer.Network);
                             validated &= !this.chainState.IsMarkedInvalid(tip.HashBlock);
                             if (!validated)
                             {
@@ -287,7 +287,7 @@ namespace Stratis.Bitcoin.Base
                             uint maxReorgLength = this.chainState.MaxReorgLength;
                             if (maxReorgLength != 0)
                             {
-                                Network network = this.AttachedPeer?.Network;
+                                Network network = peer.Network;
                                 ChainedBlock consensusTip = this.chainState.ConsensusTip;
                                 if ((network != null) && (consensusTip != null))
                                 {

--- a/src/Stratis.Bitcoin/Base/ChainHeadersBehavior.cs
+++ b/src/Stratis.Bitcoin/Base/ChainHeadersBehavior.cs
@@ -246,7 +246,18 @@ namespace Stratis.Bitcoin.Base
 
                                 if (prev == null)
                                 {
-                                    this.logger.LogTrace("Previous header of the new header '{0}' was not found on our chain either, probably a reorg happened recently.", header);
+                                    this.logger.LogTrace("Previous header of the new header '{0}' was not found on our chain either.", header);
+
+                                    // If we can't connect the header we received from the peer, we might be on completely different chain or 
+                                    // a reorg happened recently. If we ignored it, we would have invalid view of the peer and the propagation 
+                                    // of blocks would not work well. So we ask the peer for headers using "getheaders" message.
+                                    var getHeadersPayload = new GetHeadersPayload()
+                                    {
+                                        BlockLocators = pendingTipBefore.GetLocator(),
+                                        HashStop = null
+                                    };
+
+                                    peer.SendMessageVoidAsync(getHeadersPayload);
                                     break;
                                 }
 


### PR DESCRIPTION
This one is big, it fixes 2 block propagation bugs and the tests show incredible improvement when this is applied. 

There was one typo bug `==` vs `!=` in the recent code that fixed another bugs in propagation, but there was one more bug in ChainHeadersBehavior that prevented new blocks to be propagated. Hopefully this is fixed.

Some polishing included, lots of new logs (very useful for debugging this stuff), some renaming, asyncing etc.