### PR TITLE
json fields formatting

### DIFF
--- a/src/Stratis.Bitcoin.Features.Miner/Models/GetStakingInfoModel.cs
+++ b/src/Stratis.Bitcoin.Features.Miner/Models/GetStakingInfoModel.cs
@@ -21,15 +21,15 @@ namespace Stratis.Bitcoin.Features.Miner.Models
         public string Errors { get; set; }
 
         /// <summary>Size of the next block the node wants to mine in bytes.</summary>
-        [JsonProperty(PropertyName = "currentblocksize")]
+        [JsonProperty(PropertyName = "currentBlockSize")]
         public long CurrentBlockSize { get; set; }
 
         /// <summary>Number of transactions the node wants to put in the next block.</summary>
-        [JsonProperty(PropertyName = "currentblocktx")]
+        [JsonProperty(PropertyName = "currentBlockTx")]
         public long CurrentBlockTx { get; set; }
 
         /// <summary>Number of transactions in the memory pool.</summary>
-        [JsonProperty(PropertyName = "pooledtx")]
+        [JsonProperty(PropertyName = "pooledTx")]
         public long PooledTx { get; set; }
 
         /// <summary>Target difficulty that the next block must meet.</summary>
@@ -37,7 +37,7 @@ namespace Stratis.Bitcoin.Features.Miner.Models
         public double Difficulty { get; set; }
 
         /// <summary>Length of the last staking search interval in seconds.</summary>
-        [JsonProperty(PropertyName = "search-interval")]
+        [JsonProperty(PropertyName = "searchInterval")]
         public int SearchInterval { get; set; }
 
         /// <summary>Staking weight of the node.</summary>
@@ -45,11 +45,11 @@ namespace Stratis.Bitcoin.Features.Miner.Models
         public long Weight { get; set; }
 
         /// <summary>Estimation of the total staking weight of all nodes on the network.</summary>
-        [JsonProperty(PropertyName = "netstakeweight")]
+        [JsonProperty(PropertyName = "netStakeWeight")]
         public long NetStakeWeight { get; set; }
 
         /// <summary>Expected time of the node to find new block in seconds.</summary>
-        [JsonProperty(PropertyName = "expectedtime")]
+        [JsonProperty(PropertyName = "expectedTime")]
         public long ExpectedTime { get; set; }
 
         /// <inheritdoc />

--- a/src/Stratis.Bitcoin.Features.RPC.Tests/Controller/GetInfoActionTests.cs
+++ b/src/Stratis.Bitcoin.Features.RPC.Tests/Controller/GetInfoActionTests.cs
@@ -24,16 +24,16 @@ namespace Stratis.Bitcoin.Features.RPC.Tests.Controller
             uint expectedProtocolVersion = (uint)nodeSettings.ProtocolVersion;
             var expectedRelayFee = nodeSettings.MinRelayTxFeeRate.FeePerK.ToUnit(NBitcoin.MoneyUnit.BTC);
             Assert.NotNull(info);
-            Assert.Equal(0, info.blocks);
-            Assert.NotEqual<uint>(0, info.version);
-            Assert.Equal(expectedProtocolVersion, info.protocolversion);
-            Assert.Equal(0, info.timeoffset);
-            Assert.Equal(0, info.connections);
-            Assert.NotNull(info.proxy);
-            Assert.Equal(0, info.difficulty);
-            Assert.False(info.testnet);
-            Assert.Equal(expectedRelayFee, info.relayfee);
-            Assert.Empty(info.errors);
+            Assert.Equal(0, info.Blocks);
+            Assert.NotEqual<uint>(0, info.Version);
+            Assert.Equal(expectedProtocolVersion, info.ProtocolVersion);
+            Assert.Equal(0, info.TimeOffset);
+            Assert.Equal(0, info.Connections);
+            Assert.NotNull(info.Proxy);
+            Assert.Equal(0, info.Difficulty);
+            Assert.False(info.Testnet);
+            Assert.Equal(expectedRelayFee, info.RelayFee);
+            Assert.Empty(info.Errors);
         }
     }
 }

