### PR TITLE
IBD provider: moved test only method from interface to test-only environment mock up

### DIFF
--- a/src/Stratis.Bitcoin.Features.Consensus/InitialBlockDownloadState.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/InitialBlockDownloadState.cs
@@ -15,11 +15,11 @@ namespace Stratis.Bitcoin.Features.Consensus
     /// <seealso cref="IInitialBlockDownloadState" />
     public class InitialBlockDownloadState : IInitialBlockDownloadState
     {
+        /// <summary>A provider of the date and time.</summary>
+        protected readonly IDateTimeProvider dateTimeProvider;
+
         /// <summary>Provider of block header hash checkpoints.</summary>
         private readonly ICheckpoints checkpoints;
-
-        /// <summary>A provider of the date and time.</summary>
-        private readonly IDateTimeProvider dateTimeProvider;
 
         /// <summary>Information about node's chain.</summary>
         private readonly ChainState chainState;
@@ -29,12 +29,6 @@ namespace Stratis.Bitcoin.Features.Consensus
 
         /// <summary>User defined node settings.</summary>
         private readonly NodeSettings nodeSettings;
-
-        /// <summary>Time until IBD state can be checked.</summary>
-        private DateTime lockIbdUntil;
-
-        /// <summary>A cached result of the IBD method.</summary>
-        private bool ibdCached;
 
         /// <summary>
         /// Creates a new instance of the <see cref="InitialBlockDownloadState" /> class.
@@ -50,16 +44,11 @@ namespace Stratis.Bitcoin.Features.Consensus
             this.chainState = chainState;
             this.checkpoints = checkpoints;
             this.dateTimeProvider = DateTimeProvider.Default;
-
-            this.lockIbdUntil = DateTime.MinValue;
         }
 
         /// <inheritdoc />
-        public bool IsInitialBlockDownload()
+        public virtual bool IsInitialBlockDownload()
         {
-            if (this.lockIbdUntil >= this.dateTimeProvider.GetUtcNow())
-                return this.ibdCached;
-
             if (this.chainState == null)
                 return false;
 
@@ -76,13 +65,6 @@ namespace Stratis.Bitcoin.Features.Consensus
                 return true;
 
             return false;
-        }
-
-        /// <inheritdoc />
-        public void SetIsInitialBlockDownload(bool blockDownloadState, DateTime lockStateUntil)
-        {
-            this.lockIbdUntil = lockStateUntil;
-            this.ibdCached = blockDownloadState;
         }
     }
 }

--- a/src/Stratis.Bitcoin.Features.Consensus/InitialBlockDownloadState.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/InitialBlockDownloadState.cs
@@ -47,7 +47,7 @@ namespace Stratis.Bitcoin.Features.Consensus
         }
 
         /// <inheritdoc />
