### PR TITLE
[Bug] Seed node addresses are not added to the peer address manager during discovery

### DIFF
--- a/src/Stratis.Bitcoin.IntegrationTests/P2P/PeerConnectionTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/P2P/PeerConnectionTests.cs
@@ -91,11 +91,8 @@ namespace Stratis.Bitcoin.IntegrationTests.P2P
 
             var testFolder = TestDirectory.Create(folder);
 
-            this.nodeSettings = new NodeSettings
-            {
-                DataDir = testFolder.FolderName
-            };
-
+            this.nodeSettings = new NodeSettings();
+            this.nodeSettings.LoadArguments(new string[] { });
             this.nodeSettings.DataFolder = new DataFolder(this.nodeSettings);
 
             this.peerAddressManager = new PeerAddressManager(this.nodeSettings.DataFolder, this.loggerFactory);

--- a/src/Stratis.Bitcoin/P2P/PeerAddressManagerBehaviour.cs
+++ b/src/Stratis.Bitcoin/P2P/PeerAddressManagerBehaviour.cs
@@ -54,7 +54,15 @@ namespace Stratis.Bitcoin.P2P
             if ((this.Mode & PeerAddressManagerBehaviourMode.Discover) != 0)
             {
                 if (this.AttachedPeer.State == NetworkPeerState.Connected)
+                {
+                    //If a peer connects via the peer discovery loop but does not yet exist
+                    //in the address manager's peer list, we need to add it. 
+                    //This could be a peer address provided by one of the seed nodes.
+                    if (this.peerAddressManager.FindPeer(this.AttachedPeer.PeerAddress.Endpoint) == null)
+                        this.peerAddressManager.AddPeer(this.AttachedPeer.PeerAddress, this.AttachedPeer.RemoteSocketAddress);
+
                     this.peerAddressManager.PeerConnected(this.AttachedPeer.PeerAddress.Endpoint, this.dateTimeProvider.GetUtcNow());
+                }
             }
         }
 


### PR DESCRIPTION
Seeing as the seed node addresses aren't being added to the peer address manager's peer list during discovery, they aren't able to be selected in the peer connector.

Also, the peer discovery loop was incorrectly adding both DNS seed nodes addresses as well as the IP seed node addresses during discovery.