### PR TITLE
Move failing NBitcoin RPC client tests into integration tests

### DIFF
--- a/src/NBitcoin.Tests/RPCClientTests.cs
+++ b/src/NBitcoin.Tests/RPCClientTests.cs
@@ -357,28 +357,6 @@ namespace NBitcoin.Tests
             }
         }
 
-#if !PORTABLE
-        [Fact]
-        public void CanGetPeersInfo()
-        {
-                    /*
-         * TODO: Consider importing to FN.
-
-            using(var builder = NodeBuilder.Create())
-            {
-                var nodeA = builder.CreateNode();
-                builder.StartAll();
-                var rpc = nodeA.CreateRPCClient();
-                using(var node = nodeA.CreateNodeClient())
-                {
-                    node.VersionHandshake();
-                    var peers = rpc.GetPeersInfo();
-                    Assert.NotEmpty(peers);
-                }
-            }
-            */
-    }
-#endif
 #if !NOSOCKET
         [Fact]
         [Trait("UnitTest", "UnitTest")]

--- a/src/NBitcoin.Tests/RPCClientTests.cs
+++ b/src/NBitcoin.Tests/RPCClientTests.cs
@@ -8,7 +8,6 @@ using System.Threading.Tasks;
 using NBitcoin.RPC;
 using Newtonsoft.Json.Linq;
 using Xunit;
-using Xunit.Sdk;
 
 namespace NBitcoin.Tests
 {
@@ -69,36 +68,6 @@ namespace NBitcoin.Tests
         }
 
         [Fact]
-        public void CanGetRawMemPool()
-        {
-            using(var builder = NodeBuilder.Create())
-            {
-                var node = builder.CreateNode(true);
-                var rpc = node.CreateRPCClient();
-                builder.StartAll();
-                node.Generate(101);
-                var txid = rpc.SendToAddress(new Key().PubKey.GetAddress(rpc.Network), Money.Coins(1.0m), "hello", "world");
-                var ids = rpc.GetRawMempool();
-                Assert.Single(ids);
-                Assert.Equal(txid, ids[0]);
-            }
-        }
-
-        [Fact]
-        public void CanUseAsyncRPC()
-        {
-            using(var builder = NodeBuilder.Create())
-            {
-                var node = builder.CreateNode();
-                var rpc = node.CreateRPCClient();
-                builder.StartAll();
-                node.Generate(10);
-                var blkCount = rpc.GetBlockCountAsync().Result;
-                Assert.Equal(10, blkCount);
-            }
-        }
-
-        [Fact]
         public void CanSignRawTransaction()
         {
             using(var builder = NodeBuilder.Create())
@@ -132,21 +101,6 @@ namespace NBitcoin.Tests
         }
 
         [Fact]
-        public void EstimateFeeRate()
-        {
-            using(var builder = NodeBuilder.Create())
-            {
-                var node = builder.CreateNode();
-                node.Start();
-                node.Generate(101);
-                var rpc = node.CreateRPCClient();
-                Assert.Throws<NoEstimationException>(() => rpc.EstimateFeeRate(1));
-                Assert.Equal(Money.Coins(50m), rpc.GetBalance(1, false));
-                Assert.Equal(Money.Coins(50m), rpc.GetBalance());
-            }
-        }
-
-        [Fact]
         public void TryEstimateFeeRate()
         {
             using(var builder = NodeBuilder.Create())
@@ -160,49 +114,6 @@ namespace NBitcoin.Tests
         }
 
         [Fact]
