### PR TITLE
DNS Server integrated populated with WhiteLists

### DIFF
--- a/src/Stratis.Bitcoin.Features.Dns.Tests/GivenADnsFeature.cs
+++ b/src/Stratis.Bitcoin.Features.Dns.Tests/GivenADnsFeature.cs
@@ -384,10 +384,11 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
             {
                 // Act.
                 feature.Initialize();
-                // System.Threading.Thread.Sleep(6000);
-                nodeLifeTime.StopApplication();
+                bool waited = source.Token.WaitHandle.WaitOne(5000);
 
                 // Assert.
+                feature.Should().NotBeNull();
+                waited.Should().BeTrue();
                 mockWhitelistManager.Verify();
             }
         }

--- a/src/Stratis.Bitcoin.Features.Dns.Tests/GivenADnsFeature.cs
+++ b/src/Stratis.Bitcoin.Features.Dns.Tests/GivenADnsFeature.cs
@@ -24,13 +24,14 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
         public void WhenConstructorCalled_AndDnsServerIsNull_ThenArgumentNullExceptionIsThrown()
         {
             // Arrange.
-            IPeerAddressManager peerAddressManager = new Mock<IPeerAddressManager>().Object;
+            IWhitelistManager whitelistManager = new Mock<IWhitelistManager>().Object;
             ILoggerFactory loggerFactory = new Mock<ILoggerFactory>().Object;
             INodeLifetime nodeLifetime = new Mock<INodeLifetime>().Object;
             NodeSettings nodeSettings = NodeSettings.Default();
             nodeSettings.DataDir = @"C:\";
             DataFolder dataFolders = new Mock<DataFolder>(nodeSettings).Object;
-            Action a = () => { new DnsFeature(null, peerAddressManager, loggerFactory, nodeLifetime, nodeSettings, dataFolders); };
+            IAsyncLoopFactory asyncLoopFactory = new Mock<IAsyncLoopFactory>().Object;
+            Action a = () => { new DnsFeature(null, whitelistManager, loggerFactory, nodeLifetime, nodeSettings, dataFolders, asyncLoopFactory); };
 
             // Act and Assert.
             a.ShouldThrow<ArgumentNullException>().Which.Message.Should().Contain("dnsServer");
@@ -38,7 +39,7 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
 
         [Fact]
         [Trait("DNS", "UnitTest")]
-        public void WhenConstructorCalled_AndPeerAddressManagerIsNull_ThenArgumentNullExceptionIsThrown()
+        public void WhenConstructorCalled_AndWhiteListManagerIsNull_ThenArgumentNullExceptionIsThrown()
         {
             // Arrange.
             IDnsServer dnsServer = new Mock<IDnsServer>().Object;
@@ -47,10 +48,11 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
             NodeSettings nodeSettings = NodeSettings.Default();
             nodeSettings.DataDir = @"C:\";
             DataFolder dataFolders = new Mock<DataFolder>(nodeSettings).Object;
-            Action a = () => { new DnsFeature(dnsServer, null, loggerFactory, nodeLifetime, nodeSettings, dataFolders); };
+            IAsyncLoopFactory asyncLoopFactory = new Mock<IAsyncLoopFactory>().Object;
+            Action a = () => { new DnsFeature(dnsServer, null, loggerFactory, nodeLifetime, nodeSettings, dataFolders, asyncLoopFactory); };
 
             // Act and Assert.
-            a.ShouldThrow<ArgumentNullException>().Which.Message.Should().Contain("peerAddressManager");
+            a.ShouldThrow<ArgumentNullException>().Which.Message.Should().Contain("whitelistManager");
         }
 
         [Fact]
@@ -59,12 +61,13 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
         {
             // Arrange.
             IDnsServer dnsServer = new Mock<IDnsServer>().Object;
-            IPeerAddressManager peerAddressManager = new Mock<IPeerAddressManager>().Object;
+            IWhitelistManager whitelistManager = new Mock<IWhitelistManager>().Object;
             INodeLifetime nodeLifetime = new Mock<INodeLifetime>().Object;
             NodeSettings nodeSettings = NodeSettings.Default();
             nodeSettings.DataDir = @"C:\";
             DataFolder dataFolders = new Mock<DataFolder>(nodeSettings).Object;
-            Action a = () => { new DnsFeature(dnsServer, peerAddressManager, null, nodeLifetime, nodeSettings, dataFolders); };
+            IAsyncLoopFactory asyncLoopFactory = new Mock<IAsyncLoopFactory>().Object;
+            Action a = () => { new DnsFeature(dnsServer, whitelistManager, null, nodeLifetime, nodeSettings, dataFolders, asyncLoopFactory); };
 
             // Act and Assert.
             a.ShouldThrow<ArgumentNullException>().Which.Message.Should().Contain("loggerFactory");
@@ -76,12 +79,14 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
         {
             // Arrange.
             IDnsServer dnsServer = new Mock<IDnsServer>().Object;
+            IWhitelistManager whitelistManager = new Mock<IWhitelistManager>().Object;
             IPeerAddressManager peerAddressManager = new Mock<IPeerAddressManager>().Object;
             ILoggerFactory loggerFactory = new Mock<ILoggerFactory>().Object;
             NodeSettings nodeSettings = NodeSettings.Default();
             nodeSettings.DataDir = @"C:\";
             DataFolder dataFolders = new Mock<DataFolder>(nodeSettings).Object;
-            Action a = () => { new DnsFeature(dnsServer, peerAddressManager, loggerFactory, null, nodeSettings, dataFolders); };
+            IAsyncLoopFactory asyncLoopFactory = new Mock<IAsyncLoopFactory>().Object;
+            Action a = () => { new DnsFeature(dnsServer, whitelistManager, loggerFactory, null, nodeSettings, dataFolders, asyncLoopFactory); };
 
             // Act and Assert.
             a.ShouldThrow<ArgumentNullException>().Which.Message.Should().Contain("nodeLifetime");
@@ -93,13 +98,14 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
         {
             // Arrange.
             IDnsServer dnsServer = new Mock<IDnsServer>().Object;
-            IPeerAddressManager peerAddressManager = new Mock<IPeerAddressManager>().Object;
+            IWhitelistManager whitelistManager = new Mock<IWhitelistManager>().Object;
             ILoggerFactory loggerFactory = new Mock<ILoggerFactory>().Object;
             INodeLifetime nodeLifetime = new Mock<INodeLifetime>().Object;
             NodeSettings nodeSettings = NodeSettings.Default();
             nodeSettings.DataDir = @"C:\";
             DataFolder dataFolders = new Mock<DataFolder>(nodeSettings).Object;
-            Action a = () => { new DnsFeature(dnsServer, peerAddressManager, loggerFactory, nodeLifetime, null, dataFolders); };
+            IAsyncLoopFactory asyncLoopFactory = new Mock<IAsyncLoopFactory>().Object;
+            Action a = () => { new DnsFeature(dnsServer, whitelistManager, loggerFactory, nodeLifetime, null, dataFolders, asyncLoopFactory); };
 
             // Act and Assert.
             a.ShouldThrow<ArgumentNullException>().Which.Message.Should().Contain("nodeSettings");
@@ -111,11 +117,12 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
         {
             // Arrange.
             IDnsServer dnsServer = new Mock<IDnsServer>().Object;
-            IPeerAddressManager peerAddressManager = new Mock<IPeerAddressManager>().Object;
+            IWhitelistManager whitelistManager = new Mock<IWhitelistManager>().Object;
             ILoggerFactory loggerFactory = new Mock<ILoggerFactory>().Object;
             INodeLifetime nodeLifetime = new Mock<INodeLifetime>().Object;
             NodeSettings nodeSettings = new Mock<NodeSettings>("bitcoin", null, NodeSettings.SupportedProtocolVersion, "StratisBitcoin").Object;
-            Action a = () => { new DnsFeature(dnsServer, peerAddressManager, loggerFactory, nodeLifetime, nodeSettings, null); };
+            IAsyncLoopFactory asyncLoopFactory = new Mock<IAsyncLoopFactory>().Object;
+            Action a = () => { new DnsFeature(dnsServer, whitelistManager, loggerFactory, nodeLifetime, nodeSettings, null, asyncLoopFactory); };
 
             // Act and Assert.
             a.ShouldThrow<ArgumentNullException>().Which.Message.Should().Contain("dataFolders");
@@ -127,15 +134,16 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
         {
             // Arrange.
             IDnsServer dnsServer = new Mock<IDnsServer>().Object;
-            IPeerAddressManager peerAddressManager = new Mock<IPeerAddressManager>().Object;
+            IWhitelistManager whitelistManager = new Mock<IWhitelistManager>().Object;
             INodeLifetime nodeLifetime = new Mock<INodeLifetime>().Object;
             NodeSettings nodeSettings = NodeSettings.Default();
             nodeSettings.DataDir = @"C:\";
             DataFolder dataFolders = new Mock<DataFolder>(nodeSettings).Object;
             ILoggerFactory loggerFactory = new Mock<ILoggerFactory>().Object;
+            IAsyncLoopFactory asyncLoopFactory = new Mock<IAsyncLoopFactory>().Object;
 
             // Act.
-            DnsFeature feature = new DnsFeature(dnsServer, peerAddressManager, loggerFactory, nodeLifetime, nodeSettings, dataFolders);
+            DnsFeature feature = new DnsFeature(dnsServer, whitelistManager, loggerFactory, nodeLifetime, nodeSettings, dataFolders, asyncLoopFactory);
 
             // Assert.
             feature.Should().NotBeNull();
@@ -159,7 +167,7 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
             Mock<IMasterFile> masterFile = new Mock<IMasterFile>();
             masterFile.Setup(m => m.Load(It.IsAny<Stream>())).Verifiable();
 
-            IPeerAddressManager peerAddressManager = new Mock<IPeerAddressManager>().Object;
+            IWhitelistManager whitelistManager = new Mock<IWhitelistManager>().Object;
 
             Mock<INodeLifetime> nodeLifetime = new Mock<INodeLifetime>();
             NodeSettings nodeSettings = NodeSettings.Default();
@@ -170,8 +178,10 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
             Mock<ILoggerFactory> loggerFactory = new Mock<ILoggerFactory>();
             loggerFactory.Setup<ILogger>(f => f.CreateLogger(It.IsAny<string>())).Returns(logger.Object);
 
+            IAsyncLoopFactory asyncLoopFactory = new AsyncLoopFactory(loggerFactory.Object);
+
             // Act.
-            DnsFeature feature = new DnsFeature(dnsServer.Object, peerAddressManager, loggerFactory.Object, nodeLifetime.Object, nodeSettings, dataFolders);
+            DnsFeature feature = new DnsFeature(dnsServer.Object, whitelistManager, loggerFactory.Object, nodeLifetime.Object, nodeSettings, dataFolders, asyncLoopFactory);
             feature.Initialize();
             bool waited = waitObject.Wait(5000);
 
@@ -198,7 +208,8 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
             dnsServer.Setup(s => s.ListenAsync(It.IsAny<int>(), It.IsAny<CancellationToken>())).Callback(action);
             dnsServer.Setup(s => s.SwapMasterfile(It.IsAny<IMasterFile>())).Verifiable();
 
-            IPeerAddressManager peerAddressManager = new Mock<IPeerAddressManager>().Object;
+            Mock<IWhitelistManager> mockWhitelistManager = new Mock<IWhitelistManager>();
+            IWhitelistManager whitelistManager = mockWhitelistManager.Object;
 
             Mock<INodeLifetime> nodeLifetime = new Mock<INodeLifetime>();
             NodeSettings nodeSettings = NodeSettings.Default();
@@ -208,6 +219,8 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
             Mock<ILogger> logger = new Mock<ILogger>(MockBehavior.Loose);
             Mock<ILoggerFactory> loggerFactory = new Mock<ILoggerFactory>();
             loggerFactory.Setup<ILogger>(f => f.CreateLogger(It.IsAny<string>())).Returns(logger.Object);
+
+            IAsyncLoopFactory asyncLoopFactory = new AsyncLoopFactory(loggerFactory.Object);
 
             string masterFilePath = Path.Combine(dataFolders.DnsMasterFilePath, DnsFeature.DnsMasterFileName);
 
@@ -221,7 +234,7 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
                 }
 
                 // Run feature
-                DnsFeature feature = new DnsFeature(dnsServer.Object, peerAddressManager, loggerFactory.Object, nodeLifetime.Object, nodeSettings, dataFolders);
+                DnsFeature feature = new DnsFeature(dnsServer.Object, whitelistManager, loggerFactory.Object, nodeLifetime.Object, nodeSettings, dataFolders, asyncLoopFactory);
                 feature.Initialize();
                 bool waited = waitObject.Wait(5000);
 
@@ -258,7 +271,8 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
             dnsServer.Setup(s => s.ListenAsync(It.IsAny<int>(), It.IsAny<CancellationToken>())).Callback(action);
             dnsServer.Setup(s => s.SwapMasterfile(It.IsAny<IMasterFile>())).Verifiable();
 
-            IPeerAddressManager peerAddressManager = new Mock<IPeerAddressManager>().Object;
+            Mock<IWhitelistManager> mockWhitelistManager = new Mock<IWhitelistManager>();
+            IWhitelistManager whitelistManager = mockWhitelistManager.Object;
 
             CancellationTokenSource source = new CancellationTokenSource();
             Mock<INodeLifetime> nodeLifetime = new Mock<INodeLifetime>();
@@ -274,8 +288,10 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
             Mock<ILoggerFactory> loggerFactory = new Mock<ILoggerFactory>();
             loggerFactory.Setup<ILogger>(f => f.CreateLogger(It.IsAny<string>())).Returns(logger.Object);
 
+            IAsyncLoopFactory asyncLoopFactory = new AsyncLoopFactory(loggerFactory.Object);
+
             // Act.
-            DnsFeature feature = new DnsFeature(dnsServer.Object, peerAddressManager, loggerFactory.Object, nodeLifetimeObject, nodeSettings, dataFolders);
+            DnsFeature feature = new DnsFeature(dnsServer.Object, whitelistManager, loggerFactory.Object, nodeLifetimeObject, nodeSettings, dataFolders, asyncLoopFactory);
             feature.Initialize();
             nodeLifetimeObject.StopApplication();
             bool waited = source.Token.WaitHandle.WaitOne(5000);
@@ -300,7 +316,8 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
             dnsServer.Setup(s => s.ListenAsync(It.IsAny<int>(), It.IsAny<CancellationToken>())).Callback(action);
             dnsServer.Setup(s => s.SwapMasterfile(It.IsAny<IMasterFile>())).Verifiable();
 
-            IPeerAddressManager peerAddressManager = new Mock<IPeerAddressManager>().Object;
+            Mock<IWhitelistManager> mockWhitelistManager = new Mock<IWhitelistManager>();
+            IWhitelistManager whitelistManager = mockWhitelistManager.Object;
 
             CancellationTokenSource source = new CancellationTokenSource(3000);
             Mock<INodeLifetime> nodeLifetime = new Mock<INodeLifetime>();
@@ -318,8 +335,10 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
             Mock<ILoggerFactory> loggerFactory = new Mock<ILoggerFactory>();
             loggerFactory.Setup<ILogger>(f => f.CreateLogger(It.IsAny<string>())).Returns(logger.Object);
 
+            IAsyncLoopFactory asyncLoopFactory = new AsyncLoopFactory(loggerFactory.Object);
+
             // Act.
-            DnsFeature feature = new DnsFeature(dnsServer.Object, peerAddressManager, loggerFactory.Object, nodeLifetimeObject, nodeSettings, dataFolders);
+            DnsFeature feature = new DnsFeature(dnsServer.Object, whitelistManager, loggerFactory.Object, nodeLifetimeObject, nodeSettings, dataFolders, asyncLoopFactory);
             feature.Initialize();
             bool waited = source.Token.WaitHandle.WaitOne(5000);
 
@@ -329,6 +348,48 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
             dnsServer.Verify(s => s.SwapMasterfile(It.IsAny<IMasterFile>()), Times.Never);
             dnsServer.Verify(s => s.ListenAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()), Times.AtLeastOnce);
             serverError.Should().BeTrue();
+        }
+
+        [Fact]
+        [Trait("DNS", "UnitTest")]
+        public void WhenInitialize_ThenRefreshLoopIsStarted()
+        {
+            // Arrange.
+            Mock<IWhitelistManager> mockWhitelistManager = new Mock<IWhitelistManager>();
+            mockWhitelistManager.Setup(w => w.RefreshWhitelist()).Verifiable("the RefreshWhitelist method should be called on the WhitelistManager");
+
+            IWhitelistManager whitelistManager = mockWhitelistManager.Object;
+
+            Mock<ILogger> mockLogger = new Mock<ILogger>();
+            Mock<ILoggerFactory> mockLoggerFactory = new Mock<ILoggerFactory>();
+            mockLoggerFactory.Setup(l => l.CreateLogger(It.IsAny<string>())).Returns(mockLogger.Object);
+            ILoggerFactory loggerFactory = mockLoggerFactory.Object;
+
+            IAsyncLoopFactory asyncLoopFactory = new AsyncLoopFactory(loggerFactory);
+            INodeLifetime nodeLifeTime = new NodeLifetime();
+
+            IDnsServer dnsServer = new Mock<IDnsServer>().Object;
+
+            CancellationTokenSource source = new CancellationTokenSource(3000);
+            Mock<INodeLifetime> nodeLifetime = new Mock<INodeLifetime>();
+            nodeLifetime.Setup(n => n.StopApplication()).Callback(() => source.Cancel());
+            nodeLifetime.Setup(n => n.ApplicationStopping).Returns(source.Token);
+            INodeLifetime nodeLifetimeObject = nodeLifetime.Object;
+
+            NodeSettings nodeSettings = NodeSettings.Default();
+            nodeSettings.DataDir = Directory.GetCurrentDirectory();
+            DataFolder dataFolders = new Mock<DataFolder>(nodeSettings).Object;
+
+            using (DnsFeature feature = new DnsFeature(dnsServer, whitelistManager, loggerFactory, nodeLifetimeObject, nodeSettings, dataFolders, asyncLoopFactory))
+            {
+                // Act.
+                feature.Initialize();
+                // System.Threading.Thread.Sleep(6000);
+                nodeLifeTime.StopApplication();
+
+                // Assert.
+                mockWhitelistManager.Verify();
+            }
         }
     }
 }

--- a/src/Stratis.Bitcoin.Features.Dns.Tests/GivenADnsSeedMasterFile.cs
+++ b/src/Stratis.Bitcoin.Features.Dns.Tests/GivenADnsSeedMasterFile.cs
@@ -1,0 +1,620 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using DNS.Protocol;
+using DNS.Protocol.ResourceRecords;
+using FluentAssertions;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace Stratis.Bitcoin.Features.Dns.Tests
+{
+    /// <summary>
+    /// Tests for the<see cref="DnsSeedMasterFile"/> class.
+    /// </summary>
+    public class GivenADnsSeedMasterFile
+    {
+        [Fact]
+        [Trait("DNS", "UnitTest")]
+        public void WhenLoad_AndStreamIsNull_ThenArgumentNullExceptionIsThrown()
+        {
+            // Arrange.
+            DnsSeedMasterFile masterFile = new DnsSeedMasterFile();
+            Action a = () => { masterFile.Load(null); };
+
+            // Act and assert.
+            a.ShouldThrow<ArgumentNullException>().Which.Message.Should().Contain("stream");
+        }
+
+        [Fact]
+        [Trait("DNS", "UnitTest")]
+        public void WhenLoad_AndStreamContainsIPAddressResourceRecord_AndIsIPv4_ThenEntryIsPopulated()
+        {
+            // Arrange
+            Domain domain = new Domain("stratis.test.com");
+
+            IPAddressResourceRecord testResourceRecord = new IPAddressResourceRecord(domain, IPAddress.Parse("192.168.0.1"));
+            Question question = new Question(domain, RecordType.A);
+
+            // Act.
+            IList<IResourceRecord> resourceRecords = this.WhenLoad_AndStreamContainsEntry_ThenEntryIsPopulated(testResourceRecord, question);
+
+            // Assert.
+            resourceRecords.Should().NotBeNull();
+            resourceRecords.Should().NotBeNullOrEmpty();
+
+            IList<IPAddressResourceRecord> ipAddressResourceRecords = resourceRecords.OfType<IPAddressResourceRecord>().ToList();
+            ipAddressResourceRecords.Should().HaveCount(1);
+            ipAddressResourceRecords[0].Name.ToString().Should().Be(domain.ToString());
+            ipAddressResourceRecords[0].IPAddress.Equals(testResourceRecord.IPAddress);
+        }
+
+        [Fact]
+        [Trait("DNS", "UnitTest")]
+        public void WhenLoad_AndStreamContainsIPAddressResourceRecord_AndIsIPv6_ThenEntryIsPopulated()
+        {
+            // Arrange
+            Domain domain = new Domain("stratis.test.com");
+
+            IPAddressResourceRecord testResourceRecord = new IPAddressResourceRecord(domain, IPAddress.Parse("2001:db8:85a3:0:0:8a2e:370:7334"));
+            Question question = new Question(domain, RecordType.AAAA);
+
+            // Act.
+            IList<IResourceRecord> resourceRecords = this.WhenLoad_AndStreamContainsEntry_ThenEntryIsPopulated(testResourceRecord, question);
+
+            // Assert.
+            resourceRecords.Should().NotBeNull();
+            resourceRecords.Should().NotBeNullOrEmpty();
+
+            IList<IPAddressResourceRecord> ipAddressResourceRecords = resourceRecords.OfType<IPAddressResourceRecord>().ToList();
+            ipAddressResourceRecords.Should().HaveCount(1);
+            ipAddressResourceRecords[0].Name.ToString().Should().Be(domain.ToString());
+            ipAddressResourceRecords[0].IPAddress.Equals(testResourceRecord.IPAddress);
+        }
+
+        [Fact]
+        [Trait("DNS", "UnitTest")]
+        public void WhenLoad_AndStreamContainsCanonicalNameResourceRecord_ThenEntryIsPopulated()
+        {
+            // Arrange
+            Domain domain = new Domain("stratis.test.com");
+            Domain cNameDomain = new Domain("www.stratis.test.com");
+
+            CanonicalNameResourceRecord testResourceRecord = new CanonicalNameResourceRecord(domain, cNameDomain);
+            Question question = new Question(domain, RecordType.CNAME);
+
+            // Act.
+            IList<IResourceRecord> resourceRecords = this.WhenLoad_AndStreamContainsEntry_ThenEntryIsPopulated(testResourceRecord, question);
+
+            // Assert.
+            resourceRecords.Should().NotBeNull();
+            resourceRecords.Should().NotBeNullOrEmpty();
+
+            IList<CanonicalNameResourceRecord> canonicalResourceRecords = resourceRecords.OfType<CanonicalNameResourceRecord>().ToList();
+            canonicalResourceRecords.Should().HaveCount(1);
+            canonicalResourceRecords[0].Name.ToString().Should().Be(domain.ToString());
+            canonicalResourceRecords[0].CanonicalDomainName.ToString().Should().Be(testResourceRecord.CanonicalDomainName.ToString());
+        }
+
+        [Fact]
+        [Trait("DNS", "UnitTest")]
+        public void WhenLoad_AndStreamContainsMailExchangeResourceRecord_ThenEntryIsPopulated()
+        {
+            // Arrange
+            Domain domain = new Domain("stratis.test.com");
+            Domain exchangeDomain = new Domain("mail.stratis.test.com");
+            int preference = 10;
+
+            MailExchangeResourceRecord testResourceRecord = new MailExchangeResourceRecord(domain, preference, exchangeDomain);
+
+            Question question = new Question(domain, RecordType.MX);
+
+            // Act.
+            IList<IResourceRecord> resourceRecords = this.WhenLoad_AndStreamContainsEntry_ThenEntryIsPopulated(testResourceRecord, question);
+
+            // Assert.
+            resourceRecords.Should().NotBeNull();
+            resourceRecords.Should().NotBeNullOrEmpty();
+
+            IList<MailExchangeResourceRecord> mailExchangeResourceRecords = resourceRecords.OfType<MailExchangeResourceRecord>().ToList();
+            mailExchangeResourceRecords.Should().HaveCount(1);
+            mailExchangeResourceRecords[0].Name.ToString().Should().Be(domain.ToString());
+            mailExchangeResourceRecords[0].ExchangeDomainName.ToString().Should().Be(testResourceRecord.ExchangeDomainName.ToString());
+            mailExchangeResourceRecords[0].Preference.Should().Be(preference);
+        }
+
+        [Fact]
+        [Trait("DNS", "UnitTest")]
+        public void WhenLoad_AndStreamContainsNameServerResourceRecord_ThenEntryIsPopulated()
+        {
+            // Arrange
+            Domain domain = new Domain("stratis.test.com");
+            Domain nsDomain = new Domain("ns");
+
+            NameServerResourceRecord testResourceRecord = new NameServerResourceRecord(domain, nsDomain);
+
+            Question question = new Question(domain, RecordType.NS);
+
+            // Act.
+            IList<IResourceRecord> resourceRecords = this.WhenLoad_AndStreamContainsEntry_ThenEntryIsPopulated(testResourceRecord, question);
+
+            // Assert.
+            resourceRecords.Should().NotBeNull();
+            resourceRecords.Should().NotBeNullOrEmpty();
+
+            IList<NameServerResourceRecord> nameServerResourceRecord = resourceRecords.OfType<NameServerResourceRecord>().ToList();
+            nameServerResourceRecord.Should().HaveCount(1);
+            nameServerResourceRecord[0].Name.ToString().Should().Be(domain.ToString());
+            nameServerResourceRecord[0].NSDomainName.ToString().Should().Be(testResourceRecord.NSDomainName.ToString());
+        }
+
+        [Fact]
+        [Trait("DNS", "UnitTest")]
+        public void WhenLoad_AndStreamContainsPointerResourceRecord_ThenEntryIsPopulated()
+        {
+            // Arrange
+            Domain domain = new Domain("stratis.test.com");
+            Domain nsDomain = new Domain("pointer.stratis.test.com");
+
+            PointerResourceRecord testResourceRecord = new PointerResourceRecord(domain, nsDomain);
+
+            Question question = new Question(domain, RecordType.PTR);
+
+            // Act.
+            IList<IResourceRecord> resourceRecords = this.WhenLoad_AndStreamContainsEntry_ThenEntryIsPopulated(testResourceRecord, question);
+
+            // Assert.
+            resourceRecords.Should().NotBeNull();
+            resourceRecords.Should().NotBeNullOrEmpty();
+
+            IList<PointerResourceRecord> pointerResourceRecord = resourceRecords.OfType<PointerResourceRecord>().ToList();
+            pointerResourceRecord.Should().HaveCount(1);
+            pointerResourceRecord[0].Name.ToString().Should().Be(domain.ToString());
+            pointerResourceRecord[0].PointerDomainName.ToString().Should().Be(testResourceRecord.PointerDomainName.ToString());
+        }
+
+        [Fact]
+        [Trait("DNS", "UnitTest")]
+        public void WhenLoad_AndStreamContainsStartOfAuthorityResourceRecord_ThenEntryIsPopulated()
+        {
+            // Arrange
+            Domain domain = new Domain("stratis.test.com");
+            Domain masterDomain = new Domain("master.test.com");
+            Domain responsibleDomain = new Domain("responsible.test.com");
+            long serialNumber = 12121212;
+            TimeSpan refreshInterval = new TimeSpan(1111111111);
+            TimeSpan retryInterval = new TimeSpan(2222222222);
+            TimeSpan expireInterval = new TimeSpan(3333333333);
+            TimeSpan minimumTimeToLive = new TimeSpan(4444444444);
+
+            StartOfAuthorityResourceRecord testResourceRecord =
+                new StartOfAuthorityResourceRecord(
+                    domain,
+                    masterDomain,
+                    responsibleDomain,
+                    serialNumber,
+                    refreshInterval,
+                    retryInterval,
+                    expireInterval,
+                    minimumTimeToLive);
+
+            Question question = new Question(domain, RecordType.SOA);
+
+            // Act.
+            IList<IResourceRecord> resourceRecords = this.WhenLoad_AndStreamContainsEntry_ThenEntryIsPopulated(testResourceRecord, question);
+
+            // Assert.
+            resourceRecords.Should().NotBeNull();
+            resourceRecords.Should().NotBeNullOrEmpty();
+
+            IList<StartOfAuthorityResourceRecord> startOfAuthorityResourceRecord = resourceRecords.OfType<StartOfAuthorityResourceRecord>().ToList();
+            startOfAuthorityResourceRecord.Should().HaveCount(1);
+            startOfAuthorityResourceRecord[0].Name.ToString().Should().Be(domain.ToString());
+            startOfAuthorityResourceRecord[0].MasterDomainName.ToString().Should().Be(masterDomain.ToString());
+            startOfAuthorityResourceRecord[0].ResponsibleDomainName.ToString().Should().Be(responsibleDomain.ToString());
+            startOfAuthorityResourceRecord[0].SerialNumber.Should().Be(serialNumber);
+            startOfAuthorityResourceRecord[0].RefreshInterval.Should().Be(refreshInterval);
+            startOfAuthorityResourceRecord[0].RetryInterval.Should().Be(retryInterval);
+            startOfAuthorityResourceRecord[0].ExpireInterval.Should().Be(expireInterval);
+            startOfAuthorityResourceRecord[0].MinimumTimeToLive.Should().Be(minimumTimeToLive);
+        }
+
+        [Fact]
+        [Trait("DNS", "UnitTest")]
+        public void WhenLoad_AndStreamContainsEntries_ThenEntriesArePopulated()
+        {
+            // Arrange.
+            using (MemoryStream stream = new MemoryStream())
+            {
+                string domainName = "stratis.test.com";
+                DnsSeedMasterFile masterFile = new DnsSeedMasterFile();
+
+                IList<IResourceRecord> testResourceRecords = new List<IResourceRecord>()
+                {
+                    new IPAddressResourceRecord(new Domain(domainName), IPAddress.Parse("192.168.0.1")),
+                    new IPAddressResourceRecord(new Domain(domainName), IPAddress.Parse("192.168.0.2")),
+                    new IPAddressResourceRecord(new Domain(domainName), IPAddress.Parse("192.168.0.3")),
+                    new IPAddressResourceRecord(new Domain(domainName), IPAddress.Parse("192.168.0.4"))
+                };
+
+                JsonSerializer serializer = this.CreateSerializer();
+
+                using (var streamWriter = new StreamWriter(stream))
+                {
+                    using (var jsonTextWriter = new JsonTextWriter(streamWriter))
+                    {
+                        serializer.Serialize(jsonTextWriter, testResourceRecords);
+
+                        jsonTextWriter.Flush();
+                        stream.Seek(0, SeekOrigin.Begin);
+
+                        // Act.
+                        masterFile.Load(stream);
+                    }
+                }
+
+                // Assert.
+                Domain domain = new Domain(domainName);
+                Question question = new Question(domain, RecordType.A);
+
+                IList<IResourceRecord> resourceRecords = masterFile.Get(question);
+                resourceRecords.Should().NotBeNullOrEmpty();
+
+                IList<IPAddressResourceRecord> ipAddressResourceRecords = resourceRecords.OfType<IPAddressResourceRecord>().ToList();
+                ipAddressResourceRecords.Should().HaveSameCount(testResourceRecords);
+
+                foreach (IPAddressResourceRecord testResourceRecord in testResourceRecords)
+                {
+                    ipAddressResourceRecords.SingleOrDefault(i => i.IPAddress.Equals(testResourceRecord.IPAddress)).Should().NotBeNull();
+                }
+            }
+        }
+
+        [Fact]
+        [Trait("DNS", "UnitTest")]
+        public void WhenSave_AndMasterListContainsIPAddressResourceRecord_AndIsIPv4_ThenEntryIsSaved()
+        {
+            // Arrange
+            Domain domain = new Domain("stratis.test.com");
+
+            IPAddressResourceRecord testResourceRecord = new IPAddressResourceRecord(domain, IPAddress.Parse("192.168.0.1"));
+            DnsSeedMasterFile masterFile = new DnsSeedMasterFile();
+            masterFile.Add(testResourceRecord);
+
+            using (MemoryStream stream = new MemoryStream())
+            {
+                // Act.
+                masterFile.Save(stream);
+
+                // Assert.                
+                stream.Should().NotBeNull();
+                IList<IResourceRecord> resourceRecords = this.ReadResourceRecords(stream);
+
+                resourceRecords.Should().NotBeNull();
+                resourceRecords.Should().NotBeNullOrEmpty();
+
+                IList<IPAddressResourceRecord> ipAddressResourceRecords = resourceRecords.OfType<IPAddressResourceRecord>().ToList();
+                ipAddressResourceRecords.Should().HaveCount(1);
+                ipAddressResourceRecords[0].Name.ToString().Should().Be(domain.ToString());
+                ipAddressResourceRecords[0].IPAddress.Equals(testResourceRecord.IPAddress);
+            }
+        }
+
+        [Fact]
+        [Trait("DNS", "UnitTest")]
+        public void WhenSave_AndMasterListContainsIPAddressResourceRecord_AndIsIPv6_ThenEntryIsSaved()
+        {
+            // Arrange
+            Domain domain = new Domain("stratis.test.com");
+
+            IPAddressResourceRecord testResourceRecord = new IPAddressResourceRecord(domain, IPAddress.Parse("2001:db8:85a3:0:0:8a2e:370:7334"));
+            DnsSeedMasterFile masterFile = new DnsSeedMasterFile();
+            masterFile.Add(testResourceRecord);
+
+            using (MemoryStream stream = new MemoryStream())
+            {
+                // Act.
+                masterFile.Save(stream);
+
+                // Assert.                
+                stream.Should().NotBeNull();
+                IList<IResourceRecord> resourceRecords = this.ReadResourceRecords(stream);
+
+                resourceRecords.Should().NotBeNull();
+                resourceRecords.Should().NotBeNullOrEmpty();
+
+                IList<IPAddressResourceRecord> ipAddressResourceRecords = resourceRecords.OfType<IPAddressResourceRecord>().ToList();
+                ipAddressResourceRecords.Should().HaveCount(1);
+                ipAddressResourceRecords[0].Name.ToString().Should().Be(domain.ToString());
+                ipAddressResourceRecords[0].IPAddress.Equals(testResourceRecord.IPAddress);
+            }
+        }
+
+        [Fact]
+        [Trait("DNS", "UnitTest")]
+        public void WhenSave_AndMasterListContainsCanonicalNameResourceRecord_ThenEntryIsSaved()
+        {
+            // Arrange
+            Domain domain = new Domain("stratis.test.com");
+            Domain cNameDomain = new Domain("www.stratis.test.com");
+
+            CanonicalNameResourceRecord testResourceRecord = new CanonicalNameResourceRecord(domain, cNameDomain);
+            DnsSeedMasterFile masterFile = new DnsSeedMasterFile();
+            masterFile.Add(testResourceRecord);
+
+            using (MemoryStream stream = new MemoryStream())
+            {
+                // Act.
+                masterFile.Save(stream);
+
+                // Assert.                
+                stream.Should().NotBeNull();
+                IList<IResourceRecord> resourceRecords = this.ReadResourceRecords(stream);
+
+                resourceRecords.Should().NotBeNull();
+                resourceRecords.Should().NotBeNullOrEmpty();
+
+                IList<CanonicalNameResourceRecord> canonicalResourceRecords = resourceRecords.OfType<CanonicalNameResourceRecord>().ToList();
+                canonicalResourceRecords.Should().HaveCount(1);
+                canonicalResourceRecords[0].Name.ToString().Should().Be(domain.ToString());
+                canonicalResourceRecords[0].CanonicalDomainName.ToString().Should().Be(testResourceRecord.CanonicalDomainName.ToString());
+            }
+        }
+
+        [Fact]
+        [Trait("DNS", "UnitTest")]
+        public void WhenSave_AndMasterListContainsMailExchangeResourceRecord_ThenEntryIsSaved()
+        {
+            // Arrange
+            Domain domain = new Domain("stratis.test.com");
+            Domain exchangeDomain = new Domain("mail.stratis.test.com");
+            int preference = 10;
+
+            MailExchangeResourceRecord testResourceRecord = new MailExchangeResourceRecord(domain, preference, exchangeDomain);
+            DnsSeedMasterFile masterFile = new DnsSeedMasterFile();
+            masterFile.Add(testResourceRecord);
+            using (MemoryStream stream = new MemoryStream())
+            {
+                // Act.
+                masterFile.Save(stream);
+
+                // Assert.                
+                stream.Should().NotBeNull();
+                IList<IResourceRecord> resourceRecords = this.ReadResourceRecords(stream);
+
+                resourceRecords.Should().NotBeNull();
+                resourceRecords.Should().NotBeNullOrEmpty();
+
+                IList<MailExchangeResourceRecord> mailExchangeResourceRecords = resourceRecords.OfType<MailExchangeResourceRecord>().ToList();
+                mailExchangeResourceRecords.Should().HaveCount(1);
+                mailExchangeResourceRecords[0].Name.ToString().Should().Be(domain.ToString());
+                mailExchangeResourceRecords[0].ExchangeDomainName.ToString().Should().Be(testResourceRecord.ExchangeDomainName.ToString());
+                mailExchangeResourceRecords[0].Preference.Should().Be(preference);
+            }
+        }
+
+        [Fact]
+        [Trait("DNS", "UnitTest")]
+        public void WhenSave_AndMasterListContainsNameServerResourceRecord_ThenEntryIsSaved()
+        {
+            // Arrange
+            Domain domain = new Domain("stratis.test.com");
+            Domain nsDomain = new Domain("ns");
+
+            NameServerResourceRecord testResourceRecord = new NameServerResourceRecord(domain, nsDomain);
+            DnsSeedMasterFile masterFile = new DnsSeedMasterFile();
+            masterFile.Add(testResourceRecord);
+
+            using (MemoryStream stream = new MemoryStream())
+            {
+                // Act.
+                masterFile.Save(stream);
+
+                // Assert.                
+                stream.Should().NotBeNull();
+                IList<IResourceRecord> resourceRecords = this.ReadResourceRecords(stream);
+
+                resourceRecords.Should().NotBeNull();
+                resourceRecords.Should().NotBeNullOrEmpty();
+
+                IList<NameServerResourceRecord> nameServerResourceRecord = resourceRecords.OfType<NameServerResourceRecord>().ToList();
+                nameServerResourceRecord.Should().HaveCount(1);
+                nameServerResourceRecord[0].Name.ToString().Should().Be(domain.ToString());
+                nameServerResourceRecord[0].NSDomainName.ToString().Should().Be(testResourceRecord.NSDomainName.ToString());
+            }
+        }
+
+        [Fact]
+        [Trait("DNS", "UnitTest")]
+        public void WhenSave_AndMasterListContainsPointerResourceRecord_ThenEntryIsSaved()
+        {
+            // Arrange
+            Domain domain = new Domain("stratis.test.com");
+            Domain nsDomain = new Domain("pointer.stratis.test.com");
+
+            PointerResourceRecord testResourceRecord = new PointerResourceRecord(domain, nsDomain);
+            DnsSeedMasterFile masterFile = new DnsSeedMasterFile();
+            masterFile.Add(testResourceRecord);
+
+            using (MemoryStream stream = new MemoryStream())
+            {
+                // Act.
+                masterFile.Save(stream);
+
+                // Assert.                
+                stream.Should().NotBeNull();
+                IList<IResourceRecord> resourceRecords = this.ReadResourceRecords(stream);
+
+                resourceRecords.Should().NotBeNull();
+                resourceRecords.Should().NotBeNullOrEmpty();
+
+                IList<PointerResourceRecord> pointerResourceRecord = resourceRecords.OfType<PointerResourceRecord>().ToList();
+                pointerResourceRecord.Should().HaveCount(1);
+                pointerResourceRecord[0].Name.ToString().Should().Be(domain.ToString());
+                pointerResourceRecord[0].PointerDomainName.ToString().Should().Be(testResourceRecord.PointerDomainName.ToString());
+            }
+        }
+
+        [Fact]
+        [Trait("DNS", "UnitTest")]
+        public void WhenSave_AndMasterListContainsStartOfAuthorityResourceRecord_ThenEntryIsSaved()
+        {
+            // Arrange
+            Domain domain = new Domain("stratis.test.com");
+            Domain masterDomain = new Domain("master.test.com");
+            Domain responsibleDomain = new Domain("responsible.test.com");
+            long serialNumber = 12121212;
+            TimeSpan refreshInterval = new TimeSpan(1111111111);
+            TimeSpan retryInterval = new TimeSpan(2222222222);
+            TimeSpan expireInterval = new TimeSpan(3333333333);
+            TimeSpan minimumTimeToLive = new TimeSpan(4444444444);
+
+            StartOfAuthorityResourceRecord testResourceRecord =
+                new StartOfAuthorityResourceRecord(
+                    domain,
+                    masterDomain,
+                    responsibleDomain,
+                    serialNumber,
+                    refreshInterval,
+                    retryInterval,
+                    expireInterval,
+                    minimumTimeToLive);
+
+            DnsSeedMasterFile masterFile = new DnsSeedMasterFile();
+            masterFile.Add(testResourceRecord);
+
+            using (MemoryStream stream = new MemoryStream())
+            {
+                // Act.
+                masterFile.Save(stream);
+
+                // Assert.                
+                stream.Should().NotBeNull();
+                IList<IResourceRecord> resourceRecords = this.ReadResourceRecords(stream);
+                resourceRecords.Should().NotBeNull();
+                resourceRecords.Should().NotBeNullOrEmpty();
+
+                IList<StartOfAuthorityResourceRecord> startOfAuthorityResourceRecord = resourceRecords.OfType<StartOfAuthorityResourceRecord>().ToList();
+                startOfAuthorityResourceRecord.Should().HaveCount(1);
+                startOfAuthorityResourceRecord[0].Name.ToString().Should().Be(domain.ToString());
+                startOfAuthorityResourceRecord[0].MasterDomainName.ToString().Should().Be(masterDomain.ToString());
+                startOfAuthorityResourceRecord[0].ResponsibleDomainName.ToString().Should().Be(responsibleDomain.ToString());
+                startOfAuthorityResourceRecord[0].SerialNumber.Should().Be(serialNumber);
+                startOfAuthorityResourceRecord[0].RefreshInterval.Should().Be(refreshInterval);
+                startOfAuthorityResourceRecord[0].RetryInterval.Should().Be(retryInterval);
+                startOfAuthorityResourceRecord[0].ExpireInterval.Should().Be(expireInterval);
+                startOfAuthorityResourceRecord[0].MinimumTimeToLive.Should().Be(minimumTimeToLive);
+            }
+        }
+
+        [Fact]
+        [Trait("DNS", "UnitTest")]
+        public void WhenSave_AndMasterListContainsEntries_ThenEntriesAreSaved()
+        {
+            // Arrange.
+            string domainName = "stratis.test.com";
+
+            IList<IResourceRecord> testResourceRecords = new List<IResourceRecord>()
+                {
+                    new IPAddressResourceRecord(new Domain(domainName), IPAddress.Parse("192.168.100.1")),
+                    new IPAddressResourceRecord(new Domain(domainName), IPAddress.Parse("192.168.100.2")),
+                    new IPAddressResourceRecord(new Domain(domainName), IPAddress.Parse("192.168.100.3")),
+                    new IPAddressResourceRecord(new Domain(domainName), IPAddress.Parse("192.168.100.4"))
+                };
+
+            DnsSeedMasterFile masterFile = new DnsSeedMasterFile();
+            foreach (IResourceRecord testResourceRecord in testResourceRecords)
+            {
+                masterFile.Add(testResourceRecord);
+            }
+
+            using (MemoryStream stream = new MemoryStream())
+            {
+                // Act.
+                masterFile.Save(stream);
+
+                // Assert.                
+                stream.Should().NotBeNull();
+                IList<IResourceRecord> resourceRecords = this.ReadResourceRecords(stream);
+                resourceRecords.Should().NotBeNullOrEmpty();
+
+                IList<IPAddressResourceRecord> ipAddressResourceRecords = resourceRecords.OfType<IPAddressResourceRecord>().ToList();
+                ipAddressResourceRecords.Should().HaveSameCount(testResourceRecords);
+
+                foreach (IPAddressResourceRecord testResourceRecord in testResourceRecords)
+                {
+                    ipAddressResourceRecords.SingleOrDefault(i => i.IPAddress.Equals(testResourceRecord.IPAddress)).Should().NotBeNull();
+                }
+            }
+        }
+
+        [Fact]
+        [Trait("DNS", "UnitTest")]
+        public void WhenSave_AndStreamIsNull_ThenArgumentNullExceptionIsThrown()
+        {
+            // Arrange.
+            DnsSeedMasterFile masterFile = new DnsSeedMasterFile();
+            Action a = () => { masterFile.Save(null); };
+
+            // Act and assert.
+            a.ShouldThrow<ArgumentNullException>().Which.Message.Should().Contain("stream");
+        }
+
+        private IList<IResourceRecord> WhenLoad_AndStreamContainsEntry_ThenEntryIsPopulated(IResourceRecord testResourceRecord, Question question)
+        {
+            // Arrange.
+            using (MemoryStream stream = new MemoryStream())
+            {
+                DnsSeedMasterFile masterFile = new DnsSeedMasterFile();
+
+                IList<IResourceRecord> testResourceRecords = new List<IResourceRecord>()
+                {
+                    testResourceRecord
+                };
+
+                JsonSerializer serializer = this.CreateSerializer();
+
+                using (var streamWriter = new StreamWriter(stream))
+                {
+                    using (var jsonTextWriter = new JsonTextWriter(streamWriter))
+                    {
+                        serializer.Serialize(jsonTextWriter, testResourceRecords);
+
+                        jsonTextWriter.Flush();
+                        stream.Seek(0, SeekOrigin.Begin);
+
+                        // Act.
+                        masterFile.Load(stream);
+                    }
+                }
+
+                // Assert.
+                return masterFile.Get(question);
+            }
+        }
+
+        private JsonSerializer CreateSerializer()
+        {
+            var settings = new Newtonsoft.Json.JsonSerializerSettings();
+            settings.Converters.Add(new ResourceRecordConverter());
+            settings.Formatting = Formatting.Indented;
+
+            return JsonSerializer.Create(settings);
+        }
+
+        private IList<IResourceRecord> ReadResourceRecords(Stream stream)
+        {
+            IList<IResourceRecord> resourceRecords = null;
+            stream.Seek(0, SeekOrigin.Begin);
+
+            using (JsonTextReader textReader = new JsonTextReader(new StreamReader(stream)))
+            {
+                JsonSerializer serializer = this.CreateSerializer();
+                resourceRecords = serializer.Deserialize<List<IResourceRecord>>(textReader);
+            }
+            return resourceRecords;
+        }
+    }
+}

--- a/src/Stratis.Bitcoin.Features.Dns.Tests/GivenADnsSeedServer.cs
+++ b/src/Stratis.Bitcoin.Features.Dns.Tests/GivenADnsSeedServer.cs
@@ -373,7 +373,12 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
             bool startedLoop = false;
             logger.Setup(l => l.Log(LogLevel.Information, It.IsAny<EventId>(), It.IsAny<FormattedLogValues>(), It.IsAny<Exception>(), It.IsAny<Func<object, Exception, string>>())).Callback<LogLevel, EventId, object, Exception, Func<object, Exception, string>>((level, id, state, e, f) =>
             {
-                startedLoop = state.ToString().Contains("DNS Metrics");
+                // Don't reset if we found the trace message we were looking for
+                if (!startedLoop)
+                {
+                    // Not yet set, check trace message
+                    startedLoop = state.ToString().Contains("DNS Metrics");
+                }
             });
             Mock<ILoggerFactory> loggerFactory = new Mock<ILoggerFactory>();
             loggerFactory.Setup<ILogger>(f => f.CreateLogger(It.IsAny<string>())).Returns(logger.Object);

--- a/src/Stratis.Bitcoin.Features.Dns.Tests/GivenAWhitelistManager.cs
+++ b/src/Stratis.Bitcoin.Features.Dns.Tests/GivenAWhitelistManager.cs
@@ -1,0 +1,499 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using DNS.Protocol;
+using DNS.Protocol.ResourceRecords;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using NBitcoin;
+using NBitcoin.Protocol;
+using Stratis.Bitcoin.Configuration;
+using Stratis.Bitcoin.P2P;
+using Stratis.Bitcoin.Utilities;
+using Xunit;
+
+namespace Stratis.Bitcoin.Features.Dns.Tests
+{
+    /// <summary>
+    /// Defines unit tests for the <see cref="WhitelistManager"/> class.
+    /// </summary>
+    public class GivenAWhitelistManager
+    {
+        [Fact]
+        [Trait("DNS", "UnitTest")]
+        public void WhenConstructorCalled_AndDatetimeProviderIsNull_ThenArgumentNullExceptionIsThrown()
+        {
+            // Arrange.
+            Action a = () => { new WhitelistManager(null, null, null, null, null); };
+
+            // Act and Assert.
+            a.ShouldThrow<ArgumentNullException>().Which.Message.Should().Contain("dateTimeProvider");
+        }
+
+        [Fact]
+        [Trait("DNS", "UnitTest")]
+        public void WhenConstructorCalled_AndLoggerFactoryIsNull_ThenArgumentNullExceptionIsThrown()
+        {
+            // Arrange.
+            IDateTimeProvider dateTimeProvider = new Mock<IDateTimeProvider>().Object;
+
+            Action a = () => { new WhitelistManager(dateTimeProvider, null, null, null, null); };
+
+            // Act and Assert.
+            a.ShouldThrow<ArgumentNullException>().Which.Message.Should().Contain("loggerFactory");
+        }
+
+        [Fact]
+        [Trait("DNS", "UnitTest")]
+        public void WhenConstructorCalled_AndPeerAddressManagerIsNull_ThenArgumentNullExceptionIsThrown()
+        {
+            // Arrange.
+            IDateTimeProvider dateTimeProvider = new Mock<IDateTimeProvider>().Object;
+            ILoggerFactory loggerFactory = new Mock<ILoggerFactory>().Object;
+
+            Action a = () => { new WhitelistManager(dateTimeProvider, loggerFactory, null, null, null); };
+
+            // Act and Assert.
+            a.ShouldThrow<ArgumentNullException>().Which.Message.Should().Contain("peerAddressManager");
+        }
+
+        [Fact]
+        [Trait("DNS", "UnitTest")]
+        public void WhenConstructorCalled_AndDnsServerIsNull_ThenArgumentNullExceptionIsThrown()
+        {
+            // Arrange.
+            IDateTimeProvider dateTimeProvider = new Mock<IDateTimeProvider>().Object;
+            ILoggerFactory loggerFactory = new Mock<ILoggerFactory>().Object;
+            IPeerAddressManager peerAddressManager = new Mock<IPeerAddressManager>().Object;
+
+            Action a = () => { new WhitelistManager(dateTimeProvider, loggerFactory, peerAddressManager, null, null); };
+
+            // Act and Assert.
+            a.ShouldThrow<ArgumentNullException>().Which.Message.Should().Contain("dnsServer");
+        }
+
+        [Fact]
+        [Trait("DNS", "UnitTest")]
+        public void WhenConstructorCalled_AndNodeSettingsAreNull_ThenArgumentNullExceptionIsThrown()
+        {
+            // Arrange.
+            IDateTimeProvider dateTimeProvider = new Mock<IDateTimeProvider>().Object;
+            ILoggerFactory loggerFactory = new Mock<ILoggerFactory>().Object;
+            IPeerAddressManager peerAddressManager = new Mock<IPeerAddressManager>().Object;
+            IDnsServer dnsServer = new Mock<IDnsServer>().Object;
+
+            Action a = () => { new WhitelistManager(dateTimeProvider, loggerFactory, peerAddressManager, dnsServer, null); };
+
+            // Act and Assert.
+            a.ShouldThrow<ArgumentNullException>().Which.Message.Should().Contain("nodeSettings");
+        }
+
+        [Fact]
+        [Trait("DNS", "UnitTest")]
+        public void WhenConstructorCalled_AndNodeSettingsDnsHostNameIsNull_ThenArgumentNullExceptionIsThrown()
+        {
+            // Arrange.
+            IDateTimeProvider dateTimeProvider = new Mock<IDateTimeProvider>().Object;
+            ILoggerFactory loggerFactory = new Mock<ILoggerFactory>().Object;
+            IPeerAddressManager peerAddressManager = new Mock<IPeerAddressManager>().Object;
+            IDnsServer dnsServer = new Mock<IDnsServer>().Object;
+            NodeSettings nodeSettings = NodeSettings.Default();
+
+            Action a = () => { new WhitelistManager(dateTimeProvider, loggerFactory, peerAddressManager, dnsServer, nodeSettings); };
+
+            // Act and Assert.
+            a.ShouldThrow<ArgumentNullException>().Which.Message.Should().Contain("DnsHostName");
+        }
+
+        [Fact]
+        [Trait("DNS", "UnitTest")]
+        public void WhenConstructorCalled_AndNodeSettingsConnectionManagerIsNull_ThenArgumentNullExceptionIsThrown()
+        {
+            // Arrange.
+            IDateTimeProvider dateTimeProvider = new Mock<IDateTimeProvider>().Object;
+            ILoggerFactory loggerFactory = new Mock<ILoggerFactory>().Object;
+            IPeerAddressManager peerAddressManager = new Mock<IPeerAddressManager>().Object;
+            IDnsServer dnsServer = new Mock<IDnsServer>().Object;
+            NodeSettings nodeSettings = NodeSettings.Default();
+            nodeSettings.DnsHostName = "stratis.test.com";
+            nodeSettings.ConnectionManager = null;
+
+            Action a = () => { new WhitelistManager(dateTimeProvider, loggerFactory, peerAddressManager, dnsServer, nodeSettings); };
+
+            // Act and Assert.
+            a.ShouldThrow<ArgumentNullException>().Which.Message.Should().Contain("ConnectionManager");
+        }
+
+        [Fact]
+        [Trait("DNS", "UnitTest")]
+        public void WhenRefreshWhitelist_AndActivePeersAvailable_ThenWhitelistContainsActivePeers()
+        {
+            // Arrange.
+            Mock<IDateTimeProvider> mockDateTimeProvider = new Mock<IDateTimeProvider>();
+
+            Mock<ILogger> mockLogger = new Mock<ILogger>();
+            Mock<ILoggerFactory> mockLoggerFactory = new Mock<ILoggerFactory>();
+            mockLoggerFactory.Setup(l => l.CreateLogger(It.IsAny<string>())).Returns(mockLogger.Object);
+            ILoggerFactory loggerFactory = mockLoggerFactory.Object;
+
+            mockDateTimeProvider.Setup(d => d.GetTimeOffset()).Returns(new DateTimeOffset(new DateTime(2017, 8, 30, 1, 2, 3))).Verifiable();
+            IDateTimeProvider dateTimeProvider = mockDateTimeProvider.Object;
+
+            int inactiveTimePeriod = 2000;
+
+            IPAddress activeIpAddressOne = IPAddress.Parse("::ffff:192.168.0.1");
+            NetworkAddress activeNetworkAddressOne = new NetworkAddress(activeIpAddressOne, 80);
+
+            IPAddress activeIpAddressTwo = IPAddress.Parse("::ffff:192.168.0.2");
+            NetworkAddress activeNetworkAddressTwo = new NetworkAddress(activeIpAddressTwo, 80);
+
+            IPAddress activeIpAddressThree = IPAddress.Parse("::ffff:192.168.0.3");
+            NetworkAddress activeNetworkAddressThree = new NetworkAddress(activeIpAddressThree, 80);
+
+            IPAddress activeIpAddressFour = IPAddress.Parse("::ffff:192.168.0.4");
+            NetworkAddress activeNetworkAddressFour = new NetworkAddress(activeIpAddressFour, 80);
+
+            List<Tuple<NetworkAddress, DateTimeOffset>> testDataSet = new List<Tuple<NetworkAddress, DateTimeOffset>>()
+            {
+                new Tuple<NetworkAddress, DateTimeOffset> (activeNetworkAddressOne,  dateTimeProvider.GetTimeOffset().AddSeconds(-inactiveTimePeriod).AddSeconds(10)),
+                new Tuple<NetworkAddress, DateTimeOffset>(activeNetworkAddressTwo, dateTimeProvider.GetTimeOffset().AddSeconds(-inactiveTimePeriod).AddSeconds(20)),
+                new Tuple<NetworkAddress, DateTimeOffset>(activeNetworkAddressThree, dateTimeProvider.GetTimeOffset().AddSeconds(-inactiveTimePeriod).AddSeconds(30)),
+                new Tuple<NetworkAddress, DateTimeOffset>(activeNetworkAddressFour, dateTimeProvider.GetTimeOffset().AddSeconds(-inactiveTimePeriod).AddSeconds(40))
+            };
+
+            IPeerAddressManager peerAddressManager = this.CreateTestPeerAddressManager(testDataSet);
+
+            IMasterFile spiedMasterFile = null;
+            Mock<IDnsServer> mockDnsServer = new Mock<IDnsServer>();
+            mockDnsServer.Setup(d => d.SwapMasterfile(It.IsAny<IMasterFile>()))
+                .Callback<IMasterFile>(m =>
+                {
+                    spiedMasterFile = m;
+                })
+                .Verifiable();
+
+            NodeSettings nodeSettings = NodeSettings.Default();
+            nodeSettings.DnsPeerBlacklistThresholdInSeconds = inactiveTimePeriod;
+            nodeSettings.DnsHostName = "stratis.test.com";
+
+            WhitelistManager whitelistManager = new WhitelistManager(dateTimeProvider, loggerFactory, peerAddressManager, mockDnsServer.Object, nodeSettings);
+
+            // Act.
+            whitelistManager.RefreshWhitelist();
+
+            // Assert.
+            spiedMasterFile.Should().NotBeNull();
+
+            Question question = new Question(new Domain(nodeSettings.DnsHostName), RecordType.AAAA);
+            IList<IResourceRecord> resourceRecords = spiedMasterFile.Get(question);
+            resourceRecords.Should().NotBeNullOrEmpty();
+
+            IList<IPAddressResourceRecord> ipAddressResourceRecords = resourceRecords.OfType<IPAddressResourceRecord>().ToList();
+            ipAddressResourceRecords.Should().HaveSameCount(testDataSet);
+
+            foreach (Tuple<NetworkAddress, DateTimeOffset> testData in testDataSet)
+            {
+                ipAddressResourceRecords.SingleOrDefault(i => i.IPAddress.Equals(testData.Item1.Endpoint.Address)).Should().NotBeNull();
+            }
+        }
+
+        [Fact]
+        [Trait("DNS", "UnitTest")]
+        public void WhenRefreshWhitelist_AndOwnIPInPeers_AndNotRunningFullNode_ThenWhitelistDoesNotContainOwnIP()
+        {
+            // Arrange.
+            Mock<IDateTimeProvider> mockDateTimeProvider = new Mock<IDateTimeProvider>();
+
+            Mock<ILogger> mockLogger = new Mock<ILogger>();
+            Mock<ILoggerFactory> mockLoggerFactory = new Mock<ILoggerFactory>();
+            mockLoggerFactory.Setup(l => l.CreateLogger(It.IsAny<string>())).Returns(mockLogger.Object);
+            ILoggerFactory loggerFactory = mockLoggerFactory.Object;
+
+            mockDateTimeProvider.Setup(d => d.GetTimeOffset()).Returns(new DateTimeOffset(new DateTime(2017, 8, 30, 1, 2, 3))).Verifiable();
+            IDateTimeProvider dateTimeProvider = mockDateTimeProvider.Object;
+
+            int inactiveTimePeriod = 5000;
+
+            IPAddress activeIpAddressOne = IPAddress.Parse("::ffff:192.168.0.1");
+            NetworkAddress activeNetworkAddressOne = new NetworkAddress(activeIpAddressOne, 80);
+
+            IPAddress activeIpAddressTwo = IPAddress.Parse("::ffff:192.168.0.2");
+            NetworkAddress activeNetworkAddressTwo = new NetworkAddress(activeIpAddressTwo, 80);
+
+            IPAddress activeIpAddressThree = IPAddress.Parse("::ffff:192.168.0.3");
+            NetworkAddress activeNetworkAddressThree = new NetworkAddress(activeIpAddressThree, 80);
+
+            List<Tuple<NetworkAddress, DateTimeOffset>> activeTestDataSet = new List<Tuple<NetworkAddress, DateTimeOffset>>()
+            {
+                new Tuple<NetworkAddress, DateTimeOffset> (activeNetworkAddressOne,  dateTimeProvider.GetTimeOffset().AddSeconds(-inactiveTimePeriod).AddSeconds(10)),
+                new Tuple<NetworkAddress, DateTimeOffset>(activeNetworkAddressTwo, dateTimeProvider.GetTimeOffset().AddSeconds(-inactiveTimePeriod).AddSeconds(20)),
+                new Tuple<NetworkAddress, DateTimeOffset>(activeNetworkAddressThree, dateTimeProvider.GetTimeOffset().AddSeconds(-inactiveTimePeriod).AddSeconds(30)),
+            };
+
+            IPAddress externalIPAdress = IPAddress.Parse("::ffff:192.168.99.99");
+            int externalPort = 80;
+            NetworkAddress externalNetworkAddress = new NetworkAddress(externalIPAdress, externalPort);
+
+            List<Tuple<NetworkAddress, DateTimeOffset>> externalIPTestDataSet = new List<Tuple<NetworkAddress, DateTimeOffset>>()
+            {
+                new Tuple<NetworkAddress, DateTimeOffset> (externalNetworkAddress,  dateTimeProvider.GetTimeOffset().AddSeconds(-inactiveTimePeriod).AddSeconds(40)),
+            };
+
+            IPeerAddressManager peerAddressManager = this.CreateTestPeerAddressManager(activeTestDataSet.Union(externalIPTestDataSet).ToList());
+
+            string[] args = new string[] {
+                $"-dnspeeractivethreshold={inactiveTimePeriod.ToString()}",
+                $"-externalip={externalNetworkAddress.Endpoint.Address.ToString()}",
+                $"-port={externalPort.ToString()}",
+            };
+
+            IMasterFile spiedMasterFile = null;
+            Mock<IDnsServer> mockDnsServer = new Mock<IDnsServer>();
+            mockDnsServer.Setup(d => d.SwapMasterfile(It.IsAny<IMasterFile>()))
+                .Callback<IMasterFile>(m =>
+                {
+                    spiedMasterFile = m;
+                })
+                .Verifiable();
+
+            Network network = Network.StratisTest;
+            NodeSettings nodeSettings = new NodeSettings(network.Name, network).LoadArguments(args);
+            nodeSettings.DnsPeerBlacklistThresholdInSeconds = inactiveTimePeriod;
+            nodeSettings.DnsHostName = "stratis.test.com";
+            nodeSettings.DnsFullNode = false;
+
+            WhitelistManager whitelistManager = new WhitelistManager(dateTimeProvider, loggerFactory, peerAddressManager, mockDnsServer.Object, nodeSettings);
+
+            // Act.
+            whitelistManager.RefreshWhitelist();
+
+            // Assert.
+            spiedMasterFile.Should().NotBeNull();
+
+            Question question = new Question(new Domain(nodeSettings.DnsHostName), RecordType.AAAA);
+            IList<IResourceRecord> resourceRecords = spiedMasterFile.Get(question);
+            resourceRecords.Should().NotBeNullOrEmpty();
+
+            IList<IPAddressResourceRecord> ipAddressResourceRecords = resourceRecords.OfType<IPAddressResourceRecord>().ToList();
+            ipAddressResourceRecords.Should().HaveSameCount(activeTestDataSet);
+
+            foreach (Tuple<NetworkAddress, DateTimeOffset> testData in activeTestDataSet)
+            {
+                ipAddressResourceRecords.SingleOrDefault(i => i.IPAddress.Equals(testData.Item1.Endpoint.Address)).Should().NotBeNull();
+            }
+
+            // External IP.
+            ipAddressResourceRecords.SingleOrDefault(i => i.IPAddress.Equals(externalNetworkAddress.Endpoint)).Should().BeNull("the external IP peer should not be in DNS as not running full node.");
+        }
+
+        [Fact]
+        [Trait("DNS", "UnitTest")]
+        public void WhenRefreshWhitelist_AndOwnIPInPeers_AndAreRunningFullNode_ThenWhitelistDoesContainOwnIP()
+        {
+            // Arrange.
+            Mock<IDateTimeProvider> mockDateTimeProvider = new Mock<IDateTimeProvider>();
+
+            Mock<ILogger> mockLogger = new Mock<ILogger>();
+            Mock<ILoggerFactory> mockLoggerFactory = new Mock<ILoggerFactory>();
+            mockLoggerFactory.Setup(l => l.CreateLogger(It.IsAny<string>())).Returns(mockLogger.Object);
+            ILoggerFactory loggerFactory = mockLoggerFactory.Object;
+
+            mockDateTimeProvider.Setup(d => d.GetTimeOffset()).Returns(new DateTimeOffset(new DateTime(2017, 8, 30, 1, 2, 3))).Verifiable();
+            IDateTimeProvider dateTimeProvider = mockDateTimeProvider.Object;
+
+            int inactiveTimePeriod = 5000;
+
+            IPAddress activeIpAddressOne = IPAddress.Parse("::ffff:192.168.0.1");
+            NetworkAddress activeNetworkAddressOne = new NetworkAddress(activeIpAddressOne, 80);
+
+            IPAddress activeIpAddressTwo = IPAddress.Parse("::ffff:192.168.0.2");
+            NetworkAddress activeNetworkAddressTwo = new NetworkAddress(activeIpAddressTwo, 80);
+
+            IPAddress activeIpAddressThree = IPAddress.Parse("::ffff:192.168.0.3");
+            NetworkAddress activeNetworkAddressThree = new NetworkAddress(activeIpAddressThree, 80);
+
+            IPAddress externalIPAdress = IPAddress.Parse("::ffff:192.168.99.99");
+            int externalPort = 80;
+            NetworkAddress externalNetworkAddress = new NetworkAddress(externalIPAdress, externalPort);
+
+            List<Tuple<NetworkAddress, DateTimeOffset>> activeTestDataSet = new List<Tuple<NetworkAddress, DateTimeOffset>>()
+            {
+                new Tuple<NetworkAddress, DateTimeOffset> (activeNetworkAddressOne,  dateTimeProvider.GetTimeOffset().AddSeconds(-inactiveTimePeriod).AddSeconds(10)),
+                new Tuple<NetworkAddress, DateTimeOffset>(activeNetworkAddressTwo, dateTimeProvider.GetTimeOffset().AddSeconds(-inactiveTimePeriod).AddSeconds(20)),
+                new Tuple<NetworkAddress, DateTimeOffset>(activeNetworkAddressThree, dateTimeProvider.GetTimeOffset().AddSeconds(-inactiveTimePeriod).AddSeconds(30)),
+                new Tuple<NetworkAddress, DateTimeOffset> (externalNetworkAddress,  dateTimeProvider.GetTimeOffset().AddSeconds(-inactiveTimePeriod).AddSeconds(40))
+            };
+
+            IPeerAddressManager peerAddressManager = this.CreateTestPeerAddressManager(activeTestDataSet);
+
+            string[] args = new string[] {
+                $"-dnspeeractivethreshold={inactiveTimePeriod.ToString()}",
+                $"-externalip={externalNetworkAddress.Endpoint.Address.ToString()}",
+                $"-port={externalPort.ToString()}",
+            };
+
+            IMasterFile spiedMasterFile = null;
+            Mock<IDnsServer> mockDnsServer = new Mock<IDnsServer>();
+            mockDnsServer.Setup(d => d.SwapMasterfile(It.IsAny<IMasterFile>()))
+                .Callback<IMasterFile>(m =>
+                {
+                    spiedMasterFile = m;
+                })
+                .Verifiable();
+
+            Network network = Network.StratisTest;
+            NodeSettings nodeSettings = new NodeSettings(network.Name, network).LoadArguments(args);
+            nodeSettings.DnsFullNode = true;
+            nodeSettings.DnsPeerBlacklistThresholdInSeconds = inactiveTimePeriod;
+            nodeSettings.DnsHostName = "stratis.test.com";
+
+            WhitelistManager whitelistManager = new WhitelistManager(dateTimeProvider, loggerFactory, peerAddressManager, mockDnsServer.Object, nodeSettings);
+
+            // Act.
+            whitelistManager.RefreshWhitelist();
+
+            // Assert.
+            spiedMasterFile.Should().NotBeNull();
+
+            Question question = new Question(new Domain(nodeSettings.DnsHostName), RecordType.AAAA);
+            IList<IResourceRecord> resourceRecords = spiedMasterFile.Get(question);
+            resourceRecords.Should().NotBeNullOrEmpty();
+
+            IList<IPAddressResourceRecord> ipAddressResourceRecords = resourceRecords.OfType<IPAddressResourceRecord>().ToList();
+            ipAddressResourceRecords.Should().HaveSameCount(activeTestDataSet);
+
+            foreach (Tuple<NetworkAddress, DateTimeOffset> testData in activeTestDataSet)
+            {
+                ipAddressResourceRecords.SingleOrDefault(i => i.IPAddress.Equals(testData.Item1.Endpoint.Address)).Should().NotBeNull();
+            }
+        }
+
+        [Fact]
+        [Trait("DNS", "UnitTest")]
+        public void WhenRefreshWhitelist_AndInactivePeersInWhitelist_ThenWhitelistDoesNotContainInactivePeers()
+        {
+            // Arrange.
+            Mock<IDateTimeProvider> mockDateTimeProvider = new Mock<IDateTimeProvider>();
+
+            Mock<ILogger> mockLogger = new Mock<ILogger>();
+            Mock<ILoggerFactory> mockLoggerFactory = new Mock<ILoggerFactory>();
+            mockLoggerFactory.Setup(l => l.CreateLogger(It.IsAny<string>())).Returns(mockLogger.Object);
+            ILoggerFactory loggerFactory = mockLoggerFactory.Object;
+
+            mockDateTimeProvider.Setup(d => d.GetTimeOffset()).Returns(new DateTimeOffset(new DateTime(2017, 8, 30, 1, 2, 3))).Verifiable();
+            IDateTimeProvider dateTimeProvider = mockDateTimeProvider.Object;
+
+            int inactiveTimePeriod = 3000;
+
+            IPAddress activeIpAddressOne = IPAddress.Parse("::ffff:192.168.0.1");
+            NetworkAddress activeNetworkAddressOne = new NetworkAddress(activeIpAddressOne, 80);
+
+            IPAddress activeIpAddressTwo = IPAddress.Parse("::ffff:192.168.0.2");
+            NetworkAddress activeNetworkAddressTwo = new NetworkAddress(activeIpAddressTwo, 80);
+
+            IPAddress activeIpAddressThree = IPAddress.Parse("::ffff:192.168.0.3");
+            NetworkAddress activeNetworkAddressThree = new NetworkAddress(activeIpAddressThree, 80);
+
+            IPAddress activeIpAddressFour = IPAddress.Parse("::ffff:192.168.0.4");
+            NetworkAddress activeNetworkAddressFour = new NetworkAddress(activeIpAddressFour, 80);
+
+            List<Tuple<NetworkAddress, DateTimeOffset>> activeTestDataSet = new List<Tuple<NetworkAddress, DateTimeOffset>>()
+            {
+                new Tuple<NetworkAddress, DateTimeOffset> (activeNetworkAddressOne,  dateTimeProvider.GetTimeOffset().AddSeconds(-inactiveTimePeriod).AddSeconds(10)),
+                new Tuple<NetworkAddress, DateTimeOffset>(activeNetworkAddressTwo, dateTimeProvider.GetTimeOffset().AddSeconds(-inactiveTimePeriod).AddSeconds(20)),
+                new Tuple<NetworkAddress, DateTimeOffset>(activeNetworkAddressThree, dateTimeProvider.GetTimeOffset().AddSeconds(-inactiveTimePeriod).AddSeconds(30)),
+                new Tuple<NetworkAddress, DateTimeOffset>(activeNetworkAddressFour, dateTimeProvider.GetTimeOffset().AddSeconds(-inactiveTimePeriod).AddSeconds(40))
+            };
+
+            IPAddress inactiveIpAddressOne = IPAddress.Parse("::ffff:192.168.100.1");
+            NetworkAddress inactiveNetworkAddressOne = new NetworkAddress(inactiveIpAddressOne, 80);
+
+            IPAddress inactiveIpAddressTwo = IPAddress.Parse("::ffff:192.168.100.2");
+            NetworkAddress inactiveNetworkAddressTwo = new NetworkAddress(inactiveIpAddressTwo, 80);
+
+            IPAddress inactiveIpAddressThree = IPAddress.Parse("::ffff:192.168.100.3");
+            NetworkAddress inactiveNetworkAddressThree = new NetworkAddress(inactiveIpAddressThree, 80);
+
+            List<Tuple<NetworkAddress, DateTimeOffset>> inactiveTestDataSet = new List<Tuple<NetworkAddress, DateTimeOffset>>()
+            {
+                new Tuple<NetworkAddress, DateTimeOffset> (inactiveNetworkAddressOne,  dateTimeProvider.GetTimeOffset().AddSeconds(-inactiveTimePeriod).AddSeconds(-10)),
+                new Tuple<NetworkAddress, DateTimeOffset>(inactiveNetworkAddressTwo, dateTimeProvider.GetTimeOffset().AddSeconds(-inactiveTimePeriod).AddSeconds(-20)),
+                new Tuple<NetworkAddress, DateTimeOffset>(inactiveNetworkAddressThree, dateTimeProvider.GetTimeOffset().AddSeconds(-inactiveTimePeriod).AddSeconds(-30))
+            };
+
+            IPeerAddressManager peerAddressManager = this.CreateTestPeerAddressManager(activeTestDataSet.Concat(inactiveTestDataSet).ToList());
+
+            IMasterFile spiedMasterFile = null;
+            Mock<IDnsServer> mockDnsServer = new Mock<IDnsServer>();
+            mockDnsServer.Setup(d => d.SwapMasterfile(It.IsAny<IMasterFile>()))
+                .Callback<IMasterFile>(m =>
+                {
+                    spiedMasterFile = m;
+                })
+                .Verifiable();
+
+            NodeSettings nodeSettings = NodeSettings.Default();
+            nodeSettings.DnsPeerBlacklistThresholdInSeconds = inactiveTimePeriod;
+            nodeSettings.DnsHostName = "stratis.test.com";
+
+            WhitelistManager whitelistManager = new WhitelistManager(dateTimeProvider, loggerFactory, peerAddressManager, mockDnsServer.Object, nodeSettings);
+
+            // Act.
+            whitelistManager.RefreshWhitelist();
+
+            // Assert.
+            spiedMasterFile.Should().NotBeNull();
+
+            Question question = new Question(new Domain(nodeSettings.DnsHostName), RecordType.AAAA);
+            IList<IResourceRecord> resourceRecords = spiedMasterFile.Get(question);
+            resourceRecords.Should().NotBeNullOrEmpty();
+
+            IList<IPAddressResourceRecord> ipAddressResourceRecords = resourceRecords.OfType<IPAddressResourceRecord>().ToList();
+            ipAddressResourceRecords.Should().HaveSameCount(activeTestDataSet);
+
+            foreach (Tuple<NetworkAddress, DateTimeOffset> testData in activeTestDataSet)
+            {
+                ipAddressResourceRecords.SingleOrDefault(i => i.IPAddress.Equals(testData.Item1.Endpoint.Address)).Should().NotBeNull("the ip address is active and should be in DNS");
+            }
+
+            foreach (Tuple<NetworkAddress, DateTimeOffset> testData in inactiveTestDataSet)
+            {
+                ipAddressResourceRecords.SingleOrDefault(i => i.IPAddress.Equals(testData.Item1.Endpoint.Address)).Should().BeNull("the ip address is inactive and should not be returned from DNS");
+            }
+        }
+
+        private IPeerAddressManager CreateTestPeerAddressManager(List<Tuple<NetworkAddress, DateTimeOffset>> testDataSet)
+        {
+            ConcurrentDictionary<IPEndPoint, PeerAddress> peers = new ConcurrentDictionary<IPEndPoint, PeerAddress>();
+
+            string dataFolderDirectory = Path.Combine(AppContext.BaseDirectory, "WhitelistTests");
+
+            if (Directory.Exists(dataFolderDirectory))
+            {
+                Directory.Delete(dataFolderDirectory, true);
+            }
+            Directory.CreateDirectory(dataFolderDirectory);
+
+            var peerFolder = new DataFolder(new NodeSettings { DataDir = dataFolderDirectory });
+
+            Mock<ILogger> mockLogger = new Mock<ILogger>();
+            Mock<ILoggerFactory> mockLoggerFactory = new Mock<ILoggerFactory>();
+            mockLoggerFactory.Setup(l => l.CreateLogger(It.IsAny<string>())).Returns(mockLogger.Object);
+            ILoggerFactory loggerFactory = mockLoggerFactory.Object;
+
+            IPeerAddressManager peerAddressManager = new PeerAddressManager(peerFolder, loggerFactory);
+
+            foreach (Tuple<NetworkAddress, DateTimeOffset> testData in testDataSet)
+            {
+                peerAddressManager.AddPeer(testData.Item1, IPAddress.Loopback);
+                peerAddressManager.PeerHandshaked(testData.Item1.Endpoint, testData.Item2);
+            }
+
+            return peerAddressManager;
+        }
+    }
+}

--- a/src/Stratis.Bitcoin.Features.Dns.Tests/Stratis.Bitcoin.Features.Dns.Tests.csproj
+++ b/src/Stratis.Bitcoin.Features.Dns.Tests/Stratis.Bitcoin.Features.Dns.Tests.csproj
@@ -30,6 +30,7 @@
     <PackageReference Include="FluentAssertions" Version="4.19.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="Moq" Version="4.7.142" />
+    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Stratis.Bitcoin.Features.Dns/DnsFeature.cs
+++ b/src/Stratis.Bitcoin.Features.Dns/DnsFeature.cs
@@ -22,7 +22,7 @@ namespace Stratis.Bitcoin.Features.Dns
         /// <summary>
         /// Defines the name of the masterfile on disk.
         /// </summary>
-        public const string DnsMasterFileName = "masterfile.dat";
+        public const string DnsMasterFileName = "masterfile.json";
 
         /// <summary>
         /// Defines the DNS server.

--- a/src/Stratis.Bitcoin.Features.Dns/DnsFeature.cs
+++ b/src/Stratis.Bitcoin.Features.Dns/DnsFeature.cs
@@ -1,17 +1,16 @@
 ﻿using System;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
-using Stratis.Bitcoin.Builder;
 using Stratis.Bitcoin.Builder.Feature;
 using Stratis.Bitcoin.Configuration;
-using Stratis.Bitcoin.P2P;
 using Stratis.Bitcoin.Utilities;
 
 namespace Stratis.Bitcoin.Features.Dns
 {
     /// <summary>
-    /// Responsible for managing the Dns feature.
+    /// Responsible for managing the DNS feature.
     /// </summary>
     public class DnsFeature : FullNodeFeature
     {
@@ -31,6 +30,11 @@ namespace Stratis.Bitcoin.Features.Dns
         private readonly IDnsServer dnsServer;
         
         /// <summary>
+        /// Defines the whitelist manager.
+        /// </summary>
+        private readonly IWhitelistManager whitelistManager;
+
+       /// <summary>
         /// Defines the logger.
         /// </summary>
         private readonly ILogger logger;
@@ -56,32 +60,50 @@ namespace Stratis.Bitcoin.Features.Dns
         private Task dnsTask;
 
         /// <summary>
+        /// Factory for creating background async loop tasks.
+        /// </summary>
+        private readonly IAsyncLoopFactory asyncLoopFactory;
+        
+        /// <summary>
+        /// The async loop to refresh the whitelist.
+        /// </summary>
+        private IAsyncLoop whitelistRefreshLoop;
+        /// <summary>
+        /// Defines a flag used to indicate whether the object has been disposed or not.
+        /// </summary>
+        private bool disposed = false;
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="DnsFeature"/> class.
         /// </summary>
         /// <param name="dnsServer">The DNS server.</param>
-        /// <param name="peerAddressManager">The peer address manager.</param>
+        /// <param name="whitelistManager">The whitelist manager.</param>
         /// <param name="loggerFactory">The factory to create the logger.</param>
         /// <param name="nodeLifetime">The node lifetime object used for graceful shutdown.</param>
         /// <param name="nodeSettings">The node settings object containing node configuration.</param>
         /// <param name="dataFolders">The data folders of the system.</param>
-        public DnsFeature(IDnsServer dnsServer, IPeerAddressManager peerAddressManager, ILoggerFactory loggerFactory, INodeLifetime nodeLifetime, NodeSettings nodeSettings, DataFolder dataFolders)
+        /// <param name="asyncLoopFactory">The asynchronous loop factory.</param>
+        public DnsFeature(IDnsServer dnsServer, IWhitelistManager whitelistManager, ILoggerFactory loggerFactory, INodeLifetime nodeLifetime, NodeSettings nodeSettings, DataFolder dataFolders, IAsyncLoopFactory asyncLoopFactory)
         {
             Guard.NotNull(dnsServer, nameof(dnsServer));
-            Guard.NotNull(peerAddressManager, nameof(peerAddressManager));
+            Guard.NotNull(whitelistManager, nameof(whitelistManager));
             Guard.NotNull(loggerFactory, nameof(loggerFactory));
             Guard.NotNull(nodeLifetime, nameof(nodeLifetime));
             Guard.NotNull(nodeSettings, nameof(nodeSettings));
             Guard.NotNull(dataFolders, nameof(dataFolders));
+            Guard.NotNull(asyncLoopFactory, nameof(asyncLoopFactory));
 
             this.dnsServer = dnsServer;
+            this.whitelistManager = whitelistManager;
             this.logger = loggerFactory.CreateLogger(this.GetType().FullName);
+            this.asyncLoopFactory = asyncLoopFactory;
             this.nodeLifetime = nodeLifetime;
             this.nodeSettings = nodeSettings;
             this.dataFolders = dataFolders;
         }
 
         /// <summary>
-        /// Initializes the Dns feature.
+        /// Initializes the DNS feature.
         /// </summary>
         public override void Initialize()
         {
@@ -89,6 +111,8 @@ namespace Stratis.Bitcoin.Features.Dns
 
             // Create long running task for DNS service.
             this.dnsTask = Task.Factory.StartNew(this.RunDnsService, TaskCreationOptions.LongRunning);
+
+            this.StartWhitelistRefreshLoop();
 
             this.logger.LogTrace("(-)");
         }
@@ -162,6 +186,53 @@ namespace Stratis.Bitcoin.Features.Dns
                     restarted = true;
                 }
             }
+
+            this.logger.LogTrace("(-)");
+        }
+
+        /// <summary>
+        /// Disposes of the object.
+        /// </summary>
+        public override void Dispose()
+        {
+            this.logger.LogInformation("Stopping DNS...");
+
+            this.Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// Disposes of the object.
+        /// </summary>
+        /// <param name="disposing"><c>true</c> if the object is being disposed of deterministically, otherwise <c>false</c>.</param>
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!this.disposed)
+            {
+                if (disposing)
+                {
+                    IDisposable disposablewhitelistRefreshLoop = this.whitelistRefreshLoop as IDisposable;
+                    disposablewhitelistRefreshLoop?.Dispose();
+                }
+
+                this.disposed = true;
+            }
+        }
+
+        /// <summary>
+        /// Starts the loop to refresh the whitelist.
+        /// </summary>
+        private void StartWhitelistRefreshLoop()
+        {
+            this.logger.LogTrace("()");
+
+            this.whitelistRefreshLoop = this.asyncLoopFactory.Run($"{nameof(DnsFeature)}.WhitelistRefreshLoop", token =>
+            {
+                this.whitelistManager.RefreshWhitelist();
+                return Task.CompletedTask;
+            },
+            this.nodeLifetime.ApplicationStopping,
+            repeatEvery: new TimeSpan(0, 0, 30));
 
             this.logger.LogTrace("(-)");
         }

