### PR TITLE
[BlockStoreSignaled] Replaced 1 second announcing loop with event-based announcing

### DIFF
--- a/src/Stratis.Bitcoin.Features.BlockStore/BlockStoreFeature.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/BlockStoreFeature.cs
@@ -126,7 +126,7 @@ namespace Stratis.Bitcoin.Features.BlockStore
             this.signals.SubscribeForBlocks(this.blockStoreSignaled);
 
             this.blockRepository.InitializeAsync().GetAwaiter().GetResult();
-            this.blockStoreSignaled.RelayWorker();
+            this.blockStoreSignaled.Initialize();
             this.blockStoreLoop.InitializeAsync().GetAwaiter().GetResult();
 
             this.logger.LogTrace("(-)");

--- a/src/Stratis.Bitcoin.Features.BlockStore/BlockStoreFeature.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/BlockStoreFeature.cs
@@ -137,7 +137,7 @@ namespace Stratis.Bitcoin.Features.BlockStore
         {
             this.logger.LogInformation("Stopping {0}...", this.name);
 
-            this.blockStoreSignaled.ShutDown();
+            this.blockStoreSignaled.Dispose();
             this.blockStoreManager.BlockStoreLoop.ShutDown();
             this.blockStoreCache.Dispose();
             this.blockRepository.Dispose();

--- a/src/Stratis.Bitcoin.Features.BlockStore/BlockStoreSignaled.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/BlockStoreSignaled.cs
@@ -16,6 +16,9 @@ namespace Stratis.Bitcoin.Features.BlockStore
 {
     public class BlockStoreSignaled : SignalObserver<Block>
     {
+        /// <summary>Maximum time in seconds for forming a new batch.</summary>
+        private const double FlushFrequencySeconds = 0.5;
+
         private Task relayWorkerTask;
 
         private readonly IBlockRepository blockRepository;
@@ -41,11 +44,11 @@ namespace Stratis.Bitcoin.Features.BlockStore
         /// <summary>Queue of chained blocks that will be announced to the peers.</summary>
         private readonly ConcurrentQueue<ChainedBlock> blocksToAnnounce;
 
+        /// <summary>Event slim that is set when a new block gets enqueued.</summary>
         private ManualResetEventSlim blockEnqueued;
 
+        /// <summary>Timestamp of last announcement event.</summary>
         private DateTime lastBlockAnnounceTimeStamp;
-
-        private const double FlushFrequencySeconds = 0.5;
 
         public BlockStoreSignaled(
             BlockStoreLoop blockStoreLoop,

--- a/src/Stratis.Bitcoin.Features.BlockStore/BlockStoreSignaled.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/BlockStoreSignaled.cs
@@ -147,7 +147,7 @@ namespace Stratis.Bitcoin.Features.BlockStore
                 while (!this.nodeLifetime.ApplicationStopping.IsCancellationRequested)
                 {
                     // Wait until a new block is added to the queue.
-                    this.blockEnqueued.Wait();
+                    this.blockEnqueued.Wait(this.nodeLifetime.ApplicationStopping);
 
                     // Make sure that at least 'FlushFrequencySeconds' seconds passed since the last announcement.
                     // This is needed in order to ensure announcing blocks in batches to reduce the overhead.

--- a/src/Stratis.Bitcoin.Features.BlockStore/BlockStoreSignaled.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/BlockStoreSignaled.cs
@@ -151,8 +151,12 @@ namespace Stratis.Bitcoin.Features.BlockStore
         /// </remarks>
         private async Task RelayWorkerAsync()
         {
+            this.logger.LogTrace("()");
+
             while (!this.nodeLifetime.ApplicationStopping.IsCancellationRequested)
             {
+                this.logger.LogTrace("()");
+
                 try
                 {
                     // Wait until a new block is added to the queue.
@@ -172,8 +176,6 @@ namespace Stratis.Bitcoin.Features.BlockStore
                 {
                     return;
                 }
-
-                this.logger.LogTrace("()");
 
                 int announceBlockCount = this.blocksToAnnounce.Count;
                 if (announceBlockCount == 0)
@@ -243,6 +245,8 @@ namespace Stratis.Bitcoin.Features.BlockStore
                 foreach (BlockStoreBehavior behaviour in behaviours)
                     await behaviour.AnnounceBlocksAsync(broadcastItems).ConfigureAwait(false);
             }
+
+            this.logger.LogTrace("(-)");
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
Replaced an async loop with a 'producer-consumer' pattern based even system. 

Fix: #930 