### PR TITLE
Running multiple nodes on the same host

### DIFF
--- a/src/Stratis.Bitcoin.Api.Tests/ApiSettingsTest.cs
+++ b/src/Stratis.Bitcoin.Api.Tests/ApiSettingsTest.cs
@@ -1,0 +1,198 @@
+﻿using System;
+using NBitcoin;
+using Stratis.Bitcoin.Builder;
+using Stratis.Bitcoin.Configuration;
+using Stratis.Bitcoin.Features.Api;
+using Stratis.Bitcoin.Tests;
+using Xunit;
+
+namespace Stratis.Bitcoin.Api.Tests
+{
+    /// <summary>
+    /// Tests the settings for the API features.
+    /// The default settings are:
+    /// ApiPort: 37220 for bitcoin, 37221 for Stratis.
+    /// ApiUri: http://localhost:37220 or http://localhost:37221.
+    /// </summary>
+    public class ApiSettingsTest : TestBase
+    {
+        public ApiSettingsTest()
+        {
+            // These flags are being set on an individual test case basis.
+            // Assume the default values for the static flags.
+            Transaction.TimeStamp = false;
+            Block.BlockSignature = false;
+        }
+
+        /// <summary>
+        /// Tests that if no API settings are passed and we're on the bitcoin network, the defaults settings are used.
+        /// </summary>
+        [Fact]
+        public void GivenNoApiSettingsAreProvidedAndOnBitcoinNetworkThenDefaultSettingAreUsed()
+        {
+            // Arrange.
+            Network network = Network.Main;
+            NodeSettings nodeSettings = new NodeSettings("bitcoin", network).LoadArguments(new string[0]);
+
+            // Act.
+            ApiSettings settings = new FullNodeBuilder()
+                .UseNodeSettings(nodeSettings)
+                .UseApi()
+                .Build()
+                .NodeService<ApiSettings>();
+            settings.Load(nodeSettings);
+
+            // Assert.
+            Assert.Equal(ApiSettings.DefaultBitcoinApiPort, settings.ApiPort);
+            Assert.Equal(new Uri($"{ApiSettings.DefaultApiHost}:{ApiSettings.DefaultBitcoinApiPort}"), settings.ApiUri);
+        }
+
+        /// <summary>
+        /// Tests that if no API settings are passed and we're on the Stratis network, the defaults settings are used.
+        /// </summary>
+        [Fact]
+        public void GivenNoApiSettingsAreProvidedAndOnStratisNetworkThenDefaultSettingAreUsed()
+        {
+            // Arrange.
+            Transaction.TimeStamp = true;
+            Block.BlockSignature = true;
+            Network network = Network.StratisMain;
+            NodeSettings nodeSettings = new NodeSettings("stratis", network).LoadArguments(new string[0]);
+
+            // Act.
+            ApiSettings settings = new FullNodeBuilder()
+                .UseNodeSettings(nodeSettings)
+                .UseApi()
+                .Build()
+                .NodeService<ApiSettings>();
+            settings.Load(nodeSettings);
+
+            // Assert.
+            Assert.Equal(ApiSettings.DefaultStratisApiPort, settings.ApiPort);
+            Assert.Equal(new Uri($"{ApiSettings.DefaultApiHost}:{ApiSettings.DefaultStratisApiPort}"), settings.ApiUri);
+        }
+
+        /// <summary>
+        /// Tests that if a custom API port is passed, the port is used in conjunction with the default API URI.
+        /// </summary>
+        [Fact]
+        public void GivenApiPortIsProvidedThenPortIsUsedWithDefaultApiUri()
+        {
+            // Arrange.
+            int customPort = 55555;
+            NodeSettings nodeSettings = new NodeSettings().LoadArguments(new[] { $"-apiport={customPort}" });
+
+            // Act.
+            ApiSettings settings = new FullNodeBuilder()
+                .UseNodeSettings(nodeSettings)
+                .UseApi()
+                .Build()
+                .NodeService<ApiSettings>();
+            settings.Load(nodeSettings);
+
+            // Assert.
+            Assert.Equal(customPort, settings.ApiPort);
+            Assert.Equal(new Uri($"{ApiSettings.DefaultApiHost}:{customPort}"), settings.ApiUri);
+        }
+
+        /// <summary>
+        /// Tests that if a custom API URI is passed and we're on the bitcoin network, the bitcoin port is used in conjunction with the passed API URI.
+        /// </summary>
+        [Fact]
+        public void GivenApiUriIsProvidedAndGivenBitcoinNetworkThenApiUriIsUsedWithDefaultBitcoinApiPort()
+        {
+            // Arrange.
+            string customApiUri = "http://0.0.0.0";
+            Network network = Network.Main;
+            NodeSettings nodeSettings = new NodeSettings("bitcoin", network).LoadArguments(new[] { $"-apiuri={customApiUri}" });
+
+            // Act.
+            ApiSettings settings = new FullNodeBuilder()
+                .UseNodeSettings(nodeSettings)
+                .UseApi()
+                .Build()
+                .NodeService<ApiSettings>();
+            settings.Load(nodeSettings);
+
+            // Assert.
+            Assert.Equal(ApiSettings.DefaultBitcoinApiPort, settings.ApiPort);
+            Assert.Equal(new Uri($"{customApiUri}:{ApiSettings.DefaultBitcoinApiPort}"), settings.ApiUri);
+        }
+
+        /// <summary>
+        /// Tests that if a custom API URI is passed and we're on the Stratis network, the bitcoin port is used in conjunction with the passed API URI.
+        /// </summary>
+        [Fact]
+        public void GivenApiUriIsProvidedAndGivenStratisNetworkThenApiUriIsUsedWithDefaultStratisApiPort()
+        {
+            // Arrange.
+            Transaction.TimeStamp = true;
+            Block.BlockSignature = true;
+            string customApiUri = "http://0.0.0.0";
+            Network network = Network.StratisMain;
+            NodeSettings nodeSettings = new NodeSettings("stratis", network).LoadArguments(new[] { $"-apiuri={customApiUri}" });
+
+            // Act.
+            ApiSettings settings = new FullNodeBuilder()
+                .UseNodeSettings(nodeSettings)
+                .UseApi()
+                .Build()
+                .NodeService<ApiSettings>();
+            settings.Load(nodeSettings);
+
+            // Assert.
+            Assert.Equal(ApiSettings.DefaultStratisApiPort, settings.ApiPort);
+            Assert.Equal(new Uri($"{customApiUri}:{ApiSettings.DefaultStratisApiPort}"), settings.ApiUri);
+        }
+
+        /// <summary>
+        /// Tests that if a custom API URI and a custom API port are passed, both are used in conjunction to make the API URI.
+        /// </summary>
+        [Fact]
+        public void GivenApiUriAndApiPortIsProvidedAndGivenBitcoinNetworkThenApiUriIsUsedWithApiPort()
+        {
+            // Arrange.
+            string customApiUri = "http://0.0.0.0";
+            int customPort = 55555;
+            Network network = Network.Main;
+            NodeSettings nodeSettings = new NodeSettings("bitcoin", network).LoadArguments(new[] { $"-apiuri={customApiUri}", $"-apiport={customPort}" });
+
+            // Act.
+            ApiSettings settings = new FullNodeBuilder()
+                .UseNodeSettings(nodeSettings)
+                .UseApi()
+                .Build()
+                .NodeService<ApiSettings>();
+            settings.Load(nodeSettings);
+
+            // Assert.
+            Assert.Equal(customPort, settings.ApiPort);
+            Assert.Equal(new Uri($"{customApiUri}:{customPort}"), settings.ApiUri);
+        }
+
+        /// <summary>
+        /// Tests that if a custom API URI is passed and we're on the Stratis network, the bitcoin port is used in conjunction with the passed API URI.
+        /// </summary>
+        [Fact]
+        public void GivenApiUriIncludingPortIsProvidedThenUseThePassedApiUri()
+        {
+            // Arrange.
+            int customPort = 5522;
+            string customApiUri = $"http://0.0.0.0:{customPort}";
+            Network network = Network.Main;
+            NodeSettings nodeSettings = new NodeSettings("bitcoin", network).LoadArguments(new[] { $"-apiuri={customApiUri}" });
+
+            // Act.
+            ApiSettings settings = new FullNodeBuilder()
+                .UseNodeSettings(nodeSettings)
+                .UseApi()
+                .Build()
+                .NodeService<ApiSettings>();
+            settings.Load(nodeSettings);
+
+            // Assert.
+            Assert.Equal(customPort, settings.ApiPort);
+            Assert.Equal(new Uri($"{customApiUri}"), settings.ApiUri);
+        }
+    }
+}

--- a/src/Stratis.Bitcoin.Api.Tests/ApiSettingsTest.cs
+++ b/src/Stratis.Bitcoin.Api.Tests/ApiSettingsTest.cs
@@ -28,7 +28,7 @@ namespace Stratis.Bitcoin.Api.Tests
         /// Tests that if no API settings are passed and we're on the bitcoin network, the defaults settings are used.
         /// </summary>
         [Fact]
