### PR TITLE
MaximumNodeConnections : rename and config

### DIFF
--- a/src/Stratis.Bitcoin.Tests/P2P/PeerConnectorTests.cs
+++ b/src/Stratis.Bitcoin.Tests/P2P/PeerConnectorTests.cs
@@ -166,6 +166,8 @@ namespace Stratis.Bitcoin.Tests.P2P
             {
                 ConnectionManager = new Configuration.Settings.ConnectionManagerSettings()
             };
+            nodeSettings.LoadArguments(new string[] { });
+
             nodeSettings.ConnectionManager.AddNode.Add(networkAddressAddNode.Endpoint);
             nodeSettings.ConnectionManager.Connect.Add(networkAddressConnectNode.Endpoint);
             var connector = this.CreatePeerConnectorDiscovery(nodeSettings, peerAddressManager);
@@ -186,6 +188,7 @@ namespace Stratis.Bitcoin.Tests.P2P
             {
                 ConnectionManager = new Configuration.Settings.ConnectionManagerSettings()
             };
+            nodeSettings.LoadArguments(new string[] { });
 
             var connector = this.CreatePeerConnectorDiscovery(nodeSettings, peerAddressManager);
             Assert.True(connector.CanStartConnect);
@@ -198,6 +201,7 @@ namespace Stratis.Bitcoin.Tests.P2P
             {
                 ConnectionManager = new Configuration.Settings.ConnectionManagerSettings()
             };
+            nodeSettings.LoadArguments(new string[] { });
 
             var ipAddressThree = IPAddress.Parse("::ffff:192.168.0.3");
             var networkAddressConnectNode = new NetworkAddress(ipAddressThree, 80);

--- a/src/Stratis.Bitcoin/Connection/ConnectionManager.cs
+++ b/src/Stratis.Bitcoin/Connection/ConnectionManager.cs
@@ -381,7 +381,7 @@ namespace Stratis.Bitcoin.Connection
             if (!this.NodeSettings.ConnectionManager.AddNode.Any(p => p.Match(ipEndpoint)))
             {
                 this.NodeSettings.ConnectionManager.AddNode.Add(ipEndpoint);
-                this.PeerConnectors.FirstOrDefault(pc => pc is PeerConnectorAddNode).MaximumNodeConnections++;
+                this.PeerConnectors.FirstOrDefault(pc => pc is PeerConnectorAddNode).MaxOutboundConnections++;
             }
             else
                 this.logger.LogTrace("The endpoint already exists in the add node collection.");

--- a/src/Stratis.Bitcoin/Connection/DropNodesBehaviour.cs
+++ b/src/Stratis.Bitcoin/Connection/DropNodesBehaviour.cs
@@ -57,7 +57,7 @@ namespace Stratis.Bitcoin.Connection
                     peerConnector = this.connection.PeerConnectors.First(pc => pc is PeerConnectorDiscovery);
 
                 // Find how much 20% max nodes.
-                decimal thresholdCount = Math.Round(peerConnector.MaximumNodeConnections * this.dropThreshold, MidpointRounding.ToEven);
+                decimal thresholdCount = Math.Round(peerConnector.MaxOutboundConnections * this.dropThreshold, MidpointRounding.ToEven);
 
                 if (thresholdCount < this.connection.ConnectedNodes.Count())
                     if (version.StartHeight < this.chain.Height)

--- a/src/Stratis.Bitcoin/P2P/PeerConnector.cs
+++ b/src/Stratis.Bitcoin/P2P/PeerConnector.cs
@@ -22,7 +22,7 @@ namespace Stratis.Bitcoin.P2P
         void Initialize(IConnectionManager connectionManager);
 
         /// <summary>The maximum amount of peers the node can connect to (defaults to 8).</summary>
-        int MaximumNodeConnections { get; set; }
+        int MaxOutboundConnections { get; set; }
 
         /// <summary>Specification of requirements the <see cref="PeerConnector"/> has when connecting to other peers.</summary>
         NetworkPeerRequirement Requirements { get; }
@@ -46,7 +46,7 @@ namespace Stratis.Bitcoin.P2P
         /// <summary>
         /// Starts an asynchronous loop that connects to peers in one second intervals.
         /// <para>
-        /// If the maximum amount of connections has been reached (<see cref="MaximumNodeConnections"/>), the action gets skipped.
+        /// If the maximum amount of connections has been reached (<see cref="MaxOutboundConnections"/>), the action gets skipped.
         /// </para>
         /// </summary>
         void StartConnectAsync();
@@ -84,7 +84,7 @@ namespace Stratis.Bitcoin.P2P
         private readonly ILogger logger;
 
         /// <inheritdoc/>
