### PR TITLE
Feature/async queue dequeue

### DIFF
--- a/src/Stratis.Bitcoin.Tests/Utilities/AsyncQueueTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Utilities/AsyncQueueTest.cs
@@ -397,5 +397,21 @@ namespace Stratis.Bitcoin.Tests.Utilities
             }
         }
 
+        /// <summary>
+        /// Tests that <see cref="AsyncQueue{T}.DequeueAsync(CancellationToken)"/> throws 
+        /// exception when it is called on a queue operating in callback mode.
+        /// </summary>
+        [Fact]
+        public void AsyncQueue_DequeueThrowsInCallbackMode()
+        {
+            var asyncQueue = new AsyncQueue<int>((item, cancellation) =>
+            {
+                return Task.CompletedTask;
+            });
+
+            // Enqueue an item, which should trigger the callback.
+            Assert.ThrowsAsync< InvalidOperationException>(async () => await asyncQueue.DequeueAsync());
+        }
+
     }
 }

--- a/src/Stratis.Bitcoin/Utilities/AsyncQueue.cs
+++ b/src/Stratis.Bitcoin/Utilities/AsyncQueue.cs
@@ -47,7 +47,7 @@ namespace Stratis.Bitcoin.Utilities
         private readonly CancellationTokenSource cancellationTokenSource;
 
         /// <summary>Number of pending dequeue operations which need to be finished before the queue can fully dispose.</summary>
-        private int unfinishedDequeueCount;
+        private volatile int unfinishedDequeueCount;
 
         /// <summary><c>true</c> if <see cref="Dispose"/> was called, <c>false</c> otherwise.</summary>
         private bool disposed;

--- a/src/Stratis.Bitcoin/Utilities/AsyncQueue.cs
+++ b/src/Stratis.Bitcoin/Utilities/AsyncQueue.cs
@@ -53,7 +53,7 @@ namespace Stratis.Bitcoin.Utilities
         private bool disposed;
 
         /// <summary><c>true</c> if the queue operates in callback mode, <c>false</c> if it operates in blocking dequeue mode.</summary>
-        private bool callbackMode;
+        private readonly bool callbackMode;
 
         /// <summary>
         /// Initializes the queue either in blocking dequeue mode or in callback mode.