-        public virtual bool IsInitialBlockDownload()
+        public bool IsInitialBlockDownload()
         {
             if (this.chainState == null)
                 return false;

--- a/src/Stratis.Bitcoin.IntegrationTests/EnvironmentMockUpHelpers/CoreNode.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/EnvironmentMockUpHelpers/CoreNode.cs
@@ -29,6 +29,7 @@ using Stratis.Bitcoin.Features.Miner.Interfaces;
 using Stratis.Bitcoin.Features.RPC;
 using Stratis.Bitcoin.Features.Wallet;
 using Stratis.Bitcoin.Features.Wallet.Interfaces;
+using Stratis.Bitcoin.IntegrationTests.EnvironmentMockUpHelpers;
 using Stratis.Bitcoin.Interfaces;
 using Stratis.Bitcoin.P2P.Peer;
 using Stratis.Bitcoin.P2P.Protocol.Payloads;
@@ -125,7 +126,7 @@ namespace Stratis.Bitcoin.IntegrationTests
         public void NotInIBD()
         {
             // not in IBD
-            this.FullNode.NodeService<IInitialBlockDownloadState>().SetIsInitialBlockDownload(false, DateTime.UtcNow.AddMinutes(5));
+            (this.FullNode.NodeService<IInitialBlockDownloadState>() as MockedInitialBlockDownloadState).SetIsInitialBlockDownload(false, DateTime.UtcNow.AddMinutes(5));
         }
 
         public void Start()

--- a/src/Stratis.Bitcoin.IntegrationTests/EnvironmentMockUpHelpers/CoreNode.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/EnvironmentMockUpHelpers/CoreNode.cs
@@ -126,7 +126,7 @@ namespace Stratis.Bitcoin.IntegrationTests
         public void NotInIBD()
         {
             // not in IBD
-            (this.FullNode.NodeService<IInitialBlockDownloadState>() as MockedInitialBlockDownloadState).SetIsInitialBlockDownload(false, DateTime.UtcNow.AddMinutes(5));
+            (this.FullNode.NodeService<IInitialBlockDownloadState>() as InitialBlockDownloadStateMock).SetIsInitialBlockDownload(false, DateTime.UtcNow.AddMinutes(5));
         }
 
         public void Start()

--- a/src/Stratis.Bitcoin.IntegrationTests/EnvironmentMockUpHelpers/InitialBlockDownloadStateMock.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/EnvironmentMockUpHelpers/InitialBlockDownloadStateMock.cs
@@ -6,7 +6,7 @@ using Stratis.Bitcoin.Features.Consensus;
 
 namespace Stratis.Bitcoin.IntegrationTests.EnvironmentMockUpHelpers
 {
-    public class MockedInitialBlockDownloadState : InitialBlockDownloadState
+    public class InitialBlockDownloadStateMock : InitialBlockDownloadState
     {
         /// <summary>Time until IBD state can be checked.</summary>
         private DateTime lockIbdUntil;
@@ -14,7 +14,7 @@ namespace Stratis.Bitcoin.IntegrationTests.EnvironmentMockUpHelpers
         /// <summary>A cached result of the IBD method.</summary>
         private bool ibdCached;
 
-        public MockedInitialBlockDownloadState(ChainState chainState, Network network, NodeSettings nodeSettings,
+        public InitialBlockDownloadStateMock(ChainState chainState, Network network, NodeSettings nodeSettings,
             ICheckpoints checkpoints) : base (chainState, network, nodeSettings, checkpoints)
         {
             this.lockIbdUntil = DateTime.MinValue;

--- a/src/Stratis.Bitcoin.IntegrationTests/EnvironmentMockUpHelpers/InitialBlockDownloadStateMock.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/EnvironmentMockUpHelpers/InitialBlockDownloadStateMock.cs
@@ -12,7 +12,7 @@ namespace Stratis.Bitcoin.IntegrationTests.EnvironmentMockUpHelpers
         private DateTime lockIbdUntil;
 
         /// <summary>A cached result of the IBD method.</summary>
-        private bool ibdCached;
+        private bool blockDownloadState;
 
         public InitialBlockDownloadStateMock(ChainState chainState, Network network, NodeSettings nodeSettings,
             ICheckpoints checkpoints) : base (chainState, network, nodeSettings, checkpoints)
@@ -23,7 +23,7 @@ namespace Stratis.Bitcoin.IntegrationTests.EnvironmentMockUpHelpers
         public override bool IsInitialBlockDownload()
         {
             if (this.lockIbdUntil >= this.dateTimeProvider.GetUtcNow())
-                return this.ibdCached;
+                return this.blockDownloadState;
 
             return base.IsInitialBlockDownload();
         }
@@ -37,7 +37,7 @@ namespace Stratis.Bitcoin.IntegrationTests.EnvironmentMockUpHelpers
         public void SetIsInitialBlockDownload(bool blockDownloadState, DateTime lockStateUntil)
         {
             this.lockIbdUntil = lockStateUntil;
-            this.ibdCached = blockDownloadState;
+            this.blockDownloadState = blockDownloadState;
         }
     }
 }

--- a/src/Stratis.Bitcoin.IntegrationTests/EnvironmentMockUpHelpers/InitialBlockDownloadStateMock.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/EnvironmentMockUpHelpers/InitialBlockDownloadStateMock.cs
@@ -40,13 +40,12 @@ namespace Stratis.Bitcoin.IntegrationTests.EnvironmentMockUpHelpers
 
         /// <summary>
         /// Sets last IBD status update time and result.
-        /// <para>Used in tests only.</para>
         /// </summary>
         /// <param name="blockDownloadState">New value for the IBD status, <c>true</c> means the node is considered in IBD.</param>
-        /// <param name="lockStateUntil">Time until IBD state won't be changed.</param>
-        public void SetIsInitialBlockDownload(bool blockDownloadState, DateTime lockStateUntil)
+        /// <param name="lockIbdUntil">Time until IBD state won't be changed.</param>
+        public void SetIsInitialBlockDownload(bool blockDownloadState, DateTime lockIbdUntil)
         {
-            this.lockIbdUntil = lockStateUntil;
+            this.lockIbdUntil = lockIbdUntil;
             this.blockDownloadState = blockDownloadState;
         }
     }

--- a/src/Stratis.Bitcoin.IntegrationTests/EnvironmentMockUpHelpers/MockedInitialBlockDownloadState.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/EnvironmentMockUpHelpers/MockedInitialBlockDownloadState.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using NBitcoin;
+using Stratis.Bitcoin.Base;
+using Stratis.Bitcoin.Configuration;
+using Stratis.Bitcoin.Features.Consensus;
+
+namespace Stratis.Bitcoin.IntegrationTests.EnvironmentMockUpHelpers
+{
+    public class MockedInitialBlockDownloadState : InitialBlockDownloadState
+    {
+        /// <summary>Time until IBD state can be checked.</summary>
+        private DateTime lockIbdUntil;
+
+        /// <summary>A cached result of the IBD method.</summary>
+        private bool ibdCached;
+
+        public MockedInitialBlockDownloadState(ChainState chainState, Network network, NodeSettings nodeSettings,
+            ICheckpoints checkpoints) : base (chainState, network, nodeSettings, checkpoints)
+        {
+            this.lockIbdUntil = DateTime.MinValue;
+        }
+
+        public override bool IsInitialBlockDownload()
+        {
+            if (this.lockIbdUntil >= this.dateTimeProvider.GetUtcNow())
+                return this.ibdCached;
+
+            return base.IsInitialBlockDownload();
+        }
+
+        /// <summary>
+        /// Sets last IBD status update time and result.
+        /// <para>Used in tests only.</para>
+        /// </summary>
+        /// <param name="blockDownloadState">New value for the IBD status, <c>true</c> means the node is considered in IBD.</param>
+        /// <param name="lockStateUntil">Time until IBD state won't be changed.</param>
+        public void SetIsInitialBlockDownload(bool blockDownloadState, DateTime lockStateUntil)
+        {
+            this.lockIbdUntil = lockStateUntil;
+            this.ibdCached = blockDownloadState;
+        }
+    }
+}

--- a/src/Stratis.Bitcoin.IntegrationTests/EnvironmentMockUpHelpers/NodeRunners.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/EnvironmentMockUpHelpers/NodeRunners.cs
@@ -272,7 +272,7 @@ namespace Stratis.Bitcoin.IntegrationTests
                         if (ibdService != null)
                         {
                             services.Remove(ibdService);
-                            services.AddSingleton<IInitialBlockDownloadState, MockedInitialBlockDownloadState>();
+                            services.AddSingleton<IInitialBlockDownloadState, InitialBlockDownloadStateMock>();
                         }
                     });
                 }

