### PR TITLE
[DNS] Added SOA and NS support, other fixes

### DIFF
--- a/src/Stratis.Bitcoin.Features.Dns.Tests/GivenADnsFeature.cs
+++ b/src/Stratis.Bitcoin.Features.Dns.Tests/GivenADnsFeature.cs
@@ -162,13 +162,8 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
                 throw new OperationCanceledException();
             };
             dnsServer.Setup(s => s.ListenAsync(It.IsAny<int>(), It.IsAny<CancellationToken>())).Callback(action);
-            IWhitelistManager whitelistManager = new Mock<IWhitelistManager>().Object;
-            IAsyncLoopFactory asyncLoopFactory = new AsyncLoopFactory(loggerFactory.Object);
 
-            DnsFeature feature = new DnsFeature(dnsServer.Object, whitelistManager, loggerFactory.Object, nodeLifetime.Object, nodeSettings, dataFolders, asyncLoopFactory);
-
-            Mock<IWhitelistManager> mockWhitelistManager = new Mock<IWhitelistManager>();
-            IWhitelistManager whitelistManager = mockWhitelistManager.Object;
+            Mock<IWhitelistManager> whitelistManager = new Mock<IWhitelistManager>();
 
             Mock<INodeLifetime> nodeLifetime = new Mock<INodeLifetime>();
             NodeSettings nodeSettings = NodeSettings.Default();
@@ -182,7 +177,7 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
             IAsyncLoopFactory asyncLoopFactory = new AsyncLoopFactory(loggerFactory.Object);
 
             // Act.
-                DnsFeature feature = new DnsFeature(dnsServer.Object, whitelistManager, loggerFactory.Object, nodeLifetime.Object, nodeSettings, dataFolders, asyncLoopFactory);
+            DnsFeature feature = new DnsFeature(dnsServer.Object, whitelistManager.Object, loggerFactory.Object, nodeLifetime.Object, nodeSettings, dataFolders, asyncLoopFactory);
             feature.Initialize();
             bool waited = waitObject.Wait(5000);
 

--- a/src/Stratis.Bitcoin.Features.Dns.Tests/GivenADnsFeature.cs
+++ b/src/Stratis.Bitcoin.Features.Dns.Tests/GivenADnsFeature.cs
@@ -151,7 +151,7 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
 
         [Fact]
         [Trait("DNS", "UnitTest")]
-        public void WhenDnsFeatureInitialized_AndDnsServerStarted_AndNoMasterFileOnDisk_ThenDnsServerSuccessfullyStarts()
+        public void WhenDnsFeatureInitialized_ThenDnsServerSuccessfullyStarts()
         {
             // Arrange.
             Mock<IDnsServer> dnsServer = new Mock<IDnsServer>();
@@ -162,51 +162,10 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
                 throw new OperationCanceledException();
             };
             dnsServer.Setup(s => s.ListenAsync(It.IsAny<int>(), It.IsAny<CancellationToken>())).Callback(action);
-            dnsServer.Setup(s => s.SwapMasterfile(It.IsAny<IMasterFile>())).Verifiable();
-
-            Mock<IMasterFile> masterFile = new Mock<IMasterFile>();
-            masterFile.Setup(m => m.Load(It.IsAny<Stream>())).Verifiable();
-
             IWhitelistManager whitelistManager = new Mock<IWhitelistManager>().Object;
-
-            Mock<INodeLifetime> nodeLifetime = new Mock<INodeLifetime>();
-            NodeSettings nodeSettings = NodeSettings.Default();
-            nodeSettings.DataDir = Directory.GetCurrentDirectory();
-            DataFolder dataFolders = new Mock<DataFolder>(nodeSettings).Object;
-
-            Mock<ILogger> logger = new Mock<ILogger>(MockBehavior.Loose);
-            Mock<ILoggerFactory> loggerFactory = new Mock<ILoggerFactory>();
-            loggerFactory.Setup<ILogger>(f => f.CreateLogger(It.IsAny<string>())).Returns(logger.Object);
-
             IAsyncLoopFactory asyncLoopFactory = new AsyncLoopFactory(loggerFactory.Object);
 
-            // Act.
             DnsFeature feature = new DnsFeature(dnsServer.Object, whitelistManager, loggerFactory.Object, nodeLifetime.Object, nodeSettings, dataFolders, asyncLoopFactory);
-            feature.Initialize();
-            bool waited = waitObject.Wait(5000);
-
-            // Assert.
-            feature.Should().NotBeNull();
-            waited.Should().BeTrue();
-            masterFile.Verify(m => m.Load(It.IsAny<Stream>()), Times.Never);
-            dnsServer.Verify(s => s.SwapMasterfile(It.IsAny<IMasterFile>()), Times.Never);
-            dnsServer.Verify(s => s.ListenAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()), Times.Once);
-        }
-
-        [Fact]
-        [Trait("DNS", "UnitTest")]
-        public void WhenDnsFeatureInitialized_AndDnsServerStarted_AndMasterFileOnDisk_ThenDnsServerSuccessfullyStarts()
-        {
-            // Arrange.
-            Mock<IDnsServer> dnsServer = new Mock<IDnsServer>();
-            ManualResetEventSlim waitObject = new ManualResetEventSlim(false);
-            Action<int, CancellationToken> action = (port, token) =>
-            {
-                waitObject.Set();
-                throw new OperationCanceledException();
-            };
-            dnsServer.Setup(s => s.ListenAsync(It.IsAny<int>(), It.IsAny<CancellationToken>())).Callback(action);
-            dnsServer.Setup(s => s.SwapMasterfile(It.IsAny<IMasterFile>())).Verifiable();
 
             Mock<IWhitelistManager> mockWhitelistManager = new Mock<IWhitelistManager>();
             IWhitelistManager whitelistManager = mockWhitelistManager.Object;
@@ -222,36 +181,15 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
 
             IAsyncLoopFactory asyncLoopFactory = new AsyncLoopFactory(loggerFactory.Object);
 
-            string masterFilePath = Path.Combine(dataFolders.DnsMasterFilePath, DnsFeature.DnsMasterFileName);
-
             // Act.
-            try
-            {
-                // Create masterfile on disk
-                using (FileStream stream = File.Create(masterFilePath))
-                {
-                    stream.Close();
-                }
-
-                // Run feature
                 DnsFeature feature = new DnsFeature(dnsServer.Object, whitelistManager, loggerFactory.Object, nodeLifetime.Object, nodeSettings, dataFolders, asyncLoopFactory);
-                feature.Initialize();
-                bool waited = waitObject.Wait(5000);
+            feature.Initialize();
+            bool waited = waitObject.Wait(5000);
 
-                // Assert.
-                feature.Should().NotBeNull();
-                waited.Should().BeTrue();
-                dnsServer.Verify(s => s.SwapMasterfile(It.IsAny<IMasterFile>()), Times.Once);
-                dnsServer.Verify(s => s.ListenAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()), Times.Once);
-            }
-            finally
-            {
-                // Try and remove created
-                if (File.Exists(masterFilePath))
-                {
-                    File.Delete(masterFilePath);
-                }
-            }
+            // Assert.
+            feature.Should().NotBeNull();
+            waited.Should().BeTrue();
+            dnsServer.Verify(s => s.ListenAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()), Times.Once);
         }
 
         [Fact]