-        public void TestFundRawTransaction()
-        {
-            using(var builder = NodeBuilder.Create())
-            {
-                var node = builder.CreateNode();
-                node.Start();
-                node.Generate(101);
-
-                var k = new Key();
-                var tx = new Transaction();
-                tx.Outputs.Add(new TxOut(Money.Coins(1), k));
-                var rpc = node.CreateRPCClient();
-                var result = rpc.FundRawTransaction(tx);
-                TestFundRawTransactionResult(tx, result);
-
-                result = rpc.FundRawTransaction(tx, new FundRawTransactionOptions());
-                TestFundRawTransactionResult(tx, result);
-                var result1 = result;
-
-                var change = rpc.GetNewAddress();
-                var change2 = rpc.GetRawChangeAddress();
-                result = rpc.FundRawTransaction(tx, new FundRawTransactionOptions()
-                {
-                    FeeRate = new FeeRate(Money.Satoshis(50), 1),
-                    IncludeWatching = true,
-                    ChangeAddress = change,
-                });
-                TestFundRawTransactionResult(tx, result);
-                Assert.True(result1.Fee < result.Fee);
-                Assert.Contains(result.Transaction.Outputs, o => o.ScriptPubKey == change.ScriptPubKey);
-            }
-        }
-
-        private static void TestFundRawTransactionResult(Transaction tx, FundRawTransactionResponse result)
-        {
-            Assert.Equal(tx.Version, result.Transaction.Version);
-            Assert.True(result.Transaction.Inputs.Count > 0);
-            Assert.True(result.Transaction.Outputs.Count > 1);
-            Assert.True(result.ChangePos != -1);
-            Assert.Equal(Money.Coins(50m) - result.Transaction.Outputs.Select(txout => txout.Value).Sum(), result.Fee);
-        }
-
-        [Fact]
         public void CanGetTxOutNoneFromRPC()
         {
             using (var builder = NodeBuilder.Create())
@@ -213,44 +124,6 @@ namespace NBitcoin.Tests
                 var txid = rpc.Generate(1).Single();
                 var resultTxOut = rpc.GetTxOut(txid, 0, true);
                 Assert.Null(resultTxOut);
-            }
-        }
-
-        [Fact]
-        public void CanGetTxOutFromRPC()
-        {
-            using (var builder = NodeBuilder.Create())
-            {
-                var node = builder.CreateNode();
-                node.Start();
-                node.Generate(101);
-                var rpc = node.CreateRPCClient();
-                var unspent = rpc.ListUnspent();
-                Assert.True(unspent.Any());
-                var coin = unspent[0] ;
-                var resultTxOut = rpc.GetTxOut(coin.OutPoint.Hash, coin.OutPoint.N, true);
-                Assert.Equal((int)coin.Confirmations, resultTxOut.confirmations);
-                Assert.Equal(coin.Amount.ToDecimal(MoneyUnit.BTC), resultTxOut.value);
-                Assert.Equal(coin.Address.ToString(), resultTxOut.scriptPubKey.addresses[0]);
-            }
-        }
-
-        [Fact]
-        public async Task CanGetTxOutAsyncFromRPC()
-        {
-            using (var builder = NodeBuilder.Create())
-            {
-                var node = builder.CreateNode();
-                node.Start();
-                node.Generate(101);
-                var rpc = node.CreateRPCClient();
-                var unspent = rpc.ListUnspent();
-                Assert.True(unspent.Any());
-                var coin = unspent[0];
-                var resultTxOut = await rpc.GetTxOutAsync(coin.OutPoint.Hash, coin.OutPoint.N, true);
-                Assert.Equal((int)coin.Confirmations, resultTxOut.confirmations);
-                Assert.Equal(coin.Amount.ToDecimal(MoneyUnit.BTC), resultTxOut.value);
-                Assert.Equal(coin.Address.ToString(), resultTxOut.scriptPubKey.addresses[0]);
             }
         }
 
@@ -594,60 +467,6 @@ namespace NBitcoin.Tests
                     {
                         Assert.False(true, "Should have thrown RPC_METHOD_NOT_FOUND");
                     }
-                }
-            }
-        }
-
-        [Fact]
-        public void CanAddNodes()
-        {
-            using(var builder = NodeBuilder.Create())
-            {
-                var nodeA = builder.CreateNode();
-                var nodeB = builder.CreateNode();
-                builder.StartAll();
-                var rpc = nodeA.CreateRPCClient();
-                rpc.RemoveNode(nodeA.Endpoint);
-                rpc.AddNode(nodeB.Endpoint);
-
-                AddedNodeInfo[] info = null;
-                WaitAssert(() =>
-                {
-                    info = rpc.GetAddedNodeInfo(true);
-                    Assert.NotNull(info);
-                    Assert.NotEmpty(info);
-                });
-                //For some reason this one does not pass anymore in 0.13.1
-                //Assert.Equal(nodeB.Endpoint, info.First().Addresses.First().Address);
-                var oneInfo = rpc.GetAddedNodeInfo(true, nodeB.Endpoint);
-                Assert.NotNull(oneInfo);
-                Assert.True(oneInfo.AddedNode.ToString() == nodeB.Endpoint.ToString());
-                oneInfo = rpc.GetAddedNodeInfo(true, nodeA.Endpoint);
-                Assert.Null(oneInfo);
-                rpc.RemoveNode(nodeB.Endpoint);
-
-                WaitAssert(() =>
-                {
-                    info = rpc.GetAddedNodeInfo(true);
-                    Assert.Empty(info);
-                });
-            }
-        }
-
-        void WaitAssert(Action act)
-        {
-            int totalTry = 30;
-            while(totalTry > 0)
-            {
-                try
-                {
-                    act();
-                    return;
-                }
-                catch(AssertActualExpectedException)
-                {
-                    Thread.Sleep(100);
-                    totalTry--;
                 }
             }
         }