--- a/src/Stratis.Bitcoin.IntegrationTests/EnvironmentMockUpHelpers/NodeRunners.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/EnvironmentMockUpHelpers/NodeRunners.cs
@@ -1,8 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
-using System.Text;
+using System.Linq;
 using NBitcoin;
 using NBitcoin.Protocol;
 using Stratis.Bitcoin.Builder;
@@ -14,6 +13,10 @@ using Stratis.Bitcoin.Features.Miner;
 using Stratis.Bitcoin.Features.RPC;
 using Stratis.Bitcoin.Features.Wallet;
 using Stratis.Bitcoin.Utilities;
+using Microsoft.Extensions.DependencyInjection;
+using Stratis.Bitcoin.Builder.Feature;
+using Stratis.Bitcoin.IntegrationTests.EnvironmentMockUpHelpers;
+using Stratis.Bitcoin.Interfaces;
 
 namespace Stratis.Bitcoin.IntegrationTests
 {
@@ -103,6 +106,7 @@ namespace Stratis.Bitcoin.IntegrationTests
                     .UseWallet()
                     .AddPowPosMining()
                     .AddRPC()
+                    .MockIBD()
                     .Build();
             }
 
@@ -181,6 +185,7 @@ namespace Stratis.Bitcoin.IntegrationTests
                 .UseWallet()
                 .AddPowPosMining()
                 .AddRPC()