--- a/src/Stratis.Bitcoin.Features.RPC.Tests/Models/GetInfoModelTest.cs
+++ b/src/Stratis.Bitcoin.Features.RPC.Tests/Models/GetInfoModelTest.cs
@@ -45,13 +45,13 @@ namespace Stratis.Bitcoin.Features.RPC.Tests.Models
             var expectedOrderedPropertyNames = AllPropertyNames;
             var info = new GetInfoModel
             {
-                connections = 0,
-                walletversion = default(uint),
-                balance = default(decimal),
-                keypoololdest = default(long),
-                keypoolsize = default(int),
-                unlocked_until = default(uint),
-                paytxfee = default(decimal),
+                Connections = 0,
+                WalletVersion = default(uint),
+                Balance = default(decimal),
+                KeypoolOldest = default(long),
+                KeypoolSize = default(int),
+                UnlockedUntil = default(uint),
+                PayTxFee = default(decimal),
             };
 
             JObject obj = ModelToJObject(info);
@@ -124,21 +124,21 @@ namespace Stratis.Bitcoin.Features.RPC.Tests.Models
             GetInfoModel model = Newtonsoft.Json.JsonConvert.DeserializeObject<GetInfoModel>(json);
 
             Assert.Equal(expectedSortedPropertyNames, actualSortedPropertyNames);
-            Assert.Equal(1010000u, model.version);
-            Assert.Equal(70012u, model.protocolversion);
-            Assert.Equal(Money.Satoshis(2).ToUnit(MoneyUnit.BTC), model.balance);
-            Assert.Equal(460828, model.blocks);
-            Assert.Equal(0, model.timeoffset);
-            Assert.Equal(44, model.connections);
-            Assert.Empty(model.proxy);
-            Assert.Equal(499635929816.6675, model.difficulty, 3);
-            Assert.False(model.testnet);
-            Assert.Equal(1437418454, model.keypoololdest);
-            Assert.Equal(101, model.keypoolsize);
-            Assert.Equal(0u, model.unlocked_until);
-            Assert.Equal(Money.Satoshis(10000).ToUnit(MoneyUnit.BTC), model.paytxfee);
-            Assert.Equal(Money.Satoshis(1000).ToUnit(MoneyUnit.BTC), model.relayfee);
-            Assert.Equal("URGENT: Alert key compromised, upgrade required", model.errors);
+            Assert.Equal(1010000u, model.Version);
+            Assert.Equal(70012u, model.ProtocolVersion);
+            Assert.Equal(Money.Satoshis(2).ToUnit(MoneyUnit.BTC), model.Balance);
+            Assert.Equal(460828, model.Blocks);
+            Assert.Equal(0, model.TimeOffset);
+            Assert.Equal(44, model.Connections);
+            Assert.Empty(model.Proxy);
+            Assert.Equal(499635929816.6675, model.Difficulty, 3);
+            Assert.False(model.Testnet);
+            Assert.Equal(1437418454, model.KeypoolOldest);
+            Assert.Equal(101, model.KeypoolSize);
+            Assert.Equal(0u, model.UnlockedUntil);
+            Assert.Equal(Money.Satoshis(10000).ToUnit(MoneyUnit.BTC), model.PayTxFee);
+            Assert.Equal(Money.Satoshis(1000).ToUnit(MoneyUnit.BTC), model.RelayFee);
+            Assert.Equal("URGENT: Alert key compromised, upgrade required", model.Errors);
         }
     }
 }

--- a/src/Stratis.Bitcoin.Features.RPC.Tests/Models/GetStakingInfoTest.cs
+++ b/src/Stratis.Bitcoin.Features.RPC.Tests/Models/GetStakingInfoTest.cs
@@ -17,14 +17,14 @@ namespace Stratis.Bitcoin.Features.RPC.Tests.Models
             "enabled",
             "staking",
             "errors",
-            "currentblocksize",
-            "currentblocktx",
-            "pooledtx",
+            "currentBlockSize",
+            "currentBlockTx",
+            "pooledTx",
             "difficulty",
-            "search-interval",
+            "searchInterval",
             "weight",
-            "netstakeweight",
-            "expectedtime",
+            "netStakeWeight",
+            "expectedTime",
         };
 
         /// <summary>
@@ -54,14 +54,14 @@ namespace Stratis.Bitcoin.Features.RPC.Tests.Models
                 + "  \"enabled\": true,\n"
                 + "  \"staking\": true,\n"
                 + "  \"errors\": \"Block rejected by peers\",\n"