@@ -126,7 +126,7 @@ namespace Stratis.Bitcoin.Utilities
         public async Task<T> DequeueAsync(CancellationToken cancellation = default(CancellationToken))
         {
             if (this.callbackMode)
-                throw new InvalidOperationException();
+                throw new InvalidOperationException($"{nameof(DequeueAsync)} called on queue in callback mode.");
 
             // Increment the counter so that the queue's cancellation source is not disposed when we are using it.
             Interlocked.Increment(ref this.unfinishedDequeueCount);

--- a/src/Stratis.Bitcoin/Utilities/AsyncQueue.cs
+++ b/src/Stratis.Bitcoin/Utilities/AsyncQueue.cs
@@ -1,15 +1,18 @@
 ﻿using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
 namespace Stratis.Bitcoin.Utilities
 {
     /// <summary>
-    /// Async queue is a simple thread-safe queue that asynchronously executes 
-    /// a user-defined callback when a new item is added to the queue.
+    /// Async queue is a thread-safe queue that can operate in callback mode or blocking dequeue mode.
+    /// In callback mode it asynchronously executes a user-defined callback when a new item is added to the queue.
+    /// In blocking dequeue mode, <see cref="DequeueAsync(CancellationToken)"/> is used to wait for and dequeue 
+    /// an item from the queue once it becomes available.
     /// <para>
-    /// The queue guarantees that the user-defined callback is executed only once at the time. 
+    /// In callback mode, the queue guarantees that the user-defined callback is executed only once at the time. 
     /// If another item is added to the queue, the callback is called again after the current execution 
     /// is finished.
     /// </para>
@@ -24,8 +27,12 @@ namespace Stratis.Bitcoin.Utilities
         /// <param name="cancellationToken">Cancellation token that the callback method should use for its async operations to avoid blocking the queue during shutdown.</param>
         public delegate Task OnEnqueueAsync(T item, CancellationToken cancellationToken);
 
+        /// <summary>Lock object to protect access to <see cref="items"/>.</summary>
+        private readonly object lockObject;
+
         /// <summary>Storage of items in the queue that are waiting to be consumed.</summary>
-        private readonly ConcurrentQueue<T> items;
+        /// <remarks>All access to this object has to be protected by <see cref="lockObject"/>.</remarks>
+        private readonly Queue<T> items;
 
         /// <summary>Event that is triggered when at least one new item is waiting in the queue.</summary>
         private readonly AsyncManualResetEvent signal;
@@ -39,19 +46,24 @@ namespace Stratis.Bitcoin.Utilities
         /// <summary>Cancellation that is triggered when the component is disposed.</summary>
         private readonly CancellationTokenSource cancellationTokenSource;
 
-        /// <summary>
-        /// Initializes the queue.
-        /// </summary>
-        /// <param name="onEnqueueAsync">Callback routine to be called when a new item is added to the queue.</param>
-        public AsyncQueue(OnEnqueueAsync onEnqueueAsync)
-        {
-            Guard.NotNull(onEnqueueAsync, nameof(onEnqueueAsync));
+        /// <summary>Number of pending dequeue operations which need to be finished before the queue can fully dispose.</summary>
+        private int unfinishedDequeueCount;
 
-            this.items = new ConcurrentQueue<T>();
+        /// <summary><c>true</c> if <see cref="Dispose"/> was called, <c>false</c> otherwise.</summary>
+        private bool disposed;
+
+        /// <summary>
+        /// Initializes the queue either in blocking dequeue mode or in callback mode.
+        /// </summary>
+        /// <param name="onEnqueueAsync">Callback routine to be called when a new item is added to the queue, or <c>null</c> to operate in blocking dequeue mode.</param>
+        public AsyncQueue(OnEnqueueAsync onEnqueueAsync = null)
+        {
+            this.lockObject = new object();
+            this.items = new Queue<T>();
             this.signal = new AsyncManualResetEvent();
             this.onEnqueueAsync = onEnqueueAsync;
             this.cancellationTokenSource = new CancellationTokenSource();
-            this.consumerTask = ConsumerAsync();
+            this.consumerTask = this.onEnqueueAsync != null ? this.ConsumerAsync() : null;
         }
 
         /// <summary>
@@ -60,13 +72,19 @@ namespace Stratis.Bitcoin.Utilities
         /// <param name="item">Item to be added to the queue.</param>
         public void Enqueue(T item)
         {
-            this.items.Enqueue(item);
-            this.signal.Set();
+            lock (this.lockObject)
+            {
+                this.items.Enqueue(item);
+                this.signal.Set();
+            }
         }
 
         /// <summary>
         /// Consumer of the newly added items to the queue that waits for the signal 
         /// and then executes the user-defined callback.
+        /// <para>
+        /// This consumer loop is only used when the queue is operating in the callback mode.
+        /// </para>
         /// </summary>
         private async Task ConsumerAsync()
         {
@@ -81,7 +99,7 @@ namespace Stratis.Bitcoin.Utilities
 
                     // Dequeue all items and execute the callback.
                     T item;
-                    while (this.items.TryDequeue(out item) && !cancellationToken.IsCancellationRequested)
+                    while (this.TryDequeue(out item) && !cancellationToken.IsCancellationRequested)
                     {
                         await this.onEnqueueAsync(item, cancellationToken).ConfigureAwait(false);
                     }
@@ -93,11 +111,93 @@ namespace Stratis.Bitcoin.Utilities
             }
         }
 
+        /// <summary>
+        /// Dequeues an item from the queue if there is one. 
+        /// If the queue is empty, the method waits until an item is available.
+        /// </summary>
+        /// <param name="cancellation">Cancellation token that allows aborting the wait if the queue is empty.</param>
+        /// <returns>Dequeued item from the queue.</returns>
+        /// <exception cref="OperationCanceledException">Thrown when the cancellation token is triggered or when the queue is disposed.</exception>
+        public async Task<T> DequeueAsync(CancellationToken cancellation = default(CancellationToken))
+        {
+            // Increment the counter so that the queue's cancellation source is not disposed when we are using it.
+            Interlocked.Increment(ref this.unfinishedDequeueCount);
+
+            try
+            {
+                if (this.disposed)
+                    throw new OperationCanceledException();
+
+                // First check if an item is available. If it is, just return it.
+                T item;
+                if (this.TryDequeue(out item))
+                    return item;
+
+                // If the queue is empty, we need to wait until there is an item available.
+                using (var cancellationSource = CancellationTokenSource.CreateLinkedTokenSource(cancellation, this.cancellationTokenSource.Token))
+                {
+                    while (true)
+                    {
+                        await this.signal.WaitAsync(cancellationSource.Token).ConfigureAwait(false);
+
+                        // Note that another thread could consume the message before us, 
+                        // so dequeue safely and loop if nothing is available.
+                        lock (this.lockObject)
+                        {
+                            if (this.items.Count > 0)
+                            {
+                                item = this.items.Dequeue();
+
+                                if (this.items.Count == 0)
+                                    this.signal.Reset();
+
+                                return item;
+                            }
+                        }
+                    }
+                }
+            }
+            finally
+            {
+                Interlocked.Decrement(ref this.unfinishedDequeueCount);
+            }
+        }
+
+        /// <summary>
+        /// Dequeues an item from the queue if there is any.
+        /// </summary>
+        /// <param name="item">If the function succeeds, this is filled with the dequeued item.</param>
+        /// <returns><c>true</c> if an item was dequeued, <c>false</c> if the queue was empty.</returns>
+        private bool TryDequeue(out T item)
+        {
+            item = default(T);
+            lock (this.lockObject)
+            {
+                if (this.items.Count > 0)
+                {
+                    item = this.items.Dequeue();
+                    return true;
+                }
+
+                return false;
+            }
+        }
+
         /// <inheritdoc/>
         public void Dispose()
         {
+            // We do not need synchronization over this, if it is going to be missed
+            // we just wait a little longer.
+            this.disposed = true;
+
             this.cancellationTokenSource.Cancel();
-            this.consumerTask.Wait();
+            this.consumerTask?.Wait();
+
+            // We have to wait until all pending dequeue operations are finished.
+            // This should be very fast, so we can wait actively.
+            while (this.unfinishedDequeueCount > 0)
+                Thread.Sleep(10);
+
             this.cancellationTokenSource.Dispose();
         }
     }


### PR DESCRIPTION
This PR enriches our current AsyncQueue to support blocking dequeue operation (but asynchronous!), which will allow us to use it instead of BlockingCollection, which is used in PollMessageListener, which is used by NetworkPeerListener, which I'm interested to fix (convert to full async) as a part of the node refactoring job.

The blocking dequeue is little more complex and not trivial, therefore I needed to introduce a lock into async queue, so I got rid of concurrent queue to avoid double locking.

Tests are included.