@@ -269,7 +207,6 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
                 }
             };
             dnsServer.Setup(s => s.ListenAsync(It.IsAny<int>(), It.IsAny<CancellationToken>())).Callback(action);
-            dnsServer.Setup(s => s.SwapMasterfile(It.IsAny<IMasterFile>())).Verifiable();
 
             Mock<IWhitelistManager> mockWhitelistManager = new Mock<IWhitelistManager>();
             IWhitelistManager whitelistManager = mockWhitelistManager.Object;
@@ -299,7 +236,6 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
             // Assert.
             feature.Should().NotBeNull();
             waited.Should().BeTrue();
-            dnsServer.Verify(s => s.SwapMasterfile(It.IsAny<IMasterFile>()), Times.Never);
             dnsServer.Verify(s => s.ListenAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()), Times.Once);
         }
 
@@ -314,7 +250,6 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
                 throw new ArgumentException("Bad port");
             };
             dnsServer.Setup(s => s.ListenAsync(It.IsAny<int>(), It.IsAny<CancellationToken>())).Callback(action);
-            dnsServer.Setup(s => s.SwapMasterfile(It.IsAny<IMasterFile>())).Verifiable();
 
             Mock<IWhitelistManager> mockWhitelistManager = new Mock<IWhitelistManager>();
             IWhitelistManager whitelistManager = mockWhitelistManager.Object;
@@ -345,7 +280,6 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
             // Assert.
             feature.Should().NotBeNull();
             waited.Should().BeTrue();
-            dnsServer.Verify(s => s.SwapMasterfile(It.IsAny<IMasterFile>()), Times.Never);
             dnsServer.Verify(s => s.ListenAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()), Times.AtLeastOnce);
             serverError.Should().BeTrue();
         }

--- a/src/Stratis.Bitcoin.Features.Dns.Tests/GivenADnsSeedServer.cs
+++ b/src/Stratis.Bitcoin.Features.Dns.Tests/GivenADnsSeedServer.cs
@@ -34,7 +34,10 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
             INodeLifetime nodeLifetime = new Mock<INodeLifetime>().Object;
             ILoggerFactory loggerFactory = new Mock<ILoggerFactory>().Object;
             IDateTimeProvider dateTimeProvider = new Mock<IDateTimeProvider>().Object;
-            Action a = () => { new DnsSeedServer(null, masterFile, asyncLoopFactory, nodeLifetime, loggerFactory, dateTimeProvider); };
+            NodeSettings nodeSettings = NodeSettings.Default();
+            nodeSettings.DataDir = @"C:\";
+            DataFolder dataFolders = new Mock<DataFolder>(nodeSettings).Object;
+            Action a = () => { new DnsSeedServer(null, masterFile, asyncLoopFactory, nodeLifetime, loggerFactory, dateTimeProvider, nodeSettings, dataFolders); };
 
             // Act and Assert.
             a.ShouldThrow<ArgumentNullException>().Which.Message.Should().Contain("client");
@@ -50,7 +53,10 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
             INodeLifetime nodeLifetime = new Mock<INodeLifetime>().Object;
             ILoggerFactory loggerFactory = new Mock<ILoggerFactory>().Object;
             IDateTimeProvider dateTimeProvider = new Mock<IDateTimeProvider>().Object;
-            Action a = () => { new DnsSeedServer(udpClient, null, asyncLoopFactory, nodeLifetime, loggerFactory, dateTimeProvider); };
+            NodeSettings nodeSettings = NodeSettings.Default();
+            nodeSettings.DataDir = @"C:\";
+            DataFolder dataFolders = new Mock<DataFolder>(nodeSettings).Object;
+            Action a = () => { new DnsSeedServer(udpClient, null, asyncLoopFactory, nodeLifetime, loggerFactory, dateTimeProvider, nodeSettings, dataFolders); };
 
             // Act and Assert.
             a.ShouldThrow<ArgumentNullException>().Which.Message.Should().Contain("masterFile");
@@ -66,7 +72,10 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
             INodeLifetime nodeLifetime = new Mock<INodeLifetime>().Object;
             ILoggerFactory loggerFactory = new Mock<ILoggerFactory>().Object;
             IDateTimeProvider dateTimeProvider = new Mock<IDateTimeProvider>().Object;
