### PR TITLE
Stratis mining test

### DIFF
--- a/src/Stratis.Bitcoin.Features.Consensus/PosConsensusValidator.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/PosConsensusValidator.cs
@@ -505,7 +505,7 @@ namespace Stratis.Bitcoin.Features.Consensus
             if (this.IsPremine(height))
                 return this.consensusOptions.PremineReward;
 
-            return this.ConsensusOptions.ProofOfWorkReward;
+            return this.consensusOptions.ProofOfWorkReward;
         }
 
         /// <summary>

--- a/src/Stratis.Bitcoin.Features.Miner/PosBlockAssembler.cs
+++ b/src/Stratis.Bitcoin.Features.Miner/PosBlockAssembler.cs
@@ -41,11 +41,15 @@ namespace Stratis.Bitcoin.Features.Miner
 
             base.CreateNewBlock(scriptPubKeyIn, fMineWitnessTx);
 
-            this.coinbase.Outputs[0].ScriptPubKey = new Script();
-            this.coinbase.Outputs[0].Value = Money.Zero;
-
             PosConsensusValidator posValidator = this.consensusLoop.Validator as PosConsensusValidator;
             Guard.NotNull(posValidator, nameof(posValidator));
+
+            // Without this the coinbase transaction has a zero value
+            this.coinbase.Outputs[0].Value = this.fees + posValidator.GetProofOfWorkReward(this.height);
+            this.pblocktemplate.TotalFee = this.fees;
+
+            this.UpdateHeaders();
+            this.TestBlockValidity();
 
             this.logger.LogTrace("(-)");
             return this.pblocktemplate;

--- a/src/Stratis.Bitcoin.IntegrationTests/StratisMinerTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/StratisMinerTests.cs
@@ -36,10 +36,11 @@ namespace Stratis.Bitcoin.IntegrationTests
 
                 node1.NotInIBD();
 
-                // Create the originating node's wallet
+                // Create the generating node's wallet
                 var wm1 = node1.FullNode.NodeService<IWalletManager>() as WalletManager;
                 wm1.CreateWallet("Source1", "source");
 
+                // Get the miner secret by obtaining the private key of one of the source node's addresses
                 var wallet1 = wm1.GetWalletByName("source");
                 var account1 = wallet1.GetAccountsByCoinType((CoinType)node1.FullNode.Network.Consensus.CoinType).First();
                 var address1 = account1.GetFirstUnusedReceivingAddress();
@@ -48,9 +49,10 @@ namespace Stratis.Bitcoin.IntegrationTests
                 // We can use SetDummyMinerSecret here because the private key is already in the wallet
                 node1.SetDummyMinerSecret(new BitcoinSecret(secret1.PrivateKey, node1.FullNode.Network));
 
-                // Generate a block so we have some funds to create a transaction with
+                // Generate a block so we receive some coins
                 node1.GenerateStratisWithMiner(1);
 
+                // The generated coins should immediately appear in the wallet with 1 confirmation
                 Assert.True(account1.GetSpendableAmount().ConfirmedAmount > 0);
 
                 node1.Kill();

--- a/src/Stratis.Bitcoin.IntegrationTests/StratisMinerTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/StratisMinerTests.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using NBitcoin;
+using Stratis.Bitcoin.Features.BlockStore;
+using Stratis.Bitcoin.Features.Consensus;
+using Stratis.Bitcoin.Features.MemoryPool;
+using Stratis.Bitcoin.Features.Miner;
+using Stratis.Bitcoin.Features.Notifications;
+using Stratis.Bitcoin.Features.RPC;
+using Stratis.Bitcoin.Features.Wallet;
+using Stratis.Bitcoin.Features.Wallet.Interfaces;
+using Stratis.Bitcoin.Features.WatchOnlyWallet;
+using Xunit;
+
+namespace Stratis.Bitcoin.IntegrationTests
+{
+    public class StratisMinerTests
+    {
+        [Fact]
+        public void CanMineStratisCoins()
+        {
+            using (NodeBuilder builder = NodeBuilder.Create())
+            {
+                CoreNode node1 = builder.CreateStratisPosNode(true, fullNodeBuilder =>
+                {
+                    fullNodeBuilder
+                        .UseStratisConsensus()
+                        .UseBlockStore()
+                        .UseMempool()
+                        .UseWallet()
+                        .AddPowPosMining()
+                        .AddRPC();
+                });
+
+                node1.NotInIBD();
+
+                // Create the originating node's wallet
+                var wm1 = node1.FullNode.NodeService<IWalletManager>() as WalletManager;
+                wm1.CreateWallet("Source1", "source");
+
+                var wallet1 = wm1.GetWalletByName("source");
+                var account1 = wallet1.GetAccountsByCoinType((CoinType)node1.FullNode.Network.Consensus.CoinType).First();
+                var address1 = account1.GetFirstUnusedReceivingAddress();
+                var secret1 = wallet1.GetExtendedPrivateKeyForAddress("Source1", address1);
+
+                // We can use SetDummyMinerSecret here because the private key is already in the wallet
+                node1.SetDummyMinerSecret(new BitcoinSecret(secret1.PrivateKey, node1.FullNode.Network));
+
+                // Generate a block so we have some funds to create a transaction with
+                node1.GenerateStratisWithMiner(1);
+
+                Assert.True(account1.GetSpendableAmount().ConfirmedAmount > 0);
+
+                node1.Kill();
+            }
+        }
+    }
+}


### PR DESCRIPTION
There do not seem to be tests that specifically test the creation of coins in the PoW phase on StratisRegTest. As a result there are some apparent bugs or gaps in this functionality, particularly for usage in integration tests.

It is intended that this initial test be fleshed out into multiple tests that validate the functionality of coins mined on StratisRegTest end-to-end (i.e. generated coins can be used for transactions, the resulting transactions pass validation on a secondary node, the test framework's block generation correctly transitions from PoW to PoS at the right block height, etc.)