-        public void GivenNoApiSettingsAreProvidedAndOnBitcoinNetworkThenDefaultSettingAreUsed()
+        public void GivenNoApiSettingsAreProvided_AndOnBitcoinNetwork_ThenDefaultSettingAreUsed()
         {
             // Arrange.
             Network network = Network.Main;
@@ -51,7 +51,7 @@ namespace Stratis.Bitcoin.Api.Tests
         /// Tests that if no API settings are passed and we're on the Stratis network, the defaults settings are used.
         /// </summary>
         [Fact]
-        public void GivenNoApiSettingsAreProvidedAndOnStratisNetworkThenDefaultSettingAreUsed()
+        public void GivenNoApiSettingsAreProvided_AndOnStratisNetwork_ThenDefaultSettingAreUsed()
         {
             // Arrange.
             Transaction.TimeStamp = true;
@@ -76,7 +76,7 @@ namespace Stratis.Bitcoin.Api.Tests
         /// Tests that if a custom API port is passed, the port is used in conjunction with the default API URI.
         /// </summary>
         [Fact]
-        public void GivenApiPortIsProvidedThenPortIsUsedWithDefaultApiUri()
+        public void GivenApiPortIsProvided_ThenPortIsUsedWithDefaultApiUri()
         {
             // Arrange.
             int customPort = 55555;
@@ -99,7 +99,7 @@ namespace Stratis.Bitcoin.Api.Tests
         /// Tests that if a custom API URI is passed and we're on the bitcoin network, the bitcoin port is used in conjunction with the passed API URI.
         /// </summary>
         [Fact]
-        public void GivenApiUriIsProvidedAndGivenBitcoinNetworkThenApiUriIsUsedWithDefaultBitcoinApiPort()
+        public void GivenApiUriIsProvided_AndGivenBitcoinNetwork_ThenApiUriIsUsedWithDefaultBitcoinApiPort()
         {
             // Arrange.
             string customApiUri = "http://0.0.0.0";
@@ -123,7 +123,7 @@ namespace Stratis.Bitcoin.Api.Tests
         /// Tests that if a custom API URI is passed and we're on the Stratis network, the bitcoin port is used in conjunction with the passed API URI.
         /// </summary>
         [Fact]
-        public void GivenApiUriIsProvidedAndGivenStratisNetworkThenApiUriIsUsedWithDefaultStratisApiPort()
+        public void GivenApiUriIsProvided_AndGivenStratisNetwork_ThenApiUriIsUsedWithDefaultStratisApiPort()
         {
             // Arrange.
             Transaction.TimeStamp = true;
@@ -149,7 +149,7 @@ namespace Stratis.Bitcoin.Api.Tests
         /// Tests that if a custom API URI and a custom API port are passed, both are used in conjunction to make the API URI.
         /// </summary>
         [Fact]
-        public void GivenApiUriAndApiPortIsProvidedAndGivenBitcoinNetworkThenApiUriIsUsedWithApiPort()
+        public void GivenApiUri_AndApiPortIsProvided_AndGivenBitcoinNetwork_ThenApiUriIsUsedWithApiPort()
         {
             // Arrange.
             string customApiUri = "http://0.0.0.0";
@@ -174,7 +174,7 @@ namespace Stratis.Bitcoin.Api.Tests
         /// Tests that if a custom API URI is passed and we're on the Stratis network, the bitcoin port is used in conjunction with the passed API URI.
         /// </summary>
         [Fact]
-        public void GivenApiUriIncludingPortIsProvidedThenUseThePassedApiUri()
+        public void GivenApiUriIncludingPortIsProvided_ThenUseThePassedApiUri()
         {
             // Arrange.
             int customPort = 5522;

--- a/src/Stratis.Bitcoin.Api.Tests/Stratis.Bitcoin.Api.Tests.csproj
+++ b/src/Stratis.Bitcoin.Api.Tests/Stratis.Bitcoin.Api.Tests.csproj
@@ -16,11 +16,19 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Stratis.Bitcoin.Features.Api\Stratis.Bitcoin.Features.Api.csproj" />
+    <ProjectReference Include="..\Stratis.Bitcoin.Tests\Stratis.Bitcoin.Tests.csproj" />
     <ProjectReference Include="..\Stratis.Bitcoin\Stratis.Bitcoin.csproj" />
   </ItemGroup>
 
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="xunit.runner.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
 </Project>

--- a/src/Stratis.Bitcoin.Api.Tests/xunit.runner.json
+++ b/src/Stratis.Bitcoin.Api.Tests/xunit.runner.json
@@ -1,0 +1,5 @@
+﻿{
+    "methodDisplay": "method",
+    "parallelizeAssembly": false,
+    "parallelizeTestCollections": false
+}

--- a/src/Stratis.Bitcoin.Features.Api/ApiSettings.cs
+++ b/src/Stratis.Bitcoin.Features.Api/ApiSettings.cs
@@ -9,8 +9,20 @@ namespace Stratis.Bitcoin.Features.Api
     /// </summary>
     public class ApiSettings
     {
+        /// <summary>The default port used by the API when the node runs on the bitcoin network.</summary>
+        public const int DefaultBitcoinApiPort = 37220;
+
+        /// <summary>The default port used by the API when the node runs on the Stratis network.</summary>
+        public const int DefaultStratisApiPort = 37221;
+
+        /// <summary>The default port used by the API when the node runs on the Stratis network.</summary>
+        public const string DefaultApiHost = "http://localhost";
+
         /// <summary>URI to node's API interface.</summary>
         public Uri ApiUri { get; set; }
+
+        /// <summary>URI to node's API interface.</summary>
+        public int ApiPort { get; set; }
 
         /// <summary>The callback used to override/constrain/extend the settings provided by the Load method.</summary>
         private Action<ApiSettings> callback;
@@ -33,10 +45,24 @@ namespace Stratis.Bitcoin.Features.Api
         {
             TextFileConfiguration config = nodeSettings.ConfigReader;
 
-            var port = nodeSettings.Network.IsBitcoin() ? 37220 : 37221;
+            var apiHost = config.GetOrDefault("apiuri", DefaultApiHost);
+            Uri apiUri = new Uri(apiHost);
 
-            this.ApiUri = config.GetOrDefault("apiuri", new Uri($"http://localhost:{port}"));
-
+            var apiPort = config.GetOrDefault("apiport", nodeSettings.Network.IsBitcoin() ? DefaultBitcoinApiPort : DefaultStratisApiPort);
+            
+            // If no port is set in the API URI.
+            if (apiUri.IsDefaultPort)
+            {
+                this.ApiUri = new Uri($"{apiHost}:{apiPort}");
+                this.ApiPort = apiPort;
+            }
+            // If a port is set in the -apiuri, it takes precedence over the default port or the port passed in -apiport.
+            else
+            {
+                this.ApiUri = apiUri;
+                this.ApiPort = apiUri.Port;
+            }
+            
             this.callback?.Invoke(this);
         }
     }

--- a/src/Stratis.Bitcoin.Features.BlockStore/Stratis.Bitcoin.Features.BlockStore.csproj
+++ b/src/Stratis.Bitcoin.Features.BlockStore/Stratis.Bitcoin.Features.BlockStore.csproj
@@ -34,9 +34,6 @@
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <DefineConstants>$(DefineConstants);NETCORE</DefineConstants>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net462' ">
-    <DefineConstants>$(DefineConstants);NOASSEMBLYCONTEXT</DefineConstants>
-  </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <NoWarn>1701;1702;1705;IDE0008;</NoWarn>

--- a/src/Stratis.Bitcoin.Features.Consensus/Stratis.Bitcoin.Features.Consensus.csproj
+++ b/src/Stratis.Bitcoin.Features.Consensus/Stratis.Bitcoin.Features.Consensus.csproj
@@ -39,9 +39,6 @@
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <DefineConstants>$(DefineConstants);NETCORE</DefineConstants>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net462' ">
-    <DefineConstants>$(DefineConstants);NOASSEMBLYCONTEXT</DefineConstants>
-  </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <NoWarn>1701;1702;1705;IDE0008;</NoWarn>

--- a/src/Stratis.Bitcoin.Features.Dns.Tests/GivenADnsFeature.cs
+++ b/src/Stratis.Bitcoin.Features.Dns.Tests/GivenADnsFeature.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.Logging.Internal;
 using Moq;
 using Stratis.Bitcoin.Configuration;
 using Stratis.Bitcoin.P2P;
+using Stratis.Bitcoin.Tests;
 using Stratis.Bitcoin.Utilities;
 using Xunit;
 
@@ -15,7 +16,7 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
     /// <summary>
     /// Tests for the <see cref="DnsFeature"/> class.
     /// </summary>
-    public class GivenADnsFeature
+    public class GivenADnsFeature : TestBase
     {
         [Fact]
         [Trait("DNS", "UnitTest")]
@@ -27,10 +28,9 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
             INodeLifetime nodeLifetime = new Mock<INodeLifetime>().Object;
             NodeSettings nodeSettings = NodeSettings.Default();
             DnsSettings dnsSettings = new Mock<DnsSettings>().Object;
-            nodeSettings.DataDir = @"C:\";
-            DataFolder dataFolders = new Mock<DataFolder>(nodeSettings).Object;
+            DataFolder dataFolder = CreateDataFolder(this);
             IAsyncLoopFactory asyncLoopFactory = new Mock<IAsyncLoopFactory>().Object;
-            Action a = () => { new DnsFeature(null, whitelistManager, loggerFactory, nodeLifetime, dnsSettings, nodeSettings, dataFolders, asyncLoopFactory); };
+            Action a = () => { new DnsFeature(null, whitelistManager, loggerFactory, nodeLifetime, dnsSettings, nodeSettings, dataFolder, asyncLoopFactory); };
 
             // Act and Assert.
             a.ShouldThrow<ArgumentNullException>().Which.Message.Should().Contain("dnsServer");
@@ -45,10 +45,9 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
             ILoggerFactory loggerFactory = new Mock<ILoggerFactory>().Object;
             INodeLifetime nodeLifetime = new Mock<INodeLifetime>().Object;
             NodeSettings nodeSettings = NodeSettings.Default();
-            nodeSettings.DataDir = @"C:\";
-            DataFolder dataFolders = new Mock<DataFolder>(nodeSettings).Object;
+            DataFolder dataFolder = CreateDataFolder(this);
             IAsyncLoopFactory asyncLoopFactory = new Mock<IAsyncLoopFactory>().Object;
-            Action a = () => { new DnsFeature(dnsServer, null, loggerFactory, nodeLifetime, DnsSettings.Load(nodeSettings), nodeSettings, dataFolders, asyncLoopFactory); };
+            Action a = () => { new DnsFeature(dnsServer, null, loggerFactory, nodeLifetime, DnsSettings.Load(nodeSettings), nodeSettings, dataFolder, asyncLoopFactory); };
 
             // Act and Assert.
             a.ShouldThrow<ArgumentNullException>().Which.Message.Should().Contain("whitelistManager");
@@ -63,10 +62,9 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
             IWhitelistManager whitelistManager = new Mock<IWhitelistManager>().Object;
             INodeLifetime nodeLifetime = new Mock<INodeLifetime>().Object;
             NodeSettings nodeSettings = NodeSettings.Default();
-            nodeSettings.DataDir = @"C:\";
-            DataFolder dataFolders = new Mock<DataFolder>(nodeSettings).Object;
+            DataFolder dataFolder = CreateDataFolder(this);
             IAsyncLoopFactory asyncLoopFactory = new Mock<IAsyncLoopFactory>().Object;
-            Action a = () => { new DnsFeature(dnsServer, whitelistManager, null, nodeLifetime, DnsSettings.Load(nodeSettings), nodeSettings, dataFolders, asyncLoopFactory); };
+            Action a = () => { new DnsFeature(dnsServer, whitelistManager, null, nodeLifetime, DnsSettings.Load(nodeSettings), nodeSettings, dataFolder, asyncLoopFactory); };
 
             // Act and Assert.
             a.ShouldThrow<ArgumentNullException>().Which.Message.Should().Contain("loggerFactory");
@@ -82,10 +80,9 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
             IPeerAddressManager peerAddressManager = new Mock<IPeerAddressManager>().Object;
             ILoggerFactory loggerFactory = new Mock<ILoggerFactory>().Object;
             NodeSettings nodeSettings = NodeSettings.Default();
-            nodeSettings.DataDir = @"C:\";
-            DataFolder dataFolders = new Mock<DataFolder>(nodeSettings).Object;
+            DataFolder dataFolder = CreateDataFolder(this);
             IAsyncLoopFactory asyncLoopFactory = new Mock<IAsyncLoopFactory>().Object;
-            Action a = () => { new DnsFeature(dnsServer, whitelistManager, loggerFactory, null, DnsSettings.Load(nodeSettings), nodeSettings, dataFolders, asyncLoopFactory); };
+            Action a = () => { new DnsFeature(dnsServer, whitelistManager, loggerFactory, null, DnsSettings.Load(nodeSettings), nodeSettings, dataFolder, asyncLoopFactory); };
 
             // Act and Assert.
             a.ShouldThrow<ArgumentNullException>().Which.Message.Should().Contain("nodeLifetime");
@@ -101,10 +98,9 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
             ILoggerFactory loggerFactory = new Mock<ILoggerFactory>().Object;
             INodeLifetime nodeLifetime = new Mock<INodeLifetime>().Object;
             NodeSettings nodeSettings = NodeSettings.Default();
-            nodeSettings.DataDir = @"C:\";
-            DataFolder dataFolders = new Mock<DataFolder>(nodeSettings).Object;
+            DataFolder dataFolder = CreateDataFolder(this);
             IAsyncLoopFactory asyncLoopFactory = new Mock<IAsyncLoopFactory>().Object;
-            Action a = () => { new DnsFeature(dnsServer, whitelistManager, loggerFactory, nodeLifetime, DnsSettings.Load(nodeSettings), null, dataFolders, asyncLoopFactory); };
+            Action a = () => { new DnsFeature(dnsServer, whitelistManager, loggerFactory, nodeLifetime, DnsSettings.Load(nodeSettings), null, dataFolder, asyncLoopFactory); };
 
             // Act and Assert.
             a.ShouldThrow<ArgumentNullException>().Which.Message.Should().Contain("nodeSettings");
@@ -112,7 +108,7 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
 
         [Fact]
         [Trait("DNS", "UnitTest")]
-        public void WhenConstructorCalled_AndDataFoldersIsNull_ThenArgumentNullExceptionIsThrown()
+        public void WhenConstructorCalled_AnddataFolderIsNull_ThenArgumentNullExceptionIsThrown()
         {
             // Arrange.
             IDnsServer dnsServer = new Mock<IDnsServer>().Object;
@@ -125,7 +121,7 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
             Action a = () => { new DnsFeature(dnsServer, whitelistManager, loggerFactory, nodeLifetime, dnsSettings, nodeSettings, null, asyncLoopFactory); };
 
             // Act and Assert.
-            a.ShouldThrow<ArgumentNullException>().Which.Message.Should().Contain("dataFolders");
+            a.ShouldThrow<ArgumentNullException>().Which.Message.Should().Contain("dataFolder");
         }
 
         [Fact]
@@ -137,13 +133,12 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
             IWhitelistManager whitelistManager = new Mock<IWhitelistManager>().Object;
             INodeLifetime nodeLifetime = new Mock<INodeLifetime>().Object;
             NodeSettings nodeSettings = NodeSettings.Default();
-            nodeSettings.DataDir = @"C:\";
-            DataFolder dataFolders = new Mock<DataFolder>(nodeSettings).Object;
+            DataFolder dataFolder = CreateDataFolder(this);
             ILoggerFactory loggerFactory = new Mock<ILoggerFactory>().Object;
             IAsyncLoopFactory asyncLoopFactory = new Mock<IAsyncLoopFactory>().Object;
 
             // Act.
-            DnsFeature feature = new DnsFeature(dnsServer, whitelistManager, loggerFactory, nodeLifetime, DnsSettings.Load(nodeSettings), nodeSettings, dataFolders, asyncLoopFactory);
+            DnsFeature feature = new DnsFeature(dnsServer, whitelistManager, loggerFactory, nodeLifetime, DnsSettings.Load(nodeSettings), nodeSettings, dataFolder, asyncLoopFactory);
 
             // Assert.
             feature.Should().NotBeNull();
@@ -168,7 +163,7 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
             Mock<INodeLifetime> nodeLifetime = new Mock<INodeLifetime>();
             NodeSettings nodeSettings = NodeSettings.Default();
             nodeSettings.DataDir = Directory.GetCurrentDirectory();
-            DataFolder dataFolders = new Mock<DataFolder>(nodeSettings).Object;
+            DataFolder dataFolder = CreateDataFolder(this);
 
             Mock<ILogger> logger = new Mock<ILogger>(MockBehavior.Loose);
             Mock<ILoggerFactory> loggerFactory = new Mock<ILoggerFactory>();
@@ -177,7 +172,7 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
             IAsyncLoopFactory asyncLoopFactory = new AsyncLoopFactory(loggerFactory.Object);
 
             // Act.
-            DnsFeature feature = new DnsFeature(dnsServer.Object, whitelistManager.Object, loggerFactory.Object, nodeLifetime.Object, DnsSettings.Load(nodeSettings), nodeSettings, dataFolders, asyncLoopFactory);
+            DnsFeature feature = new DnsFeature(dnsServer.Object, whitelistManager.Object, loggerFactory.Object, nodeLifetime.Object, DnsSettings.Load(nodeSettings), nodeSettings, dataFolder, asyncLoopFactory);
             feature.Initialize();
             bool waited = waitObject.Wait(5000);
 
@@ -214,7 +209,7 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
 
             NodeSettings nodeSettings = NodeSettings.Default();
             nodeSettings.DataDir = Directory.GetCurrentDirectory();
-            DataFolder dataFolders = new Mock<DataFolder>(nodeSettings).Object;
+            DataFolder dataFolder = CreateDataFolder(this);
 
             Mock<ILogger> logger = new Mock<ILogger>(MockBehavior.Loose);
             Mock<ILoggerFactory> loggerFactory = new Mock<ILoggerFactory>();
@@ -223,7 +218,7 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
             IAsyncLoopFactory asyncLoopFactory = new AsyncLoopFactory(loggerFactory.Object);
 
             // Act.
-            DnsFeature feature = new DnsFeature(dnsServer.Object, whitelistManager, loggerFactory.Object, nodeLifetimeObject, DnsSettings.Load(nodeSettings), nodeSettings, dataFolders, asyncLoopFactory);
+            DnsFeature feature = new DnsFeature(dnsServer.Object, whitelistManager, loggerFactory.Object, nodeLifetimeObject, DnsSettings.Load(nodeSettings), nodeSettings, dataFolder, asyncLoopFactory);
             feature.Initialize();
             nodeLifetimeObject.StopApplication();
             bool waited = source.Token.WaitHandle.WaitOne(5000);
@@ -257,7 +252,7 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
 
             NodeSettings nodeSettings = NodeSettings.Default();
             nodeSettings.DataDir = Directory.GetCurrentDirectory();
-            DataFolder dataFolders = new Mock<DataFolder>(nodeSettings).Object;
+            DataFolder dataFolder = CreateDataFolder(this);
 
             Mock<ILogger> logger = new Mock<ILogger>();
             bool serverError = false;
@@ -268,7 +263,7 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
             IAsyncLoopFactory asyncLoopFactory = new AsyncLoopFactory(loggerFactory.Object);
 
             // Act.
-            DnsFeature feature = new DnsFeature(dnsServer.Object, whitelistManager, loggerFactory.Object, nodeLifetimeObject, DnsSettings.Load(nodeSettings), nodeSettings, dataFolders, asyncLoopFactory);
+            DnsFeature feature = new DnsFeature(dnsServer.Object, whitelistManager, loggerFactory.Object, nodeLifetimeObject, DnsSettings.Load(nodeSettings), nodeSettings, dataFolder, asyncLoopFactory);
             feature.Initialize();
             bool waited = source.Token.WaitHandle.WaitOne(5000);
 
@@ -307,9 +302,9 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
 
             NodeSettings nodeSettings = NodeSettings.Default();
             nodeSettings.DataDir = Directory.GetCurrentDirectory();
-            DataFolder dataFolders = new Mock<DataFolder>(nodeSettings).Object;
+            DataFolder dataFolder = CreateDataFolder(this);
 
-            using (DnsFeature feature = new DnsFeature(dnsServer, whitelistManager, loggerFactory, nodeLifetimeObject, DnsSettings.Load(nodeSettings), nodeSettings, dataFolders, asyncLoopFactory))
+            using (DnsFeature feature = new DnsFeature(dnsServer, whitelistManager, loggerFactory, nodeLifetimeObject, DnsSettings.Load(nodeSettings), nodeSettings, dataFolder, asyncLoopFactory))
             {
                 // Act.
                 feature.Initialize();

--- a/src/Stratis.Bitcoin.Features.Dns.Tests/GivenADnsSeedServer.cs
+++ b/src/Stratis.Bitcoin.Features.Dns.Tests/GivenADnsSeedServer.cs
@@ -12,6 +12,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Internal;
 using Moq;
 using Stratis.Bitcoin.Configuration;
+using Stratis.Bitcoin.Tests;
 using Stratis.Bitcoin.Utilities;
 using Xunit;
 
@@ -20,7 +21,7 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
     /// <summary>
     /// Tests for the <see cref="DnsSeedServer"/> class.
     /// </summary>
-    public class GivenADnsSeedServer
+    public class GivenADnsSeedServer : TestBase
     {
         [Fact]
         [Trait("DNS", "UnitTest")]
@@ -33,9 +34,8 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
             ILoggerFactory loggerFactory = new Mock<ILoggerFactory>().Object;
             IDateTimeProvider dateTimeProvider = new Mock<IDateTimeProvider>().Object;
             NodeSettings nodeSettings = NodeSettings.Default();
-            nodeSettings.DataDir = @"C:\";
-            DataFolder dataFolders = new Mock<DataFolder>(nodeSettings).Object;
-            Action a = () => { new DnsSeedServer(null, masterFile, asyncLoopFactory, nodeLifetime, loggerFactory, dateTimeProvider, DnsSettings.Load(nodeSettings), dataFolders); };
+            DataFolder dataFolder = CreateDataFolder(this);
+            Action a = () => { new DnsSeedServer(null, masterFile, asyncLoopFactory, nodeLifetime, loggerFactory, dateTimeProvider, DnsSettings.Load(nodeSettings), dataFolder); };
 
             // Act and Assert.
             a.ShouldThrow<ArgumentNullException>().Which.Message.Should().Contain("client");
@@ -52,9 +52,8 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
             ILoggerFactory loggerFactory = new Mock<ILoggerFactory>().Object;
             IDateTimeProvider dateTimeProvider = new Mock<IDateTimeProvider>().Object;
             NodeSettings nodeSettings = NodeSettings.Default();
-            nodeSettings.DataDir = @"C:\";
-            DataFolder dataFolders = new Mock<DataFolder>(nodeSettings).Object;
-            Action a = () => { new DnsSeedServer(udpClient, null, asyncLoopFactory, nodeLifetime, loggerFactory, dateTimeProvider, DnsSettings.Load(nodeSettings), dataFolders); };
+            DataFolder dataFolder = CreateDataFolder(this);
+            Action a = () => { new DnsSeedServer(udpClient, null, asyncLoopFactory, nodeLifetime, loggerFactory, dateTimeProvider, DnsSettings.Load(nodeSettings), dataFolder); };
 
             // Act and Assert.
             a.ShouldThrow<ArgumentNullException>().Which.Message.Should().Contain("masterFile");
@@ -71,9 +70,8 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
             ILoggerFactory loggerFactory = new Mock<ILoggerFactory>().Object;
             IDateTimeProvider dateTimeProvider = new Mock<IDateTimeProvider>().Object;
             NodeSettings nodeSettings = NodeSettings.Default();
-            nodeSettings.DataDir = @"C:\";
-            DataFolder dataFolders = new Mock<DataFolder>(nodeSettings).Object;
-            Action a = () => { new DnsSeedServer(udpClient, masterFile, null, nodeLifetime, loggerFactory, dateTimeProvider, DnsSettings.Load(nodeSettings), dataFolders); };
+            DataFolder dataFolder = CreateDataFolder(this);
+            Action a = () => { new DnsSeedServer(udpClient, masterFile, null, nodeLifetime, loggerFactory, dateTimeProvider, DnsSettings.Load(nodeSettings), dataFolder); };
 
             // Act and Assert.
             a.ShouldThrow<ArgumentNullException>().Which.Message.Should().Contain("asyncLoopFactory");
@@ -90,9 +88,8 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
             ILoggerFactory loggerFactory = new Mock<ILoggerFactory>().Object;
             IDateTimeProvider dateTimeProvider = new Mock<IDateTimeProvider>().Object;
             NodeSettings nodeSettings = NodeSettings.Default();
-            nodeSettings.DataDir = @"C:\";
-            DataFolder dataFolders = new Mock<DataFolder>(nodeSettings).Object;
-            Action a = () => { new DnsSeedServer(udpClient, masterFile, asyncLoopFactory, null, loggerFactory, dateTimeProvider, DnsSettings.Load(nodeSettings), dataFolders); };
+            DataFolder dataFolder = CreateDataFolder(this);
+            Action a = () => { new DnsSeedServer(udpClient, masterFile, asyncLoopFactory, null, loggerFactory, dateTimeProvider, DnsSettings.Load(nodeSettings), dataFolder); };
 
             // Act and Assert.
             a.ShouldThrow<ArgumentNullException>().Which.Message.Should().Contain("nodeLifetime");
@@ -109,9 +106,8 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
             INodeLifetime nodeLifetime = new Mock<INodeLifetime>().Object;
             IDateTimeProvider dateTimeProvider = new Mock<IDateTimeProvider>().Object;
             NodeSettings nodeSettings = NodeSettings.Default();
-            nodeSettings.DataDir = @"C:\";
-            DataFolder dataFolders = new Mock<DataFolder>(nodeSettings).Object;
-            Action a = () => { new DnsSeedServer(udpClient, masterFile, asyncLoopFactory, nodeLifetime, null, dateTimeProvider, DnsSettings.Load(nodeSettings), dataFolders); };
+            DataFolder dataFolder = CreateDataFolder(this);
+            Action a = () => { new DnsSeedServer(udpClient, masterFile, asyncLoopFactory, nodeLifetime, null, dateTimeProvider, DnsSettings.Load(nodeSettings), dataFolder); };
 
             // Act and Assert.
             a.ShouldThrow<ArgumentNullException>().Which.Message.Should().Contain("loggerFactory");
@@ -128,9 +124,8 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
             INodeLifetime nodeLifetime = new Mock<INodeLifetime>().Object;
             ILoggerFactory loggerFactory = new Mock<ILoggerFactory>().Object;
             NodeSettings nodeSettings = NodeSettings.Default();
-            nodeSettings.DataDir = @"C:\";
-            DataFolder dataFolders = new Mock<DataFolder>(nodeSettings).Object;
-            Action a = () => { new DnsSeedServer(udpClient, masterFile, asyncLoopFactory, nodeLifetime, loggerFactory, null, DnsSettings.Load(nodeSettings), dataFolders); };
+            DataFolder dataFolder = CreateDataFolder(this);
+            Action a = () => { new DnsSeedServer(udpClient, masterFile, asyncLoopFactory, nodeLifetime, loggerFactory, null, DnsSettings.Load(nodeSettings), dataFolder); };
 
             // Act and Assert.
             a.ShouldThrow<ArgumentNullException>().Which.Message.Should().Contain("dateTimeProvider");
@@ -147,10 +142,8 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
             INodeLifetime nodeLifetime = new Mock<INodeLifetime>().Object;
             ILoggerFactory loggerFactory = new Mock<ILoggerFactory>().Object;
             IDateTimeProvider dateTimeProvider = new Mock<IDateTimeProvider>().Object;
-            NodeSettings nodeSettings = NodeSettings.Default();
-            nodeSettings.DataDir = @"C:\";
-            DataFolder dataFolders = new Mock<DataFolder>(nodeSettings).Object;
-            Action a = () => { new DnsSeedServer(udpClient, masterFile, asyncLoopFactory, nodeLifetime, loggerFactory, dateTimeProvider, null, dataFolders); };
+            DataFolder dataFolder = CreateDataFolder(this);
+            Action a = () => { new DnsSeedServer(udpClient, masterFile, asyncLoopFactory, nodeLifetime, loggerFactory, dateTimeProvider, null, dataFolder); };
 
             // Act and Assert.
             a.ShouldThrow<ArgumentNullException>().Which.Message.Should().Contain("dnsSettings");
@@ -187,11 +180,10 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
             ILoggerFactory loggerFactory = new Mock<ILoggerFactory>().Object;
             IDateTimeProvider dateTimeProvider = new Mock<IDateTimeProvider>().Object;
             NodeSettings nodeSettings = NodeSettings.Default();
-            nodeSettings.DataDir = @"C:\";
-            DataFolder dataFolders = new Mock<DataFolder>(nodeSettings).Object;
+            DataFolder dataFolder = CreateDataFolder(this);
 
             // Act.
-            DnsSeedServer server = new DnsSeedServer(udpClient, masterFile, asyncLoopFactory, nodeLifetime, loggerFactory, dateTimeProvider, DnsSettings.Load(nodeSettings), dataFolders);
+            DnsSeedServer server = new DnsSeedServer(udpClient, masterFile, asyncLoopFactory, nodeLifetime, loggerFactory, dateTimeProvider, DnsSettings.Load(nodeSettings), dataFolder);
 
             // Assert.
             server.Should().NotBeNull();
@@ -215,17 +207,15 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
             loggerFactory.Setup<ILogger>(f => f.CreateLogger(It.IsAny<string>())).Returns(logger.Object);
 
             IDateTimeProvider dateTimeProvider = new Mock<IDateTimeProvider>().Object;
-            NodeSettings nodeSettings = NodeSettings.Default();
-            nodeSettings.DataDir = Directory.GetCurrentDirectory();
             DnsSettings dnsSettings = new Mock<DnsSettings>().Object;
             dnsSettings.DnsHostName = "host.example.com";
             dnsSettings.DnsNameServer = "ns1.host.example.com";
             dnsSettings.DnsMailBox = "admin@host.example.com";
-            DataFolder dataFolders = new Mock<DataFolder>(nodeSettings).Object;
+            DataFolder dataFolder = CreateDataFolder(this);
 
             // Act.
             CancellationTokenSource source = new CancellationTokenSource();
-            DnsSeedServer server = new DnsSeedServer(udpClient.Object, masterFile.Object, asyncLoopFactory, nodeLifetime, loggerFactory.Object, dateTimeProvider, dnsSettings, dataFolders);
+            DnsSeedServer server = new DnsSeedServer(udpClient.Object, masterFile.Object, asyncLoopFactory, nodeLifetime, loggerFactory.Object, dateTimeProvider, dnsSettings, dataFolder);
             Func<Task> func = async () => await server.ListenAsync(53, source.Token);
 
             // Assert.
@@ -250,13 +240,11 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
 
             IAsyncLoopFactory asyncLoopFactory = new Mock<IAsyncLoopFactory>().Object;
             INodeLifetime nodeLifetime = new Mock<INodeLifetime>().Object;
-            NodeSettings nodeSettings = NodeSettings.Default();
-            nodeSettings.DataDir = Directory.GetCurrentDirectory();
             DnsSettings dnsSettings = new Mock<DnsSettings>().Object;
             dnsSettings.DnsHostName = "host.example.com";
             dnsSettings.DnsNameServer = "ns1.host.example.com";
             dnsSettings.DnsMailBox = "admin@host.example.com";
-            DataFolder dataFolders = new Mock<DataFolder>(nodeSettings).Object;
+            DataFolder dataFolder = CreateDataFolder(this);
 
             Mock<ILogger> logger = new Mock<ILogger>(MockBehavior.Loose);
             bool receivedSocketException = false;
@@ -276,7 +264,7 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
 
             // Act.
             CancellationTokenSource source = new CancellationTokenSource(2000);
-            DnsSeedServer server = new DnsSeedServer(udpClient.Object, masterFile.Object, asyncLoopFactory, nodeLifetime, loggerFactory.Object, dateTimeProvider, dnsSettings, dataFolders);
+            DnsSeedServer server = new DnsSeedServer(udpClient.Object, masterFile.Object, asyncLoopFactory, nodeLifetime, loggerFactory.Object, dateTimeProvider, dnsSettings, dataFolder);
 
             try
             {
@@ -314,13 +302,11 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
 
             IAsyncLoopFactory asyncLoopFactory = new Mock<IAsyncLoopFactory>().Object;
             INodeLifetime nodeLifetime = new Mock<INodeLifetime>().Object;
-            NodeSettings nodeSettings = NodeSettings.Default();
-            nodeSettings.DataDir = Directory.GetCurrentDirectory();
             DnsSettings dnsSettings = new Mock<DnsSettings>().Object;
             dnsSettings.DnsHostName = "host.example.com";
             dnsSettings.DnsNameServer = "ns1.host.example.com";
             dnsSettings.DnsMailBox = "admin@host.example.com";
-            DataFolder dataFolders = new Mock<DataFolder>(nodeSettings).Object;
+            DataFolder dataFolder = CreateDataFolder(this);
 
             Mock<ILogger> logger = new Mock<ILogger>();
             bool receivedRequest = false;
@@ -351,7 +337,7 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
 
             // Act.
             CancellationTokenSource source = new CancellationTokenSource(2000);
-            DnsSeedServer server = new DnsSeedServer(udpClient.Object, masterFile.Object, asyncLoopFactory, nodeLifetime, loggerFactory.Object, dateTimeProvider, dnsSettings, dataFolders);
+            DnsSeedServer server = new DnsSeedServer(udpClient.Object, masterFile.Object, asyncLoopFactory, nodeLifetime, loggerFactory.Object, dateTimeProvider, dnsSettings, dataFolder);
 
             try
             {
@@ -392,13 +378,11 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
 
             IAsyncLoopFactory asyncLoopFactory = new Mock<IAsyncLoopFactory>().Object;
             INodeLifetime nodeLifetime = new Mock<INodeLifetime>().Object;
-            NodeSettings nodeSettings = NodeSettings.Default();
-            nodeSettings.DataDir = Directory.GetCurrentDirectory();
             DnsSettings dnsSettings = new Mock<DnsSettings>().Object;
             dnsSettings.DnsHostName = "host.example.com";
             dnsSettings.DnsNameServer = "ns1.host.example.com";
             dnsSettings.DnsMailBox = "admin@host.example.com";
-            DataFolder dataFolders = new Mock<DataFolder>(nodeSettings).Object;
+            DataFolder dataFolder = CreateDataFolder(this);
 
             Mock<ILogger> logger = new Mock<ILogger>();
             bool receivedRequest = false;
@@ -418,7 +402,7 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
 
             // Act.
             CancellationTokenSource source = new CancellationTokenSource(2000);
-            DnsSeedServer server = new DnsSeedServer(udpClient.Object, masterFile.Object, asyncLoopFactory, nodeLifetime, loggerFactory.Object, dateTimeProvider, dnsSettings, dataFolders);
+            DnsSeedServer server = new DnsSeedServer(udpClient.Object, masterFile.Object, asyncLoopFactory, nodeLifetime, loggerFactory.Object, dateTimeProvider, dnsSettings, dataFolder);
 
             try
             {
@@ -465,15 +449,13 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
             asyncLoopFactory.Setup(f => f.Run(It.IsAny<string>(), It.IsAny<Func<CancellationToken, Task>>(), It.IsAny<TimeSpan?>(), It.IsAny<TimeSpan?>())).Returns(new Mock<IAsyncLoop>().Object);
             
             IDateTimeProvider dateTimeProvider = new Mock<IDateTimeProvider>().Object;
-            NodeSettings nodeSettings = NodeSettings.Default();
-            nodeSettings.DataDir = Directory.GetCurrentDirectory();
             DnsSettings dnsSettings = new Mock<DnsSettings>().Object;
             dnsSettings.DnsHostName = "host.example.com";
             dnsSettings.DnsNameServer = "ns1.host.example.com";
             dnsSettings.DnsMailBox = "admin@host.example.com";
-            DataFolder dataFolders = new Mock<DataFolder>(nodeSettings).Object;
+            DataFolder dataFolder = CreateDataFolder(this);
 
-            string masterFilePath = Path.Combine(dataFolders.DnsMasterFilePath, DnsFeature.DnsMasterFileName);
+            string masterFilePath = Path.Combine(dataFolder.DnsMasterFilePath, DnsFeature.DnsMasterFileName);
 
             // Try and remove if already exists
             if (File.Exists(masterFilePath))
@@ -482,7 +464,7 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
             }
 
             // Act.
-            DnsSeedServer server = new DnsSeedServer(udpClient.Object, masterFile.Object, asyncLoopFactory.Object, nodeLifetime.Object, loggerFactory.Object, dateTimeProvider, dnsSettings, dataFolders);
+            DnsSeedServer server = new DnsSeedServer(udpClient.Object, masterFile.Object, asyncLoopFactory.Object, nodeLifetime.Object, loggerFactory.Object, dateTimeProvider, dnsSettings, dataFolder);
             server.Initialize();
             bool waited = source.Token.WaitHandle.WaitOne();
 
@@ -513,15 +495,13 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
             asyncLoopFactory.Setup(f => f.Run(It.IsAny<string>(), It.IsAny<Func<CancellationToken, Task>>(), It.IsAny<TimeSpan?>(), It.IsAny<TimeSpan?>())).Returns(new Mock<IAsyncLoop>().Object);
 
             IDateTimeProvider dateTimeProvider = new Mock<IDateTimeProvider>().Object;
-            NodeSettings nodeSettings = NodeSettings.Default();
-            nodeSettings.DataDir = Directory.GetCurrentDirectory();
             DnsSettings dnsSettings = new Mock<DnsSettings>().Object;
             dnsSettings.DnsHostName = "host.example.com";
             dnsSettings.DnsNameServer = "ns1.host.example.com";
             dnsSettings.DnsMailBox = "admin@host.example.com";
-            DataFolder dataFolders = new Mock<DataFolder>(nodeSettings).Object;
+            DataFolder dataFolder = CreateDataFolder(this);
 
-            string masterFilePath = Path.Combine(dataFolders.DnsMasterFilePath, DnsFeature.DnsMasterFileName);
+            string masterFilePath = Path.Combine(dataFolder.DnsMasterFilePath, DnsFeature.DnsMasterFileName);
 
             // Act.
             try
@@ -533,7 +513,7 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
                 }
 
                 // Run server
-                DnsSeedServer server = new DnsSeedServer(udpClient.Object, masterFile.Object, asyncLoopFactory.Object, nodeLifetime.Object, loggerFactory.Object, dateTimeProvider, dnsSettings, dataFolders);
+                DnsSeedServer server = new DnsSeedServer(udpClient.Object, masterFile.Object, asyncLoopFactory.Object, nodeLifetime.Object, loggerFactory.Object, dateTimeProvider, dnsSettings, dataFolder);
                 server.Initialize();
                 bool waited = source.Token.WaitHandle.WaitOne();
 
@@ -582,16 +562,14 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
             IAsyncLoopFactory asyncLoopFactory = new AsyncLoopFactory(loggerFactory.Object);
 
             IDateTimeProvider dateTimeProvider = new Mock<IDateTimeProvider>().Object;
-            NodeSettings nodeSettings = NodeSettings.Default();
-            nodeSettings.DataDir = Directory.GetCurrentDirectory();
             DnsSettings dnsSettings = new Mock<DnsSettings>().Object;
             dnsSettings.DnsHostName = "host.example.com";
             dnsSettings.DnsNameServer = "ns1.host.example.com";
             dnsSettings.DnsMailBox = "admin@host.example.com";
-            DataFolder dataFolders = new Mock<DataFolder>(nodeSettings).Object;
+            DataFolder dataFolder = CreateDataFolder(this);
 
             // Act.
-            DnsSeedServer server = new DnsSeedServer(udpClient.Object, masterFile.Object, asyncLoopFactory, nodeLifetime.Object, loggerFactory.Object, dateTimeProvider, dnsSettings, dataFolders);
+            DnsSeedServer server = new DnsSeedServer(udpClient.Object, masterFile.Object, asyncLoopFactory, nodeLifetime.Object, loggerFactory.Object, dateTimeProvider, dnsSettings, dataFolder);
             server.Initialize();
             bool waited = source.Token.WaitHandle.WaitOne();
 
@@ -622,16 +600,14 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
             IAsyncLoopFactory asyncLoopFactory = new AsyncLoopFactory(loggerFactory.Object);
 
             IDateTimeProvider dateTimeProvider = new Mock<IDateTimeProvider>().Object;
-            NodeSettings nodeSettings = NodeSettings.Default();
-            nodeSettings.DataDir = Directory.GetCurrentDirectory();
             DnsSettings dnsSettings = new Mock<DnsSettings>().Object;
             dnsSettings.DnsHostName = "host.example.com";
             dnsSettings.DnsNameServer = "ns1.host.example.com";
             dnsSettings.DnsMailBox = "admin@host.example.com";
-            DataFolder dataFolders = new Mock<DataFolder>(nodeSettings).Object;
+            DataFolder dataFolder = CreateDataFolder(this);
 
             // Act.
-            DnsSeedServer server = new DnsSeedServer(udpClient.Object, masterFile.Object, asyncLoopFactory, nodeLifetime.Object, loggerFactory.Object, dateTimeProvider, dnsSettings, dataFolders);
+            DnsSeedServer server = new DnsSeedServer(udpClient.Object, masterFile.Object, asyncLoopFactory, nodeLifetime.Object, loggerFactory.Object, dateTimeProvider, dnsSettings, dataFolder);
             server.Initialize();
             bool waited = source.Token.WaitHandle.WaitOne();
 
@@ -666,13 +642,11 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
 
             IAsyncLoopFactory asyncLoopFactory = new Mock<IAsyncLoopFactory>().Object;
             INodeLifetime nodeLifetime = new Mock<INodeLifetime>().Object;
-            NodeSettings nodeSettings = NodeSettings.Default();
-            nodeSettings.DataDir = Directory.GetCurrentDirectory();
             DnsSettings dnsSettings = new Mock<DnsSettings>().Object;
             dnsSettings.DnsHostName = "host.example.com";
             dnsSettings.DnsNameServer = "ns1.host.example.com";
             dnsSettings.DnsMailBox = "admin@host.example.com";
-            DataFolder dataFolders = new Mock<DataFolder>(nodeSettings).Object;
+            DataFolder dataFolder = CreateDataFolder(this);
 
             Mock<ILogger> logger = new Mock<ILogger>();
             Mock<ILoggerFactory> loggerFactory = new Mock<ILoggerFactory>();
@@ -681,7 +655,7 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
             IDateTimeProvider dateTimeProvider = new Mock<IDateTimeProvider>().Object;
 
             // Act (Part 1).
-            DnsSeedServer server = new DnsSeedServer(udpClient.Object, masterFile, asyncLoopFactory, nodeLifetime, loggerFactory.Object, dateTimeProvider, dnsSettings, dataFolders);
+            DnsSeedServer server = new DnsSeedServer(udpClient.Object, masterFile, asyncLoopFactory, nodeLifetime, loggerFactory.Object, dateTimeProvider, dnsSettings, dataFolder);
 
             try
             {

--- a/src/Stratis.Bitcoin.Features.Dns.Tests/GivenAWhitelistManager.cs
+++ b/src/Stratis.Bitcoin.Features.Dns.Tests/GivenAWhitelistManager.cs
@@ -476,7 +476,7 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
             }
             Directory.CreateDirectory(dataFolderDirectory);
 
-            var peerFolder = new DataFolder(new NodeSettings { DataDir = dataFolderDirectory });
+            var peerFolder = new DataFolder(new NodeSettings { DataDir = dataFolderDirectory }.DataDir);
 
             Mock<ILogger> mockLogger = new Mock<ILogger>();
             Mock<ILoggerFactory> mockLoggerFactory = new Mock<ILoggerFactory>();

--- a/src/Stratis.Bitcoin.Features.Dns/Stratis.Bitcoin.Features.Dns.csproj
+++ b/src/Stratis.Bitcoin.Features.Dns/Stratis.Bitcoin.Features.Dns.csproj
@@ -30,10 +30,7 @@
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <DefineConstants>$(DefineConstants);NETCORE</DefineConstants>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net462' ">
-    <DefineConstants>$(DefineConstants);NOASSEMBLYCONTEXT</DefineConstants>
-  </PropertyGroup>
-
+  
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <NoWarn>1701;1702;1705;IDE0008;</NoWarn>
     <DocumentationFile></DocumentationFile>

--- a/src/Stratis.Bitcoin.Features.MemoryPool/Stratis.Bitcoin.Features.MemoryPool.csproj
+++ b/src/Stratis.Bitcoin.Features.MemoryPool/Stratis.Bitcoin.Features.MemoryPool.csproj
@@ -41,9 +41,6 @@
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <DefineConstants>$(DefineConstants);NETCORE</DefineConstants>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net462' ">
-    <DefineConstants>$(DefineConstants);NOASSEMBLYCONTEXT</DefineConstants>
-  </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <NoWarn>1701;1702;1705;IDE0008;</NoWarn>

--- a/src/Stratis.Bitcoin.Features.Miner/Stratis.Bitcoin.Features.Miner.csproj
+++ b/src/Stratis.Bitcoin.Features.Miner/Stratis.Bitcoin.Features.Miner.csproj
@@ -39,9 +39,6 @@
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <DefineConstants>$(DefineConstants);NETCORE</DefineConstants>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net462' ">
-    <DefineConstants>$(DefineConstants);NOASSEMBLYCONTEXT</DefineConstants>
-  </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <NoWarn>1701;1702;1705;IDE0008;</NoWarn>

--- a/src/Stratis.Bitcoin.Features.Notifications/Stratis.Bitcoin.Features.Notifications.csproj
+++ b/src/Stratis.Bitcoin.Features.Notifications/Stratis.Bitcoin.Features.Notifications.csproj
@@ -34,9 +34,6 @@
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <DefineConstants>$(DefineConstants);NETCORE</DefineConstants>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net462' ">
-    <DefineConstants>$(DefineConstants);NOASSEMBLYCONTEXT</DefineConstants>
-  </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <NoWarn>1701;1702;1705;IDE0008;</NoWarn>

--- a/src/Stratis.Bitcoin.Features.RPC/Stratis.Bitcoin.Features.RPC.csproj
+++ b/src/Stratis.Bitcoin.Features.RPC/Stratis.Bitcoin.Features.RPC.csproj
@@ -42,9 +42,6 @@
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <DefineConstants>$(DefineConstants);NETCORE</DefineConstants>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net462' ">
-    <DefineConstants>$(DefineConstants);NOASSEMBLYCONTEXT</DefineConstants>
-  </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <NoWarn>1701;1702;1705;IDE0008;</NoWarn>

--- a/src/Stratis.Bitcoin.Features.Wallet.Tests/WalletTransactionHandlerTest.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet.Tests/WalletTransactionHandlerTest.cs
@@ -51,7 +51,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
                 chain.Setup(c => c.Tip).Returns(new ChainedBlock(block, block.GetHash(), 1));
 
                 var walletManager = new WalletManager(this.LoggerFactory.Object, Network.Main, chain.Object, NodeSettings.Default(),
-                    new DataFolder(new NodeSettings { DataDir = "TestData/WalletTransactionHandlerTest/BuildTransactionNoSpendableTransactionsThrowsWalletException" }), new Mock<IWalletFeePolicy>().Object, new Mock<IAsyncLoopFactory>().Object, new NodeLifetime(), DateTimeProvider.Default);
+                    new DataFolder(new NodeSettings { DataDir = "TestData/WalletTransactionHandlerTest/BuildTransactionNoSpendableTransactionsThrowsWalletException" }.DataDir), new Mock<IWalletFeePolicy>().Object, new Mock<IAsyncLoopFactory>().Object, new NodeLifetime(), DateTimeProvider.Default);
                 var walletTransactionHandler = new WalletTransactionHandler(this.LoggerFactory.Object, walletManager, new Mock<IWalletFeePolicy>().Object, Network.Main);
 
                 walletManager.Wallets.Add(wallet);
@@ -115,7 +115,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
                 });
 
                 var walletManager = new WalletManager(this.LoggerFactory.Object, Network.Main, chain, NodeSettings.Default(),
-                    new DataFolder(new NodeSettings { DataDir = "TestData/WalletTransactionHandlerTest/BuildTransactionFeeTooLowThrowsWalletException" }), walletFeePolicy.Object, new Mock<IAsyncLoopFactory>().Object, new NodeLifetime(), DateTimeProvider.Default);
+                    new DataFolder(new NodeSettings { DataDir = "TestData/WalletTransactionHandlerTest/BuildTransactionFeeTooLowThrowsWalletException" }.DataDir), walletFeePolicy.Object, new Mock<IAsyncLoopFactory>().Object, new NodeLifetime(), DateTimeProvider.Default);
                 var walletTransactionHandler = new WalletTransactionHandler(this.LoggerFactory.Object, walletManager, walletFeePolicy.Object, Network.Main);
 
                 walletManager.Wallets.Add(wallet);

--- a/src/Stratis.Bitcoin.Features.Wallet/Stratis.Bitcoin.Features.Wallet.csproj
+++ b/src/Stratis.Bitcoin.Features.Wallet/Stratis.Bitcoin.Features.Wallet.csproj
@@ -44,9 +44,6 @@
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <DefineConstants>$(DefineConstants);NETCORE</DefineConstants>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net462' ">
-    <DefineConstants>$(DefineConstants);NOASSEMBLYCONTEXT</DefineConstants>
-  </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <NoWarn>1701;1702;1705;IDE0008;</NoWarn>

--- a/src/Stratis.Bitcoin.Features.WatchOnlyWallet/Stratis.Bitcoin.Features.WatchOnlyWallet.csproj
+++ b/src/Stratis.Bitcoin.Features.WatchOnlyWallet/Stratis.Bitcoin.Features.WatchOnlyWallet.csproj
@@ -37,9 +37,6 @@
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <DefineConstants>$(DefineConstants);NETCORE</DefineConstants>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net462' ">
-    <DefineConstants>$(DefineConstants);NOASSEMBLYCONTEXT</DefineConstants>
-  </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <NoWarn>1701;1702;1705;IDE0008;</NoWarn>

--- a/src/Stratis.Bitcoin.IntegrationTests/APITests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/APITests.cs
@@ -211,9 +211,12 @@ namespace Stratis.Bitcoin.IntegrationTests
 
             // start api on different ports
             this.stratisPowNode.ConfigParameters.Add("apiuri", "http://localhost:37221");
-
-            this.InitializeTestWallet(this.stratisPowNode);
             this.builder.StartAll();
+
+            // Move a wallet file to the right folder and restart the wallet manager to take it into account.
+            this.InitializeTestWallet(this.stratisPowNode.FullNode.DataFolder.WalletPath);
+            var walletManager = this.stratisPowNode.FullNode.NodeService<IWalletManager>() as WalletManager;
+            walletManager.Start();
 
             Block.BlockSignature = true;
 
@@ -244,10 +247,10 @@ namespace Stratis.Bitcoin.IntegrationTests
         /// <summary>
         /// Copies the test wallet into data folder for node if it isnt' already present.
         /// </summary>
-        /// <param name="node">Core node for the test.</param>
-        private void InitializeTestWallet(CoreNode node)
+        /// <param name="path">The path of the folder to move the wallet to.</param>
+        public void InitializeTestWallet(string path)
         {
-            string testWalletPath = Path.Combine(node.DataFolder, "test.wallet.json");
+            string testWalletPath = Path.Combine(path, "test.wallet.json");
             if (!File.Exists(testWalletPath))
                 File.Copy("Data/test.wallet.json", testWalletPath);
         }

--- a/src/Stratis.Bitcoin.IntegrationTests/P2P/PeerConnectionTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/P2P/PeerConnectionTests.cs
@@ -98,7 +98,7 @@ namespace Stratis.Bitcoin.IntegrationTests.P2P
 
             this.nodeSettings = new NodeSettings();
             this.nodeSettings.LoadArguments(new string[] { });
-            this.nodeSettings.DataFolder = new DataFolder(this.nodeSettings);
+            this.nodeSettings.DataFolder = new DataFolder(this.nodeSettings.DataDir);
 
             this.connectionSetting = new ConnectionManagerSettings();
             this.connectionSetting.Load(this.nodeSettings);

--- a/src/Stratis.Bitcoin.IntegrationTests/RPC/RPCTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/RPC/RPCTests.cs
@@ -4,6 +4,8 @@ using NBitcoin;
 using NBitcoin.Protocol;
 using NBitcoin.RPC;
 using Stratis.Bitcoin.Connection;
+using Stratis.Bitcoin.Features.Wallet;
+using Stratis.Bitcoin.Features.Wallet.Interfaces;
 using Stratis.Bitcoin.IntegrationTests.EnvironmentMockUpHelpers;
 using Xunit;
 
@@ -19,13 +21,15 @@ namespace Stratis.Bitcoin.IntegrationTests.RPC
         {
             this.Builder = NodeBuilder.Create();
             this.Node = this.Builder.CreateStratisPowNode();
-            this.InitializeTestWallet(this.Node);
             this.Builder.StartAll();
-
             this.RpcClient = this.Node.CreateRPCClient();
-
             this.NetworkPeerClient = this.Node.CreateNetworkPeerClient();
             this.NetworkPeerClient.VersionHandshakeAsync().GetAwaiter().GetResult();
+
+            // Move a wallet file to the right folder and restart the wallet manager to take it into account.
+            this.InitializeTestWallet(this.Node.FullNode.DataFolder.WalletPath);
+            var walletManager = this.Node.FullNode.NodeService<IWalletManager>() as WalletManager; ;
+            walletManager.Start();
         }
     }
 

--- a/src/Stratis.Bitcoin.IntegrationTests/RPC/RpcBitcoinImmutableTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/RPC/RpcBitcoinImmutableTests.cs
@@ -16,7 +16,7 @@ namespace Stratis.Bitcoin.IntegrationTests.RPC
         {
             this.Builder = NodeBuilder.Create();
             this.Node = this.Builder.CreateNode();
-            this.InitializeTestWallet(this.Node);
+            this.InitializeTestWallet(this.Node.DataFolder);
             this.Builder.StartAll();
 
             this.RpcClient = this.Node.CreateRPCClient();

--- a/src/Stratis.Bitcoin.IntegrationTests/RPC/RpcTestFixtureBase.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/RPC/RpcTestFixtureBase.cs
@@ -49,10 +49,10 @@ namespace Stratis.Bitcoin.IntegrationTests.RPC
         /// <summary>
         /// Copies the test wallet into data folder for node if it isnt' already present.
         /// </summary>
-        /// <param name="node">Core node for the test.</param>
-        protected void InitializeTestWallet(CoreNode node)
+        /// <param name="path">The path of the folder to move the wallet to.</param>
+        protected void InitializeTestWallet(string path)
         {
-            string testWalletPath = Path.Combine(node.DataFolder, "test.wallet.json");
+            string testWalletPath = Path.Combine(path, "test.wallet.json");
             if (!File.Exists(testWalletPath))
                 File.Copy("Data/test.wallet.json", testWalletPath);
         }

--- a/src/Stratis.Bitcoin.IntegrationTests/WalletTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/WalletTests.cs
@@ -85,8 +85,13 @@ namespace Stratis.Bitcoin.IntegrationTests
             using (NodeBuilder builder = NodeBuilder.Create())
             {
                 CoreNode stratisNodeSync = builder.CreateStratisPowNode();
-                this.InitializeTestWallet(stratisNodeSync);
                 builder.StartAll();
+
+                // Move a wallet file to the right folder and restart the wallet manager to take it into account.
+                this.InitializeTestWallet(stratisNodeSync.FullNode.DataFolder.WalletPath);
+                var walletManager = stratisNodeSync.FullNode.NodeService<IWalletManager>() as WalletManager;
+                walletManager.Start();
+
                 var rpc = stratisNodeSync.CreateRPCClient();
                 rpc.SendCommand(NBitcoin.RPC.RPCOperations.generate, 10);
                 Assert.Equal(10, rpc.GetBlockCount());
@@ -454,10 +459,10 @@ namespace Stratis.Bitcoin.IntegrationTests
         /// <summary>
         /// Copies the test wallet into data folder for node if it isnt' already present.
         /// </summary>
-        /// <param name="node">Core node for the test.</param>
-        private void InitializeTestWallet(CoreNode node)
+        /// <param name="path">The path of the folder to move the wallet to.</param>
+        private void InitializeTestWallet(string path)
         {
-            string testWalletPath = Path.Combine(node.DataFolder, "test.wallet.json");
+            string testWalletPath = Path.Combine(path, "test.wallet.json");
             if (!File.Exists(testWalletPath))
                 File.Copy("Data/test.wallet.json", testWalletPath);
         }

--- a/src/Stratis.Bitcoin.Tests/Builder/FullNodeBuilderTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Builder/FullNodeBuilderTest.cs
@@ -105,7 +105,7 @@ namespace Stratis.Bitcoin.Tests.Builder
             var nodeSettings = new NodeSettings();
             nodeSettings.LoadArguments(new string[] { });
             nodeSettings.DataDir = "TestData/FullNodeBuilder/BuildWithInitialServicesSetup";
-            nodeSettings.DataFolder = new DataFolder(nodeSettings);
+            nodeSettings.DataFolder = new DataFolder(nodeSettings.DataDir);
 
             this.fullNodeBuilder = new FullNodeBuilder(nodeSettings, this.serviceCollectionDelegates, this.serviceProviderDelegates, this.featureCollectionDelegates, this.featureCollection);
 

--- a/src/Stratis.Bitcoin.Tests/TestBase.cs
+++ b/src/Stratis.Bitcoin.Tests/TestBase.cs
@@ -26,7 +26,7 @@ namespace Stratis.Bitcoin.Tests
 
         public static DataFolder AssureEmptyDirAsDataFolder(string dir)
         {
-            var dataFolder = new DataFolder(new NodeSettings { DataDir = AssureEmptyDir(dir) });
+            var dataFolder = new DataFolder(new NodeSettings { DataDir = AssureEmptyDir(dir) }.DataDir);
             return dataFolder;
         }
 

--- a/src/Stratis.Bitcoin/Base/ChainRepository.cs
+++ b/src/Stratis.Bitcoin/Base/ChainRepository.cs
@@ -114,7 +114,7 @@ namespace Stratis.Bitcoin.Base
         /// <inheritdoc />
         public void Dispose()
         {
-            this.dbreeze.Dispose();
+            this.dbreeze?.Dispose();
         }
     }
 }

--- a/src/Stratis.Bitcoin/Configuration/DataFolder.cs
+++ b/src/Stratis.Bitcoin/Configuration/DataFolder.cs
@@ -16,10 +16,9 @@ namespace Stratis.Bitcoin.Configuration
         /// <summary>
         /// Initializes the path locations.
         /// </summary>
-        /// <param name="settings">Node configuration.</param>
-        public DataFolder(NodeSettings settings)
+        /// <param name="path">The data directory root path.</param>
+        public DataFolder(string path)
         {
-            string path = settings.DataDir;
             this.CoinViewPath = Path.Combine(path, "coinview");
             this.AddressManagerFilePath = path;
             this.ChainPath = Path.Combine(path, "chain");

--- a/src/Stratis.Bitcoin/Configuration/NodeSettings.cs
+++ b/src/Stratis.Bitcoin/Configuration/NodeSettings.cs
@@ -147,14 +147,14 @@ namespace Stratis.Bitcoin.Configuration
             // By default, we look for a file named '<network>.conf' in the network's data directory,
             // but both the data directory and the configuration file path may be changed using the -datadir and -conf command-line arguments.
             this.ConfigurationFile = args.GetValueOf("-conf")?.NormalizeDirectorySeparator();
-            this.DataDir = args.GetValueOf("-datadir")?.NormalizeDirectorySeparator();
+            var dataDir = args.GetValueOf("-datadir")?.NormalizeDirectorySeparator();
 
             // If the configuration file is relative then assume it is relative to the data folder and combine the paths
-            if (this.DataDir != null && this.ConfigurationFile != null)
+            if (dataDir != null && this.ConfigurationFile != null)
             {
                 bool isRelativePath = Path.GetFullPath(this.ConfigurationFile).Length > this.ConfigurationFile.Length;
                 if (isRelativePath)
-                    this.ConfigurationFile = Path.Combine(this.DataDir, this.ConfigurationFile);
+                    this.ConfigurationFile = Path.Combine(dataDir, this.ConfigurationFile);
             }
 
             // Find out if we need to run on testnet or regtest from the config file.
@@ -178,14 +178,21 @@ namespace Stratis.Bitcoin.Configuration
                 throw new ConfigurationException("Invalid combination of -regtest and -testnet.");
 
             this.Network = this.GetNetwork();
-            if (this.DataDir == null)
+
+            // Setting the data directory.
+            if (dataDir == null)
             {
                 this.DataDir = this.CreateDefaultDataDirectories(Path.Combine("StratisNode", this.Name), this.Network);
             }
-
-            if (!Directory.Exists(this.DataDir))
-                throw new ConfigurationException($"Data directory {this.DataDir} does not exist.");
-
+            else
+            {
+                // Create the data directories if they don't exist.
+                string directoryPath = Path.Combine(dataDir, this.Name, this.Network.Name);
+                Directory.CreateDirectory(directoryPath);
+                this.DataDir = directoryPath;
+                this.Logger.LogDebug("Data directory initialized with path {0}.", directoryPath);
+            }
+            
             // If no configuration file path is passed in the args, load the default file.
             if (this.ConfigurationFile == null)
             {

--- a/src/Stratis.Bitcoin/Configuration/NodeSettings.cs
+++ b/src/Stratis.Bitcoin/Configuration/NodeSettings.cs
@@ -200,7 +200,7 @@ namespace Stratis.Bitcoin.Configuration
             this.ConfigReader = config;
             consoleConfig.MergeInto(config);
 
-            this.DataFolder = new DataFolder(this);
+            this.DataFolder = new DataFolder(this.DataDir);
             if (!Directory.Exists(this.DataFolder.CoinViewPath))
                 Directory.CreateDirectory(this.DataFolder.CoinViewPath);
 

--- a/src/Stratis.Bitcoin/Configuration/NodeSettings.cs
+++ b/src/Stratis.Bitcoin/Configuration/NodeSettings.cs
@@ -357,7 +357,6 @@ namespace Stratis.Bitcoin.Configuration
             }
 
             // Create the data directories if they don't exist.
-            Directory.CreateDirectory(directoryPath);
             directoryPath = Path.Combine(directoryPath, network.Name);
             Directory.CreateDirectory(directoryPath);
 

--- a/src/Stratis.Bitcoin/Stratis.Bitcoin.csproj
+++ b/src/Stratis.Bitcoin/Stratis.Bitcoin.csproj
@@ -50,9 +50,6 @@
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <DefineConstants>$(DefineConstants);NETCORE</DefineConstants>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net462' ">
-    <DefineConstants>$(DefineConstants);NOASSEMBLYCONTEXT</DefineConstants>
-  </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <NoWarn>1701;1702;1705;IDE0008;</NoWarn>

--- a/src/Stratis.Bitcoin/Utilities/FullNodeExtensions.cs
+++ b/src/Stratis.Bitcoin/Utilities/FullNodeExtensions.cs
@@ -37,10 +37,10 @@ namespace Stratis.Bitcoin.Utilities
                     
                     done.Wait();
                 };
-#if !NOASSEMBLYCONTEXT
+
                 var assemblyLoadContext = AssemblyLoadContext.GetLoadContext(typeof(FullNode).GetTypeInfo().Assembly);
                 assemblyLoadContext.Unloading += context => shutdown();
-#endif
+
                 Console.CancelKeyPress += (sender, eventArgs) =>
                 {
                     shutdown();

--- a/src/Stratis.Bitcoin/Utilities/FullNodeExtensions.cs
+++ b/src/Stratis.Bitcoin/Utilities/FullNodeExtensions.cs
@@ -34,7 +34,7 @@ namespace Stratis.Bitcoin.Utilities
                             Console.WriteLine(exception.Message);
                         }
                     }
-
+                    
                     done.Wait();
                 };
 #if !NOASSEMBLYCONTEXT
@@ -48,7 +48,15 @@ namespace Stratis.Bitcoin.Utilities
                     eventArgs.Cancel = true;
                 };
 
-                await node.RunAsync(cts.Token, "Application started. Press Ctrl+C to shut down.", "Application stopped.").ConfigureAwait(false);
+                try
+                {
+                    await node.RunAsync(cts.Token, "Application started. Press Ctrl+C to shut down.", "Application stopped.").ConfigureAwait(false);
+                }
+                catch (Exception e)
+                {
+                    Console.WriteLine(e);
+                }
+
                 done.Set();
             }
         }
@@ -63,7 +71,7 @@ namespace Stratis.Bitcoin.Utilities
         public static async Task RunAsync(this IFullNode node, CancellationToken cancellationToken, string shutdownMessage, string shutdownCompleteMessage)
         {
             node.Start();
-
+            
             if (!string.IsNullOrEmpty(shutdownMessage))
             {
                 Console.WriteLine();

--- a/src/Stratis.Bitcoin/Utilities/FullNodeExtensions.cs
+++ b/src/Stratis.Bitcoin/Utilities/FullNodeExtensions.cs
@@ -52,12 +52,10 @@ namespace Stratis.Bitcoin.Utilities
                 {
                     await node.RunAsync(cts.Token, "Application started. Press Ctrl+C to shut down.", "Application stopped.").ConfigureAwait(false);
                 }
-                catch (Exception e)
+                finally
                 {
-                    Console.WriteLine(e);
+                    done.Set();
                 }
-
-                done.Set();
             }
         }
 


### PR DESCRIPTION
This PR contains a few commits allowing multiple nodes to run on the same machine:

* Make sure the node terminates:
If an exception is thrown (for example the DBreeze fails to initialize), the ManualResetEventSlim is never set and the node stays waiting for it. So if for example a second node is started on a machine, it will fail whilst creating the DBreeze db but the process will keep running. This fix allows the process to terminate.

* Checking for null before disposing of Dbreeze

* Allow setting of custom data directory.
Previously, trying to start a node with a directory different than the default one would throw an exception. Now we create a directory after the one specified in the datadir argument.

* Split of ApiUri
Splitting the apiUri between ApiUri and ApiPort so that it's easier to set up a port without having to worry about setting the host.
For example, a user starting the node could just start the node with -apiport=37555.

* Removed the NOASSEMBLYCONTEXT constant from csproj files. 

Helps the following:
 https://github.com/stratisproject/Breeze/issues/322
https://github.com/stratisproject/Breeze/issues/314
https://github.com/stratisproject/StratisBitcoinFullNode/issues/806
https://github.com/stratisproject/StratisBitcoinFullNode/issues/257