--- a/src/Stratis.Bitcoin.IntegrationTests/RPC/RPCTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/RPC/RPCTests.cs
@@ -1,20 +1,38 @@
 using System;
-using System.IO;
 using System.Net;
 using NBitcoin;
 using NBitcoin.Protocol;
 using NBitcoin.RPC;
 using Stratis.Bitcoin.Connection;
-using Stratis.Bitcoin.P2P.Peer;
 using Xunit;
 
 namespace Stratis.Bitcoin.IntegrationTests.RPC
 {
-    public class RpcTests : IClassFixture<RPCTestFixture>
+    /// <summary>
+    /// Stratis test fixture for RPC tests.
+    /// </summary>
+    public class RpcTestFixtureStratis : RpcTestFixtureBase
     {
-        private readonly RPCTestFixture rpcTestFixture;
+        /// <inheritdoc />
+        protected override void InitializeFixture()
+        {
+            this.Builder = NodeBuilder.Create();
+            this.Node = this.Builder.CreateStratisPowNode();
+            this.InitializeTestWallet(this.Node);
+            this.Builder.StartAll();
 
-        public RpcTests(RPCTestFixture RpcTestFixture)
+            this.RpcClient = this.Node.CreateRPCClient();
+
+            this.NetworkPeerClient = this.Node.CreateNetworkPeerClient();
+            this.NetworkPeerClient.VersionHandshakeAsync().GetAwaiter().GetResult();
+        }
+    }
+
+    public class RpcTests : IClassFixture<RpcTestFixtureStratis>
+    {
+        private readonly RpcTestFixtureStratis rpcTestFixture;
+
+        public RpcTests(RpcTestFixtureStratis RpcTestFixture)
         {
             this.rpcTestFixture = RpcTestFixture;
         }
@@ -162,45 +180,6 @@ namespace Stratis.Bitcoin.IntegrationTests.RPC
         {
             string resp = this.rpcTestFixture.RpcClient.SendCommand("generate", "1").ResultString;
             Assert.StartsWith("[" + Environment.NewLine + "  \"", resp);
-        }
-    }
-
-    public class RPCTestFixture : IDisposable
-    {
-        private readonly NodeBuilder builder;
-        public readonly CoreNode Node;
-        public readonly RPCClient RpcClient;
-        public readonly NetworkPeer NetworkPeerClient;
-
-        public RPCTestFixture()
-        {
-            this.builder = NodeBuilder.Create();
-            this.Node = this.builder.CreateStratisPowNode();
-            this.InitializeTestWallet(this.Node);
-            this.builder.StartAll();
-
-            this.RpcClient = this.Node.CreateRPCClient();
-
-            this.NetworkPeerClient = this.Node.CreateNetworkPeerClient();
-            this.NetworkPeerClient.VersionHandshakeAsync().GetAwaiter().GetResult();
-        }
-
-        // note: do not call this dispose in the class itself xunit will handle it.
-        public void Dispose()
-        {
-            this.builder.Dispose();
-            this.NetworkPeerClient.Dispose();
-        }
-
-        /// <summary>
-        /// Copies the test wallet into data folder for node if it isnt' already present.
-        /// </summary>
-        /// <param name="node">Core node for the test.</param>
-        private void InitializeTestWallet(CoreNode node)
-        {
-            string testWalletPath = Path.Combine(node.DataFolder, "test.wallet.json");
-            if (!File.Exists(testWalletPath))
-                File.Copy("Data/test.wallet.json", testWalletPath);
         }
     }
 }

