### PR TITLE
Added testnet API ports.

### DIFF
--- a/src/Stratis.Bitcoin.Api.Tests/ApiSettingsTest.cs
+++ b/src/Stratis.Bitcoin.Api.Tests/ApiSettingsTest.cs
@@ -10,9 +10,6 @@ namespace Stratis.Bitcoin.Api.Tests
 {
     /// <summary>
     /// Tests the settings for the API features.
-    /// The default settings are:
-    /// ApiPort: 37220 for bitcoin, 37221 for Stratis.
-    /// ApiUri: http://localhost:37220 or http://localhost:37221.
     /// </summary>
     public class ApiSettingsTest : TestBase
     {
@@ -193,6 +190,94 @@ namespace Stratis.Bitcoin.Api.Tests
             // Assert.
             Assert.Equal(customPort, settings.ApiPort);
             Assert.Equal(new Uri($"{customApiUri}"), settings.ApiUri);
+        }
+
+        /// <summary>
+        /// Tests that if we're on the Bitcoin main network, the port used in the API is the right one.
+        /// </summary>
+        [Fact]
+        public void GivenBitcoinMain_ThenUseTheCorrectPort()
+        {
+            // Arrange.
+            NodeSettings nodeSettings = NodeSettings.Default(Network.Main);
+
+            // Act.
+            ApiSettings settings = new FullNodeBuilder()
+                .UseNodeSettings(nodeSettings)
+                .UseApi()
+                .Build()
+                .NodeService<ApiSettings>();
+            settings.Load(nodeSettings);
+
+            // Assert.
+            Assert.Equal(ApiSettings.DefaultBitcoinApiPort, settings.ApiPort);
+        }
+
+        /// <summary>
+        /// Tests that if we're on the Bitcoin test network, the port used in the API is the right one.
+        /// </summary>
+        [Fact]
+        public void GivenBitcoinTestnet_ThenUseTheCorrectPort()
+        {
+            // Arrange.
+            NodeSettings nodeSettings = NodeSettings.Default(Network.TestNet);
+
+            // Act.
+            ApiSettings settings = new FullNodeBuilder()
+                .UseNodeSettings(nodeSettings)
+                .UseApi()
+                .Build()
+                .NodeService<ApiSettings>();
+            settings.Load(nodeSettings);
+
+            // Assert.
+            Assert.Equal(ApiSettings.TestBitcoinApiPort, settings.ApiPort);
+        }
+
+        /// <summary>
+        /// Tests that if we're on the Stratis main network, the port used in the API is the right one.
+        /// </summary>
+        [Fact]
+        public void GivenStratisMainnet_ThenUseTheCorrectPort()
+        {
+            // Arrange.
+            Transaction.TimeStamp = true;
+            Block.BlockSignature = true;
+            NodeSettings nodeSettings = NodeSettings.Default(Network.StratisMain);
+
+            // Act.
+            ApiSettings settings = new FullNodeBuilder()
+                .UseNodeSettings(nodeSettings)
+                .UseApi()
+                .Build()
+                .NodeService<ApiSettings>();
+            settings.Load(nodeSettings);
+
+            // Assert.
+            Assert.Equal(ApiSettings.DefaultStratisApiPort, settings.ApiPort);
+        }
+
+        /// <summary>
+        /// Tests that if we're on the Stratis test network, the port used in the API is the right one.
+        /// </summary>
+        [Fact]
+        public void GivenStratisTestnet_ThenUseTheCorrectPort()
+        {
+            // Arrange.
+            Transaction.TimeStamp = true;
+            Block.BlockSignature = true;
+            NodeSettings nodeSettings = NodeSettings.Default(Network.StratisTest);
+
+            // Act.
+            ApiSettings settings = new FullNodeBuilder()
+                .UseNodeSettings(nodeSettings)
+                .UseApi()
+                .Build()
+                .NodeService<ApiSettings>();
+            settings.Load(nodeSettings);
+
+            // Assert.
+            Assert.Equal(ApiSettings.TestStratisApiPort, settings.ApiPort);
         }
     }
 }

--- a/src/Stratis.Bitcoin.Features.Api/ApiSettings.cs
+++ b/src/Stratis.Bitcoin.Features.Api/ApiSettings.cs
@@ -15,6 +15,12 @@ namespace Stratis.Bitcoin.Features.Api
         /// <summary>The default port used by the API when the node runs on the Stratis network.</summary>
         public const int DefaultStratisApiPort = 37221;
 
+        /// <summary>The default port used by the API when the node runs on the bitcoin testnet network.</summary>
+        public const int TestBitcoinApiPort = 38220;
+
+        /// <summary>The default port used by the API when the node runs on the Stratis testnet network.</summary>
+        public const int TestStratisApiPort = 38221;
+
         /// <summary>The default port used by the API when the node runs on the Stratis network.</summary>
         public const string DefaultApiHost = "http://localhost";
 
@@ -48,7 +54,18 @@ namespace Stratis.Bitcoin.Features.Api
             var apiHost = config.GetOrDefault("apiuri", DefaultApiHost);
             Uri apiUri = new Uri(apiHost);
 
-            var apiPort = config.GetOrDefault("apiport", nodeSettings.Network.IsBitcoin() ? DefaultBitcoinApiPort : DefaultStratisApiPort);
+            // Find out which port should be used for the API.
+            int port;
+            if (nodeSettings.Network.IsBitcoin())
+            {
+                port = nodeSettings.Network.IsTest() ? TestBitcoinApiPort : DefaultBitcoinApiPort;
+            }
+            else
+            {
+                port = nodeSettings.Network.IsTest() ? TestStratisApiPort : DefaultStratisApiPort;
+            }
+
+            var apiPort = config.GetOrDefault("apiport", port);
             
             // If no port is set in the API URI.
             if (apiUri.IsDefaultPort)


### PR DESCRIPTION
Added ports 38220 and 38221 to be the API ports for bitcoin testnet and stratis testnet respectively.
This allows mainnet and a testnet nodes to be run at the same time on a single machine.