### PR TITLE
Removed .NodeService<T> usages from non-test methods

### DIFF
--- a/src/Stratis.Bitcoin.Features.Api/ApiFeature.cs
+++ b/src/Stratis.Bitcoin.Features.Api/ApiFeature.cs
@@ -56,7 +56,7 @@ namespace Stratis.Bitcoin.Features.Api
         public override void Initialize()
         {
             this.logger.LogInformation("API starting on URL '{0}'.", this.apiSettings.ApiUri);
-            this.webHost = Program.Initialize(this.fullNodeBuilder.Services, this.fullNode);
+            this.webHost = Program.Initialize(this.fullNodeBuilder.Services, this.fullNode, this.apiSettings);
 
             this.TryStartKeepaliveMonitor();
         }

--- a/src/Stratis.Bitcoin.Features.Api/Program.cs
+++ b/src/Stratis.Bitcoin.Features.Api/Program.cs
@@ -13,11 +13,11 @@ namespace Stratis.Bitcoin.Features.Api
         {
         }
 
-        public static IWebHost Initialize(IEnumerable<ServiceDescriptor> services, FullNode fullNode)
+        public static IWebHost Initialize(IEnumerable<ServiceDescriptor> services, FullNode fullNode, ApiSettings apiSettings)
         {
             Guard.NotNull(fullNode, nameof(fullNode));
 
-            Uri apiUri = fullNode.NodeService<ApiSettings>().ApiUri;
+            Uri apiUri = apiSettings.ApiUri;
 
             IWebHost host = new WebHostBuilder()
                 .UseKestrel()

--- a/src/Stratis.Bitcoin.Features.Consensus/ConsensusFeature.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/ConsensusFeature.cs
@@ -209,7 +209,7 @@ namespace Stratis.Bitcoin.Features.Consensus
                         services.AddSingleton<IConsensusLoop, ConsensusLoop>();
                         services.AddSingleton<StakeChainStore>().AddSingleton<StakeChain, StakeChainStore>(provider => provider.GetService<StakeChainStore>());
                         services.AddSingleton<IStakeValidator, StakeValidator>();
-                        services.AddSingleton<ConsensusManager>().AddSingleton<INetworkDifficulty, ConsensusManager>();
+                        services.AddSingleton<ConsensusManager>().AddSingleton<INetworkDifficulty, ConsensusManager>().AddSingleton<IGetUnspentTransaction, ConsensusManager>();
                         services.AddSingleton<IInitialBlockDownloadState, InitialBlockDownloadState>();
                         services.AddSingleton<ConsensusController>();
                         services.AddSingleton<ConsensusStats>();

--- a/src/Stratis.Bitcoin.Features.Consensus/ConsensusFeature.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/ConsensusFeature.cs
@@ -209,7 +209,8 @@ namespace Stratis.Bitcoin.Features.Consensus
                         services.AddSingleton<IConsensusLoop, ConsensusLoop>();
                         services.AddSingleton<StakeChainStore>().AddSingleton<StakeChain, StakeChainStore>(provider => provider.GetService<StakeChainStore>());
                         services.AddSingleton<IStakeValidator, StakeValidator>();
-                        services.AddSingleton<ConsensusManager>().AddSingleton<INetworkDifficulty, ConsensusManager>().AddSingleton<IGetUnspentTransaction, ConsensusManager>();
+                        services.AddSingleton<ConsensusManager>().AddSingleton<INetworkDifficulty, ConsensusManager>()
+                            .AddSingleton<IGetUnspentTransaction, ConsensusManager>();
                         services.AddSingleton<IInitialBlockDownloadState, InitialBlockDownloadState>();
                         services.AddSingleton<ConsensusController>();
                         services.AddSingleton<ConsensusStats>();

--- a/src/Stratis.Bitcoin.Features.RPC/Controllers/FullNodeController.cs
+++ b/src/Stratis.Bitcoin.Features.RPC/Controllers/FullNodeController.cs
@@ -31,12 +31,15 @@ namespace Stratis.Bitcoin.Features.RPC.Controllers
 
         private readonly INetworkDifficulty networkDifficulty;
 
+        private readonly IConsensusLoop consensusLoop;
+
         public FullNodeController(
             ILoggerFactory loggerFactory,
             IPooledTransaction pooledTransaction,
             IPooledGetUnspentTransaction pooledGetUnspentTransaction,
             IGetUnspentTransaction getUnspentTransaction,
             INetworkDifficulty networkDifficulty,
+            IConsensusLoop consensusLoop,
             IFullNode fullNode = null,
             NodeSettings nodeSettings = null,
             Network network = null,
@@ -56,6 +59,7 @@ namespace Stratis.Bitcoin.Features.RPC.Controllers
             this.pooledGetUnspentTransaction = pooledGetUnspentTransaction;
             this.getUnspentTransaction = getUnspentTransaction;
             this.networkDifficulty = networkDifficulty;
+            this.consensusLoop = consensusLoop;
         }
 
         [ActionName("stop")]
@@ -133,8 +137,7 @@ namespace Stratis.Bitcoin.Features.RPC.Controllers
         [ActionDescription("Gets the current consensus tip height.")]
         public int GetBlockCount()
         {
-            var consensusLoop = this.FullNode.Services.ServiceProvider.GetRequiredService<IConsensusLoop>();
-            return consensusLoop.Tip.Height;
+            return this.consensusLoop.Tip.Height;
         }
 
         [ActionName("getinfo")]

--- a/src/Stratis.Bitcoin.Features.RPC/Controllers/FullNodeController.cs
+++ b/src/Stratis.Bitcoin.Features.RPC/Controllers/FullNodeController.cs
@@ -2,14 +2,11 @@
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using NBitcoin;
-using NBitcoin.DataEncoders;
 using Newtonsoft.Json.Linq;
 using Stratis.Bitcoin.Base;
 using Stratis.Bitcoin.Configuration;
-using Stratis.Bitcoin.Features.Consensus;
 using Stratis.Bitcoin.Features.Consensus.Interfaces;
 using Stratis.Bitcoin.Features.RPC.Models;
 using Stratis.Bitcoin.Interfaces;
@@ -25,12 +22,15 @@ namespace Stratis.Bitcoin.Features.RPC.Controllers
 
         private readonly IPooledTransaction pooledTransaction;
 
+        /// <summary>An interface implementation used to retrieve unspent transactions from a pooled source.</summary>
         private readonly IPooledGetUnspentTransaction pooledGetUnspentTransaction;
 
+        /// <summary>An interface implementation used to retrieve unspent transactions.</summary>
         private readonly IGetUnspentTransaction getUnspentTransaction;
 
         private readonly INetworkDifficulty networkDifficulty;
 
+        /// <summary>Manager of the longest fully validated chain of blocks.</summary>
         private readonly IConsensusLoop consensusLoop;
 
         public FullNodeController(

--- a/src/Stratis.Bitcoin.Features.RPC/Controllers/FullNodeController.cs
+++ b/src/Stratis.Bitcoin.Features.RPC/Controllers/FullNodeController.cs
@@ -35,11 +35,11 @@ namespace Stratis.Bitcoin.Features.RPC.Controllers
 
         public FullNodeController(
             ILoggerFactory loggerFactory,
-            IPooledTransaction pooledTransaction,
-            IPooledGetUnspentTransaction pooledGetUnspentTransaction,
-            IGetUnspentTransaction getUnspentTransaction,
-            INetworkDifficulty networkDifficulty,
-            IConsensusLoop consensusLoop,
+            IPooledTransaction pooledTransaction = null,
+            IPooledGetUnspentTransaction pooledGetUnspentTransaction = null,
+            IGetUnspentTransaction getUnspentTransaction = null,
+            INetworkDifficulty networkDifficulty = null,
+            IConsensusLoop consensusLoop = null,
             IFullNode fullNode = null,
             NodeSettings nodeSettings = null,
             Network network = null,

--- a/src/Stratis.Bitcoin.Features.RPC/Startup.cs
+++ b/src/Stratis.Bitcoin.Features.RPC/Startup.cs
@@ -33,7 +33,8 @@ namespace Stratis.Bitcoin.Features.RPC
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
         public void Configure(IApplicationBuilder app, IHostingEnvironment env,
             ILoggerFactory loggerFactory,
-            IServiceProvider serviceProvider)
+            IServiceProvider serviceProvider,
+            RpcSettings rpcSettings)
         {
             if (env.IsDevelopment())
             {
@@ -46,12 +47,11 @@ namespace Stratis.Bitcoin.Features.RPC
             var cookieStr = "__cookie__:" + new uint256(RandomUtils.GetBytes(32));
             File.WriteAllText(fullNode.DataFolder.RpcCookieFile, cookieStr);
             authorizedAccess.Authorized.Add(cookieStr);
-            var settings = fullNode.NodeService<RpcSettings>();
-            if (settings.RpcPassword != null)
+            if (rpcSettings.RpcPassword != null)
             {
-                authorizedAccess.Authorized.Add(settings.RpcUser + ":" + settings.RpcPassword);
+                authorizedAccess.Authorized.Add(rpcSettings.RpcUser + ":" + rpcSettings.RpcPassword);
             }
-            authorizedAccess.AllowIp.AddRange(settings.AllowIp);
+            authorizedAccess.AllowIp.AddRange(rpcSettings.AllowIp);
 
             var options = GetMVCOptions(serviceProvider);
             Serializer.RegisterFrontConverters(options.SerializerSettings, fullNode.Network);

--- a/src/Stratis.Bitcoin/Interfaces/IGetUnspentTransaction.cs
+++ b/src/Stratis.Bitcoin/Interfaces/IGetUnspentTransaction.cs
@@ -5,7 +5,7 @@ using Stratis.Bitcoin.Utilities;
 namespace Stratis.Bitcoin.Interfaces
 {
     /// <summary>
-    /// An interface used to retieve unspent transactions
+    /// An interface used to retrieve unspent transactions
     /// </summary>
     public interface IGetUnspentTransaction
     {

--- a/src/Stratis.Bitcoin/Interfaces/IPooledGetUnspentTransaction.cs
+++ b/src/Stratis.Bitcoin/Interfaces/IPooledGetUnspentTransaction.cs
@@ -1,7 +1,7 @@
 ﻿namespace Stratis.Bitcoin.Interfaces
 {
     /// <summary>
-    /// An interface used to retieve unspent transactions from a pooled source
+    /// An interface used to retrieve unspent transactions from a pooled source
     /// </summary>
     public interface IPooledGetUnspentTransaction : IGetUnspentTransaction
     {


### PR DESCRIPTION
As @dangershony said: the whole design behind .NodeService is wrong: we are supposed to inject services, not ask for them.

So in this PR .NodeService<T> usages for non-test methods are removed. 