--- a/src/Stratis.Bitcoin.IntegrationTests/RPC/RpcBitcoinImmutableTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/RPC/RpcBitcoinImmutableTests.cs
@@ -88,6 +88,16 @@ namespace Stratis.Bitcoin.IntegrationTests.RPC
         }
 
         /// <summary>
+        /// <seealso cref="https://github.com/MetacoSA/NBitcoin/blob/master/NBitcoin.Tests/RPCClientTests.cs">NBitcoin test CanGetPeersInfo</seealso>
+        /// </summary>
+        [Fact]
+        public void GetPeersInfoWithValidPeersThenReturnsPeerInfo()
+        {
+            PeerInfo[] peers = this.rpcTestFixture.RpcClient.GetPeersInfo();
+            Assert.NotEmpty(peers);
+        }
+
+        /// <summary>
         /// <seealso cref="https://github.com/MetacoSA/NBitcoin/blob/master/NBitcoin.Tests/RPCClientTests.cs">NBitcoin test EstimateFeeRate</seealso>
         /// </summary>
         [Fact]

--- a/src/Stratis.Bitcoin.IntegrationTests/RPC/RpcBitcoinImmutableTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/RPC/RpcBitcoinImmutableTests.cs
@@ -1,0 +1,141 @@
+﻿using System.Linq;
+using NBitcoin;
+using NBitcoin.RPC;
+using Xunit;
+
+namespace Stratis.Bitcoin.IntegrationTests.RPC
+{
+    /// <summary>
+    /// Bitcoin test fixture for RPC tests.
+    /// </summary>
+    public class RpcTestFixtureBitcoin : RpcTestFixtureBase
+    {
+        /// <inheritdoc />
+        protected override void InitializeFixture()
+        {
+            this.Builder = NodeBuilder.Create();
+            this.Node = this.Builder.CreateNode();
+            this.InitializeTestWallet(this.Node);
+            this.Builder.StartAll();
+
+            this.RpcClient = this.Node.CreateRPCClient();
+
+            this.NetworkPeerClient = this.Node.CreateNetworkPeerClient();
+            this.NetworkPeerClient.VersionHandshakeAsync().GetAwaiter().GetResult();
+
+            // generate 101 blocks
+            this.Node.GenerateAsync(101).GetAwaiter().GetResult();
+        }
+    }
+
+    /// <summary>
+    /// These tests share a test fixture that creates a 101 block chain of transactions to be queried via RPC.
+    /// This transaction chain should not be modified by the tests as the tests here assume the state of the
+    /// chain is immutable.
+    /// Tests that require modifying the transactions should be done in <see cref="RpcBitcoinMutableTests"/>
+    /// and set up the chain in each test.
+    /// </summary>
+    public class RpcBitcoinImmutableTests : IClassFixture<RpcTestFixtureBitcoin>
+    {
+        private readonly RpcTestFixtureBitcoin rpcTestFixture;
+
+        public RpcBitcoinImmutableTests(RpcTestFixtureBitcoin RpcTestFixture)
+        {
+            this.rpcTestFixture = RpcTestFixture;
+        }
+
+        /// <summary>
+        /// <seealso cref="https://github.com/MetacoSA/NBitcoin/blob/master/NBitcoin.Tests/RPCClientTests.cs">NBitcoin test CanGetTxOutFromRPC</seealso>
+        /// </summary>
+        [Fact]
+        public void GetTxOutWithValidTxThenReturnsCorrectUnspentTx()
+        {
+            RPCClient rpc = this.rpcTestFixture.RpcClient;
+            UnspentCoin[] unspent = rpc.ListUnspent();
+            Assert.True(unspent.Any());
+            UnspentCoin coin = unspent[0];
+            UnspentTransaction resultTxOut = rpc.GetTxOut(coin.OutPoint.Hash, coin.OutPoint.N, true);
+            Assert.Equal((int)coin.Confirmations, resultTxOut.confirmations);
+            Assert.Equal(coin.Amount.ToDecimal(MoneyUnit.BTC), resultTxOut.value);
+            Assert.Equal(coin.Address.ToString(), resultTxOut.scriptPubKey.addresses[0]);
+        }
+
+        /// <summary>
+        /// <seealso cref="https://github.com/MetacoSA/NBitcoin/blob/master/NBitcoin.Tests/RPCClientTests.cs">NBitcoin test CanGetTxOutAsyncFromRPC</seealso>
+        /// </summary>
+        [Fact]
+        public async void GetTxOutAsyncWithValidTxThenReturnsCorrectUnspentTxAsync()
+        {
+            RPCClient rpc = this.rpcTestFixture.RpcClient;
+            UnspentCoin[] unspent = rpc.ListUnspent();
+            Assert.True(unspent.Any());
+            UnspentCoin coin = unspent[0];
+            UnspentTransaction resultTxOut = await rpc.GetTxOutAsync(coin.OutPoint.Hash, coin.OutPoint.N, true);
+            Assert.Equal((int)coin.Confirmations, resultTxOut.confirmations);
+            Assert.Equal(coin.Amount.ToDecimal(MoneyUnit.BTC), resultTxOut.value);
+            Assert.Equal(coin.Address.ToString(), resultTxOut.scriptPubKey.addresses[0]);
+        }
+
+        /// <summary>
+        /// <seealso cref="https://github.com/MetacoSA/NBitcoin/blob/master/NBitcoin.Tests/RPCClientTests.cs">NBitcoin test CanUseAsyncRPC</seealso>
+        /// </summary>
+        [Fact]
+        public void GetBlockCountAsyncWithValidChainReturnsCorrectCount()
+        {
+            RPCClient rpc = this.rpcTestFixture.RpcClient;
+            int blkCount = rpc.GetBlockCountAsync().Result;
+            Assert.Equal(101, blkCount);
+        }
+
+        /// <summary>
+        /// <seealso cref="https://github.com/MetacoSA/NBitcoin/blob/master/NBitcoin.Tests/RPCClientTests.cs">NBitcoin test EstimateFeeRate</seealso>
+        /// </summary>
+        [Fact]
+        public void EstimateFeeRateReturnsCorrectValues()
+        {
+            RPCClient rpc = this.rpcTestFixture.RpcClient;
+            Assert.Throws<NoEstimationException>(() => rpc.EstimateFeeRate(1));
+            Assert.Equal(Money.Coins(50m), rpc.GetBalance(1, false));
+            Assert.Equal(Money.Coins(50m), rpc.GetBalance());
+        }
+
+        /// <summary>
+        /// <seealso cref="https://github.com/MetacoSA/NBitcoin/blob/master/NBitcoin.Tests/RPCClientTests.cs">NBitcoin test TestFundRawTransaction</seealso>
+        /// </summary>
+        [Fact]
+        public void FundRawTransactionWithValidTxsThenReturnsCorrectResponse()
+        {
+            var k = new Key();
+            var tx = new Transaction();
+            tx.Outputs.Add(new TxOut(Money.Coins(1), k));
+            RPCClient rpc = this.rpcTestFixture.RpcClient;
+            FundRawTransactionResponse result = rpc.FundRawTransaction(tx);
+            TestFundRawTransactionResult(tx, result);
+
+            result = rpc.FundRawTransaction(tx, new FundRawTransactionOptions());
+            TestFundRawTransactionResult(tx, result);
+            FundRawTransactionResponse result1 = result;
+
+            BitcoinAddress change = rpc.GetNewAddress();
+            BitcoinAddress change2 = rpc.GetRawChangeAddress();
+            result = rpc.FundRawTransaction(tx, new FundRawTransactionOptions()
+            {
+                FeeRate = new FeeRate(Money.Satoshis(50), 1),
+                IncludeWatching = true,
+                ChangeAddress = change,
+            });
+            TestFundRawTransactionResult(tx, result);
+            Assert.True(result1.Fee < result.Fee);
+            Assert.Contains(result.Transaction.Outputs, o => o.ScriptPubKey == change.ScriptPubKey);
+        }
+
+        private static void TestFundRawTransactionResult(Transaction tx, FundRawTransactionResponse result)
+        {
+            Assert.Equal(tx.Version, result.Transaction.Version);
+            Assert.True(result.Transaction.Inputs.Count > 0);
+            Assert.True(result.Transaction.Outputs.Count > 1);
+            Assert.True(result.ChangePos != -1);
+            Assert.Equal(Money.Coins(50m) - result.Transaction.Outputs.Select(txout => txout.Value).Sum(), result.Fee);
+        }
+    }
+}

