### PR TITLE
Getting the first node connection speedup.

### DIFF
--- a/src/Stratis.Bitcoin.Tests/Builder/FullNodeBuilderTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Builder/FullNodeBuilderTest.cs
@@ -103,6 +103,7 @@ namespace Stratis.Bitcoin.Tests.Builder
         public void BuildWithInitialServicesSetupConfiguresFullNodeUsingConfiguration()
         {
             var nodeSettings = new NodeSettings();
+            nodeSettings.LoadArguments(new string[] { });
             nodeSettings.DataDir = "TestData/FullNodeBuilder/BuildWithInitialServicesSetup";
             nodeSettings.DataFolder = new DataFolder(nodeSettings);
 

--- a/src/Stratis.Bitcoin.Tests/P2P/PeerConnectorTests.cs
+++ b/src/Stratis.Bitcoin.Tests/P2P/PeerConnectorTests.cs
@@ -72,6 +72,7 @@ namespace Stratis.Bitcoin.Tests.P2P
             {
                 ConnectionManager = new Configuration.Settings.ConnectionManagerSettings()
             };
+            nodeSettings.LoadArguments(new string[] { });
 
             var connector = this.CreatePeerConnecterAddNode(nodeSettings, peerAddressManager);
             Assert.True(connector.CanStartConnect);
@@ -100,6 +101,8 @@ namespace Stratis.Bitcoin.Tests.P2P
             {
                 ConnectionManager = new Configuration.Settings.ConnectionManagerSettings()
             };
+            nodeSettings.LoadArguments(new string[] { });
+
             nodeSettings.ConnectionManager.Connect.Add(networkAddressConnectNode.Endpoint);
             var connector = this.CreatePeerConnectorConnectNode(nodeSettings, peerAddressManager);
 
@@ -122,6 +125,7 @@ namespace Stratis.Bitcoin.Tests.P2P
             {
                 ConnectionManager = new Configuration.Settings.ConnectionManagerSettings()
             };
+            nodeSettings.LoadArguments(new string[] { });
 
             nodeSettings.ConnectionManager.Connect.Add(networkAddressConnectNode.Endpoint);
 
@@ -138,6 +142,7 @@ namespace Stratis.Bitcoin.Tests.P2P
             {
                 ConnectionManager = new Configuration.Settings.ConnectionManagerSettings()
             };
+            nodeSettings.LoadArguments(new string[] { });
 
             var connector = this.CreatePeerConnectorConnectNode(nodeSettings, peerAddressManager);
             Assert.False(connector.CanStartConnect);

--- a/src/Stratis.Bitcoin/P2P/PeerConnector.cs
+++ b/src/Stratis.Bitcoin/P2P/PeerConnector.cs
@@ -107,6 +107,12 @@ namespace Stratis.Bitcoin.P2P
         /// <inheritdoc/>
         public NetworkPeerRequirement Requirements { get; internal set; }
 
+        /// <summary>Connections number after which burst connectivity mode (connection attempts with no delay in between) will be disabled.</summary>
+        public int BurstModeTargetConnections { get; private set; }
+
+        /// <summary>Default time interval between making a connection attempt.</summary>
+        private TimeSpan DefaultConnectionAttemptInterval;
+
         /// <summary>Parameterless constructor for dependency injection.</summary>
         protected PeerConnector(
             IAsyncLoopFactory asyncLoopFactory,
@@ -129,6 +135,9 @@ namespace Stratis.Bitcoin.P2P
             this.NodeSettings = nodeSettings;
             this.peerAddressManager = peerAddressManager;
             this.Requirements = new NetworkPeerRequirement { MinVersion = this.NodeSettings.ProtocolVersion };
+
+            this.DefaultConnectionAttemptInterval = TimeSpans.Second;
+            this.BurstModeTargetConnections = this.NodeSettings.ConfigReader.GetOrDefault("burstModeTargetConnections", 1);
         }
 
         /// <inheritdoc/>
@@ -149,6 +158,9 @@ namespace Stratis.Bitcoin.P2P
             Guard.NotNull(peer, nameof(peer));
 
             this.ConnectedPeers.Add(peer);
+
+            if (this.ConnectedPeers.Count >= this.BurstModeTargetConnections)
+                this.asyncLoop.RepeatEvery = this.DefaultConnectionAttemptInterval;
         }
 
         /// <summary>Determines whether or not a connector can be started.</summary>
@@ -167,6 +179,9 @@ namespace Stratis.Bitcoin.P2P
         public void RemovePeer(NetworkPeer peer, string reason)
         {
             this.ConnectedPeers.Remove(peer, reason);
+
+            if (this.ConnectedPeers.Count < this.BurstModeTargetConnections)
+                this.asyncLoop.RepeatEvery = TimeSpan.Zero;
         }
 
         /// <summary>
@@ -197,7 +212,7 @@ namespace Stratis.Bitcoin.P2P
                 await this.OnConnectAsync().ConfigureAwait(false);
             },
             this.nodeLifetime.ApplicationStopping,
-            repeatEvery: TimeSpans.Second);
+            repeatEvery: TimeSpan.Zero);
         }
 
         /// <summary>Attempts to connect to a random peer.</summary>

--- a/src/Stratis.Bitcoin/P2P/PeerConnector.cs
+++ b/src/Stratis.Bitcoin/P2P/PeerConnector.cs
@@ -216,7 +216,7 @@ namespace Stratis.Bitcoin.P2P
                 await this.OnConnectAsync().ConfigureAwait(false);
             },
             this.nodeLifetime.ApplicationStopping,
-            repeatEvery: burstConnectionInterval);
+            repeatEvery: this.burstConnectionInterval);
         }
 
         /// <summary>Attempts to connect to a random peer.</summary>


### PR DESCRIPTION
This change removes 1 second delay between connection attempts until we are connected to at least 1 peer- after that set it back to normal.