### PR TITLE
Allow WO wallet to track incoming and outgoing tx

### DIFF
--- a/src/Stratis.Bitcoin.Features.WatchOnlyWallet.Tests/WatchOnlyWalletManagerTest.cs
+++ b/src/Stratis.Bitcoin.Features.WatchOnlyWallet.Tests/WatchOnlyWalletManagerTest.cs
@@ -140,7 +140,7 @@ namespace Stratis.Bitcoin.Features.WatchOnlyWallet.Tests
             DataFolder dataFolder = CreateDataFolder(this);
 
             // Create the wallet to watch.
-            var wallet = this.CreateAndPersistAWatchOnlyWallet(dataFolder);
+            WatchOnlyWallet wallet = this.CreateAndPersistAWatchOnlyWallet(dataFolder);
 
             // Create the address to watch.
             Script newScript = BitcoinAddress.Create("mnSmvy2q4dFNKQF18EBsrZrS7WEy6CieEE", Network.TestNet).ScriptPubKey;

--- a/src/Stratis.Bitcoin.Features.WatchOnlyWallet/WatchOnlyWallet.cs
+++ b/src/Stratis.Bitcoin.Features.WatchOnlyWallet/WatchOnlyWallet.cs
@@ -82,15 +82,24 @@ namespace Stratis.Bitcoin.Features.WatchOnlyWallet
                 {
                     // Check to see if there is better information in
                     // the watched transaction than the watched address.
-                    // If there is, use the watched transaction instead.
+                    // If there is, use the watched transaction info instead.
 
                     TransactionData existingTx = txDict[transaction.Id];
 
-                    if ((existingTx.MerkleProof == null && transaction.MerkleProof != null) ||
-                        (existingTx.BlockHash == null && transaction.BlockHash != null))
+                    if (existingTx.MerkleProof == null)
                     {
-                        txDict.TryUpdate(transaction.Id, transaction, existingTx);
+                        existingTx.MerkleProof = transaction.MerkleProof;
                     }
+
+                    if (existingTx.BlockHash == null)
+                    {
+                        existingTx.MerkleProof = transaction.MerkleProof;
+                    }
+
+                    // At this stage the transaction info in txDict should
+                    // include the best available information from both
+                    // sources. There is therefore no need to explicitly
+                    // update txDict.
                 }
             }
 

--- a/src/Stratis.Bitcoin.Features.WatchOnlyWallet/WatchOnlyWallet.cs
+++ b/src/Stratis.Bitcoin.Features.WatchOnlyWallet/WatchOnlyWallet.cs
@@ -61,7 +61,6 @@ namespace Stratis.Bitcoin.Features.WatchOnlyWallet
         /// Returns a dictionary of all the transactions being watched (both under addresses
         /// and standalone).
         /// </summary>