--- a/src/Stratis.Bitcoin.Features.Dns/IDnsServer.cs
+++ b/src/Stratis.Bitcoin.Features.Dns/IDnsServer.cs
@@ -1,9 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using System.Threading;
+﻿using System.Threading;
 using System.Threading.Tasks;
-using DNS.Server;
 
 namespace Stratis.Bitcoin.Features.Dns
 {

--- a/src/Stratis.Bitcoin.Features.Dns/IFullNodeBuilderExtensions.cs
+++ b/src/Stratis.Bitcoin.Features.Dns/IFullNodeBuilderExtensions.cs
@@ -17,7 +17,7 @@ namespace Stratis.Bitcoin.Features.Dns
         public static IFullNodeBuilder UseDns(this IFullNodeBuilder fullNodeBuilder)
         {
             LoggingConfiguration.RegisterFeatureNamespace<DnsFeature>("dns");
-            
+
             fullNodeBuilder.ConfigureFeature(features =>
             {
                 features
@@ -28,9 +28,10 @@ namespace Stratis.Bitcoin.Features.Dns
                     services.AddSingleton<IMasterFile, DnsSeedMasterFile>();
                     services.AddSingleton<IDnsServer, DnsSeedServer>();
                     services.AddSingleton<IUdpClient, DnsSeedUdpClient>();
+                    services.AddSingleton<IWhitelistManager, WhitelistManager>();
                 });
             });
