### PR TITLE
Bugfix/stratisx sync issue 986

### DIFF
--- a/src/Stratis.Bitcoin.Features.BlockStore/BlockStoreBehavior.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/BlockStoreBehavior.cs
@@ -213,8 +213,16 @@ namespace Stratis.Bitcoin.Features.BlockStore
             int count = inv.Inventory.Count;
             if (count > 0)
             {
-                this.logger.LogTrace("Setting peer's pending tip to '{0}'.", lastAddedChainedBlock);
                 ChainHeadersBehavior chainBehavior = peer.Behavior<ChainHeadersBehavior>();
+
+                // New nodes do not use "getblocks" messages and their syncing is based on "getheaders"
+                // messages. StratisX nodes do need "getblocks", but then our node tries to sync 
+                // with the modern method. So we need to disable it to prevent collisions of those two methods.
+                // However, this should be only done if the peer is syncing from us and not vice versa.
+                // And when the sync is done, we should enable it again.
+                chainBehavior.CanSync = (chainBehavior.PendingTip != null) && (this.chain.Tip.ChainWork > chainBehavior.PendingTip.ChainWork);
+
+                this.logger.LogTrace("Setting peer's pending tip to '{0}'.", lastAddedChainedBlock);
                 chainBehavior.SetPendingTip(lastAddedChainedBlock);
 
                 this.logger.LogTrace("Sending inventory with {0} block hashes.", count);

--- a/src/Stratis.Bitcoin.Features.BlockStore/BlockStoreBehavior.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/BlockStoreBehavior.cs
@@ -314,7 +314,6 @@ namespace Stratis.Bitcoin.Features.BlockStore
 
         private async Task ProcessGetDataAsync(NetworkPeer peer, GetDataPayload getDataPayload)
         {
-            Guard.Assert(peer != null);
             this.logger.LogTrace("({0}:'{1}',{2}.{3}.{4}:{5})", nameof(peer), peer.RemoteSocketEndpoint, nameof(getDataPayload), nameof(getDataPayload.Inventory), nameof(getDataPayload.Inventory.Count), getDataPayload.Inventory.Count);
 
             // TODO: bring logic from core

--- a/src/Stratis.Bitcoin.Features.BlockStore/BlockStoreBehavior.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/BlockStoreBehavior.cs
@@ -205,7 +205,7 @@ namespace Stratis.Bitcoin.Features.BlockStore
                 }
 
                 // In case of reorg, we just try again, eventually we succeed.
-                if (chainTip.FindAncestorOrSelf(forkPoint) != null)
+                if (chainTip.FindAncestorOrSelf(forkPoint) == null)
                 {
                     chainTip = this.chain.Tip;
                     forkPoint = null;

--- a/src/Stratis.Bitcoin.Features.BlockStore/BlockStoreBehavior.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/BlockStoreBehavior.cs
@@ -229,16 +229,16 @@ namespace Stratis.Bitcoin.Features.BlockStore
             this.logger.LogTrace("(-)");
         }
 
-        private Task ProcessSendCmpctPayload(NetworkPeer node, SendCmpctPayload sendCmpct)
+        private Task ProcessSendCmpctPayload(NetworkPeer peer, SendCmpctPayload sendCmpct)
         {
             // TODO: announce using compact blocks
             return Task.CompletedTask;
         }
 
-        private async Task ProcessGetDataAsync(NetworkPeer node, GetDataPayload getDataPayload)
+        private async Task ProcessGetDataAsync(NetworkPeer peer, GetDataPayload getDataPayload)
         {
-            this.logger.LogTrace("({0}:'{1}',{2}.{3}.{4}:{5})", nameof(node), node?.RemoteSocketEndpoint, nameof(getDataPayload), nameof(getDataPayload.Inventory), nameof(getDataPayload.Inventory.Count), getDataPayload.Inventory.Count);
-            Guard.Assert(node != null);
+            this.logger.LogTrace("({0}:'{1}',{2}.{3}.{4}:{5})", nameof(peer), peer?.RemoteSocketEndpoint, nameof(getDataPayload), nameof(getDataPayload.Inventory), nameof(getDataPayload.Inventory.Count), getDataPayload.Inventory.Count);
+            Guard.Assert(peer != null);
 
             // TODO: bring logic from core
             foreach (InventoryVector item in getDataPayload.Inventory.Where(inv => inv.Type.HasFlag(InventoryType.MSG_BLOCK)))
@@ -248,10 +248,10 @@ namespace Stratis.Bitcoin.Features.BlockStore
 
                 if (block != null)
                 {
-                    this.logger.LogTrace("Sending block '{0}' to peer '{1}'.", item.Hash, node?.RemoteSocketEndpoint);
+                    this.logger.LogTrace("Sending block '{0}' to peer '{1}'.", item.Hash, peer?.RemoteSocketEndpoint);
 
                     //TODO strip block of witness if node does not support
-                    await node.SendMessageAsync(new BlockPayload(block.WithOptions(node.SupportedTransactionOptions))).ConfigureAwait(false);
+                    await peer.SendMessageAsync(new BlockPayload(block.WithOptions(peer.SupportedTransactionOptions))).ConfigureAwait(false);
                 }
             }
 

--- a/src/Stratis.Bitcoin.Features.BlockStore/BlockStoreBehavior.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/BlockStoreBehavior.cs
@@ -115,7 +115,7 @@ namespace Stratis.Bitcoin.Features.BlockStore
 
         private async void AttachedNode_MessageReceivedAsync(NetworkPeer peer, IncomingMessage message)
         {
-            this.logger.LogTrace("({0}:'{1}',{2}:'{3}')", nameof(peer), peer?.RemoteSocketEndpoint, nameof(message), message?.Message?.Command);
+            this.logger.LogTrace("({0}:'{1}',{2}:'{3}')", nameof(peer), peer.RemoteSocketEndpoint, nameof(message), message.Message.Command);
 
             try
             {
@@ -124,7 +124,7 @@ namespace Stratis.Bitcoin.Features.BlockStore
             catch (OperationCanceledException opx)
             {
                 if (!opx.CancellationToken.IsCancellationRequested)
-                    if (this.AttachedPeer?.IsConnected ?? false)
+                    if (peer.IsConnected)
                     {
                         this.logger.LogTrace("(-)[CANCELED_EXCEPTION]");
                         throw;
@@ -143,7 +143,7 @@ namespace Stratis.Bitcoin.Features.BlockStore
 
         private async Task ProcessMessageAsync(NetworkPeer peer, IncomingMessage message)
         {
-            this.logger.LogTrace("({0}:'{1}',{2}:'{3}')", nameof(peer), peer?.RemoteSocketEndpoint, nameof(message), message?.Message?.Command);
+            this.logger.LogTrace("({0}:'{1}',{2}:'{3}')", nameof(peer), peer.RemoteSocketEndpoint, nameof(message), message.Message.Command);
 
             switch (message.Message.Payload)
             {
@@ -325,7 +325,7 @@ namespace Stratis.Bitcoin.Features.BlockStore
 
                 if (block != null)
                 {
-                    this.logger.LogTrace("Sending block '{0}' to peer '{1}'.", item.Hash, peer?.RemoteSocketEndpoint);
+                    this.logger.LogTrace("Sending block '{0}' to peer '{1}'.", item.Hash, peer.RemoteSocketEndpoint);
 
                     //TODO strip block of witness if node does not support
                     await peer.SendMessageAsync(new BlockPayload(block.WithOptions(peer.SupportedTransactionOptions))).ConfigureAwait(false);
@@ -357,7 +357,7 @@ namespace Stratis.Bitcoin.Features.BlockStore
 
         private async Task SendAsBlockInventoryAsync(NetworkPeer peer, IEnumerable<uint256> blocks)
         {
-            this.logger.LogTrace("({0}:'{1}',{2}.Count:{3})", nameof(peer), peer?.RemoteSocketEndpoint, nameof(blocks), blocks.Count());
+            this.logger.LogTrace("({0}:'{1}',{2}.Count:{3})", nameof(peer), peer.RemoteSocketEndpoint, nameof(blocks), blocks.Count());
 
             var queue = new Queue<InventoryVector>(blocks.Select(s => new InventoryVector(InventoryType.MSG_BLOCK, s)));
             while (queue.Count > 0)

--- a/src/Stratis.Bitcoin.Features.BlockStore/BlockStoreBehavior.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/BlockStoreBehavior.cs
@@ -225,7 +225,7 @@ namespace Stratis.Bitcoin.Features.BlockStore
 
                 this.logger.LogTrace("Setting peer's pending tip to '{0}'.", lastAddedChainedBlock);
                 int peersHeight = peerTip != null ? peerTip.Height : 0;
-                if (peerTip.Height < lastAddedChainedBlock.Height) chainBehavior.SetPendingTip(lastAddedChainedBlock);
+                if (peersHeight < lastAddedChainedBlock.Height) chainBehavior.SetPendingTip(lastAddedChainedBlock);
 
                 this.logger.LogTrace("Sending inventory with {0} block hashes.", count);
                 await peer.SendMessageAsync(inv).ConfigureAwait(false);

--- a/src/Stratis.Bitcoin.Features.BlockStore/BlockStoreBehavior.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/BlockStoreBehavior.cs
@@ -194,6 +194,12 @@ namespace Stratis.Bitcoin.Features.BlockStore
         	for (int limit = 0; limit < InvPayload.MaxGetBlocksInventorySize; limit++)
         	{
         		chainedBlock = this.chain.GetBlock(chainedBlock.Height + 1);
+                if (chainedBlock == null)
+                {
+                    this.logger.LogTrace("Tip reached.");
+                    break;
+                }
+
                 if (chainedBlock.HashBlock == getBlocksPayload.HashStop)
                 {
                     this.logger.LogTrace("Hash stop has been reached.");

--- a/src/Stratis.Bitcoin.Features.BlockStore/BlockStoreBehavior.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/BlockStoreBehavior.cs
@@ -103,13 +103,13 @@ namespace Stratis.Bitcoin.Features.BlockStore
             this.logger.LogTrace("(-)");
         }
 
-        private async void AttachedNode_MessageReceivedAsync(NetworkPeer node, IncomingMessage message)
+        private async void AttachedNode_MessageReceivedAsync(NetworkPeer peer, IncomingMessage message)
         {
-            this.logger.LogTrace("({0}:'{1}',{2}:'{3}')", nameof(node), node?.RemoteSocketEndpoint, nameof(message), message?.Message?.Command);
+            this.logger.LogTrace("({0}:'{1}',{2}:'{3}')", nameof(peer), peer?.RemoteSocketEndpoint, nameof(message), message?.Message?.Command);
 
             try
             {
-                await this.ProcessMessageAsync(node, message).ConfigureAwait(false);
+                await this.ProcessMessageAsync(peer, message).ConfigureAwait(false);
             }
             catch (OperationCanceledException opx)
             {

--- a/src/Stratis.Bitcoin.Features.BlockStore/BlockStoreBehavior.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/BlockStoreBehavior.cs
@@ -161,7 +161,7 @@ namespace Stratis.Bitcoin.Features.BlockStore
                     // TODO: this is not used in core anymore consider deleting it
                     // However, this is required for StratisX to be able to sync from us.
 
-                    if (!this.CanRespondToGetDataPayload)
+                    if (!this.CanRespondToGetBlocksPayload)
                     {
                         this.logger.LogTrace("Can't respond to 'getblocks'.");
                         break;
@@ -248,8 +248,7 @@ namespace Stratis.Bitcoin.Features.BlockStore
                 lastBlock = lastBlock.Previous;
             }
 
-            // Now we compile inventory payload and we also consider hash stop given by the peer
-            // and we also check if the blocks to be announced are really present in the store.
+            // Now we compile inventory payload and we also consider hash stop given by the peer.
             bool sendContinuation = true;
             ChainedBlock lastAddedChainedBlock = null;
             var inv = new InvPayload();
@@ -259,12 +258,6 @@ namespace Stratis.Bitcoin.Features.BlockStore
                 if (chainedBlock.HashBlock == getBlocksPayload.HashStop)
                 {
                     this.logger.LogTrace("Hash stop has been reached.");
-                    break;
-                }
-
-                if (!await this.blockRepository.ExistAsync(chainedBlock.HashBlock).ConfigureAwait(false))
-                {
-                    this.logger.LogTrace("Block '{0}' is not ready in the store yet, we won't announce it now.");
                     break;
                 }
 
@@ -331,7 +324,7 @@ namespace Stratis.Bitcoin.Features.BlockStore
                 }
 
                 // If the peer is syncing using "getblocks" message we are supposed to send 
-                // an "inv" message with our tip to it once we it asks for all blocks
+                // an "inv" message with our tip to it once it asks for all blocks
                 // from the previous batch.
                 if (item.Hash == this.getBlocksBatchLastItemHash)
                 {

--- a/src/Stratis.Bitcoin.Features.BlockStore/BlockStoreBehavior.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/BlockStoreBehavior.cs
@@ -252,9 +252,9 @@ namespace Stratis.Bitcoin.Features.BlockStore
             // and we also check if the blocks to be announced are really present in the store.
             bool sendContinuation = true;
             ChainedBlock lastAddedChainedBlock = null;
-        	var inv = new InvPayload();
-        	for (int i = 0; i < headersToAnnounce.Length; i++)
-        	{
+            var inv = new InvPayload();
+            for (int i = 0; i < headersToAnnounce.Length; i++)
+            {
                 ChainedBlock chainedBlock = headersToAnnounce[i];
                 if (chainedBlock.HashBlock == getBlocksPayload.HashStop)
                 {
@@ -276,7 +276,7 @@ namespace Stratis.Bitcoin.Features.BlockStore
                     this.logger.LogTrace("Tip of the chain has been reached.");
                     sendContinuation = false;
                 }
-        	}
+            }
 
             int count = inv.Inventory.Count;
             if (count > 0)

--- a/src/Stratis.Bitcoin.Features.BlockStore/BlockStoreBehavior.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/BlockStoreBehavior.cs
@@ -190,6 +190,8 @@ namespace Stratis.Bitcoin.Features.BlockStore
                 return;
             }
 
+            this.logger.LogTrace("Block store tip is '{0}'.", blockStoreTip);
+
             // Now we want to find the last common block between our chain and the block locator the peer sent us.
             ChainedBlock chainTip = this.chain.Tip;
             ChainedBlock forkPoint = null;
@@ -211,6 +213,8 @@ namespace Stratis.Bitcoin.Features.BlockStore
                     forkPoint = null;
                 }
             }
+
+            this.logger.LogTrace("Fork point is '{0}'.", forkPoint);
 
             // If block store is lower than the fork point, or it is on different chain, we don't have anything to contribute to this peer at this point.
             if (blockStoreTip.FindAncestorOrSelf(forkPoint) == null)

--- a/src/Stratis.Bitcoin/P2P/Protocol/Payloads/InvPayload.cs
+++ b/src/Stratis.Bitcoin/P2P/Protocol/Payloads/InvPayload.cs
@@ -10,6 +10,9 @@ namespace Stratis.Bitcoin.P2P.Protocol.Payloads
     [Payload("inv")]
     public class InvPayload : Payload, IEnumerable<InventoryVector>
     {
+        /// <summary>Maximal number of inventory items in response to "getblocks" message.</summary>
+        public const int MaxGetBlocksInventorySize = 500;
+
         public const int MaxInventorySize = 50000;
 
         private List<InventoryVector> inventory = new List<InventoryVector>();


### PR DESCRIPTION
Somewhat controversial PR, but probably needed (the controversion here is only about whether we should support outdated mechanisms or not).

The problem is that StratisX is unable to sync from C# node. The reason for that is C# node does not implement `getblocks` network message, which is the mechanism that is no longer used by Bitcoin Core, but it is still used by StratisX. Without it, StratisX can only sync from StratisX which implements that.

So this reimplements (from the old source code) support for `getblocks`. The protocol says that in response to `getblocks`, the node should reply with up to 500 items of inventory, but if just that is done, the asking StratisX node would not continue to sync. So the C# node has to send a continuation inventory message with its tip (we are using block store tip for this). And it is important to send it just after StratisX node asks for the last block data (`getdata` message) from the last batch of those 500 items. 

Testing is still heavily in progress. 

# TESTING
We have the following testing scenarios that we need to test
**Note that for testing below, you can't use just any random C# nodes on the network, only C# nodes running this PR code counts. Contant me on slack for IP address if you don't have such a node.**

**General**
```
[x] Unit tests (apro | AppVeyor)
[x] Integration tests (apro)
```

**Stratis Testnet network**
```
[x] Try to sync StratisX from a single C# node from scratch. (apro-qt-both staking | demon-daemon)
[x] Try to sync StratisX from multiple C# nodes from scratch. (apro-qt-both staking | demon-daemon)
[x] Try to keep synced StratisX node in sync with network when it is connected only to a single C# node. (apro, qt, both staking)
[x] Try to keep synced StratisX node in sync with network when it is connected to multiple C# nodes. (apro-qt-both staking | demon-daemon)
[x] Try to sync C# node from a single StratisX node from scratch. (apro-staking)
[x] Try to sync C# node from a single C# node from scratch. (apro-both staking | noescape)
```

**Stratis Mainnet network**
```
[x] Try to sync StratisX from a single C# node from scratch. (demon-daemon)
[x] Try to sync StratisX from multiple C# nodes from scratch. (demon-daemon)
[x] Try to keep synced StratisX node in sync with network when it is connected only to a single C# node. (demon-daemon)
[x] Try to keep synced StratisX node in sync with network when it is connected to multiple C# nodes. (demon-daemon)
```

**Bitcoin Testnet or Mainnet**
```
[x] Try to sync C# node on Bitcoin mainnet or testnet. (apro - all good except for #999 but that seems completely unrelated)
```

Fix #986

  