-                + "  \"currentblocksize\": 151,\n"
-                + "  \"currentblocktx\": 1,\n"
-                + "  \"pooledtx\": 120,\n"
+                + "  \"currentBlockSize\": 151,\n"
+                + "  \"currentBlockTx\": 1,\n"
+                + "  \"pooledTx\": 120,\n"
                 + "  \"difficulty\": 77856.9675875571,\n"
-                + "  \"search-interval\": 16,\n"
+                + "  \"searchInterval\": 16,\n"
                 + "  \"weight\": 98076279000000,\n"
-                + "  \"netstakeweight\": 101187415332927,\n"
-                + "  \"expectedtime\": 66\n"
+                + "  \"netStakeWeight\": 101187415332927,\n"
+                + "  \"expectedTime\": 66\n"
                 + "}\n";
 
             JObject obj = JObject.Parse(json);

--- a/src/Stratis.Bitcoin.Features.RPC/Controllers/FullNodeController.cs
+++ b/src/Stratis.Bitcoin.Features.RPC/Controllers/FullNodeController.cs
@@ -124,24 +124,24 @@ namespace Stratis.Bitcoin.Features.RPC.Controllers
         {
             var model = new GetInfoModel
             {
-                version = this.FullNode?.Version.ToUint() ?? 0,
-                protocolversion = (uint)(this.Settings?.ProtocolVersion ?? NodeSettings.SupportedProtocolVersion),
-                blocks = this.ChainState?.ConsensusTip?.Height ?? 0,
-                timeoffset = this.ConnectionManager?.ConnectedPeers?.GetMedianTimeOffset() ?? 0,
-                connections = this.ConnectionManager?.ConnectedPeers?.Count(),
-                proxy = string.Empty,
-                difficulty = this.GetNetworkDifficulty()?.Difficulty ?? 0,
-                testnet = this.Network.IsTest(),
-                relayfee = this.Settings.MinRelayTxFeeRate.FeePerK.ToUnit(MoneyUnit.BTC),
-                errors = string.Empty,
+                Version = this.FullNode?.Version.ToUint() ?? 0,
+                ProtocolVersion = (uint)(this.Settings?.ProtocolVersion ?? NodeSettings.SupportedProtocolVersion),
+                Blocks = this.ChainState?.ConsensusTip?.Height ?? 0,
+                TimeOffset = this.ConnectionManager?.ConnectedPeers?.GetMedianTimeOffset() ?? 0,
+                Connections = this.ConnectionManager?.ConnectedPeers?.Count(),
+                Proxy = string.Empty,
+                Difficulty = this.GetNetworkDifficulty()?.Difficulty ?? 0,
+                Testnet = this.Network.IsTest(),
+                RelayFee = this.Settings.MinRelayTxFeeRate.FeePerK.ToUnit(MoneyUnit.BTC),
+                Errors = string.Empty,
 
                 //TODO: Wallet related infos: walletversion, balance, keypoololdest, keypoolsize, unlocked_until, paytxfee
-                walletversion = null,
-                balance = null,
-                keypoololdest = null,
-                keypoolsize = null,
-                unlocked_until = null,
-                paytxfee = null
+                WalletVersion = null,
+                Balance = null,
+                KeypoolOldest = null,
+                KeypoolSize = null,
+                UnlockedUntil = null,
+                PayTxFee = null
             };
 
             return model;

--- a/src/Stratis.Bitcoin.Features.RPC/Models/GetInfoModel.cs
+++ b/src/Stratis.Bitcoin.Features.RPC/Models/GetInfoModel.cs
@@ -3,59 +3,55 @@ using Stratis.Bitcoin.Features.RPC.Converters;
 
 namespace Stratis.Bitcoin.Features.RPC.Models
 {
-#pragma warning disable IDE1006 // Naming Styles (ignore lowercase)
-
     public class GetInfoModel
     {
-        [JsonProperty(Order = 0)]
-        public uint version { get; set; }
+        [JsonProperty(Order = 0, PropertyName = "version")]
+        public uint Version { get; set; }
 
-        [JsonProperty(Order = 1)]
-        public uint protocolversion { get; set; }
+        [JsonProperty(Order = 1, PropertyName = "protocolversion")]
+        public uint ProtocolVersion { get; set; }
 
-        [JsonProperty(Order = 4)]
-        public int blocks { get; set; }
+        [JsonProperty(Order = 4, PropertyName = "blocks")]
+        public int Blocks { get; set; }
 
-        [JsonProperty(Order = 5)]
-        public long timeoffset { get; set; }
+        [JsonProperty(Order = 5, PropertyName = "timeoffset")]
+        public long TimeOffset { get; set; }
 
-        [JsonProperty(Order = 6, DefaultValueHandling = DefaultValueHandling.Ignore)]
-        public int? connections { get; set; }
+        [JsonProperty(Order = 6, PropertyName = "connections", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public int? Connections { get; set; }
 
-        [JsonProperty(Order = 7)]
-        public string proxy { get; set; }
+        [JsonProperty(Order = 7, PropertyName = "proxy")]
+        public string Proxy { get; set; }
 
-        [JsonProperty(Order = 8)]
-        public double difficulty { get; set; }
+        [JsonProperty(Order = 8, PropertyName = "difficulty")]
+        public double Difficulty { get; set; }
 
-        [JsonProperty(Order = 9)]
-        public bool testnet { get; set; }
+        [JsonProperty(Order = 9, PropertyName = "testnet")]
+        public bool Testnet { get; set; }
 
         [JsonConverter(typeof(BtcDecimalJsonConverter))]
-        [JsonProperty(Order = 14)]
-        public decimal relayfee { get; set; }
+        [JsonProperty(Order = 14, PropertyName = "relayfee")]
+        public decimal RelayFee { get; set; }
 
-        [JsonProperty(Order = 15)]
-        public string errors { get; set; }
+        [JsonProperty(Order = 15, PropertyName = "errors")]
+        public string Errors { get; set; }
 
-        [JsonProperty(Order = 2, DefaultValueHandling = DefaultValueHandling.Ignore)]
-        public uint? walletversion { get; set; }
+        [JsonProperty(Order = 2, PropertyName = "walletversion", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public uint? WalletVersion { get; set; }
 
-        [JsonProperty(Order = 3, DefaultValueHandling = DefaultValueHandling.Ignore)]
-        public decimal? balance { get; set; }
+        [JsonProperty(Order = 3, PropertyName = "balance", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public decimal? Balance { get; set; }
 
-        [JsonProperty(Order = 10, DefaultValueHandling = DefaultValueHandling.Ignore)]
-        public long? keypoololdest { get; set; }
+        [JsonProperty(Order = 10, PropertyName = "keypoololdest", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public long? KeypoolOldest { get; set; }
 
-        [JsonProperty(Order = 11, DefaultValueHandling = DefaultValueHandling.Ignore)]
-        public int? keypoolsize { get; set; }
+        [JsonProperty(Order = 11, PropertyName = "keypoolsize", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public int? KeypoolSize { get; set; }
 
-        [JsonProperty(Order = 12, DefaultValueHandling = DefaultValueHandling.Ignore)]
-        public uint? unlocked_until { get; set; }
+        [JsonProperty(Order = 12, PropertyName = "unlocked_until", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public uint? UnlockedUntil { get; set; }
 
-        [JsonProperty(Order = 13, DefaultValueHandling = DefaultValueHandling.Ignore)]
-        public decimal? paytxfee { get; set; }
+        [JsonProperty(Order = 13, PropertyName = "paytxfee", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public decimal? PayTxFee { get; set; }
     }
 }
-
-#pragma warning restore IDE1006 // Naming Styles

--- a/src/Stratis.Bitcoin.Features.RPC/Models/GetTxOutModel.cs
+++ b/src/Stratis.Bitcoin.Features.RPC/Models/GetTxOutModel.cs
@@ -18,30 +18,30 @@ namespace Stratis.Bitcoin.Features.RPC.Models
             if (unspentOutputs != null)
             {
                 var output = unspentOutputs.TryGetOutput(vout);
-                this.bestblock = tip.HashBlock;
-                this.coinbase = unspentOutputs.IsCoinbase;
-                this.confirmations = NetworkExtensions.MempoolHeight == unspentOutputs.Height ? 0 : tip.Height - (int)unspentOutputs.Height + 1;
+                this.BestBlock = tip.HashBlock;
+                this.Coinbase = unspentOutputs.IsCoinbase;
+                this.Confirmations = NetworkExtensions.MempoolHeight == unspentOutputs.Height ? 0 : tip.Height - (int)unspentOutputs.Height + 1;
                 if (output != null)
                 {
-                    this.value = output.Value;
-                    this.scriptPubKey = new ScriptPubKey(output.ScriptPubKey, network);
+                    this.Value = output.Value;
+                    this.ScriptPubKey = new ScriptPubKey(output.ScriptPubKey, network);
                 }
             }
         }
 
-        [JsonProperty(Order = 0)]
-        public uint256 bestblock { get; set; }
+        [JsonProperty(Order = 0, PropertyName = "bestblock")]
+        public uint256 BestBlock { get; set; }
 
-        [JsonProperty(Order = 1)]
-        public int confirmations { get; set; }
+        [JsonProperty(Order = 1, PropertyName = "confirmations")]
+        public int Confirmations { get; set; }
 
-        [JsonProperty(Order = 2)]
-        public Money value { get; set; }
+        [JsonProperty(Order = 2, PropertyName = "value")]
+        public Money Value { get; set; }
 
-        [JsonProperty(Order = 3)]
-        public ScriptPubKey scriptPubKey { get; set; }
+        [JsonProperty(Order = 3, PropertyName = "scriptPubKey")]
+        public ScriptPubKey ScriptPubKey { get; set; }
 
-        [JsonProperty(Order = 4)]
-        public bool coinbase { get; set; }
+        [JsonProperty(Order = 4, PropertyName = "coinbase")]
+        public bool Coinbase { get; set; }
     }
 }

--- a/src/Stratis.Bitcoin.Features.RPC/Models/TransactionModel.cs
+++ b/src/Stratis.Bitcoin.Features.RPC/Models/TransactionModel.cs
@@ -5,9 +5,6 @@ using NBitcoin.DataEncoders;
 using Newtonsoft.Json;
 using Stratis.Bitcoin.Features.RPC.Converters;
 
-#pragma warning disable IDE1006 // Naming Styles (ignore lowercase)
-#pragma warning disable IDE1006 // Naming Styles (ignore lowercase)
-
 namespace Stratis.Bitcoin.Features.RPC.Models
 {
     public abstract class TransactionModel
@@ -18,15 +15,15 @@ namespace Stratis.Bitcoin.Features.RPC.Models
 
         public TransactionModel(Transaction trx)
         {
-            this.hex = trx?.ToHex();
+            this.Hex = trx?.ToHex();
         }
 
-        [JsonProperty(Order = 0)]
-        public string hex { get; set; }
+        [JsonProperty(Order = 0, PropertyName = "hex")]
+        public string Hex { get; set; }
 
         public override string ToString()
         {
-            return this.hex;
+            return this.Hex;
         }
     }
 
@@ -52,55 +49,55 @@ namespace Stratis.Bitcoin.Features.RPC.Models
         {
             if (trx != null)
             {
-                this.txid = trx.GetHash().ToString();
-                this.size = trx.GetSerializedSize();
-                this.version = trx.Version;
-                this.locktime = trx.LockTime;
+                this.TxId = trx.GetHash().ToString();
+                this.Size = trx.GetSerializedSize();
+                this.Version = trx.Version;
+                this.LockTime = trx.LockTime;
 
-                this.vin = trx.Inputs.Select(txin => new Vin(txin.PrevOut, txin.Sequence, txin.ScriptSig)).ToList();
+                this.VIn = trx.Inputs.Select(txin => new Vin(txin.PrevOut, txin.Sequence, txin.ScriptSig)).ToList();
 
                 int n = 0;
-                this.vout = trx.Outputs.Select(txout => new Vout(n++, txout, network)).ToList();
+                this.VOut = trx.Outputs.Select(txout => new Vout(n++, txout, network)).ToList();
 
                 if (block != null)
                 {
-                    this.blockhash = block.HashBlock.ToString();
-                    this.time = this.blocktime = Utils.DateTimeToUnixTime(block.Header.BlockTime);
+                    this.BlockHash = block.HashBlock.ToString();
+                    this.Time = this.BlockTime = Utils.DateTimeToUnixTime(block.Header.BlockTime);
                     if (tip != null)
-                        this.confirmations = tip.Height - block.Height + 1;
+                        this.Confirmations = tip.Height - block.Height + 1;
                 }
             }
         }
 
-        [JsonProperty(Order = 1)]
-        public string txid { get; set; }
+        [JsonProperty(Order = 1, PropertyName = "txid")]
+        public string TxId { get; set; }
 
-        [JsonProperty(Order = 2)]
-        public int size { get; set; }
+        [JsonProperty(Order = 2, PropertyName = "size")]
+        public int Size { get; set; }
 
-        [JsonProperty(Order = 3)]
-        public uint version { get; set; }
+        [JsonProperty(Order = 3, PropertyName = "version")]
+        public uint Version { get; set; }
 
-        [JsonProperty(Order = 4)]
-        public uint locktime { get; set; }
+        [JsonProperty(Order = 4, PropertyName = "locktime")]
+        public uint LockTime { get; set; }
 
-        [JsonProperty(Order = 5)]
-        public List<Vin> vin { get; set; }
+        [JsonProperty(Order = 5, PropertyName = "vin")]
+        public List<Vin> VIn { get; set; }
 
-        [JsonProperty(Order = 6)]
-        public List<Vout> vout { get; set; }
+        [JsonProperty(Order = 6, PropertyName = "vout")]
+        public List<Vout> VOut { get; set; }
 
-        [JsonProperty(Order = 7, DefaultValueHandling = DefaultValueHandling.Ignore)]
-        public string blockhash { get; set; }
+        [JsonProperty(Order = 7, PropertyName = "blockhash", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string BlockHash { get; set; }
 
-        [JsonProperty(Order = 8, DefaultValueHandling = DefaultValueHandling.Ignore)]
-        public int? confirmations { get; set; }
+        [JsonProperty(Order = 8, PropertyName = "confirmations", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public int? Confirmations { get; set; }
 
-        [JsonProperty(Order = 9, DefaultValueHandling = DefaultValueHandling.Ignore)]
-        public uint? time { get; set; }
+        [JsonProperty(Order = 9, PropertyName = "time", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public uint? Time { get; set; }
 
-        [JsonProperty(Order = 10, DefaultValueHandling = DefaultValueHandling.Ignore)]
-        public uint? blocktime { get; set; }
+        [JsonProperty(Order = 10, PropertyName = "blocktime", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public uint? BlockTime { get; set; }
     }
 
     public class Vin
@@ -113,31 +110,31 @@ namespace Stratis.Bitcoin.Features.RPC.Models
         {
             if (prevOut.Hash == uint256.Zero)
             {
-                this.coinbase = Encoders.Hex.EncodeData(scriptSig.ToBytes());
+                this.Coinbase = Encoders.Hex.EncodeData(scriptSig.ToBytes());
             }
             else
             {
-                this.txid = prevOut.Hash.ToString();
-                this.vout = prevOut.N;
-                this.scriptSig = new Script(scriptSig);
+                this.TxId = prevOut.Hash.ToString();
+                this.VOut = prevOut.N;
+                this.ScriptSig = new Script(scriptSig);
             }
-            this.sequence = (uint)sequence;
+            this.Sequence = (uint)sequence;
         }
 
-        [JsonProperty(Order = 0, DefaultValueHandling = DefaultValueHandling.Ignore)]
-        public string coinbase { get; set; }
+        [JsonProperty(Order = 0, PropertyName = "coinbase", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string Coinbase { get; set; }
 
-        [JsonProperty(Order = 1, DefaultValueHandling = DefaultValueHandling.Ignore)]
-        public string txid { get; set; }
+        [JsonProperty(Order = 1, PropertyName = "txid", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string TxId { get; set; }
 
-        [JsonProperty(Order = 2, DefaultValueHandling = DefaultValueHandling.Ignore)]
-        public uint? vout { get; set; }
+        [JsonProperty(Order = 2, PropertyName = "vout", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public uint? VOut { get; set; }
 
-        [JsonProperty(Order = 3, DefaultValueHandling = DefaultValueHandling.Ignore)]
-        public Script scriptSig { get; set; }
+        [JsonProperty(Order = 3, PropertyName = "scriptSig", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public Script ScriptSig { get; set; }
 
-        [JsonProperty(Order = 4)]
-        public uint sequence { get; set; }
+        [JsonProperty(Order = 4, PropertyName = "sequence")]
+        public uint Sequence { get; set; }
     }
 
     public class Vout
@@ -148,20 +145,20 @@ namespace Stratis.Bitcoin.Features.RPC.Models
 
         public Vout(int N, TxOut txout, Network network)
         {
-            this.n = N;
-            this.value = txout.Value.ToDecimal(MoneyUnit.BTC);
-            this.scriptPubKey = new ScriptPubKey(txout.ScriptPubKey, network);
+            this.N = N;
+            this.Value = txout.Value.ToDecimal(MoneyUnit.BTC);
+            this.ScriptPubKey = new ScriptPubKey(txout.ScriptPubKey, network);
         }
 
         [JsonConverter(typeof(BtcDecimalJsonConverter))]
-        [JsonProperty(Order = 0)]
-        public decimal value { get; set; }
+        [JsonProperty(Order = 0, PropertyName = "value")]
+        public decimal Value { get; set; }
 
-        [JsonProperty(Order = 1)]
-        public int n { get; set; }
+        [JsonProperty(Order = 1, PropertyName = "n")]
+        public int N { get; set; }
 
-        [JsonProperty(Order = 2)]
-        public ScriptPubKey scriptPubKey { get; set; }
+        [JsonProperty(Order = 2, PropertyName = "scriptPubKey")]
+        public ScriptPubKey ScriptPubKey { get; set; }
     }
 
     public class Script
@@ -172,15 +169,15 @@ namespace Stratis.Bitcoin.Features.RPC.Models
 
         public Script(NBitcoin.Script script)
         {
-            this.asm = script.ToString();
-            this.hex = Encoders.Hex.EncodeData(script.ToBytes());
+            this.Asm = script.ToString();
+            this.Hex = Encoders.Hex.EncodeData(script.ToBytes());
         }
 
-        [JsonProperty(Order = 0)]
-        public string asm { get; set; }
+        [JsonProperty(Order = 0, PropertyName = "asm")]
+        public string Asm { get; set; }
 
-        [JsonProperty(Order = 1)]
-        public string hex { get; set; }
+        [JsonProperty(Order = 1, PropertyName = "hex")]
+        public string Hex { get; set; }
     }
 
     public class ScriptPubKey : Script
@@ -192,7 +189,7 @@ namespace Stratis.Bitcoin.Features.RPC.Models
         public ScriptPubKey(NBitcoin.Script script, Network network) : base(script)
         {
             var destinations = new List<TxDestination> { script.GetDestination() };
-            this.type = this.GetScriptType(script.FindTemplate());
+            this.Type = this.GetScriptType(script.FindTemplate());
             if (destinations[0] == null)
             {
                 destinations = script.GetDestinationPublicKeys()
@@ -203,26 +200,26 @@ namespace Stratis.Bitcoin.Features.RPC.Models
             {
                 if (destinations.Count == 1)
                 {
-                    this.reqSigs = 1;
-                    this.addresses = new List<string> { destinations[0].GetAddress(network).ToString() };
+                    this.ReqSigs = 1;
+                    this.Addresses = new List<string> { destinations[0].GetAddress(network).ToString() };
                 }
                 else
                 {
                     PayToMultiSigTemplateParameters multi = PayToMultiSigTemplate.Instance.ExtractScriptPubKeyParameters(script);
-                    this.reqSigs = multi.SignatureCount;
-                    this.addresses = multi.PubKeys.Select(m => m.GetAddress(network).ToString()).ToList();
+                    this.ReqSigs = multi.SignatureCount;
+                    this.Addresses = multi.PubKeys.Select(m => m.GetAddress(network).ToString()).ToList();
                 }
             }
         }
 
-        [JsonProperty(Order = 2, DefaultValueHandling = DefaultValueHandling.Ignore)]
-        public int? reqSigs { get; set; }
+        [JsonProperty(Order = 2, PropertyName = "reqSigs", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public int? ReqSigs { get; set; }
 
-        [JsonProperty(Order = 3, DefaultValueHandling = DefaultValueHandling.Ignore)]
-        public string type { get; set; }
+        [JsonProperty(Order = 3, PropertyName = "type", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string Type { get; set; }
 
-        [JsonProperty(Order = 4, DefaultValueHandling = DefaultValueHandling.Ignore)]
-        public List<string> addresses { get; set; }
+        [JsonProperty(Order = 4, PropertyName = "addresses", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public List<string> Addresses { get; set; }
 
         protected string GetScriptType(ScriptTemplate template)
         {
@@ -249,5 +246,3 @@ namespace Stratis.Bitcoin.Features.RPC.Models
         }
     }
 }
-
-#pragma warning restore IDE1006 // Naming Styles


### PR DESCRIPTION
Changed json fields returned by `getstakinginfo` api method to be pascal case.
Changed the properties for `GetInfoModel`, `GetTxOutModel `and `TransactionModel `to follow our code style for properties and used Json.NET property name attribute to specify serialization formatting.