--- a/src/Stratis.Bitcoin.IntegrationTests/RPC/RpcBitcoinMutableTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/RPC/RpcBitcoinMutableTests.cs
@@ -1,9 +1,6 @@
-﻿using System;
-using System.Threading;
-using NBitcoin;
+﻿using NBitcoin;
 using NBitcoin.RPC;
 using Xunit;
-using Xunit.Sdk;
 
 namespace Stratis.Bitcoin.IntegrationTests.RPC
 {
@@ -52,12 +49,14 @@ namespace Stratis.Bitcoin.IntegrationTests.RPC
                 rpc.AddNode(nodeB.Endpoint);
 
                 AddedNodeInfo[] info = null;
-                WaitAssert(() =>
+                TestHelper.WaitLoop(() =>
                 {
                     info = rpc.GetAddedNodeInfo(true);
-                    Assert.NotNull(info);
-                    Assert.NotEmpty(info);
+                    return info != null && info.Length > 0;
                 });
+                Assert.NotNull(info);
+                Assert.NotEmpty(info);
+
                 //For some reason this one does not pass anymore in 0.13.1
                 //Assert.Equal(nodeB.Endpoint, info.First().Addresses.First().Address);
                 AddedNodeInfo oneInfo = rpc.GetAddedNodeInfo(true, nodeB.Endpoint);
@@ -67,29 +66,13 @@ namespace Stratis.Bitcoin.IntegrationTests.RPC
                 Assert.Null(oneInfo);
                 rpc.RemoveNode(nodeB.Endpoint);
 
-                WaitAssert(() =>
+                TestHelper.WaitLoop(() =>
                 {
                     info = rpc.GetAddedNodeInfo(true);
-                    Assert.Empty(info);
+                    return info.Length == 0;
                 });
-            }
-        }
 
-        private void WaitAssert(Action act)
-        {
-            int totalTry = 50;
-            while (totalTry > 0)
-            {
-                try
-                {
-                    act();
-                    return;
-                }
-                catch (AssertActualExpectedException)
-                {
-                    Thread.Sleep(200);
-                    totalTry--;
-                }
+                Assert.Empty(info);
             }
         }
     }