-        public int MaximumNodeConnections { get; set; }
+        public int MaxOutboundConnections { get; set; }
 
         /// <summary>Global application life cycle control - triggers when application shuts down.</summary>
         protected INodeLifetime nodeLifetime;
@@ -188,7 +188,7 @@ namespace Stratis.Bitcoin.P2P
                 if (!this.peerAddressManager.Peers.Any())
                     return;
 
-                if (this.ConnectedPeers.Count >= this.MaximumNodeConnections)
+                if (this.ConnectedPeers.Count >= this.MaxOutboundConnections)
                     return;
 
                 await this.OnConnectAsync().ConfigureAwait(false);

--- a/src/Stratis.Bitcoin/P2P/PeerConnectorAddNode.cs
+++ b/src/Stratis.Bitcoin/P2P/PeerConnectorAddNode.cs
@@ -34,7 +34,7 @@ namespace Stratis.Bitcoin.P2P
         /// <inheritdoc/>
         public override void OnInitialize()
         {
-            this.MaximumNodeConnections = this.NodeSettings.ConnectionManager.AddNode.Count;
+            this.MaxOutboundConnections = this.NodeSettings.ConnectionManager.AddNode.Count;
 
             foreach (var ipEndpoint in this.NodeSettings.ConnectionManager.AddNode)
             {

--- a/src/Stratis.Bitcoin/P2P/PeerConnectorConnect.cs
+++ b/src/Stratis.Bitcoin/P2P/PeerConnectorConnect.cs
@@ -35,7 +35,7 @@ namespace Stratis.Bitcoin.P2P
         /// <inheritdoc/>
         public override void OnInitialize()
         {
-            this.MaximumNodeConnections = this.NodeSettings.ConnectionManager.Connect.Count;
+            this.MaxOutboundConnections = this.NodeSettings.ConnectionManager.Connect.Count;
 
             // Add the endpoints from the -connect arg to the address manager
             foreach (var ipEndpoint in this.NodeSettings.ConnectionManager.Connect)

--- a/src/Stratis.Bitcoin/P2P/PeerConnectorDiscovery.cs
+++ b/src/Stratis.Bitcoin/P2P/PeerConnectorDiscovery.cs
@@ -40,7 +40,7 @@ namespace Stratis.Bitcoin.P2P
         /// <inheritdoc/>
         public override void OnInitialize()
         {
-            this.MaximumNodeConnections = 8;
+            this.MaxOutboundConnections = 8;
         }
 
         /// <summary>This connector is only started if there are NO peers in the -connect args.</summary>

--- a/src/Stratis.Bitcoin/P2P/PeerConnectorDiscovery.cs
+++ b/src/Stratis.Bitcoin/P2P/PeerConnectorDiscovery.cs
@@ -40,6 +40,7 @@ namespace Stratis.Bitcoin.P2P
         /// <inheritdoc/>
         public override void OnInitialize()
         {
+            // TODO: make sure that this is moved to a new config implementation when it's ready.
             this.MaxOutboundConnections = this.NodeSettings.ConfigReader.GetOrDefault("maxOutboundConnections", 8);
         }
 

--- a/src/Stratis.Bitcoin/P2P/PeerConnectorDiscovery.cs
+++ b/src/Stratis.Bitcoin/P2P/PeerConnectorDiscovery.cs
@@ -40,7 +40,7 @@ namespace Stratis.Bitcoin.P2P
         /// <inheritdoc/>
         public override void OnInitialize()
         {
-            this.MaxOutboundConnections = 8;
+            this.MaxOutboundConnections = this.NodeSettings.ConfigReader.GetOrDefault("maxOutboundConnections", 8);
         }
 
         /// <summary>This connector is only started if there are NO peers in the -connect args.</summary>
@@ -97,7 +97,7 @@ namespace Stratis.Bitcoin.P2P
                     continue;
                 }
 
-                // If the peer exists in the -addnode collection don't 
+                // If the peer exists in the -addnode collection don't
                 // try and connect to it.
                 var peerExistsInAddNode = this.NodeSettings.ConnectionManager.AddNode.Any(p => p.MapToIpv6().Match(peer.NetworkAddress.Endpoint));
                 if (peerExistsInAddNode)
@@ -107,7 +107,7 @@ namespace Stratis.Bitcoin.P2P
                     continue;
                 }
 
-                // If the peer exists in the -connect collection don't 
+                // If the peer exists in the -connect collection don't
                 // try and connect to it.
                 var peerExistsInConnectNode = this.NodeSettings.ConnectionManager.Connect.Any(p => p.MapToIpv6().Match(peer.NetworkAddress.Endpoint));
                 if (peerExistsInConnectNode)


### PR DESCRIPTION
Renamed MaximumNodeConnections  to MaxOutboundConnections since prev name was misleading and made people assume that this value is limiting overall connections count.  

Made MaxOutboundConnections configurable.
  
Fix: #931