-           
+
             return fullNodeBuilder;
         }
     }

--- a/src/Stratis.Bitcoin.Features.Dns/IMasterFile.cs
+++ b/src/Stratis.Bitcoin.Features.Dns/IMasterFile.cs
@@ -1,11 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.IO;
-using System.Text;
 using DNS.Protocol;
 using DNS.Protocol.ResourceRecords;
-using DNS.Server;
-using Stratis.Bitcoin.P2P.Peer;
 
 namespace Stratis.Bitcoin.Features.Dns
 {
@@ -15,16 +11,10 @@ namespace Stratis.Bitcoin.Features.Dns
     public interface IMasterFile
     {
         /// <summary>
-        /// Adds a <see cref="NetworkPeer"/> object to the masterfile.
+        /// Adds a entry to the master file.
         /// </summary>
-        /// <param name="peer">The peer to add to the masterfile so that the IP address of the peer can be returned in a DNS resolve request.</param>
-        void AddPeer(NetworkPeer peer);
-
-        /// <summary>
-        /// Adds a collection of <see cref="NetworkPeer"/> objects to the masterfile.
-        /// </summary>
-        /// <param name="peers">The peers to add to the masterfile so that the IP address of the peer can be returned in a DNS resolve request.</param>
-        void AddPeers(IEnumerable<NetworkPeer> peers);
+        /// <param name="entry">The resource record to add.</param>
+        void Add(IResourceRecord entry);
 
         /// <summary>
         /// Gets a list of resource records that match the question.

--- a/src/Stratis.Bitcoin.Features.Dns/IMasterFile.cs
+++ b/src/Stratis.Bitcoin.Features.Dns/IMasterFile.cs
@@ -11,9 +11,9 @@ namespace Stratis.Bitcoin.Features.Dns
     public interface IMasterFile
     {
         /// <summary>
-        /// Adds a entry to the master file.
+        /// Adds <see cref="IResourceRecord"/> to the master file.
         /// </summary>
-        /// <param name="entry">The resource record to add.</param>
+        /// <param name="entry">The resource record to add to the masterfile so that the IP address of the peer can be returned in a DNS resolve request.</param>
         void Add(IResourceRecord entry);
 
         /// <summary>

--- a/src/Stratis.Bitcoin.Features.Dns/IWhitelistManager.cs
+++ b/src/Stratis.Bitcoin.Features.Dns/IWhitelistManager.cs
@@ -1,0 +1,13 @@
+﻿namespace Stratis.Bitcoin.Features.Dns
+{
+    /// <summary>
+    /// Defines the interface to manage the whitelist.
+    /// </summary>
+    public interface IWhitelistManager
+    {
+        /// <summary>
+        /// Refreshes the managed whitelist.
+        /// </summary>
+        void RefreshWhitelist();
+    }
+}

--- a/src/Stratis.Bitcoin.Features.Dns/ResourceRecordConverter.cs
+++ b/src/Stratis.Bitcoin.Features.Dns/ResourceRecordConverter.cs
@@ -32,7 +32,7 @@ namespace Stratis.Bitcoin.Features.Dns
         /// Determines whether this instance can convert the specified object type.
         /// </summary>
         /// <param name="objectType">The type of object to convert.</param>
-        /// <returns><c>True</c> if the object can be converted otherwise returns false.</returns>
+        /// <returns><c>True</c> if the object can be converted otherwise returns <c>false</c>.</returns>
         public override bool CanConvert(Type objectType)
         {
             return (typeof(IResourceRecord).IsAssignableFrom(objectType));

--- a/src/Stratis.Bitcoin.Features.Dns/ResourceRecordConverter.cs
+++ b/src/Stratis.Bitcoin.Features.Dns/ResourceRecordConverter.cs
@@ -1,0 +1,326 @@
+﻿using System;
+using System.Net;
+using DNS.Protocol;
+using DNS.Protocol.ResourceRecords;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Stratis.Bitcoin.Features.Dns
+{
+    /// <summary>
+    /// Defines a <see cref="JsonConverter"/> implementation for an <see cref="IResourceRecord"/> object.
+    /// </summary>
+    public class ResourceRecordConverter : JsonConverter
+    {
+        private const string TypeFieldName = "Type";
+        private const string IPAddressFieldName = "IPAddress";
+        private const string NameFieldName = "Name";
+        private const string CanonicalDomainNameFieldName = "CanonicalDomainName";
+        private const string ExchangeDomainNameFieldName = "ExchangeDomainName";
+        private const string PreferenceFieldName = "Preference";
+        private const string NSDomainNameFieldName = "NSDomainName";
+        private const string PointerDomainNameFieldName = "PointerDomainName";
+        private const string MasterDomainNameFieldName = "MasterDomainName";
+        private const string ResponsibleDomainNameFieldName = "ResponsibleDomainName";
+        private const string SerialNumberFieldName = "SerialNumber";
+        private const string RefreshIntervalFieldName = "RefreshInterval";
+        private const string RetryIntervalFieldName = "RetryInterval";
+        private const string ExpireIntervalFieldName = "ExpireInterval";
+        private const string MinimumTimeToLiveFieldName = "MinimumTimeToLive";
+
+        /// <summary>
+        /// Determines whether this instance can convert the specified object type.
+        /// </summary>
+        /// <param name="objectType">The type of object to convert.</param>
+        /// <returns><c>True</c> if the object can be converted otherwise returns false.</returns>
+        public override bool CanConvert(Type objectType)
+        {
+            return (typeof(IResourceRecord).IsAssignableFrom(objectType));
+        }
+
+        /// <summary>
+        /// Reads the JSON representation of the object.
+        /// </summary>
+        /// <param name="reader">The <see cref="JsonReader"/> to read from.</param>
+        /// <param name="objectType">The type of object.</param>
+        /// <param name="existingValue">The existing value of object being read.</param>
+        /// <param name="serializer">The calling serializer.</param>
+        /// <returns>The object value.</returns>
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            JObject jObject = JObject.Load(reader);
+            string resourceRecordType = jObject[TypeFieldName].Value<string>();
+
+            if (resourceRecordType == typeof(IPAddressResourceRecord).Name)
+            {
+                return this.ReadIPAddressResourceRecordJson(jObject);
+            }
+            else if (resourceRecordType == typeof(CanonicalNameResourceRecord).Name)
+            {
+                return this.ReadCanonicalNameResourceRecordJson(jObject);
+            }
+            else if (resourceRecordType == typeof(MailExchangeResourceRecord).Name)
+            {
+                return ReadMailExchangeResourceRecordJson(jObject);
+            }
+            else if (resourceRecordType == typeof(NameServerResourceRecord).Name)
+            {
+                return ReadNameServerResourceRecordJson(jObject);
+            }
+            else if (resourceRecordType == typeof(PointerResourceRecord).Name)
+            {
+                return this.ReadPointerResourceRecordJson(jObject);
+            }
+            else if (resourceRecordType == typeof(StartOfAuthorityResourceRecord).Name)
+            {
+                return this.ReadStartOfAuthorityResourceRecordJson(jObject, serializer);
+            }
+            else
+            {
+                throw new ArgumentOutOfRangeException(resourceRecordType);
+            }
+        }
+
+        /// <summary>
+        /// Writes the JSON representation of the object.
+        /// </summary>
+        /// <param name="writer">The Newtonsoft.Json.JsonWriter to write to.</param>
+        /// <param name="value">The value to write.</param>
+        /// <param name="serializer">The calling serializer.</param>
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            JObject jObject = null;
+
+            if (value is IPAddressResourceRecord)
+            {
+                jObject = this.WriteIPAddressResourceRecordJson((IPAddressResourceRecord)value);
+            }
+            else if (value is CanonicalNameResourceRecord)
+            {
+                jObject = this.WriteCanonicalNameResourceRecordJson((CanonicalNameResourceRecord)value);
+            }
+            else if (value is MailExchangeResourceRecord)
+            {
+                jObject = this.WriteMailExchangeResourceRecordJson((MailExchangeResourceRecord)value);
+            }
+            else if (value is NameServerResourceRecord)
+            {
+                jObject = this.WriteNameServerResourceRecordJson((NameServerResourceRecord)value);
+            }
+            else if (value is PointerResourceRecord)
+            {
+                jObject = this.WritePointerResourceRecordJson((PointerResourceRecord)value);
+            }
+            else if (value is StartOfAuthorityResourceRecord)
+            {
+                jObject = this.WriteStartOfAuthorityResourceRecordJson((StartOfAuthorityResourceRecord)value, serializer);
+            }
+            else
+            {
+                throw new ArgumentOutOfRangeException(value.GetType().Name);
+            }
+
+            jObject.WriteTo(writer);
+        }
+
+        /// <summary>
+        /// Reads a <see cref="IPAddressResourceRecord"/> from JSON.
+        /// </summary>
+        /// <param name="jObject">The JSON object to read from.</param>
+        /// <returns>The read <see cref="IPAddressResourceRecord"/>.</returns>
+        private IPAddressResourceRecord ReadIPAddressResourceRecordJson(JObject jObject)
+        {
+            IPAddress ipaddress = this.ReadIPAddressJson(jObject);
+            Domain domain = ReadDomainJson(jObject, NameFieldName);
+            return new IPAddressResourceRecord(domain, ipaddress);
+        }
+
+        /// <summary>
+        /// Reads a <see cref="CanonicalNameResourceRecord"/> from JSON.
+        /// </summary>
+        /// <param name="jObject">The JSON object to read from.</param>
+        /// <returns>The read <see cref="CanonicalNameResourceRecord"/>.</returns>
+        private CanonicalNameResourceRecord ReadCanonicalNameResourceRecordJson(JObject jObject)
+        {
+            Domain domain = this.ReadDomainJson(jObject, NameFieldName);
+            Domain cName = this.ReadDomainJson(jObject, CanonicalDomainNameFieldName);
+
+            return new CanonicalNameResourceRecord(domain, cName);
+        }
+
+        /// <summary>
+        /// Reads a <see cref="MailExchangeResourceRecord"/> from JSON.
+        /// </summary>
+        /// <param name="jObject">The JSON object to read from.</param>
+        /// <returns>The read <see cref="MailExchangeResourceRecord"/>.</returns>
+        private MailExchangeResourceRecord ReadMailExchangeResourceRecordJson(JObject jObject)
+        {
+            Domain domain = this.ReadDomainJson(jObject, NameFieldName);
+            Domain exchangeDomain = this.ReadDomainJson(jObject, ExchangeDomainNameFieldName);
+            int preference = jObject[PreferenceFieldName].Value<int>();
+
+            return new MailExchangeResourceRecord(domain, preference, exchangeDomain);
+        }
+
+        /// <summary>
+        /// Reads a <see cref="NameServerResourceRecord"/> from JSON.
+        /// </summary>
+        /// <param name="jObject">The JSON object to read from.</param>
+        /// <returns>The read <see cref="NameServerResourceRecord"/>.</returns>
+        private NameServerResourceRecord ReadNameServerResourceRecordJson(JObject jObject)
+        {
+            Domain domain = this.ReadDomainJson(jObject, NameFieldName);
+            Domain nsDomain = this.ReadDomainJson(jObject, NSDomainNameFieldName);
+            return new NameServerResourceRecord(domain, nsDomain);
+        }
+
+        /// <summary>
+        /// Reads a <see cref="PointerResourceRecord"/> from JSON.
+        /// </summary>
+        /// <param name="jObject">The JSON object to read from.</param>
+        /// <returns>The read <see cref="PointerResourceRecord"/>.</returns>
+        private PointerResourceRecord ReadPointerResourceRecordJson(JObject jObject)
+        {
+            Domain domain = this.ReadDomainJson(jObject, NameFieldName);
+            Domain pointerDomain = this.ReadDomainJson(jObject, PointerDomainNameFieldName);
+            return new PointerResourceRecord(domain, pointerDomain);
+        }
+
+        /// <summary>
+        /// Reads a <see cref="StartOfAuthorityResourceRecord"/> from JSON.
+        /// </summary>
+        /// <param name="jObject">The JSON object to read from.</param>
+        /// <returns>The read <see cref="StartOfAuthorityResourceRecord"/>.</returns>
+        private StartOfAuthorityResourceRecord ReadStartOfAuthorityResourceRecordJson(JObject jObject, JsonSerializer serializer)
+        {
+            Domain domain = this.ReadDomainJson(jObject, NameFieldName);
+            Domain masterDomain = this.ReadDomainJson(jObject, MasterDomainNameFieldName);
+            Domain responsibleDomain = this.ReadDomainJson(jObject, ResponsibleDomainNameFieldName);
+            long serialNumber = jObject[SerialNumberFieldName].Value<long>();
+
+            TimeSpan refreshInterval = jObject[RefreshIntervalFieldName].ToObject<TimeSpan>(serializer);
+            TimeSpan retryInterval = jObject[RetryIntervalFieldName].ToObject<TimeSpan>(serializer);
+            TimeSpan expireInterval = jObject[ExpireIntervalFieldName].ToObject<TimeSpan>(serializer);
+            TimeSpan minimumTimeToLive = jObject[MinimumTimeToLiveFieldName].ToObject<TimeSpan>(serializer);
+
+            return new StartOfAuthorityResourceRecord(domain, masterDomain, responsibleDomain, serialNumber, refreshInterval, retryInterval, expireInterval, minimumTimeToLive);
+        }
+
+        /// <summary>
+        /// Reads a <see cref="IPAddress"/> from JSON.
+        /// </summary>
+        /// <param name="jObject">The JSON object to read from.</param>
+        /// <returns>The read <see cref="IPAddress"/>.</returns>
+        private IPAddress ReadIPAddressJson(JObject jObject)
+        {
+            return IPAddress.Parse(jObject[IPAddressFieldName].Value<string>());
+        }
+
+        /// <summary>
+        /// Reads a <see cref="Domain"/> from JSON.
+        /// </summary>
+        /// <param name="jObject">The JSON object to read from.</param>
+        /// <returns>The read <see cref="Domain"/>.</returns>
+        private Domain ReadDomainJson(JObject jObject, string fieldName)
+        {
+            return new Domain(jObject[fieldName].Value<string>());
+        }
+
+        /// <summary>
+        /// Writes a <see cref="IPAddressResourceRecord"/> to JSON.
+        /// </summary>
+        /// <param name="resourceRecord">The <see cref="IPAddressResourceRecord"/> to write.</param>
+        /// <returns>The written JSON.</returns>
+        private JObject WriteIPAddressResourceRecordJson(IPAddressResourceRecord resourceRecord)
+        {
+            return new JObject
+            {
+                { TypeFieldName, resourceRecord.GetType().Name },
+                { IPAddressFieldName, resourceRecord.IPAddress.ToString() },
+                { NameFieldName, resourceRecord.Name.ToString()}
+            };
+        }
+
+        /// <summary>
+        /// Writes a <see cref="CanonicalNameResourceRecord"/> to JSON.
+        /// </summary>
+        /// <param name="resourceRecord">The <see cref="CanonicalNameResourceRecord"/> to write.</param>
+        /// <returns>The written JSON.</returns>
+        private JObject WriteCanonicalNameResourceRecordJson(CanonicalNameResourceRecord resourceRecord)
+        {
+            return new JObject
+            {
+                { TypeFieldName, resourceRecord.GetType().Name },
+                { NameFieldName, resourceRecord.Name.ToString() },
+                { CanonicalDomainNameFieldName, resourceRecord.CanonicalDomainName.ToString()}
+             };
+        }
+
+        /// <summary>
+        /// Writes a <see cref="MailExchangeResourceRecord"/> to JSON.
+        /// </summary>
+        /// <param name="resourceRecord">The <see cref="MailExchangeResourceRecord"/> to write.</param>
+        /// <returns>The written JSON.</returns>
+        private JObject WriteMailExchangeResourceRecordJson(MailExchangeResourceRecord resourceRecord)
+        {
+            return new JObject
+            {
+                { TypeFieldName, resourceRecord.GetType().Name },
+                { NameFieldName, resourceRecord.Name.ToString() },
+                { ExchangeDomainNameFieldName, resourceRecord.ExchangeDomainName.ToString() },
+                { PreferenceFieldName, resourceRecord.Preference }
+             };
+        }
+
+        /// <summary>
+        /// Writes a <see cref="NameServerResourceRecord"/> to JSON.
+        /// </summary>
+        /// <param name="resourceRecord">The <see cref="NameServerResourceRecord"/> to write.</param>
+        /// <returns>The written JSON.</returns>
+        private JObject WriteNameServerResourceRecordJson(NameServerResourceRecord resourceRecord)
+        {
+            return new JObject
+            {
+                { TypeFieldName, resourceRecord.GetType().Name },
+                { NameFieldName, resourceRecord.Name.ToString() },
+                { NSDomainNameFieldName, resourceRecord.NSDomainName.ToString() }
+             };
+        }
+
+        /// <summary>
+        /// Writes a <see cref="PointerResourceRecord"/> to JSON.
+        /// </summary>
+        /// <param name="resourceRecord">The <see cref="PointerResourceRecord"/> to write.</param>
+        /// <returns>The written JSON.</returns>
+        private JObject WritePointerResourceRecordJson(PointerResourceRecord resourceRecord)
+        {
+            return new JObject
+            {
+                { TypeFieldName, resourceRecord.GetType().Name },
+                { NameFieldName, resourceRecord.Name.ToString() },
+                { PointerDomainNameFieldName, resourceRecord.PointerDomainName.ToString() }
+             };
+        }
+
+        /// <summary>
+        /// Writes a <see cref="StartOfAuthorityResourceRecord"/> to JSON.
+        /// </summary>
+        /// <param name="resourceRecord">The <see cref="StartOfAuthorityResourceRecord"/> to write.</param>
+        /// <returns>The written JSON.</returns>
+        private JObject WriteStartOfAuthorityResourceRecordJson(StartOfAuthorityResourceRecord resourceRecord, JsonSerializer serializer)
+        {
+            return new JObject
+            {
+                { TypeFieldName, resourceRecord.GetType().Name },
+                { NameFieldName, resourceRecord.Name.ToString() },
+                { MasterDomainNameFieldName, resourceRecord.MasterDomainName.ToString() },
+                { ResponsibleDomainNameFieldName, resourceRecord.ResponsibleDomainName.ToString() },
+                { SerialNumberFieldName, resourceRecord.SerialNumber },
+                { RefreshIntervalFieldName, JToken.FromObject(resourceRecord.RefreshInterval, serializer)},
+                { RetryIntervalFieldName, JToken.FromObject(resourceRecord.RetryInterval, serializer)},
+                { ExpireIntervalFieldName, JToken.FromObject(resourceRecord.ExpireInterval, serializer)},
+                { MinimumTimeToLiveFieldName, JToken.FromObject(resourceRecord.MinimumTimeToLive, serializer)}
+             };
+        }
+    }
+}

--- a/src/Stratis.Bitcoin.Features.Dns/Stratis.Bitcoin.Features.Dns.csproj
+++ b/src/Stratis.Bitcoin.Features.Dns/Stratis.Bitcoin.Features.Dns.csproj
@@ -20,6 +20,7 @@
 
   <ItemGroup>
     <PackageReference Include="DNS" Version="2.1.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Stratis.Bitcoin.Features.Dns/WhitelistManager.cs
+++ b/src/Stratis.Bitcoin.Features.Dns/WhitelistManager.cs
@@ -106,9 +106,6 @@ namespace Stratis.Bitcoin.Features.Dns
             {
                 Domain domain = new Domain(this.dnsHostName);
 
-                // TODO: remove
-                this.logger.LogInformation($"Adding a Peer to the resource records.");
-
                 IPAddressResourceRecord resourceRecord = new IPAddressResourceRecord(domain, whitelistEntry.NetworkAddress.Endpoint.Address);
                 masterFile.Add(resourceRecord);
             }

--- a/src/Stratis.Bitcoin.Features.Dns/WhitelistManager.cs
+++ b/src/Stratis.Bitcoin.Features.Dns/WhitelistManager.cs
@@ -1,0 +1,121 @@
+﻿using System;
+using System.Linq;
+using System.Net;
+using DNS.Protocol;
+using DNS.Protocol.ResourceRecords;
+using Microsoft.Extensions.Logging;
+using Stratis.Bitcoin.Configuration;
+using Stratis.Bitcoin.P2P;
+using Stratis.Bitcoin.Utilities;
+using Stratis.Bitcoin.Utilities.Extensions;
+
+namespace Stratis.Bitcoin.Features.Dns
+{
+    /// <summary>
+    /// Responsible for managing the whitelist used by the DNS server as a master file.
+    /// </summary>
+    public class WhitelistManager : IWhitelistManager
+    {
+        /// <summary>
+        /// Defines the provider for the datetime.
+        /// </summary>
+        private readonly IDateTimeProvider dateTimeProvider;
+
+        /// <summary>
+        /// Defines the logger.
+        /// </summary>
+        private readonly ILogger logger;
+
+        /// <summary>
+        /// Defines the manager implementation for peer addresses used to populate the whitelist.
+        /// </summary>
+        private readonly IPeerAddressManager peerAddressManager;
+
+        /// <summary>
+        /// Defines the DNS server.
+        /// </summary>
+        private readonly IDnsServer dnsServer;
+
+        /// <summary>
+        /// Defines the peroid in seconds that the peer should last have been seen to be included in the whitelist.
+        /// </summary>
+        private readonly int dnsPeerBlacklistThresholdInSeconds;
+
+        /// <summary>
+        /// Defines the DNS host name of the DNS Server.
+        /// </summary>
+        private readonly string dnsHostName;
+
+        /// <summary>
+        /// Defines the external endpoint for the dns node.
+        /// </summary>
+        private readonly IPEndPoint externalEndpoint;
+
+        /// <summary>
+        /// Defines if DNS server daemon is running as full node <c>true</c> or not <c>false</c>.
+        /// </summary>
+        private readonly bool fullNodeMode = false;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="WhitelistManager"/> class.
+        /// </summary>
+        /// <param name="dateTimeProvider">The provider for datetime.</param>
+        /// <param name="loggerFactory">The factory to create the logger.</param>
+        /// <param name="peerAddressManager">The manager implementation for peer addresses.</param>
+        /// <param name="dnsServer">The DNS server.</param>
+        /// <param name="nodeSettings">The node settings.</param>
+        public WhitelistManager(IDateTimeProvider dateTimeProvider, ILoggerFactory loggerFactory, IPeerAddressManager peerAddressManager, IDnsServer dnsServer, NodeSettings nodeSettings)
+        {
+            Guard.NotNull(dateTimeProvider, nameof(dateTimeProvider));
+            Guard.NotNull(loggerFactory, nameof(loggerFactory));
+            Guard.NotNull(peerAddressManager, nameof(peerAddressManager));
+            Guard.NotNull(dnsServer, nameof(dnsServer));
+            Guard.NotNull(nodeSettings, nameof(nodeSettings));
+            Guard.NotNull(nodeSettings.DnsHostName, nameof(nodeSettings.DnsHostName));
+            Guard.NotNull(nodeSettings.ConnectionManager, nameof(nodeSettings.ConnectionManager));
+
+            this.dateTimeProvider = dateTimeProvider;
+            this.logger = loggerFactory.CreateLogger(this.GetType().FullName);
+            this.peerAddressManager = peerAddressManager;
+            this.dnsServer = dnsServer;
+            this.dnsPeerBlacklistThresholdInSeconds = nodeSettings.DnsPeerBlacklistThresholdInSeconds;
+            this.dnsHostName = nodeSettings.DnsHostName;
+            this.externalEndpoint = nodeSettings.ConnectionManager.ExternalEndpoint;
+            this.fullNodeMode = nodeSettings.DnsFullNode;
+        }
+
+        /// <summary>
+        /// Refreshes the managed whitelist.
+        /// </summary>
+        public void RefreshWhitelist()
+        {
+            this.logger.LogTrace("()");
+
+            DateTimeOffset activePeerLimit = this.dateTimeProvider.GetTimeOffset().AddSeconds(-this.dnsPeerBlacklistThresholdInSeconds);
+            
+            var whitelist = this.peerAddressManager.Peers.Where(p => p.Value.LastConnectionHandshake > activePeerLimit).Select(p => p.Value);
+            
+            if (!this.fullNodeMode)
+            {
+                // Exclude the current external ip address from DNS as its not a full node.
+                whitelist = whitelist.Where(p => !p.NetworkAddress.Endpoint.Match(this.externalEndpoint));
+            }
+
+            IMasterFile masterFile = new DnsSeedMasterFile();
+            foreach (PeerAddress whitelistEntry in whitelist)
+            {
+                Domain domain = new Domain(this.dnsHostName);
+
+                // TODO: remove
+                this.logger.LogInformation($"Adding a Peer to the resource records.");
+
+                IPAddressResourceRecord resourceRecord = new IPAddressResourceRecord(domain, whitelistEntry.NetworkAddress.Endpoint.Address);
+                masterFile.Add(resourceRecord);
+            }
+
+            this.dnsServer.SwapMasterfile(masterFile);
+
+            this.logger.LogTrace("(-)");
+        }
+    }
+}

--- a/src/Stratis.Bitcoin.Features.Dns/WhitelistManager.cs
+++ b/src/Stratis.Bitcoin.Features.Dns/WhitelistManager.cs
@@ -54,7 +54,7 @@ namespace Stratis.Bitcoin.Features.Dns
         /// <summary>
         /// Defines if DNS server daemon is running as full node <c>true</c> or not <c>false</c>.
         /// </summary>
-        private readonly bool fullNodeMode = false;
+        private readonly bool fullNodeMode;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="WhitelistManager"/> class.

--- a/src/Stratis.Bitcoin/Configuration/NodeSettings.cs
+++ b/src/Stratis.Bitcoin/Configuration/NodeSettings.cs
@@ -38,6 +38,9 @@ namespace Stratis.Bitcoin.Configuration
         /// <summary>Default value for Maximum tip age in seconds to consider node in initial block download.</summary>
         public const int DefaultMaxTipAge = 24 * 60 * 60;
 
+        /// <summary>The default value which a peer should have last have been connected before being blacklisted in DNS nodes.</summary>
+        public const int DefaultDnsPeerBlacklistThresholdInSeconds = 1800;
+
         /// <summary>
         /// Initializes a new instance of the object.
         /// </summary>
@@ -124,6 +127,12 @@ namespace Stratis.Bitcoin.Configuration
 
         /// <summary><c>true</c> to sync time with other peers and calculate adjusted time, <c>false</c> to use our system clock only.</summary>
         public bool SyncTimeEnabled { get; set; }
+
+        /// <summary>The value which a peer should have last have been connected before being blacklisted from the DNS nodes.</summary>
+        public int DnsPeerBlacklistThresholdInSeconds { get; set; }
+
+        /// <summary>Defines the host name for the node when running as a DNS Seed service.</summary>
+        public string DnsHostName { get; set; }
 
         /// <summary><c>true</c> if the DNS Seed service should also run as a full node, otherwise <c>false</c>.</summary>
         public bool DnsFullNode { get; set; }
@@ -231,6 +240,12 @@ namespace Stratis.Bitcoin.Configuration
 
             this.SyncTimeEnabled = config.GetOrDefault<bool>("synctime", true);
             this.Logger.LogDebug("Time synchronization with peers is {0}.", this.SyncTimeEnabled ? "enabled" : "disabled");
+
+            this.DnsPeerBlacklistThresholdInSeconds = config.GetOrDefault("dnspeerblacklistthresholdinseconds", DefaultDnsPeerBlacklistThresholdInSeconds);
+            this.Logger.LogDebug("DnsPeerBlacklistThresholdInSeconds set to {0}.", this.DnsPeerBlacklistThresholdInSeconds);
+
+            this.DnsHostName = config.GetOrDefault<string>("dnshostname", null);
+            this.Logger.LogDebug("DnsHostName set to {0}.", this.DnsHostName);
 
             if (args.Contains("-dnsfullnode", StringComparer.CurrentCultureIgnoreCase))
             {

--- a/src/Stratis.StratisDnsD/Properties/launchSettings.json
+++ b/src/Stratis.StratisDnsD/Properties/launchSettings.json
@@ -1,11 +1,11 @@
 {
-  "profiles": {
-    "Stratis.StratisDnsD": {
-      "commandName": "Project"
-    },
-    "Stratis.StratisDnsD Test": {
-      "commandName": "Project",
-      "commandLineArgs": "-testnet -dnslistenport=5399"
+    "profiles": {
+        "Stratis.StratisDnsD": {
+            "commandName": "Project"
+        },
+        "Stratis.StratisDnsD Test": {
+            "commandName": "Project",
+            "commandLineArgs": "-testnet -dnslistenport=5399 -dnshostname=dns.stratisplatform.com"
+        }
     }
-  }
 }

--- a/src/Stratis.StratisDnsD/Properties/launchSettings.json
+++ b/src/Stratis.StratisDnsD/Properties/launchSettings.json
@@ -1,11 +1,11 @@
 {
-    "profiles": {
-        "Stratis.StratisDnsD": {
-            "commandName": "Project"
-        },
-        "Stratis.StratisDnsD Test": {
-            "commandName": "Project",
-            "commandLineArgs": "-testnet -dnslistenport=5399 -dnshostname=dns.stratisplatform.com"
-        }
+  "profiles": {
+    "Stratis.StratisDnsD": {
+      "commandName": "Project"
+    },
+    "Stratis.StratisDnsD Test": {
+      "commandName": "Project",
+      "commandLineArgs": "-testnet -dnslistenport=5399 -dnshostname=dns.stratisplatform.com"
     }
+  }
 }


### PR DESCRIPTION
Contains two tasks, one to link the Peer Address Manager to the DNS Server and another to implement the load and save of the master file from disk.
- New class WhiteListManager, to allow the DNS feature to populate the resource records in the DNS 
Server using the Peer Address Manager.
- Implemented a custom JSON Converter to handle the serializing and deserializing of the 
 IResourceRecords as these are from the nuget package and do not have parameterless constructors or setters for all of the properties.
- Bought in the functionality from the MasterFile in the DNS nuget package into the customised DnsSeedMasterFile.
- Added the DNS peer blacklist threshold and DNS hostname to the node settings.
- Added relevant unit tests