--- a/src/Stratis.Bitcoin.IntegrationTests/RPC/RpcBitcoinMutableTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/RPC/RpcBitcoinMutableTests.cs
@@ -1,0 +1,92 @@
+﻿using System;
+using System.Threading;
+using NBitcoin;
+using NBitcoin.RPC;
+using Xunit;
+using Xunit.Sdk;
+
+namespace Stratis.Bitcoin.IntegrationTests.RPC
+{
+    /// <summary>
+    /// These tests are for RPC tests that require modifying the chain/nodes. 
+    /// Setup of the chain or nodes can be done in each test.
+    /// </summary>
+    public class RpcBitcoinMutableTests
+    {
+        /// <summary>
+        /// <seealso cref="https://github.com/MetacoSA/NBitcoin/blob/master/NBitcoin.Tests/RPCClientTests.cs">NBitcoin test CanGetRawMemPool</seealso>
+        /// </summary>
+        [Fact]
+        public void GetRawMemPoolWithValidTxThenReturnsSameTx()
+        {
+            NodeBuilder builder = NodeBuilder.Create();
+            CoreNode node = builder.CreateNode();
+            builder.StartAll();
+
+            RPCClient rpcClient = node.CreateRPCClient();
+
+            // generate 101 blocks
+            node.GenerateAsync(101).GetAwaiter().GetResult();
+
+            uint256 txid = rpcClient.SendToAddress(new Key().PubKey.GetAddress(rpcClient.Network), Money.Coins(1.0m), "hello", "world");
+            uint256[] ids = rpcClient.GetRawMempool();
+            Assert.Single(ids);
+            Assert.Equal(txid, ids[0]);
+        }
+
+        /// <summary>
+        /// <seealso cref="https://github.com/MetacoSA/NBitcoin/blob/master/NBitcoin.Tests/RPCClientTests.cs">NBitcoin test CanAddNodes</seealso>
+        /// </summary>
+        [Fact]
+        public void AddNodeWithValidNodeThenExecutesSuccessfully()
+        {
+            NodeBuilder builder = NodeBuilder.Create();
+            CoreNode nodeA = builder.CreateNode();
+            CoreNode nodeB = builder.CreateNode();
+            builder.StartAll();
+            RPCClient rpc = nodeA.CreateRPCClient();
+            rpc.RemoveNode(nodeA.Endpoint);
+            rpc.AddNode(nodeB.Endpoint);
+
+            AddedNodeInfo[] info = null;
+            WaitAssert(() =>
+            {
+                info = rpc.GetAddedNodeInfo(true);
+                Assert.NotNull(info);
+                Assert.NotEmpty(info);
+            });
+            //For some reason this one does not pass anymore in 0.13.1
+            //Assert.Equal(nodeB.Endpoint, info.First().Addresses.First().Address);
+            AddedNodeInfo oneInfo = rpc.GetAddedNodeInfo(true, nodeB.Endpoint);
+            Assert.NotNull(oneInfo);
+            Assert.Equal(nodeB.Endpoint.ToString(), oneInfo.AddedNode.ToString());
+            oneInfo = rpc.GetAddedNodeInfo(true, nodeA.Endpoint);
+            Assert.Null(oneInfo);
+            rpc.RemoveNode(nodeB.Endpoint);
+
+            WaitAssert(() =>
+            {
+                info = rpc.GetAddedNodeInfo(true);
+                Assert.Empty(info);
+            });
+        }
+
+        private void WaitAssert(Action act)
+        {
+            int totalTry = 30;
+            while (totalTry > 0)
+            {
+                try
+                {
+                    act();
+                    return;
+                }
+                catch (AssertActualExpectedException)
+                {
+                    Thread.Sleep(100);
+                    totalTry--;
+                }
+            }
+        }
+    }
+}