+                .MockIBD()
                 .Build();
 
             return fullNode;
@@ -241,6 +246,7 @@ namespace Stratis.Bitcoin.IntegrationTests
                     .AddMining()
                     .UseWallet()
                     .AddRPC()
+                    .MockIBD()
                     .Build();
             }
 
@@ -248,5 +254,28 @@ namespace Stratis.Bitcoin.IntegrationTests
         }
 
         public FullNode FullNode;
+    }
+
+    public static class FullNodeTestBuilderExtension
+    {
+        public static IFullNodeBuilder MockIBD(this IFullNodeBuilder fullNodeBuilder)
+        {
+            fullNodeBuilder.ConfigureFeature(features =>
+            {
+                foreach (IFeatureRegistration feature in features.FeatureRegistrations)
+                {
+                    feature.FeatureServices(services =>
+                    {
+                        // Get default IBD implementation and replace it with the mock.
+                        ServiceDescriptor ibdService = services.FirstOrDefault(x => x.ServiceType == typeof(IInitialBlockDownloadState));
+                        services.Remove(ibdService);
+
+                        services.AddSingleton<IInitialBlockDownloadState, MockedInitialBlockDownloadState>();
+                    });
+                }
+            });
+
+            return fullNodeBuilder;
+        }
     }
 }

--- a/src/Stratis.Bitcoin.IntegrationTests/EnvironmentMockUpHelpers/NodeRunners.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/EnvironmentMockUpHelpers/NodeRunners.cs
@@ -268,9 +268,12 @@ namespace Stratis.Bitcoin.IntegrationTests
                     {
                         // Get default IBD implementation and replace it with the mock.
                         ServiceDescriptor ibdService = services.FirstOrDefault(x => x.ServiceType == typeof(IInitialBlockDownloadState));
-                        services.Remove(ibdService);
 
-                        services.AddSingleton<IInitialBlockDownloadState, MockedInitialBlockDownloadState>();
+                        if (ibdService != null)
+                        {
+                            services.Remove(ibdService);
+                            services.AddSingleton<IInitialBlockDownloadState, MockedInitialBlockDownloadState>();
+                        }
                     });
                 }
             });

--- a/src/Stratis.Bitcoin.IntegrationTests/MemoryPoolTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/MemoryPoolTests.cs
@@ -857,11 +857,10 @@ namespace Stratis.Bitcoin.IntegrationTests
                 var stratisNode1 = builder.CreateStratisPowNode();
                 var stratisNode2 = builder.CreateStratisPowNode();
                 builder.StartAll();
