### PR TITLE
Fix crash in BlockPuller 

### DIFF
--- a/src/Stratis.Bitcoin/BlockPulling/BlockPuller.cs
+++ b/src/Stratis.Bitcoin/BlockPulling/BlockPuller.cs
@@ -244,7 +244,9 @@ namespace Stratis.Bitcoin.BlockPulling
                     continue;
 
                 minHeight = Math.Min(chainedBlock.Height, minHeight);
-                vectors.Add(chainedBlock.Height, vector);
+
+                if (!vectors.ContainsKey(chainedBlock.Height))
+                    vectors.Add(chainedBlock.Height, vector);
             }
 
             if (vectors.Count > 0) this.DistributeDownload(vectors, minHeight);


### PR DESCRIPTION
It can happen that the pending inventory vector queue contains a single item twice, in which case the code crashes. So this just adds check.

Fix #988