### PR TITLE
bug fix - crash in validator

### DIFF
--- a/src/Stratis.Bitcoin.Features.Consensus/ConsensusLoop.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/ConsensusLoop.cs
@@ -351,13 +351,16 @@ namespace Stratis.Bitcoin.Features.Consensus
 
                 await this.consensusRules.ExecuteAsync(blockValidationContext);
 
-                try
+                if (blockValidationContext.Error == null)
                 {
-                    await this.ValidateAndExecuteBlockAsync(blockValidationContext.RuleContext, true).ConfigureAwait(false);
-                }
-                catch (ConsensusErrorException ex)
-                {
-                    blockValidationContext.Error = ex.ConsensusError;
+                    try
+                    {
+                        await this.ValidateAndExecuteBlockAsync(blockValidationContext.RuleContext, true).ConfigureAwait(false);
+                    }
+                    catch (ConsensusErrorException ex)
+                    {
+                        blockValidationContext.Error = ex.ConsensusError;
+                    }
                 }
 
                 if (blockValidationContext.Error != null)


### PR DESCRIPTION
PR #886 introduced a critical bug in consensus loop. This PR attempts to fix that. Hopefully it succeeds in that.

So, what is the problem?

`AcceptBlockAsync` contained this code:

```
                await this.consensusRules.ExecuteAsync(blockValidationContext);

                try
                {
                    await this.ValidateAndExecuteBlockAsync(blockValidationContext.RuleContext, true).ConfigureAwait(false);
                }
                catch (ConsensusErrorException ex)
                {
                    blockValidationContext.Error = ex.ConsensusError;
                }
```

the first line of that leads to `BlockHeaderRule.RunAsync`, which may throw:
```
            if (context.BlockValidationContext.Block.Header.HashPrevBlock != context.ConsensusTip.HashBlock)
            {
                this.Logger.LogTrace("Reorganization detected.");
                ConsensusErrors.InvalidPrevTip.Throw();
            }
```

if this is thrown, then the rest of that rule is not executed, especially `context.BlockValidationContext.ChainedBlock = new ChainedBlock` is not executed and therefore `context.BlockValidationContext.ChainedBlock` remains `null`

then `consensusRules.ExecuteAsync` catches that exception and stores it in `blockValidationContext.Error`

but then we call `ValidateAndExecuteBlockAsync` even if that error was set. So, `ValidateAndExecuteBlockAsync` is called with `skipRules` set to `true`, which calls `ValidateBlock` with `skipRules` set to `true`

so then the very first thing `ValidateBlock` calls is `this.Validator.CheckBlockHeader(context);`, which calls `PosConsensusValidator.CheckBlockHeader`, where we have 

```
            context.NextWorkRequired = this.StakeValidator.GetNextTargetRequired(this.stakeChain, context.BlockValidationContext.ChainedBlock.Previous, context.Consensus,
                context.Stake.BlockStake.IsProofOfStake());
```

which crashes because `context.BlockValidationContext.ChainedBlock` is null

This crashes Consensus loop in the node when reorg happens. It also crashes `PullerVsMinerRaceCondition` test (this test quite often leads to exactly that `InvalidPrevTip` exception, in which case it fails)!

So this PR adds check whether an error is there already and skips `ValidateAndExecuteBlockAsync` if that is the case, which should prevent such crashes.

