### PR TITLE
 Remove the "name" parameter in NodeSettings

### DIFF
--- a/src/NBitcoin/Network.cs
+++ b/src/NBitcoin/Network.cs
@@ -283,7 +283,7 @@ namespace NBitcoin
 
         public string Name { get; private set; }
 
-        /// <summary> The name of the root folder containing the different blockchains. </summary>
+        /// <summary> The name of the root folder containing blockchains operating with the same consensus rules (for now, this will be bitcoin or stratis). </summary>
         public string RootFolderName { get; private set; }
 
         /// <summary> The default name used for the network configuration file. </summary>

--- a/src/NBitcoin/Network.cs
+++ b/src/NBitcoin/Network.cs
@@ -73,51 +73,7 @@ namespace NBitcoin
         WITNESS_PUBKEY_ADDRESS,
         WITNESS_SCRIPT_ADDRESS
     }
-
-    public partial class Network
-    {
-        internal byte[][] base58Prefixes = new byte[12][];
-        internal Bech32Encoder[] bech32Encoders = new Bech32Encoder[2];
-
-        public Bech32Encoder GetBech32Encoder(Bech32Type type, bool throws)
-        {
-            var encoder = this.bech32Encoders[(int) type];
-            if (encoder == null && throws)
-                throw new NotImplementedException("The network " + this + " does not have any prefix for bech32 " +
-                                                  Enum.GetName(typeof(Bech32Type), type));
-            return encoder;
-        }
-
-        public byte[] GetVersionBytes(Base58Type type, bool throws)
-        {
-            var prefix = this.base58Prefixes[(int) type];
-            if (prefix == null && throws)
-                throw new NotImplementedException("The network " + this + " does not have any prefix for base58 " +
-                                                  Enum.GetName(typeof(Base58Type), type));
-            return prefix?.ToArray();
-        }
-
-        internal static string CreateBase58(Base58Type type, byte[] bytes, Network network)
-        {
-            if (network == null)
-                throw new ArgumentNullException("network");
-            if (bytes == null)
-                throw new ArgumentNullException("bytes");
-            var versionBytes = network.GetVersionBytes(type, true);
-            return Encoders.Base58Check.EncodeData(versionBytes.Concat(bytes));
-        }
-
-        internal static string CreateBech32(Bech32Type type, byte[] bytes, byte witnessVersion, Network network)
-        {
-            if (network == null)
-                throw new ArgumentNullException("network");
-            if (bytes == null)
-                throw new ArgumentNullException("bytes");
-            Bech32Encoder encoder = network.GetBech32Encoder(type, true);
-            return encoder.Encode(witnessVersion, bytes);
-        }
-    }
-
+    
     public enum BuriedDeployments : int
     {
         /// <summary>
@@ -831,6 +787,48 @@ namespace NBitcoin
                     i = this.MagicBytesArray[0] == bytes[0] ? 0 : -1;
             }
             return true;
+        }
+
+        internal byte[][] base58Prefixes = new byte[12][];
+
+        internal Bech32Encoder[] bech32Encoders = new Bech32Encoder[2];
+
+        public Bech32Encoder GetBech32Encoder(Bech32Type type, bool throws)
+        {
+            var encoder = this.bech32Encoders[(int)type];
+            if (encoder == null && throws)
+                throw new NotImplementedException("The network " + this + " does not have any prefix for bech32 " +
+                                                  Enum.GetName(typeof(Bech32Type), type));
+            return encoder;
+        }
+
+        public byte[] GetVersionBytes(Base58Type type, bool throws)
+        {
+            var prefix = this.base58Prefixes[(int)type];
+            if (prefix == null && throws)
+                throw new NotImplementedException("The network " + this + " does not have any prefix for base58 " +
+                                                  Enum.GetName(typeof(Base58Type), type));
+            return prefix?.ToArray();
+        }
+
+        internal static string CreateBase58(Base58Type type, byte[] bytes, Network network)
+        {
+            if (network == null)
+                throw new ArgumentNullException("network");
+            if (bytes == null)
+                throw new ArgumentNullException("bytes");
+            var versionBytes = network.GetVersionBytes(type, true);
+            return Encoders.Base58Check.EncodeData(versionBytes.Concat(bytes));
+        }
+
+        internal static string CreateBech32(Bech32Type type, byte[] bytes, byte witnessVersion, Network network)
+        {
+            if (network == null)
+                throw new ArgumentNullException("network");
+            if (bytes == null)
+                throw new ArgumentNullException("bytes");
+            Bech32Encoder encoder = network.GetBech32Encoder(type, true);
+            return encoder.Encode(witnessVersion, bytes);
         }
     }
 }

