### PR TITLE
Async consumer queue

### DIFF
--- a/src/Stratis.Bitcoin/Utilities/AsyncManualResetEvent.cs
+++ b/src/Stratis.Bitcoin/Utilities/AsyncManualResetEvent.cs
@@ -1,0 +1,269 @@
+﻿/*
+The MIT License (MIT)
+
+Copyright (c) 2014 StephenCleary
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+https://github.com/StephenCleary/AsyncEx
+ */
+
+using System;
+using System.Runtime.ExceptionServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Stratis.Bitcoin.Utilities
+{
+    /// <summary>
+    /// An async-compatible manual-reset event.
+    /// </summary>
+    public sealed class AsyncManualResetEvent
+    {
+        /// <summary>
+        /// The object used for synchronization.
+        /// </summary>
+        private readonly object mutex;
+
+        /// <summary>
+        /// The current state of the event.
+        /// </summary>
+        private TaskCompletionSource<object> tcs;
+
+        /// <summary>
+        /// Creates an async-compatible manual-reset event.
+        /// </summary>
+        /// <param name="set">Whether the manual-reset event is initially set or unset.</param>
+        public AsyncManualResetEvent(bool set)
+        {
+            this.mutex = new object();
+            this.tcs = CreateAsyncTaskSource<object>();
+            if (set)
+                this.tcs.TrySetResult(null);
+        }
+
+        /// <summary>
+        /// Creates an async-compatible manual-reset event that is initially unset.
+        /// </summary>
+        public AsyncManualResetEvent()
+            : this(false)
+        {
+        }
+
+        /// <summary>
+        /// Whether this event is currently set. This member is seldom used; code using this member has a high possibility of race conditions.
+        /// </summary>
+        public bool IsSet
+        {
+            get
+            {
+                lock (this.mutex)
+                {
+                    return this.tcs.Task.IsCompleted;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Asynchronously waits for this event to be set.
+        /// </summary>
+        public Task WaitAsync()
+        {
+            lock (this.mutex)
+            {
+                return this.tcs.Task;
+            }
+        }
+
+        /// <summary>
+        /// Asynchronously waits for this event to be set or for the wait to be canceled.
+        /// </summary>
+        /// <param name="cancellationToken">The cancellation token used to cancel the wait. If this token is already canceled, this method will first check whether the event is set.</param>
+        public Task WaitAsync(CancellationToken cancellationToken)
+        {
+            Task waitTask = this.WaitAsync();
+            if (waitTask.IsCompleted)
+                return waitTask;
+
+            return WaitAsync(waitTask, cancellationToken);
+        }
+
+        /// <summary>
+        /// Synchronously waits for this event to be set. This method may block the calling thread.
+        /// </summary>
+        public void Wait()
+        {
+            WaitAndUnwrapException(this.WaitAsync());
+        }
+
+        /// <summary>
+        /// Synchronously waits for this event to be set. This method may block the calling thread.
+        /// </summary>
+        /// <param name="cancellationToken">The cancellation token used to cancel the wait. If this token is already canceled, this method will first check whether the event is set.</param>
+        public void Wait(CancellationToken cancellationToken)
+        {
+            Task ret = this.WaitAsync();
+            if (ret.IsCompleted)
+                return;
+
+            WaitAndUnwrapException(ret, cancellationToken);
+        }
+
+        /// <summary>
+        /// Sets the event, atomically completing every task returned by <see cref="O:Nito.AsyncEx.AsyncManualResetEvent.WaitAsync"/>. If the event is already set, this method does nothing.
+        /// </summary>
+        public void Set()
+        {
+            lock (this.mutex)
+            {
+                this.tcs.TrySetResult(null);
+            }
+        }
+
+        /// <summary>
+        /// Resets the event. If the event is already reset, this method does nothing.
+        /// </summary>
+        public void Reset()
+        {
+            lock (this.mutex)
+            {
+                if (this.tcs.Task.IsCompleted)
+                    this.tcs = CreateAsyncTaskSource<object>();
+            }
+        }
+
+        /// <summary>
+        /// Creates a new TCS for use with async code, and which forces its continuations to execute asynchronously.
+        /// </summary>
+        /// <typeparam name="TResult">The type of the result of the TCS.</typeparam>
+        private static TaskCompletionSource<TResult> CreateAsyncTaskSource<TResult>()
+        {
+            return new TaskCompletionSource<TResult>(TaskCreationOptions.RunContinuationsAsynchronously);
+        }
+
+        /// <summary>
+        /// Waits for the task to complete, unwrapping any exceptions.
+        /// </summary>
+        /// <param name="task">The task. May not be <c>null</c>.</param>
+        private static void WaitAndUnwrapException(Task task)
+        {
+            if (task == null)
+                throw new ArgumentNullException(nameof(task));
+            task.GetAwaiter().GetResult();
+        }
+
+        /// <summary>
+        /// Waits for the task to complete, unwrapping any exceptions.
+        /// </summary>
+        /// <param name="task">The task. May not be <c>null</c>.</param>
+        /// <param name="cancellationToken">A cancellation token to observe while waiting for the task to complete.</param>
+        /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was cancelled before the <paramref name="task"/> completed, or the <paramref name="task"/> raised an <see cref="OperationCanceledException"/>.</exception>
+        private static void WaitAndUnwrapException(Task task, CancellationToken cancellationToken)
+        {
+            if (task == null)
+                throw new ArgumentNullException(nameof(task));
+            try
+            {
+                task.Wait(cancellationToken);
+            }
+            catch (AggregateException ex)
+            {
+                throw PrepareForRethrow(ex.InnerException);
+            }
+        }
+
+        /// <summary>
+        /// Asynchronously waits for the task to complete, or for the cancellation token to be canceled.
+        /// </summary>
+        /// <param name="task">The task to wait for. May not be <c>null</c>.</param>
+        /// <param name="cancellationToken">The cancellation token that cancels the wait.</param>
+        private static Task WaitAsync(Task task, CancellationToken cancellationToken)
+        {
+            if (task == null)
+                throw new ArgumentNullException(nameof(task));
+
+            if (!cancellationToken.CanBeCanceled)
+                return task;
+            if (cancellationToken.IsCancellationRequested)
+                return Task.FromCanceled(cancellationToken);
+            return DoWaitAsync(task, cancellationToken);
+        }
+
+        private static async Task DoWaitAsync(Task task, CancellationToken cancellationToken)
+        {
+            using (var cancelTaskSource = new CancellationTokenTaskSource<object>(cancellationToken))
+                await await Task.WhenAny(task, cancelTaskSource.Task).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Attempts to prepare the exception for re-throwing by preserving the stack trace. The returned exception should be immediately thrown.
+        /// </summary>
+        /// <param name="exception">The exception. May not be <c>null</c>.</param>
+        /// <returns>The <see cref="Exception"/> that was passed into this method.</returns>
+        private static Exception PrepareForRethrow(Exception exception)
+        {
+            ExceptionDispatchInfo.Capture(exception).Throw();
+
+            // The code cannot ever get here. We just return a value to work around a badly-designed API (ExceptionDispatchInfo.Throw):
+            //  https://connect.microsoft.com/VisualStudio/feedback/details/689516/exceptiondispatchinfo-api-modifications (http://www.webcitation.org/6XQ7RoJmO)
+            return exception;
+        }
+    }
+
+    /// <summary>
+    /// Holds the task for a cancellation token, as well as the token registration. The registration is disposed when this instance is disposed.
+    /// </summary>
+    public sealed class CancellationTokenTaskSource<T> : IDisposable
+    {
+        /// <summary>
+        /// The cancellation token registration, if any. This is <c>null</c> if the registration was not necessary.
+        /// </summary>
+        private readonly IDisposable registration;
+
+        /// <summary>
+        /// Creates a task for the specified cancellation token, registering with the token if necessary.
+        /// </summary>
+        /// <param name="cancellationToken">The cancellation token to observe.</param>
+        public CancellationTokenTaskSource(CancellationToken cancellationToken)
+        {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                this.Task = System.Threading.Tasks.Task.FromCanceled<T>(cancellationToken);
+                return;
+            }
+            var tcs = new TaskCompletionSource<T>();
+            this.registration = cancellationToken.Register(() => tcs.TrySetCanceled(cancellationToken), useSynchronizationContext: false);
+            this.Task = tcs.Task;
+        }
+
+        /// <summary>
+        /// Gets the task for the source cancellation token.
+        /// </summary>
+        public Task<T> Task { get; private set; }
+
+        /// <summary>
+        /// Disposes the cancellation token registration, if any. Note that this may cause <see cref="Task"/> to never complete.
+        /// </summary>
+        public void Dispose()
+        {
+            this.registration?.Dispose();
+        }
+    }
+}
+


### PR DESCRIPTION
This PR adds a new utility class- AsyncConsumerQueue<T>
AsyncConsumerQueue is a queue of items that are processed when a certain condition is met or when a timer runs out. 

Primal usage of this is for cases when we need to periodically flush items (send them to peer or save to hard drive) with a certain interval. But if a certain condition is met we need to flush it right away without waiting. 

This will be used in 'BlockStoreSignaled' for announcing new headers.  