-            Action a = () => { new DnsSeedServer(udpClient, masterFile, null, nodeLifetime, loggerFactory, dateTimeProvider); };
+            NodeSettings nodeSettings = NodeSettings.Default();
+            nodeSettings.DataDir = @"C:\";
+            DataFolder dataFolders = new Mock<DataFolder>(nodeSettings).Object;
+            Action a = () => { new DnsSeedServer(udpClient, masterFile, null, nodeLifetime, loggerFactory, dateTimeProvider, nodeSettings, dataFolders); };
 
             // Act and Assert.
             a.ShouldThrow<ArgumentNullException>().Which.Message.Should().Contain("asyncLoopFactory");
@@ -82,7 +91,10 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
             IAsyncLoopFactory asyncLoopFactory = new Mock<IAsyncLoopFactory>().Object;
             ILoggerFactory loggerFactory = new Mock<ILoggerFactory>().Object;
             IDateTimeProvider dateTimeProvider = new Mock<IDateTimeProvider>().Object;
-            Action a = () => { new DnsSeedServer(udpClient, masterFile, asyncLoopFactory, null, loggerFactory, dateTimeProvider); };
+            NodeSettings nodeSettings = NodeSettings.Default();
+            nodeSettings.DataDir = @"C:\";
+            DataFolder dataFolders = new Mock<DataFolder>(nodeSettings).Object;
+            Action a = () => { new DnsSeedServer(udpClient, masterFile, asyncLoopFactory, null, loggerFactory, dateTimeProvider, nodeSettings, dataFolders); };
 
             // Act and Assert.
             a.ShouldThrow<ArgumentNullException>().Which.Message.Should().Contain("nodeLifetime");
@@ -98,7 +110,10 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
             IAsyncLoopFactory asyncLoopFactory = new Mock<IAsyncLoopFactory>().Object;
             INodeLifetime nodeLifetime = new Mock<INodeLifetime>().Object;
             IDateTimeProvider dateTimeProvider = new Mock<IDateTimeProvider>().Object;
-            Action a = () => { new DnsSeedServer(udpClient, masterFile, asyncLoopFactory, nodeLifetime, null, dateTimeProvider); };
+            NodeSettings nodeSettings = NodeSettings.Default();
+            nodeSettings.DataDir = @"C:\";
+            DataFolder dataFolders = new Mock<DataFolder>(nodeSettings).Object;
+            Action a = () => { new DnsSeedServer(udpClient, masterFile, asyncLoopFactory, nodeLifetime, null, dateTimeProvider, nodeSettings, dataFolders); };
 
             // Act and Assert.
             a.ShouldThrow<ArgumentNullException>().Which.Message.Should().Contain("loggerFactory");
@@ -114,10 +129,52 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
             IAsyncLoopFactory asyncLoopFactory = new Mock<IAsyncLoopFactory>().Object;
             INodeLifetime nodeLifetime = new Mock<INodeLifetime>().Object;
             ILoggerFactory loggerFactory = new Mock<ILoggerFactory>().Object;
-            Action a = () => { new DnsSeedServer(udpClient, masterFile, asyncLoopFactory, nodeLifetime, loggerFactory, null); };
+            NodeSettings nodeSettings = NodeSettings.Default();
+            nodeSettings.DataDir = @"C:\";
+            DataFolder dataFolders = new Mock<DataFolder>(nodeSettings).Object;
+            Action a = () => { new DnsSeedServer(udpClient, masterFile, asyncLoopFactory, nodeLifetime, loggerFactory, null, nodeSettings, dataFolders); };
 
             // Act and Assert.
             a.ShouldThrow<ArgumentNullException>().Which.Message.Should().Contain("dateTimeProvider");
+        }
+
+        [Fact]
+        [Trait("DNS", "UnitTest")]
+        public void WhenConstructorCalled_AndNodeSettingsIsNull_ThenArgumentNullExceptionIsThrown()
+        {
+            // Arrange.
+            IUdpClient udpClient = new Mock<IUdpClient>().Object;
+            IMasterFile masterFile = new Mock<IMasterFile>().Object;
+            IAsyncLoopFactory asyncLoopFactory = new Mock<IAsyncLoopFactory>().Object;
+            INodeLifetime nodeLifetime = new Mock<INodeLifetime>().Object;
+            ILoggerFactory loggerFactory = new Mock<ILoggerFactory>().Object;
+            IDateTimeProvider dateTimeProvider = new Mock<IDateTimeProvider>().Object;
+            NodeSettings nodeSettings = NodeSettings.Default();
+            nodeSettings.DataDir = @"C:\";
+            DataFolder dataFolders = new Mock<DataFolder>(nodeSettings).Object;
+            Action a = () => { new DnsSeedServer(udpClient, masterFile, asyncLoopFactory, nodeLifetime, loggerFactory, dateTimeProvider, null, dataFolders); };
+
+            // Act and Assert.
+            a.ShouldThrow<ArgumentNullException>().Which.Message.Should().Contain("nodeSettings");
+        }
+
+        [Fact]
+        [Trait("DNS", "UnitTest")]
+        public void WhenConstructorCalled_AndDataFoldersIsNull_ThenArgumentNullExceptionIsThrown()
+        {
+            // Arrange.
+            IUdpClient udpClient = new Mock<IUdpClient>().Object;
+            IMasterFile masterFile = new Mock<IMasterFile>().Object;
+            IAsyncLoopFactory asyncLoopFactory = new Mock<IAsyncLoopFactory>().Object;
+            INodeLifetime nodeLifetime = new Mock<INodeLifetime>().Object;
+            ILoggerFactory loggerFactory = new Mock<ILoggerFactory>().Object;
+            IDateTimeProvider dateTimeProvider = new Mock<IDateTimeProvider>().Object;
+            NodeSettings nodeSettings = NodeSettings.Default();
+            nodeSettings.DataDir = @"C:\";
+            Action a = () => { new DnsSeedServer(udpClient, masterFile, asyncLoopFactory, nodeLifetime, loggerFactory, dateTimeProvider, nodeSettings, null); };
+
+            // Act and Assert.
+            a.ShouldThrow<ArgumentNullException>().Which.Message.Should().Contain("dataFolders");
         }
 
         [Fact]