--- a/src/NBitcoin/Network.cs
+++ b/src/NBitcoin/Network.cs
@@ -283,6 +283,12 @@ namespace NBitcoin
 
         public string Name { get; private set; }
 
+        /// <summary> The name of the root folder containing the different blockchains. </summary>
+        public string RootFolderName { get; private set; }
+
+        /// <summary> The default name used for the network configuration file. </summary>
+        public string DefaultConfigFilename { get; private set; }
+
         public IEnumerable<NetworkAddress> SeedNodes => this.fixedSeeds;
 
         public IEnumerable<DNSSeedData> DNSSeeds => this.seeds;
@@ -324,6 +330,8 @@ namespace NBitcoin
 
             Network network = new Network();
             network.Name = builder.Name;
+            network.RootFolderName = builder.RootFolderName;
+            network.DefaultConfigFilename = builder.DefaultConfigFilename;
             network.consensus = builder.Consensus;
             network.magic = builder.Magic;
             network.DefaultPort = builder.Port;

--- a/src/NBitcoin/NetworkBuilder.cs
+++ b/src/NBitcoin/NetworkBuilder.cs
@@ -8,6 +8,8 @@ namespace NBitcoin
     public class NetworkBuilder
     {
         internal string Name;
+        internal string RootFolderName;
+        internal string DefaultConfigFilename;
         internal Dictionary<Base58Type, byte[]> Base58Prefixes;
         internal Dictionary<Bech32Type, Bech32Encoder> Bech32Prefixes;
         internal List<string> Aliases;
@@ -34,6 +36,28 @@ namespace NBitcoin
         public NetworkBuilder SetName(string name)
         {
             this.Name = name;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the name of the folder containing the different blockchains.
+        /// </summary>
+        /// <param name="rootFolderName">The name of the folder.</param>
+        /// <returns>A <see cref="NetworkBuilder"/>.</returns>
+        public NetworkBuilder SetRootFolderName(string rootFolderName)
+        {
+            this.RootFolderName = rootFolderName;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the default name used for the network configuration file.
+        /// </summary>
+        /// <param name="defaultConfigFilename">The name of the file.</param>
+        /// <returns>A <see cref="NetworkBuilder"/>.</returns>
+        public NetworkBuilder SetDefaultConfigFilename(string defaultConfigFilename)
+        {
+            this.DefaultConfigFilename = defaultConfigFilename;
             return this;
         }
 

--- a/src/NBitcoin/Networks.cs
+++ b/src/NBitcoin/Networks.cs
@@ -26,6 +26,18 @@ namespace NBitcoin
             Block.BlockSignature = saveSig;
         }
 
+        /// <summary> The name of the root folder containing the different Bitcoin blockchains (Main, TestNet, RegTest). </summary>
+        public const string BitcoinRootFolderName = "bitcoin";
+
+        /// <summary> The default name used for the Bitcoin configuration file. </summary>
+        public const string BitcoinDefaultConfigFilename = "bitcoin.conf";
+
+        /// <summary> The name of the root folder containing the different Stratis blockchains (StratisMain, StratisTest, StratisRegTest). </summary>
+        public const string StratisRootFolderName = "stratis";
+
+        /// <summary> The default name used for the Stratis configuration file. </summary>
+        public const string StratisDefaultConfigFilename = "stratis.conf";
+
         public static Network Main => Network.GetNetwork("Main") ?? InitMain();
 
         public static Network TestNet => Network.GetNetwork("TestNet") ?? InitTest();
@@ -40,9 +52,12 @@ namespace NBitcoin
 
         private static Network InitMain()
         {
-            Network network = new Network();
-
-            network.Name = "Main";
+            Network network = new Network
+            {
+                Name = "Main",
+                RootFolderName = BitcoinRootFolderName,
+                DefaultConfigFilename = BitcoinDefaultConfigFilename
+            };
 
             Consensus consensus = network.consensus;
 
@@ -134,9 +149,12 @@ namespace NBitcoin
 
         private static Network InitTest()
         {
-            Network network = new Network();
-
-            network.Name = "TestNet";
+            Network network = new Network
+            {
+                Name = "TestNet",
+                RootFolderName = BitcoinRootFolderName,
+                DefaultConfigFilename = BitcoinDefaultConfigFilename
+            };
 
             network.consensus.SubsidyHalvingInterval = 210000;
             network.consensus.MajorityEnforceBlockUpgrade = 51;
@@ -207,9 +225,13 @@ namespace NBitcoin
 
         private static Network InitReg()
         {
-            Network network = new Network();
-
-            network.Name = "RegTest";
+            Network network = new Network
+            {
+                Name = "RegTest",
+                RootFolderName = BitcoinRootFolderName,
+                DefaultConfigFilename = BitcoinDefaultConfigFilename
+            };
+            
             network.consensus.SubsidyHalvingInterval = 150;
             network.consensus.MajorityEnforceBlockUpgrade = 750;
             network.consensus.MajorityRejectBlockOutdated = 950;
@@ -322,6 +344,8 @@ namespace NBitcoin
 
             var builder = new NetworkBuilder()
                 .SetName("StratisMain")
+                .SetRootFolderName(StratisRootFolderName)
+                .SetDefaultConfigFilename(StratisDefaultConfigFilename)
                 .SetConsensus(consensus)
                 .SetMagic(magic)
                 .SetGenesis(genesis)
@@ -403,6 +427,8 @@ namespace NBitcoin
 
             var builder = new NetworkBuilder()
                 .SetName("StratisTest")
+                .SetRootFolderName(StratisRootFolderName)
+                .SetDefaultConfigFilename(StratisDefaultConfigFilename)
                 .SetConsensus(consensus)
                 .SetMagic(magic)
                 .SetGenesis(genesis)
@@ -464,6 +490,8 @@ namespace NBitcoin
 
             var builder = new NetworkBuilder()
                 .SetName("StratisRegTest")
+                .SetRootFolderName(StratisRootFolderName)
+                .SetDefaultConfigFilename(StratisDefaultConfigFilename)
                 .SetConsensus(consensus)
                 .SetMagic(magic)
                 .SetGenesis(genesis)

--- a/src/Stratis.Bitcoin.Api.Tests/ApiSettingsTest.cs
+++ b/src/Stratis.Bitcoin.Api.Tests/ApiSettingsTest.cs
@@ -32,7 +32,7 @@ namespace Stratis.Bitcoin.Api.Tests
         {
             // Arrange.
             Network network = Network.Main;
-            NodeSettings nodeSettings = new NodeSettings("bitcoin", network).LoadArguments(new string[0]);
+            NodeSettings nodeSettings = new NodeSettings(network).LoadArguments(new string[0]);
 
             // Act.
             ApiSettings settings = new FullNodeBuilder()
@@ -57,7 +57,7 @@ namespace Stratis.Bitcoin.Api.Tests
             Transaction.TimeStamp = true;
             Block.BlockSignature = true;
             Network network = Network.StratisMain;
-            NodeSettings nodeSettings = new NodeSettings("stratis", network).LoadArguments(new string[0]);
+            NodeSettings nodeSettings = new NodeSettings(network).LoadArguments(new string[0]);
 
             // Act.
             ApiSettings settings = new FullNodeBuilder()
@@ -104,7 +104,7 @@ namespace Stratis.Bitcoin.Api.Tests
             // Arrange.
             string customApiUri = "http://0.0.0.0";
             Network network = Network.Main;
-            NodeSettings nodeSettings = new NodeSettings("bitcoin", network).LoadArguments(new[] { $"-apiuri={customApiUri}" });
+            NodeSettings nodeSettings = new NodeSettings(network).LoadArguments(new[] { $"-apiuri={customApiUri}" });
 
             // Act.
             ApiSettings settings = new FullNodeBuilder()
@@ -130,7 +130,7 @@ namespace Stratis.Bitcoin.Api.Tests
             Block.BlockSignature = true;
             string customApiUri = "http://0.0.0.0";
             Network network = Network.StratisMain;
-            NodeSettings nodeSettings = new NodeSettings("stratis", network).LoadArguments(new[] { $"-apiuri={customApiUri}" });
+            NodeSettings nodeSettings = new NodeSettings(network).LoadArguments(new[] { $"-apiuri={customApiUri}" });
 
             // Act.
             ApiSettings settings = new FullNodeBuilder()
@@ -155,7 +155,7 @@ namespace Stratis.Bitcoin.Api.Tests
             string customApiUri = "http://0.0.0.0";
             int customPort = 55555;
             Network network = Network.Main;
-            NodeSettings nodeSettings = new NodeSettings("bitcoin", network).LoadArguments(new[] { $"-apiuri={customApiUri}", $"-apiport={customPort}" });
+            NodeSettings nodeSettings = new NodeSettings(network).LoadArguments(new[] { $"-apiuri={customApiUri}", $"-apiport={customPort}" });
 
             // Act.
             ApiSettings settings = new FullNodeBuilder()
@@ -180,7 +180,7 @@ namespace Stratis.Bitcoin.Api.Tests
             int customPort = 5522;
             string customApiUri = $"http://0.0.0.0:{customPort}";
             Network network = Network.Main;
-            NodeSettings nodeSettings = new NodeSettings("bitcoin", network).LoadArguments(new[] { $"-apiuri={customApiUri}" });
+            NodeSettings nodeSettings = new NodeSettings(network).LoadArguments(new[] { $"-apiuri={customApiUri}" });
 
             // Act.
             ApiSettings settings = new FullNodeBuilder()

--- a/src/Stratis.Bitcoin.Cli/Program.cs
+++ b/src/Stratis.Bitcoin.Cli/Program.cs
@@ -87,19 +87,16 @@ namespace Stratis.Bitcoin.Cli
                 }
 
                 // Determine API port.
-                string blockchain = string.Empty;
                 int defaultRestApiPort = 0;
                 Network network = null;
 
                 if (networkName.Contains("stratis"))
                 {
-                    blockchain = "stratis";
                     defaultRestApiPort = 37221;
                     network = Network.StratisMain;
                 }
                 else
                 {
-                    blockchain = "bitcoin";
                     defaultRestApiPort = 37220;
                     network = Network.Main;
                 }
@@ -115,7 +112,7 @@ namespace Stratis.Bitcoin.Cli
                     {
                         var options = optionList.ToArray();
 
-                        NodeSettings nodeSettings = new NodeSettings(blockchain, network).LoadArguments(options);
+                        NodeSettings nodeSettings = new NodeSettings(network).LoadArguments(options);
 
                         var rpcSettings = new RpcSettings();
 

--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/ConsensusSettingsTest.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/ConsensusSettingsTest.cs
@@ -13,7 +13,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests
             uint256 validHexBlock = new uint256("00000000229d9fb87182d73870d53f9fdd9b76bfc02c059e6d9a6c7a3507031d");
             LoggerFactory loggerFactory = new LoggerFactory();
             Network network = Network.TestNet;
-            NodeSettings nodeSettings = new NodeSettings(network.Name, network).LoadArguments(new string[] { $"-assumevalid={validHexBlock.ToString()}" });
+            NodeSettings nodeSettings = new NodeSettings(network).LoadArguments(new string[] { $"-assumevalid={validHexBlock.ToString()}" });
             ConsensusSettings settings = new ConsensusSettings(nodeSettings, loggerFactory);
             Assert.Equal(validHexBlock, settings.BlockAssumedValid);
         }
@@ -23,7 +23,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests
         {
             LoggerFactory loggerFactory = new LoggerFactory();
             Network network = Network.TestNet;
-            NodeSettings nodeSettings = new NodeSettings(network.Name, network).LoadArguments(new string[] { "-assumevalid=0" });
+            NodeSettings nodeSettings = new NodeSettings(network).LoadArguments(new string[] { "-assumevalid=0" });
             ConsensusSettings settings = new ConsensusSettings(nodeSettings, loggerFactory);
             Assert.Null(settings.BlockAssumedValid);
         }
@@ -33,7 +33,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests
         {
             LoggerFactory loggerFactory = new LoggerFactory();
             Network network = Network.TestNet;
-            NodeSettings nodeSettings = new NodeSettings(network.Name, network).LoadArguments(new string[] { "-assumevalid=xxx" });
+            NodeSettings nodeSettings = new NodeSettings(network).LoadArguments(new string[] { "-assumevalid=xxx" });
             Assert.Throws<ConfigurationException>(() => new ConsensusSettings(nodeSettings, loggerFactory));
         }
 

--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/InitialBlockDownloadTest.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/InitialBlockDownloadTest.cs
@@ -20,7 +20,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests
             this.network = Network.Main;
             this.consensusSettings = new ConsensusSettings(NodeSettings.Default(), new ExtendedLoggerFactory());
             this.checkpoints = new Checkpoints(this.network, this.consensusSettings);
-            this.nodeSettings = new NodeSettings("stratis", this.network);
+            this.nodeSettings = new NodeSettings(this.network);
             this.chainState = new ChainState(new InvalidBlockHashStore(DateTimeProvider.Default));
         }
 

--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/TestRulesContext.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/TestRulesContext.cs
@@ -55,7 +55,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules
             string dataDir = Path.Combine("TestData", pathName);
             Directory.CreateDirectory(dataDir);
 
-            testRulesContext.NodeSettings = new NodeSettings(network.Name, network).LoadArguments(new string[] { $"-datadir={dataDir}" });
+            testRulesContext.NodeSettings = new NodeSettings(network).LoadArguments(new[] { $"-datadir={dataDir}" });
 
             if (dataDir != null)
             {

--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/TestChainFactory.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/TestChainFactory.cs
@@ -67,7 +67,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests
         {
             var testChainContext = new TestChainContext() { Network = network };
 
-            testChainContext.NodeSettings = new NodeSettings(network.Name, network).LoadArguments(new string[] { $"-datadir={dataDir}" });
+            testChainContext.NodeSettings = new NodeSettings(network).LoadArguments(new string[] { $"-datadir={dataDir}" });
 
             if (dataDir != null)
             {

--- a/src/Stratis.Bitcoin.Features.Dns.Tests/GivenADnsFeature.cs
+++ b/src/Stratis.Bitcoin.Features.Dns.Tests/GivenADnsFeature.cs
@@ -115,7 +115,7 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
             IWhitelistManager whitelistManager = new Mock<IWhitelistManager>().Object;
             ILoggerFactory loggerFactory = new Mock<ILoggerFactory>().Object;
             INodeLifetime nodeLifetime = new Mock<INodeLifetime>().Object;
-            NodeSettings nodeSettings = new Mock<NodeSettings>("bitcoin", null, NodeSettings.SupportedProtocolVersion, "StratisBitcoin").Object;
+            NodeSettings nodeSettings = new Mock<NodeSettings>(null, NodeSettings.SupportedProtocolVersion, "StratisBitcoin").Object;
             DnsSettings dnsSettings = new Mock<DnsSettings>().Object;
             IAsyncLoopFactory asyncLoopFactory = new Mock<IAsyncLoopFactory>().Object;
             Action a = () => { new DnsFeature(dnsServer, whitelistManager, loggerFactory, nodeLifetime, dnsSettings, nodeSettings, null, asyncLoopFactory); };

--- a/src/Stratis.Bitcoin.Features.Dns.Tests/GivenAWhitelistManager.cs
+++ b/src/Stratis.Bitcoin.Features.Dns.Tests/GivenAWhitelistManager.cs
@@ -250,7 +250,7 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
                 .Verifiable();
 
             Network network = Network.StratisTest;
-            NodeSettings nodeSettings = new NodeSettings(network.Name, network).LoadArguments(args);
+            NodeSettings nodeSettings = new NodeSettings(network).LoadArguments(args);
             DnsSettings dnsSettings = new Mock<DnsSettings>().Object;
             dnsSettings.DnsPeerBlacklistThresholdInSeconds = inactiveTimePeriod;
             dnsSettings.DnsHostName = "stratis.test.com";
@@ -338,7 +338,7 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
                 .Verifiable();
 
             Network network = Network.StratisTest;
-            NodeSettings nodeSettings = new NodeSettings(network.Name, network).LoadArguments(args);
+            NodeSettings nodeSettings = new NodeSettings(network).LoadArguments(args);
             DnsSettings dnsSettings = new Mock<DnsSettings>().Object;
             dnsSettings.DnsFullNode = true;
             dnsSettings.DnsPeerBlacklistThresholdInSeconds = inactiveTimePeriod;

--- a/src/Stratis.Bitcoin.Features.LightWallet.Tests/LightWalletFixedFeePolicyTest.cs
+++ b/src/Stratis.Bitcoin.Features.LightWallet.Tests/LightWalletFixedFeePolicyTest.cs
@@ -66,7 +66,7 @@ namespace Stratis.Bitcoin.Features.LightWallet.Tests
         public void MinTxFee_OnStratisNetwork_IsStratisDefault()
         {
             ILoggerFactory loggerFactory = new LoggerFactory();
-            NodeSettings nodeSettings = new NodeSettings(innerNetwork: Network.StratisTest).LoadArguments(new string[0]);
+            NodeSettings nodeSettings = new NodeSettings(Network.StratisTest).LoadArguments(new string[0]);
             LightWalletFixedFeePolicy policy = new LightWalletFixedFeePolicy(loggerFactory, nodeSettings);
             Assert.Equal(new FeeRate(Network.StratisTest.FallbackFee), policy.FallbackTxFeeRate);
         }
@@ -75,7 +75,7 @@ namespace Stratis.Bitcoin.Features.LightWallet.Tests
         public void MinTxFee_OnBitcoinNetwork_IsBitcoinDefault()
         {
             ILoggerFactory loggerFactory = new LoggerFactory();
-            NodeSettings nodeSettings = new NodeSettings(innerNetwork: Network.TestNet).LoadArguments(new string[0]);
+            NodeSettings nodeSettings = new NodeSettings(Network.TestNet).LoadArguments(new string[0]);
             LightWalletFixedFeePolicy policy = new LightWalletFixedFeePolicy(loggerFactory, nodeSettings);
             Assert.Equal(new FeeRate(Network.TestNet.FallbackFee), policy.FallbackTxFeeRate);
         }

--- a/src/Stratis.Bitcoin.Features.MemoryPool.Tests/TestChainFactory.cs
+++ b/src/Stratis.Bitcoin.Features.MemoryPool.Tests/TestChainFactory.cs
@@ -63,7 +63,7 @@ namespace Stratis.Bitcoin.Features.MemoryPool.Tests
         /// <returns>Context object representing the test chain.</returns>
         public static async Task<ITestChainContext> CreateAsync(Network network, Script scriptPubKey, string dataDir)
         {
-            NodeSettings nodeSettings = new NodeSettings(network.Name, network).LoadArguments(new string[] { $"-datadir={dataDir}" });
+            NodeSettings nodeSettings = new NodeSettings(network).LoadArguments(new string[] { $"-datadir={dataDir}" });
             if (dataDir != null)
             {
                 nodeSettings.DataDir = dataDir;

--- a/src/Stratis.Bitcoin.IntegrationTests/EnvironmentMockUpHelpers/NodeRunners.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/EnvironmentMockUpHelpers/NodeRunners.cs
@@ -75,7 +75,7 @@ namespace Stratis.Bitcoin.IntegrationTests.EnvironmentMockUpHelpers
 
         public void Start(string dataDir)
         {
-            NodeSettings nodeSettings = new NodeSettings("stratis", InitStratisRegTest(), ProtocolVersion.ALT_PROTOCOL_VERSION).LoadArguments(new string[] { "-conf=stratis.conf", "-datadir=" + dataDir });
+            NodeSettings nodeSettings = new NodeSettings(InitStratisRegTest(), ProtocolVersion.ALT_PROTOCOL_VERSION).LoadArguments(new string[] { "-conf=stratis.conf", "-datadir=" + dataDir });
 
             var node = BuildFullNode(nodeSettings, this.callback);
 

--- a/src/Stratis.Bitcoin/Configuration/NodeSettings.cs
+++ b/src/Stratis.Bitcoin/Configuration/NodeSettings.cs
@@ -41,16 +41,11 @@ namespace Stratis.Bitcoin.Configuration
         /// <summary>
         /// Initializes a new instance of the object.
         /// </summary>
-        /// <param name="name">Blockchain name. Currently only "bitcoin" and "stratis" are used.</param>
         /// <param name="innerNetwork">Specification of the network the node runs on - regtest/testnet/mainnet.</param>
         /// <param name="protocolVersion">Supported protocol version for which to create the configuration.</param>
         /// <param name="agent">The nodes user agent that will be shared with peers.</param>
-        public NodeSettings(string name = "bitcoin", Network innerNetwork = null, ProtocolVersion protocolVersion = SupportedProtocolVersion, string agent = "StratisBitcoin")
+        public NodeSettings(Network innerNetwork = null, ProtocolVersion protocolVersion = SupportedProtocolVersion, string agent = "StratisBitcoin")
         {
-            if (string.IsNullOrEmpty(name))
-                throw new ConfigurationException("A network name is mandatory.");
-
-            this.Name = name;
             this.Agent = agent;
             this.Network = innerNetwork;
             this.ProtocolVersion = protocolVersion;
@@ -97,10 +92,7 @@ namespace Stratis.Bitcoin.Configuration
 
         /// <summary>Specification of the network the node runs on - regtest/testnet/mainnet.</summary>
         public Network Network { get; private set; }
-
-        /// <summary>Blockchain name. Currently only "bitcoin" and "stratis" are used.</summary>
-        public string Name { get; set; }
-
+        
         /// <summary>The node's user agent that will be shared with peers in the version handshake.</summary>
         public string Agent { get; set; }
 
@@ -174,16 +166,16 @@ namespace Stratis.Bitcoin.Configuration
                 throw new ConfigurationException("Invalid combination of -regtest and -testnet.");
 
             this.Network = this.GetNetwork();
-
+            
             // Setting the data directory.
             if (dataDir == null)
             {
-                this.DataDir = this.CreateDefaultDataDirectories(Path.Combine("StratisNode", this.Name), this.Network);
+                this.DataDir = this.CreateDefaultDataDirectories(Path.Combine("StratisNode", this.Network.RootFolderName), this.Network);
             }
             else
             {
                 // Create the data directories if they don't exist.
-                string directoryPath = Path.Combine(dataDir, this.Name, this.Network.Name);
+                string directoryPath = Path.Combine(dataDir, this.Network.RootFolderName, this.Network.Name);
                 Directory.CreateDirectory(directoryPath);
                 this.DataDir = directoryPath;
                 this.Logger.LogDebug("Data directory initialized with path {0}.", directoryPath);
@@ -283,7 +275,7 @@ namespace Stratis.Bitcoin.Configuration
         /// <returns>Path to the configuration file.</returns>
         private string CreateDefaultConfigurationFile()
         {
-            string configFilePath = Path.Combine(this.DataDir, $"{this.Name}.conf");
+            string configFilePath = Path.Combine(this.DataDir, this.Network.DefaultConfigFilename);
             this.Logger.LogDebug("Configuration file set to '{0}'.", configFilePath);
 
             // Create a config file if none exist.

--- a/src/Stratis.BreezeD/Program.cs
+++ b/src/Stratis.BreezeD/Program.cs
@@ -41,7 +41,7 @@ namespace Stratis.BreezeD
                     if (isTestNet)
                         args = args.Append("-addnode=51.141.28.47").ToArray(); // TODO: fix this temp hack
 
-                    nodeSettings = new NodeSettings("stratis", network, ProtocolVersion.ALT_PROTOCOL_VERSION, agent).LoadArguments(args);
+                    nodeSettings = new NodeSettings(network, ProtocolVersion.ALT_PROTOCOL_VERSION, agent).LoadArguments(args);
                 }
                 else
                 {

--- a/src/Stratis.StratisD/Program.cs
+++ b/src/Stratis.StratisD/Program.cs
@@ -28,7 +28,7 @@ namespace Stratis.StratisD
             try
             {
                 Network network = args.Contains("-testnet") ? Network.StratisTest : Network.StratisMain;
-                NodeSettings nodeSettings = new NodeSettings("stratis", network, ProtocolVersion.ALT_PROTOCOL_VERSION).LoadArguments(args);
+                NodeSettings nodeSettings = new NodeSettings(network, ProtocolVersion.ALT_PROTOCOL_VERSION).LoadArguments(args);
 
                 // NOTES: running BTC and STRAT side by side is not possible yet as the flags for serialization are static
 

--- a/src/Stratis.StratisDnsD/Program.cs
+++ b/src/Stratis.StratisDnsD/Program.cs
@@ -42,7 +42,7 @@ namespace Stratis.StratisDnsD
             try
             {
                 Network network = args.Contains("-testnet") ? Network.StratisTest : Network.StratisMain;
-                NodeSettings nodeSettings = new NodeSettings("stratis", network, ProtocolVersion.ALT_PROTOCOL_VERSION).LoadArguments(args);
+                NodeSettings nodeSettings = new NodeSettings(network, ProtocolVersion.ALT_PROTOCOL_VERSION).LoadArguments(args);
                 DnsSettings dnsSettings = DnsSettings.Load(nodeSettings);
 
                 // Verify that the DNS host, nameserver and mailbox arguments are set.


### PR DESCRIPTION
Removed the parameter name as well as the property as it is not really used apart for setting the root folder where the different blockchain files are stored. Furthermore, it lead to confusion and errors as the wrong name was sometimes used for another network.