--- a/src/Stratis.Bitcoin.IntegrationTests/RPC/RpcTestFixtureBase.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/RPC/RpcTestFixtureBase.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.IO;
+using NBitcoin.RPC;
+using Stratis.Bitcoin.P2P.Peer;
+
+namespace Stratis.Bitcoin.IntegrationTests.RPC
+{
+    /// <summary>
+    /// Abstract base class for RPC Test Fixtures for both Bitcoin and Stratis networks.
+    /// </summary>
+    public abstract class RpcTestFixtureBase : IDisposable
+    {
+        /// <summary>Node builder for the test fixture.</summary>
+        protected NodeBuilder Builder { get; set; }
+
+        /// <summary>The node for the test fixture.</summary>
+        public CoreNode Node { get; protected set; }
+
+        /// <summary>The RPC client for the test fixture.</summary>
+        public RPCClient RpcClient { get; protected set; }
+
+        /// <summary>The network peer client for the test fixture.</summary>
+        public NetworkPeer NetworkPeerClient { get; protected set; }
+
+        /// <summary>
+        /// Constructs the test fixture by calling initialize which should initialize the properties of the fixture.
+        /// </summary>
+        public RpcTestFixtureBase()
+        {
+            this.InitializeFixture();
+        }
+
+        /// <summary>
+        /// Initializes the test fixtures properties as approriate for the network.
+        /// </summary>
+        protected abstract void InitializeFixture();
+
+        /// <summary>
+        /// Disposes of the test fixtures resources.
+        /// Note: do not call this dispose in the class itself xunit will handle it. 
+        /// </summary>
+        public void Dispose()
+        {
+            this.Builder.Dispose();
+            this.NetworkPeerClient.Dispose();
+        }
+
+        /// <summary>
+        /// Copies the test wallet into data folder for node if it isnt' already present.
+        /// </summary>
+        /// <param name="node">Core node for the test.</param>
+        protected void InitializeTestWallet(CoreNode node)
+        {
+            string testWalletPath = Path.Combine(node.DataFolder, "test.wallet.json");
+            if (!File.Exists(testWalletPath))
+                File.Copy("Data/test.wallet.json", testWalletPath);
+        }
+    }
+}


### PR DESCRIPTION
There are several nbitcoin RPC client tests that are currently failing due to the peer refactoring. This PR moves those tests into integration test project so they can now use the new peer.

See #868 

Status of integration/nbitcoin tests for this PR can be seen here https://ci.appveyor.com/project/mikedennis/stratisci/branch/mikedennis

This PR also generalizes the RPCTestFixture class so it can be used for both Bitcoin and Stratis networks. The Bitcoin RPC tests are divided between tests that can can make use of the testfixture and others that require their own setup for each individual test.