@@ -131,9 +188,12 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
             INodeLifetime nodeLifetime = new Mock<INodeLifetime>().Object;
             ILoggerFactory loggerFactory = new Mock<ILoggerFactory>().Object;
             IDateTimeProvider dateTimeProvider = new Mock<IDateTimeProvider>().Object;
+            NodeSettings nodeSettings = NodeSettings.Default();
+            nodeSettings.DataDir = @"C:\";
+            DataFolder dataFolders = new Mock<DataFolder>(nodeSettings).Object;
 
             // Act.
-            DnsSeedServer server = new DnsSeedServer(udpClient, masterFile, asyncLoopFactory, nodeLifetime, loggerFactory, dateTimeProvider);
+            DnsSeedServer server = new DnsSeedServer(udpClient, masterFile, asyncLoopFactory, nodeLifetime, loggerFactory, dateTimeProvider, nodeSettings, dataFolders);
 
             // Assert.
             server.Should().NotBeNull();
@@ -157,10 +217,13 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
             loggerFactory.Setup<ILogger>(f => f.CreateLogger(It.IsAny<string>())).Returns(logger.Object);
 
             IDateTimeProvider dateTimeProvider = new Mock<IDateTimeProvider>().Object;
+            NodeSettings nodeSettings = NodeSettings.Default();
+            nodeSettings.DataDir = Directory.GetCurrentDirectory();
+            DataFolder dataFolders = new Mock<DataFolder>(nodeSettings).Object;
 
             // Act.
             CancellationTokenSource source = new CancellationTokenSource();
-            DnsSeedServer server = new DnsSeedServer(udpClient.Object, masterFile.Object, asyncLoopFactory, nodeLifetime, loggerFactory.Object, dateTimeProvider);
+            DnsSeedServer server = new DnsSeedServer(udpClient.Object, masterFile.Object, asyncLoopFactory, nodeLifetime, loggerFactory.Object, dateTimeProvider, nodeSettings, dataFolders);
             Func<Task> func = async () => await server.ListenAsync(53, source.Token);
 
             // Assert.
@@ -184,6 +247,9 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
 
             IAsyncLoopFactory asyncLoopFactory = new Mock<IAsyncLoopFactory>().Object;
             INodeLifetime nodeLifetime = new Mock<INodeLifetime>().Object;
+            NodeSettings nodeSettings = NodeSettings.Default();
+            nodeSettings.DataDir = Directory.GetCurrentDirectory();
+            DataFolder dataFolders = new Mock<DataFolder>(nodeSettings).Object;
 
             Mock<ILogger> logger = new Mock<ILogger>(MockBehavior.Loose);
             bool receivedSocketException = false;
@@ -203,7 +269,7 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
 
             // Act.
             CancellationTokenSource source = new CancellationTokenSource(2000);