-
-                // not in IBD
-                stratisNodeSync.FullNode.InitialBlockDownloadState.SetIsInitialBlockDownload(false, DateTime.UtcNow.AddMinutes(5));
-                stratisNode1.FullNode.InitialBlockDownloadState.SetIsInitialBlockDownload(false, DateTime.UtcNow.AddMinutes(5));
-                stratisNode2.FullNode.InitialBlockDownloadState.SetIsInitialBlockDownload(false, DateTime.UtcNow.AddMinutes(5));
+                
+                stratisNodeSync.NotInIBD();
+                stratisNode1.NotInIBD();
+                stratisNode2.NotInIBD();
 
                 // generate blocks and wait for the downloader to pickup
                 stratisNodeSync.SetDummyMinerSecret(new BitcoinSecret(new Key(), stratisNodeSync.FullNode.Network));

--- a/src/Stratis.Bitcoin.IntegrationTests/NodeSyncTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/NodeSyncTests.cs
@@ -54,8 +54,7 @@ namespace Stratis.Bitcoin.IntegrationTests
                 var coreNode = builder.CreateNode();
                 builder.StartAll();
 
-                // not in IBD
-                stratisNode.FullNode.InitialBlockDownloadState.SetIsInitialBlockDownload(false, DateTime.UtcNow.AddMinutes(5));
+                stratisNode.NotInIBD();
 
                 var tip = coreNode.FindBlock(10).Last();
                 stratisNode.CreateRPCClient().AddNode(coreNode.Endpoint, true);
@@ -83,9 +82,8 @@ namespace Stratis.Bitcoin.IntegrationTests
                 var coreCreateNode = builder.CreateNode();
                 builder.StartAll();
 
-                // not in IBD
-                stratisNode.FullNode.InitialBlockDownloadState.SetIsInitialBlockDownload(false, DateTime.UtcNow.AddMinutes(5));
-                stratisNodeSync.FullNode.InitialBlockDownloadState.SetIsInitialBlockDownload(false, DateTime.UtcNow.AddMinutes(5));
+                stratisNode.NotInIBD();
+                stratisNodeSync.NotInIBD();
 
                 // first seed a core node with blocks and sync them to a stratis node
                 // and wait till the stratis node is fully synced
@@ -116,8 +114,7 @@ namespace Stratis.Bitcoin.IntegrationTests
                 var coreCreateNode = builder.CreateNode();
                 builder.StartAll();
 
-                // not in IBD
-                stratisNode.FullNode.InitialBlockDownloadState.SetIsInitialBlockDownload(false, DateTime.UtcNow.AddMinutes(5));
+                stratisNode.NotInIBD();
 
                 // first seed a core node with blocks and sync them to a stratis node
                 // and wait till the stratis node is fully synced

--- a/src/Stratis.Bitcoin/Interfaces/IInitialBlockDownloadState.cs
+++ b/src/Stratis.Bitcoin/Interfaces/IInitialBlockDownloadState.cs
@@ -14,13 +14,5 @@ namespace Stratis.Bitcoin.Interfaces
         /// </summary>
         /// <returns><c>true</c> if the node is currently doing IBD, <c>false</c> otherwise.</returns>
         bool IsInitialBlockDownload();
-
-        /// <summary>
-        /// Sets last IBD status update time and result.
-        /// <para>Used in tests only.</para>
-        /// </summary>
-        /// <param name="blockDownloadState">New value for the IBD status, <c>true</c> means the node is considered in IBD.</param>
-        /// <param name="lockStateUntil">Time until IBD state won't be changed.</param>
-        void SetIsInitialBlockDownload(bool blockDownloadState, DateTime lockStateUntil);
     }
 }


### PR DESCRIPTION
This PR removes test-only method 'SetIsInitialBlockDownload' from the non-test codebase. 
Test implementation of 'IInitialBlockDownloadState' is added for the test environment by replacing the default service with a mock at the node build stage. 