-        /// <returns></returns>
         public ConcurrentDictionary<uint256, TransactionData> GetWatchedTransactions()
         {
             var txDict = new ConcurrentDictionary<uint256, TransactionData>();

--- a/src/Stratis.Bitcoin.Features.WatchOnlyWallet/WatchOnlyWallet.cs
+++ b/src/Stratis.Bitcoin.Features.WatchOnlyWallet/WatchOnlyWallet.cs
@@ -93,7 +93,7 @@ namespace Stratis.Bitcoin.Features.WatchOnlyWallet
 
                     if (existingTx.BlockHash == null)
                     {
-                        existingTx.MerkleProof = transaction.MerkleProof;
+                        existingTx.BlockHash = transaction.BlockHash;
                     }
 
                     // At this stage the transaction info in txDict should

--- a/src/Stratis.Bitcoin.Features.WatchOnlyWallet/WatchOnlyWalletManager.cs
+++ b/src/Stratis.Bitcoin.Features.WatchOnlyWallet/WatchOnlyWalletManager.cs
@@ -267,9 +267,8 @@ namespace Stratis.Bitcoin.Features.WatchOnlyWallet
         private void LoadTransactionLookup()
         {
             var lookup = new Dictionary<uint256, TransactionData>();
-            WatchOnlyWallet watchOnlyWallet = this.GetWatchOnlyWallet();
 
-            foreach (WatchedAddress address in watchOnlyWallet.WatchedAddresses.Values)
+            foreach (WatchedAddress address in this.Wallet.WatchedAddresses.Values)
             {
                 foreach (TransactionData transaction in address.Transactions.Values)
                 {
@@ -277,7 +276,7 @@ namespace Stratis.Bitcoin.Features.WatchOnlyWallet
                 }
             }
 
-            foreach (TransactionData transaction in watchOnlyWallet.WatchedTransactions.Values)
+            foreach (TransactionData transaction in this.Wallet.WatchedTransactions.Values)
             {
                 // It is conceivable that a transaction could be both watched
                 // in isolation and watched as a transaction under one or

--- a/src/Stratis.Bitcoin.Features.WatchOnlyWallet/WatchOnlyWalletManager.cs
+++ b/src/Stratis.Bitcoin.Features.WatchOnlyWallet/WatchOnlyWalletManager.cs
@@ -320,9 +320,7 @@ namespace Stratis.Bitcoin.Features.WatchOnlyWallet
             {
                 Network = this.network,
                 CoinType = this.coinType,
-                CreationTime = this.dateTimeProvider.GetTimeOffset(),
-                WatchedAddresses = new ConcurrentDictionary<string, WatchedAddress>(),
-                WatchedTransactions = new ConcurrentDictionary<string, TransactionData>()
+                CreationTime = this.dateTimeProvider.GetTimeOffset()
             };
 
             this.fileStorage.SaveToFile(watchOnlyWallet, WalletFileName);

--- a/src/Stratis.Bitcoin.Features.WatchOnlyWallet/WatchOnlyWalletManager.cs
+++ b/src/Stratis.Bitcoin.Features.WatchOnlyWallet/WatchOnlyWalletManager.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Concurrent;
+using System.Collections.Generic;
 using Microsoft.Extensions.Logging;
 using NBitcoin;
 using Stratis.Bitcoin.Configuration;
@@ -36,6 +37,13 @@ namespace Stratis.Bitcoin.Features.WatchOnlyWallet
         /// <summary>Provider of date time functionality.</summary>
         private readonly IDateTimeProvider dateTimeProvider;
 
+        /// <summary>
+        /// Provides a rapid lookup of transactions appearing in the watch-only wallet.
+        /// This includes both transactions under watched addresses, as well as stored
+        /// transactions.
+        /// </summary>
+        internal Dictionary<uint256, TransactionData> txLookup;
+
         public WatchOnlyWalletManager(IDateTimeProvider dateTimeProvider, ILoggerFactory loggerFactory, Network network, DataFolder dataFolder)
         {
             this.logger = loggerFactory.CreateLogger(this.GetType().FullName);
@@ -44,7 +52,7 @@ namespace Stratis.Bitcoin.Features.WatchOnlyWallet
             this.fileStorage = new FileStorage<WatchOnlyWallet>(dataFolder.WalletPath);
             this.dateTimeProvider = dateTimeProvider;
         }
-
+        
         /// <inheritdoc />
         public void Dispose()
         {
@@ -56,6 +64,8 @@ namespace Stratis.Bitcoin.Features.WatchOnlyWallet
         {
             // load the watch only wallet into memory
             this.Wallet = this.LoadWatchOnlyWallet();
+
+            LoadTransactionLookup();
         }
 
         /// <inheritdoc />
@@ -117,6 +127,68 @@ namespace Stratis.Bitcoin.Features.WatchOnlyWallet
             var transactionHash = transaction.GetHash();
             this.logger.LogDebug($"watch only wallet received transaction - hash: {transactionHash}, coin: {this.coinType}");
 
+            // Check the transaction inputs to see if a watched address is affected.
+            foreach (TxIn input in transaction.Inputs)
+            {
+                // See if the previous transaction is in the watch-only wallet.
+                this.txLookup.TryGetValue(input.PrevOut.Hash, out TransactionData prevTransaction);
+
+                // If it is null, it can't be related to one of the watched addresses (or it is the very first watched transaction)
+                if (prevTransaction == null)
+                    continue;
+
+                // Check if the previous transaction's outputs contain one of our addresses.
+                foreach (TxOut prevOutput in prevTransaction.Transaction.Outputs)
+                {
+                    this.Wallet.WatchedAddresses.TryGetValue(prevOutput.ScriptPubKey.ToString(), out WatchedAddress addressInWallet);
+
+                    if (addressInWallet != null)
+                    {
+                        // Retrieve a transaction, if present.
+                        addressInWallet.Transactions.TryGetValue(transactionHash.ToString(), out TransactionData existingTransaction);
+
+                        if (existingTransaction == null)
+                        {
+                            TransactionData newTransaction = new TransactionData
+                            {
+                                Id = transactionHash,
+                                Hex = transaction.ToHex(),
+                                BlockHash = block?.GetHash(),
+                            };
+
+                            // Add the Merkle proof to the transaction.
+                            if (block != null)
+                            {
+                                newTransaction.MerkleProof = new MerkleBlock(block, new[] { transactionHash }).PartialMerkleTree;
+                            }
+
+                            addressInWallet.Transactions.TryAdd(transactionHash.ToString(), newTransaction);
+
+                            // Update the lookup cache with the new transaction information.
+                            this.txLookup.Remove(newTransaction.Id);
+                            this.txLookup.Add(newTransaction.Id, newTransaction);
+                        }
+                        else
+                        {
+                            // If there is a transaction already present, update the hash of the block containing it.
+                            existingTransaction.BlockHash = block?.GetHash();
+
+                            // Add the Merkle proof now that the transaction is confirmed in a block.
+                            if (block != null && existingTransaction.MerkleProof == null)
+                            {
+                                existingTransaction.MerkleProof = new MerkleBlock(block, new[] { transactionHash }).PartialMerkleTree;
+                            }
+
+                            // Update the lookup cache with the new transaction information.
+                            this.txLookup.Remove(existingTransaction.Id);
+                            this.txLookup.Add(existingTransaction.Id, existingTransaction);
+                        }
+
+                        this.SaveWatchOnlyWallet();
+                    }
+                }
+            }
+
             // Check the transaction outputs for transactions we might be interested in.
             foreach (TxOut utxo in transaction.Outputs)
             {
@@ -144,6 +216,10 @@ namespace Stratis.Bitcoin.Features.WatchOnlyWallet
                         }
 
                         addressInWallet.Transactions.TryAdd(transactionHash.ToString(), newTransaction);
+
+                        // Update the lookup cache with the new transaction information.
+                        this.txLookup.Remove(newTransaction.Id);
+                        this.txLookup.Add(newTransaction.Id, newTransaction);
                     }
                     else
                     {
@@ -155,11 +231,75 @@ namespace Stratis.Bitcoin.Features.WatchOnlyWallet
                         {
                             existingTransaction.MerkleProof = new MerkleBlock(block, new[] { transactionHash }).PartialMerkleTree;
                         }
+
+                        // Update the lookup cache with the new transaction information.
+                        this.txLookup.Remove(existingTransaction.Id);
+                        this.txLookup.Add(existingTransaction.Id, existingTransaction);
                     }
 
                     this.SaveWatchOnlyWallet();
                 }
             }
+
+            this.Wallet.WatchedTransactions.TryGetValue(transactionHash.ToString(), out TransactionData existingWatchedTransaction);
+
+            if (existingWatchedTransaction != null)
+            {
+                // The transaction was previously stored, in an unconfirmed state.
+                // So now update the block hash and Merkle proof since it has
+                // appeared in a block.
+                existingWatchedTransaction.BlockHash = block.GetHash();
+                existingWatchedTransaction.MerkleProof = new MerkleBlock(block, new[] {transaction.GetHash()}).PartialMerkleTree;
+
+                // Update the lookup cache with the new transaction information.
+                this.txLookup.Remove(existingWatchedTransaction.Id);
+                this.txLookup.Add(existingWatchedTransaction.Id, existingWatchedTransaction);
+
+                this.SaveWatchOnlyWallet();
+            }
+        }
+
+        /// <summary>
+        /// Populate the transaction lookup dictionary with the current
+        /// contents of the watch only wallet's watched addresses and
+        /// transactions.
+        /// </summary>
+        private void LoadTransactionLookup()
+        {
+            var lookup = new Dictionary<uint256, TransactionData>();
+            var watchOnlyWallet = this.GetWatchOnlyWallet();
+
+            foreach (var address in watchOnlyWallet.WatchedAddresses.Values)
+            {
+                foreach (var transaction in address.Transactions.Values)
+                {
+                    lookup.Add(transaction.Id, transaction);
+                }
+            }
+
+            foreach (var transaction in watchOnlyWallet.WatchedTransactions.Values)
+            {
+                // It is conceivable that a transaction could be both watched
+                // in isolation and watched as a transaction under one or
+                // more watched addresses.
+                if (!lookup.TryAdd(transaction.Id, transaction))
+                {
+                    // Check to see if there is better information in
+                    // the watched transaction than the watched address.
+                    // If there is, use the watched transaction instead.
+
+                    var existingTx = lookup[transaction.Id];
+
+                    if ((existingTx.MerkleProof == null && transaction.MerkleProof != null) ||
+                        (existingTx.BlockHash == null && transaction.BlockHash != null))
+                    {
+                        lookup.Remove(transaction.Id);
+                        lookup.Add(transaction.Id, transaction);
+                    }
+                }
+            }
+
+            this.txLookup = lookup;
         }
 
         /// <inheritdoc />