-            DnsSeedServer server = new DnsSeedServer(udpClient.Object, masterFile.Object, asyncLoopFactory, nodeLifetime, loggerFactory.Object, dateTimeProvider);
+            DnsSeedServer server = new DnsSeedServer(udpClient.Object, masterFile.Object, asyncLoopFactory, nodeLifetime, loggerFactory.Object, dateTimeProvider, nodeSettings, dataFolders);
 
             try
             {
@@ -241,6 +307,9 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
 
             IAsyncLoopFactory asyncLoopFactory = new Mock<IAsyncLoopFactory>().Object;
             INodeLifetime nodeLifetime = new Mock<INodeLifetime>().Object;
+            NodeSettings nodeSettings = NodeSettings.Default();
+            nodeSettings.DataDir = Directory.GetCurrentDirectory();
+            DataFolder dataFolders = new Mock<DataFolder>(nodeSettings).Object;
 
             Mock<ILogger> logger = new Mock<ILogger>();
             bool receivedRequest = false;
@@ -271,7 +340,7 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
 
             // Act.
             CancellationTokenSource source = new CancellationTokenSource(2000);
-            DnsSeedServer server = new DnsSeedServer(udpClient.Object, masterFile.Object, asyncLoopFactory, nodeLifetime, loggerFactory.Object, dateTimeProvider);
+            DnsSeedServer server = new DnsSeedServer(udpClient.Object, masterFile.Object, asyncLoopFactory, nodeLifetime, loggerFactory.Object, dateTimeProvider, nodeSettings, dataFolders);
 
             try
             {
@@ -312,6 +381,9 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
 
             IAsyncLoopFactory asyncLoopFactory = new Mock<IAsyncLoopFactory>().Object;
             INodeLifetime nodeLifetime = new Mock<INodeLifetime>().Object;
+            NodeSettings nodeSettings = NodeSettings.Default();
+            nodeSettings.DataDir = Directory.GetCurrentDirectory();
+            DataFolder dataFolders = new Mock<DataFolder>(nodeSettings).Object;
 
             Mock<ILogger> logger = new Mock<ILogger>();
             bool receivedRequest = false;
@@ -331,7 +403,7 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
 
             // Act.
             CancellationTokenSource source = new CancellationTokenSource(2000);
-            DnsSeedServer server = new DnsSeedServer(udpClient.Object, masterFile.Object, asyncLoopFactory, nodeLifetime, loggerFactory.Object, dateTimeProvider);
+            DnsSeedServer server = new DnsSeedServer(udpClient.Object, masterFile.Object, asyncLoopFactory, nodeLifetime, loggerFactory.Object, dateTimeProvider, nodeSettings, dataFolders);
 
             try
             {
@@ -359,11 +431,110 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
 
         [Fact]
         [Trait("DNS", "UnitTest")]
+        public void WhenDnsServerInitialized_AndNoMasterFileOnDisk_ThenDnsServerSuccessfullyInitializes()
+        {
+            // Arrange.
+            Mock<IUdpClient> udpClient = new Mock<IUdpClient>();
+            Mock<IMasterFile> masterFile = new Mock<IMasterFile>();
+            masterFile.Setup(m => m.Get(It.IsAny<Question>())).Returns(new List<IResourceRecord>());
+
+            CancellationTokenSource source = new CancellationTokenSource(5000);
+            Mock<INodeLifetime> nodeLifetime = new Mock<INodeLifetime>();
+            nodeLifetime.Setup(n => n.ApplicationStopping).Returns(source.Token);
+
+            Mock<ILogger> logger = new Mock<ILogger>();
+            Mock<ILoggerFactory> loggerFactory = new Mock<ILoggerFactory>();
+            loggerFactory.Setup<ILogger>(f => f.CreateLogger(It.IsAny<string>())).Returns(logger.Object);
+
+            Mock<IAsyncLoopFactory> asyncLoopFactory = new Mock<IAsyncLoopFactory>();
+            asyncLoopFactory.Setup(f => f.Run(It.IsAny<string>(), It.IsAny<Func<CancellationToken, Task>>(), It.IsAny<TimeSpan?>(), It.IsAny<TimeSpan?>())).Returns(new Mock<IAsyncLoop>().Object);
+
+            IDateTimeProvider dateTimeProvider = new Mock<IDateTimeProvider>().Object;
+            NodeSettings nodeSettings = NodeSettings.Default();
+            nodeSettings.DataDir = Directory.GetCurrentDirectory();
+            nodeSettings.DnsHostName = "host.example.com";
+            nodeSettings.DnsNameServer = "ns1.host.example.com";
+            nodeSettings.DnsMailBox = "admin@host.example.com";
+            DataFolder dataFolders = new Mock<DataFolder>(nodeSettings).Object;
+
+            // Act.
+            DnsSeedServer server = new DnsSeedServer(udpClient.Object, masterFile.Object, asyncLoopFactory.Object, nodeLifetime.Object, loggerFactory.Object, dateTimeProvider, nodeSettings, dataFolders);
+            server.Initialize();
+            bool waited = source.Token.WaitHandle.WaitOne();
+
+            // Assert.
+            server.Should().NotBeNull();
+            waited.Should().BeTrue();
+            masterFile.Verify(m => m.Load(It.IsAny<Stream>()), Times.Never);
+        }
+
+        [Fact]
+        [Trait("DNS", "UnitTest")]
+        public void WhenDnsServerInitialized_AndMasterFileOnDisk_ThenDnsServerSuccessfullyInitializes()
+        {
+            // Arrange.
+            Mock<IUdpClient> udpClient = new Mock<IUdpClient>();
+            Mock<IMasterFile> masterFile = new Mock<IMasterFile>();
+            masterFile.Setup(m => m.Get(It.IsAny<Question>())).Returns(new List<IResourceRecord>());
+
+            CancellationTokenSource source = new CancellationTokenSource(5000);
+            Mock<INodeLifetime> nodeLifetime = new Mock<INodeLifetime>();
+            nodeLifetime.Setup(n => n.ApplicationStopping).Returns(source.Token);
+
+            Mock<ILogger> logger = new Mock<ILogger>();
+            Mock<ILoggerFactory> loggerFactory = new Mock<ILoggerFactory>();
+            loggerFactory.Setup<ILogger>(f => f.CreateLogger(It.IsAny<string>())).Returns(logger.Object);
+
+            Mock<IAsyncLoopFactory> asyncLoopFactory = new Mock<IAsyncLoopFactory>();
+            asyncLoopFactory.Setup(f => f.Run(It.IsAny<string>(), It.IsAny<Func<CancellationToken, Task>>(), It.IsAny<TimeSpan?>(), It.IsAny<TimeSpan?>())).Returns(new Mock<IAsyncLoop>().Object);
+
+            IDateTimeProvider dateTimeProvider = new Mock<IDateTimeProvider>().Object;
+            NodeSettings nodeSettings = NodeSettings.Default();
+            nodeSettings.DataDir = Directory.GetCurrentDirectory();
+            nodeSettings.DnsHostName = "host.example.com";
+            nodeSettings.DnsNameServer = "ns1.host.example.com";
+            nodeSettings.DnsMailBox = "admin@host.example.com";
+            DataFolder dataFolders = new Mock<DataFolder>(nodeSettings).Object;
+
+            string masterFilePath = Path.Combine(dataFolders.DnsMasterFilePath, DnsFeature.DnsMasterFileName);
+
+            // Act.
+            try
+            {
+                // Create masterfile on disk
+                using (FileStream stream = File.Create(masterFilePath))
+                {
+                    stream.Close();
+                }
+
+                // Run server
+                DnsSeedServer server = new DnsSeedServer(udpClient.Object, masterFile.Object, asyncLoopFactory.Object, nodeLifetime.Object, loggerFactory.Object, dateTimeProvider, nodeSettings, dataFolders);
+                server.Initialize();
+                bool waited = source.Token.WaitHandle.WaitOne();
+
+                // Assert.
+                server.Should().NotBeNull();
+                waited.Should().BeTrue();
+                masterFile.Verify(m => m.Load(It.IsAny<Stream>()), Times.Once);
+            }
+            finally
+            {
+                // Try and remove created
+                if (File.Exists(masterFilePath))
+                {
+                    File.Delete(masterFilePath);
+                }
+            }
+        }
+
+        [Fact]
+        [Trait("DNS", "UnitTest")]
         public void WhenDnsServerInitialized_ThenMetricsLoopStarted()
         {
             // Arrange.
             Mock<IUdpClient> udpClient = new Mock<IUdpClient>();
             Mock<IMasterFile> masterFile = new Mock<IMasterFile>();
+            masterFile.Setup(m => m.Get(It.IsAny<Question>())).Returns(new List<IResourceRecord>());
 
             CancellationTokenSource source = new CancellationTokenSource(5000);
             Mock<INodeLifetime> nodeLifetime = new Mock<INodeLifetime>();
@@ -386,9 +557,15 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
             IAsyncLoopFactory asyncLoopFactory = new AsyncLoopFactory(loggerFactory.Object);
 
             IDateTimeProvider dateTimeProvider = new Mock<IDateTimeProvider>().Object;
+            NodeSettings nodeSettings = NodeSettings.Default();
+            nodeSettings.DataDir = Directory.GetCurrentDirectory();
+            nodeSettings.DnsHostName = "host.example.com";
+            nodeSettings.DnsNameServer = "ns1.host.example.com";
+            nodeSettings.DnsMailBox = "admin@host.example.com";
+            DataFolder dataFolders = new Mock<DataFolder>(nodeSettings).Object;
 
             // Act.
-            DnsSeedServer server = new DnsSeedServer(udpClient.Object, masterFile.Object, asyncLoopFactory, nodeLifetime.Object, loggerFactory.Object, dateTimeProvider);
+            DnsSeedServer server = new DnsSeedServer(udpClient.Object, masterFile.Object, asyncLoopFactory, nodeLifetime.Object, loggerFactory.Object, dateTimeProvider, nodeSettings, dataFolders);
             server.Initialize();
             bool waited = source.Token.WaitHandle.WaitOne();
 

--- a/src/Stratis.Bitcoin.Features.Dns.Tests/GivenADnsSeedServer.cs
+++ b/src/Stratis.Bitcoin.Features.Dns.Tests/GivenADnsSeedServer.cs
@@ -219,6 +219,9 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
             IDateTimeProvider dateTimeProvider = new Mock<IDateTimeProvider>().Object;
             NodeSettings nodeSettings = NodeSettings.Default();
             nodeSettings.DataDir = Directory.GetCurrentDirectory();
+            nodeSettings.DnsHostName = "host.example.com";
+            nodeSettings.DnsNameServer = "ns1.host.example.com";
+            nodeSettings.DnsMailBox = "admin@host.example.com";
             DataFolder dataFolders = new Mock<DataFolder>(nodeSettings).Object;
 
             // Act.
@@ -244,11 +247,15 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
             udpClient.Setup(c => c.ReceiveAsync()).ThrowsAsync(new SocketException());
 
             Mock<IMasterFile> masterFile = new Mock<IMasterFile>();
+            masterFile.Setup(m => m.Get(It.IsAny<Question>())).Returns(new List<IResourceRecord>() { new IPAddressResourceRecord(Domain.FromString("google.com"), IPAddress.Loopback) });
 
             IAsyncLoopFactory asyncLoopFactory = new Mock<IAsyncLoopFactory>().Object;
             INodeLifetime nodeLifetime = new Mock<INodeLifetime>().Object;
             NodeSettings nodeSettings = NodeSettings.Default();
             nodeSettings.DataDir = Directory.GetCurrentDirectory();
+            nodeSettings.DnsHostName = "host.example.com";
+            nodeSettings.DnsNameServer = "ns1.host.example.com";
+            nodeSettings.DnsMailBox = "admin@host.example.com";
             DataFolder dataFolders = new Mock<DataFolder>(nodeSettings).Object;
 
             Mock<ILogger> logger = new Mock<ILogger>(MockBehavior.Loose);
@@ -309,6 +316,9 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
             INodeLifetime nodeLifetime = new Mock<INodeLifetime>().Object;
             NodeSettings nodeSettings = NodeSettings.Default();
             nodeSettings.DataDir = Directory.GetCurrentDirectory();
+            nodeSettings.DnsHostName = "host.example.com";
+            nodeSettings.DnsNameServer = "ns1.host.example.com";
+            nodeSettings.DnsMailBox = "admin@host.example.com";
             DataFolder dataFolders = new Mock<DataFolder>(nodeSettings).Object;
 
             Mock<ILogger> logger = new Mock<ILogger>();
@@ -383,6 +393,9 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
             INodeLifetime nodeLifetime = new Mock<INodeLifetime>().Object;
             NodeSettings nodeSettings = NodeSettings.Default();
             nodeSettings.DataDir = Directory.GetCurrentDirectory();
+            nodeSettings.DnsHostName = "host.example.com";
+            nodeSettings.DnsNameServer = "ns1.host.example.com";
+            nodeSettings.DnsMailBox = "admin@host.example.com";
             DataFolder dataFolders = new Mock<DataFolder>(nodeSettings).Object;
 
             Mock<ILogger> logger = new Mock<ILogger>();

--- a/src/Stratis.Bitcoin.Features.Dns/DnsFeature.cs
+++ b/src/Stratis.Bitcoin.Features.Dns/DnsFeature.cs
@@ -128,32 +128,10 @@ namespace Stratis.Bitcoin.Features.Dns
             // Initialize DNS server.
             this.dnsServer.Initialize();
 
-            bool restarted = false;
-
             while (true)
             {
                 try
                 {
-                    // Only load if we are starting up for the first time.
-                    if (!restarted)
-                    {
-                        // Load masterfile from disk if it exists.
-                        string path = Path.Combine(this.dataFolders.DnsMasterFilePath, DnsMasterFileName);
-                        if (File.Exists(path))
-                        {
-                            this.logger.LogInformation("Loading cached DNS masterfile from {0}", path);
-
-                            using (FileStream stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read))
-                            {
-                                IMasterFile masterFile = new DnsSeedMasterFile();
-                                masterFile.Load(stream);
-
-                                // Swap in masterfile from disk into DNS server.
-                                this.dnsServer.SwapMasterfile(masterFile);
-                            }
-                        }
-                    }
-
                     this.logger.LogInformation("Starting DNS server on port {0}", this.nodeSettings.DnsListenPort);
 
                     // Start.
@@ -182,8 +160,6 @@ namespace Stratis.Bitcoin.Features.Dns
                     }
 
                     this.logger.LogTrace("Restarting DNS server following previous failure.");
-
-                    restarted = true;
                 }
             }
 

--- a/src/Stratis.Bitcoin.Features.Dns/DnsSeedMasterFile.cs
+++ b/src/Stratis.Bitcoin.Features.Dns/DnsSeedMasterFile.cs
@@ -97,7 +97,8 @@ namespace Stratis.Bitcoin.Features.Dns
         /// <returns>The matching entries.</returns>
         public IList<IResourceRecord> Get(Domain domain, RecordType type)
         {
-            return this.entries.Where(e => Matches(domain, e.Name) && e.Type == type).ToList();
+            // Fix logic from 3rd party library to support the ANY DNS query record type
+            return this.entries.Where(e => Matches(domain, e.Name) && (e.Type == type || type == RecordType.ANY)).ToList();
         }
 
         /// <summary>

--- a/src/Stratis.Bitcoin/Configuration/NodeSettings.cs
+++ b/src/Stratis.Bitcoin/Configuration/NodeSettings.cs
@@ -140,6 +140,12 @@ namespace Stratis.Bitcoin.Configuration
         /// <summary>Defines the port that the DNS server will listen on, by default this is 53.</summary>
         public int DnsListenPort { get; set; }
 
+        /// <summary>Defines the nameserver host name used as the authoritative domain for the DNS seed service.</summary>
+        public string DnsNameServer { get; set; }
+
+        /// <summary>Defines the e-mail address used as the administrative point of contact for the domain.</summary>
+        public string DnsMailBox { get; set; }
+
         /// <summary>
         /// Initializes default configuration.
         /// </summary>
@@ -255,6 +261,15 @@ namespace Stratis.Bitcoin.Configuration
 
             this.DnsListenPort = config.GetOrDefault<int>("dnslistenport", 53);
             this.Logger.LogDebug("DNS Seed Service listen port is {0}, if running as DNS Seed.", this.DnsListenPort);
+
+            this.DnsHostName = config.GetOrDefault("dnshostname", string.Empty);
+            this.Logger.LogDebug("DNS Seed Service host name set to {0}.", this.DnsHostName);
+
+            this.DnsNameServer = config.GetOrDefault("dnsnameserver", string.Empty);
+            this.Logger.LogDebug("DNS Seed Service nameserver set to {0}.", this.DnsNameServer);
+
+            this.DnsMailBox = config.GetOrDefault("dnsmailbox", string.Empty);
+            this.Logger.LogDebug("DNS Seed Service mailbox set to {0}.", this.DnsMailBox);
 
             try
             {

--- a/src/Stratis.Bitcoin/Configuration/NodeSettings.cs
+++ b/src/Stratis.Bitcoin/Configuration/NodeSettings.cs
@@ -247,28 +247,25 @@ namespace Stratis.Bitcoin.Configuration
             this.SyncTimeEnabled = config.GetOrDefault<bool>("synctime", true);
             this.Logger.LogDebug("Time synchronization with peers is {0}.", this.SyncTimeEnabled ? "enabled" : "disabled");
 
-            this.DnsPeerBlacklistThresholdInSeconds = config.GetOrDefault("dnspeerblacklistthresholdinseconds", DefaultDnsPeerBlacklistThresholdInSeconds);
-            this.Logger.LogDebug("DnsPeerBlacklistThresholdInSeconds set to {0}.", this.DnsPeerBlacklistThresholdInSeconds);
-
-            this.DnsHostName = config.GetOrDefault<string>("dnshostname", null);
-            this.Logger.LogDebug("DnsHostName set to {0}.", this.DnsHostName);
-
             if (args.Contains("-dnsfullnode", StringComparer.CurrentCultureIgnoreCase))
             {
                 this.DnsFullNode = true;
                 this.Logger.LogDebug("DNS Seed Service is set to run as a full node, if running as DNS Seed.", this.DnsListenPort);
             }
 
+            this.DnsPeerBlacklistThresholdInSeconds = config.GetOrDefault("dnspeerblacklistthresholdinseconds", DefaultDnsPeerBlacklistThresholdInSeconds);
+            this.Logger.LogDebug("DnsPeerBlacklistThresholdInSeconds set to {0}.", this.DnsPeerBlacklistThresholdInSeconds);
+
             this.DnsListenPort = config.GetOrDefault<int>("dnslistenport", 53);
             this.Logger.LogDebug("DNS Seed Service listen port is {0}, if running as DNS Seed.", this.DnsListenPort);
 
-            this.DnsHostName = config.GetOrDefault("dnshostname", string.Empty);
+            this.DnsHostName = config.GetOrDefault<string>("dnshostname", null);
             this.Logger.LogDebug("DNS Seed Service host name set to {0}.", this.DnsHostName);
 
-            this.DnsNameServer = config.GetOrDefault("dnsnameserver", string.Empty);
+            this.DnsNameServer = config.GetOrDefault<string>("dnsnameserver", null);
             this.Logger.LogDebug("DNS Seed Service nameserver set to {0}.", this.DnsNameServer);
 
-            this.DnsMailBox = config.GetOrDefault("dnsmailbox", string.Empty);
+            this.DnsMailBox = config.GetOrDefault<string>("dnsmailbox", null);
             this.Logger.LogDebug("DNS Seed Service mailbox set to {0}.", this.DnsMailBox);
 
             try

--- a/src/Stratis.StratisDnsD/Program.cs
+++ b/src/Stratis.StratisDnsD/Program.cs
@@ -65,6 +65,9 @@ namespace Stratis.StratisDnsD
                         .AddRPC()
                         .UseDns()
                         .Build();
+
+                    // Run node.
+                    await node.RunAsync();
                 }
                 else
                 {

--- a/src/Stratis.StratisDnsD/Program.cs
+++ b/src/Stratis.StratisDnsD/Program.cs
@@ -7,9 +7,13 @@ using Stratis.Bitcoin;
 using Stratis.Bitcoin.Builder;
 using Stratis.Bitcoin.Configuration;
 using Stratis.Bitcoin.Features.Api;
+using Stratis.Bitcoin.Features.BlockStore;
 using Stratis.Bitcoin.Features.Consensus;
 using Stratis.Bitcoin.Features.Dns;
+using Stratis.Bitcoin.Features.MemoryPool;
+using Stratis.Bitcoin.Features.Miner;
 using Stratis.Bitcoin.Features.RPC;
+using Stratis.Bitcoin.Features.Wallet;
 using Stratis.Bitcoin.Utilities;
 
 namespace Stratis.StratisDnsD
@@ -40,17 +44,42 @@ namespace Stratis.StratisDnsD
                 Network network = args.Contains("-testnet") ? Network.StratisTest : Network.StratisMain;
                 NodeSettings nodeSettings = new NodeSettings("stratis", network, ProtocolVersion.ALT_PROTOCOL_VERSION).LoadArguments(args);
 
-                // build the Dns node.
-                IFullNode node = new FullNodeBuilder()
-                     .UseNodeSettings(nodeSettings)
-                     .UseStratisConsensus()
-                     .UseApi()
-                     .AddRPC()
-                     .UseDns()
-                     .Build();
+                // Verify that the DNS host, nameserver and mailbox arguments are set.
+                if (string.IsNullOrWhiteSpace(nodeSettings.DnsHostName) || string.IsNullOrWhiteSpace(nodeSettings.DnsNameServer) || string.IsNullOrWhiteSpace(nodeSettings.DnsMailBox))
+                {
+                    throw new ArgumentException("When running as a DNS Seed service, the -dnshostname, -dnsnameserver and -dnsmailbox arguments must be specified on the command line.");
+                }
 
-                // TODO: add the functionality to run a full node with Dns.
-                await node.RunAsync();
+                // Run as a full node with DNS or just a DNS service?
+                if (nodeSettings.DnsFullNode)
+                {
+                    // Build the Dns full node.
+                    IFullNode node = new FullNodeBuilder()
+                        .UseNodeSettings(nodeSettings)
+                        .UseStratisConsensus()
+                        .UseBlockStore()
+                        .UseMempool()
+                        .UseWallet()
+                        .AddPowPosMining()
+                        .UseApi()
+                        .AddRPC()
+                        .UseDns()
+                        .Build();
+                }
+                else
+                {
+                    // Build the Dns node.
+                    IFullNode node = new FullNodeBuilder()
+                        .UseNodeSettings(nodeSettings)
+                        .UseStratisConsensus()
+                        .UseApi()
+                        .AddRPC()
+                        .UseDns()
+                        .Build();
+
+                    // Run node.
+                    await node.RunAsync();
+                }
             }
             catch (Exception ex)
             {

--- a/src/Stratis.StratisDnsD/Properties/launchSettings.json
+++ b/src/Stratis.StratisDnsD/Properties/launchSettings.json
@@ -6,6 +6,10 @@
     "Stratis.StratisDnsD Test": {
       "commandName": "Project",
       "commandLineArgs": "-testnet -dnslistenport=5399 -dnshostname=dns.stratisplatform.com -dnsnameserver=ns1.dns.stratisplatform.com -dnsmailbox=admin@stratisplatform.com"
+    },
+    "Stratis.StratisDnsD FullNode Test": {
+      "commandName": "Project",
+      "commandLineArgs": "-testnet -dnsfullnode -dnslistenport=5399 -dnshostname=dns.stratisplatform.com -dnsnameserver=ns1.dns.stratisplatform.com -dnsmailbox=admin@stratisplatform.com"
     }
   }
 }

--- a/src/Stratis.StratisDnsD/Properties/launchSettings.json
+++ b/src/Stratis.StratisDnsD/Properties/launchSettings.json
@@ -5,7 +5,7 @@
     },
     "Stratis.StratisDnsD Test": {
       "commandName": "Project",
-      "commandLineArgs": "-testnet -dnslistenport=5399 -dnshostname=dns.stratisplatform.com"
+      "commandLineArgs": "-testnet -dnslistenport=5399 -dnshostname=dns.stratisplatform.com -dnsnameserver=ns1.dns.stratisplatform.com -dnsmailbox=admin@stratisplatform.com"
     }
   }
 }

