### PR TITLE
Fix: slow node shutdown if many -connect or -addNode options were specified

### DIFF
--- a/src/Stratis.Bitcoin/P2P/PeerConnector.cs
+++ b/src/Stratis.Bitcoin/P2P/PeerConnector.cs
@@ -220,8 +220,11 @@ namespace Stratis.Bitcoin.P2P
             }
             catch (OperationCanceledException timeout)
             {
-                this.logger.LogDebug("Peer {0} connection timeout.", peerAddress.NetworkAddress.Endpoint);
-                peer?.DisconnectWithException("Timeout", timeout);
+                this.logger.LogDebug(this.nodeLifetime.ApplicationStopping.IsCancellationRequested? "Peer {0} connection canceled because application is stopping." :
+                    "Peer {0} connection timeout.", peerAddress.NetworkAddress.Endpoint);
+
+                peer?.DisconnectWithException(this.nodeLifetime.ApplicationStopping.IsCancellationRequested ? "Application stopping"
+                    : "Timeout", timeout);
             }
             catch (Exception exception)
             {

--- a/src/Stratis.Bitcoin/P2P/PeerConnector.cs
+++ b/src/Stratis.Bitcoin/P2P/PeerConnector.cs
@@ -220,11 +220,16 @@ namespace Stratis.Bitcoin.P2P
             }
             catch (OperationCanceledException timeout)
             {
-                this.logger.LogDebug(this.nodeLifetime.ApplicationStopping.IsCancellationRequested? "Peer {0} connection canceled because application is stopping." :
-                    "Peer {0} connection timeout.", peerAddress.NetworkAddress.Endpoint);
-
-                peer?.DisconnectWithException(this.nodeLifetime.ApplicationStopping.IsCancellationRequested ? "Application stopping"
-                    : "Timeout", timeout);
+                if (this.nodeLifetime.ApplicationStopping.IsCancellationRequested)
+                {
+                    this.logger.LogDebug("Peer {0} connection canceled because application is stopping.", peerAddress.NetworkAddress.Endpoint);
+                    peer?.DisconnectWithException("Application stopping");
+                }
+                else
+                {
+                    this.logger.LogDebug("Peer {0} connection timeout.", peerAddress.NetworkAddress.Endpoint);
+                    peer?.DisconnectWithException("Timeout", timeout);
+                }
             }
             catch (Exception exception)
             {

--- a/src/Stratis.Bitcoin/P2P/PeerConnectorAddNode.cs
+++ b/src/Stratis.Bitcoin/P2P/PeerConnectorAddNode.cs
@@ -61,6 +61,9 @@ namespace Stratis.Bitcoin.P2P
         {
             foreach (var ipEndpoint in this.NodeSettings.ConnectionManager.AddNode)
             {
+                if (this.nodeLifetime.ApplicationStopping.IsCancellationRequested)
+                    return;
+
                 PeerAddress peerAddress = this.peerAddressManager.FindPeer(ipEndpoint);
                 if (peerAddress != null && !this.IsPeerConnected(peerAddress.NetworkAddress.Endpoint))
                     await ConnectAsync(peerAddress).ConfigureAwait(false);

--- a/src/Stratis.Bitcoin/P2P/PeerConnectorConnect.cs
+++ b/src/Stratis.Bitcoin/P2P/PeerConnectorConnect.cs
@@ -63,6 +63,9 @@ namespace Stratis.Bitcoin.P2P
         {
             foreach (var ipEndpoint in this.NodeSettings.ConnectionManager.Connect)
             {
+                if (this.nodeLifetime.ApplicationStopping.IsCancellationRequested)
+                    return;
+
                 PeerAddress peerAddress = this.peerAddressManager.FindPeer(ipEndpoint);
                 if (peerAddress != null && !this.IsPeerConnected(peerAddress.NetworkAddress.Endpoint))
                     await ConnectAsync(peerAddress).ConfigureAwait(false);


### PR DESCRIPTION
Also improved some logging and peer disconnection reason (it was treated as timeout no matter what cancellation token was used- application stopping or linked one that is cancelled after 5 sec)

Fix: #1031 