@@ -181,7 +321,8 @@ namespace Stratis.Bitcoin.Features.WatchOnlyWallet
                 Network = this.network,
                 CoinType = this.coinType,
                 CreationTime = this.dateTimeProvider.GetTimeOffset(),
-                WatchedAddresses = new ConcurrentDictionary<string, WatchedAddress>()
+                WatchedAddresses = new ConcurrentDictionary<string, WatchedAddress>(),
+                WatchedTransactions = new ConcurrentDictionary<string, TransactionData>()
             };
 
             this.fileStorage.SaveToFile(watchOnlyWallet, WalletFileName);
@@ -219,6 +360,67 @@ namespace Stratis.Bitcoin.Features.WatchOnlyWallet
             });
 
             this.SaveWatchOnlyWallet();
+        }
+
+        /// <summary>
+        /// Computes the value contained within the transactions currently
+        /// being watched for the given address by the watch-only wallet.
+        /// For high-precision applications use a block explorer instead,
+        /// as the returned balance only reflects fund movement since the
+        /// address first started being watched.
+        /// </summary>
+        /// <param name="address">The Base58 representation of the address to interrogate</param>
+        public Money GetRelativeBalance(string address)
+        {
+            var scriptToCheck = BitcoinAddress.Create(address, this.network).ScriptPubKey;
+
+            Money balance = new Money(0);
+
+            if (!this.Wallet.WatchedAddresses.ContainsKey(scriptToCheck.ToString()))
+                // Returning zero would be misleading.
+                return null;
+
+            foreach (var transaction in this.Wallet.WatchedAddresses[scriptToCheck.ToString()].Transactions.Values)
+            {
+                foreach (TxIn input in transaction.Transaction.Inputs)
+                {
+                    // See if the previous transaction is in the watch-only wallet.
+                    this.txLookup.TryGetValue(input.PrevOut.Hash, out TransactionData prevTransaction);
+
+                    // If it is null, it can't be related to the watched addresses (or it is the very first watched transaction)
+                    if (prevTransaction == null)
+                        continue;
+
+                    // A sanity check to ensure the referenced output affects the desired address
+                    if (prevTransaction.Transaction.Outputs[input.PrevOut.N].ScriptPubKey == scriptToCheck)
+                    {
+                        // Input = funds are being paid 'out of' the address in question
+
+                        // Computing the input value is not as straightforward as with an output, as the value is not directly
+                        // stored in a TxIn object. We need to check the previous output being spent by the input to get this
+                        // information. But even an OutPoint does not contain the Value - we need to check the other transactions
+                        // in the watch-only wallet to see if we have the prior transaction being referenced.
+
+                        // This does imply that the earliest transaction in the watch-only wallet (for this address) will not
+                        // have full previous transaction information stored. Therefore we can only reason about the address
+                        // balance after a given block height; any prior transactions are ignored.
+
+                        balance -= prevTransaction.Transaction.Outputs[input.PrevOut.N].Value;
+                    }
+                }
+
+                // Check if the outputs contain the watched address
+                foreach (var output in transaction.Transaction.Outputs)
+                {
+                    if (output.ScriptPubKey == scriptToCheck)
+                    {
+                        // Output = funds are being paid 'into' the address in question
+                        balance += output.Value;
+                    }
+                }
+            }
+
+            return balance;
         }
     }
 }


### PR DESCRIPTION
The watch-only wallet currently only seems to properly watch incoming transactions. This extends the functionality to detecting transactions being spent from the watched addresses as well.