--- a/src/Stratis.StratisDnsD/Stratis.StratisDnsD.csproj
+++ b/src/Stratis.StratisDnsD/Stratis.StratisDnsD.csproj
@@ -23,6 +23,7 @@
     <ProjectReference Include="..\NBitcoin\NBitcoin.csproj" />
     <ProjectReference Include="..\Stratis.Bitcoin.Features.Api\Stratis.Bitcoin.Features.Api.csproj" />
     <ProjectReference Include="..\Stratis.Bitcoin.Features.BlockStore\Stratis.Bitcoin.Features.BlockStore.csproj" />
+    <ProjectReference Include="..\Stratis.Bitcoin.Features.Consensus\Stratis.Bitcoin.Features.Consensus.csproj" />
     <ProjectReference Include="..\Stratis.Bitcoin.Features.Dns\Stratis.Bitcoin.Features.Dns.csproj" />
     <ProjectReference Include="..\Stratis.Bitcoin.Features.MemoryPool\Stratis.Bitcoin.Features.MemoryPool.csproj" />
     <ProjectReference Include="..\Stratis.Bitcoin.Features.Miner\Stratis.Bitcoin.Features.Miner.csproj" />


### PR DESCRIPTION
- For Trello item: https://trello.com/c/oMisVGrT
- Added support for SOA and NS records, adds in new command line arguments for dnsnameserver and dnsmailbox.
- Fixed and added new unit tests.
- Fixed metric output for peer counts.
- Added ANY support for DNS queries (3rd party library didn't offer this).
- Added fullnode support.
- Added new launch setting for fullnode.
- Tested both DNS only and fullnode settings.