### PR TITLE
Refactor/the node job part 24

### DIFF
--- a/src/Stratis.Bitcoin.Tests/Utilities/AsyncQueueTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Utilities/AsyncQueueTest.cs
@@ -42,7 +42,7 @@ namespace Stratis.Bitcoin.Tests.Utilities
         }
 
         /// <summary>
-        /// Tests that <see cref="AsyncQueue{T}.Dispose"/> triggers waits until the on-enqueue callback (and the consumer task) 
+        /// Tests that <see cref="AsyncQueue{T}.Dispose"/> waits until the on-enqueue callback (and the consumer task) 
         /// are finished before returning to the caller.
         /// </summary>
         [Fact]

--- a/src/Stratis.Bitcoin/P2P/Peer/NetworkPeer.cs
+++ b/src/Stratis.Bitcoin/P2P/Peer/NetworkPeer.cs
@@ -527,10 +527,8 @@ namespace Stratis.Bitcoin.P2P.Peer
 
             if (connectedToSelf)
             {
-                this.logger.LogDebug("Connection to self detected and will be aborted.");
+                this.logger.LogDebug("Connection to self detected, disconnecting.");
 
-                VersionPayload versionPayload = this.Parameters.CreateVersion(this.PeerEndPoint, this.Network, this.dateTimeProvider.GetTimeOffset());
-                await this.SendMessageAsync(versionPayload, cancellation).ConfigureAwait(false);
                 this.Disconnect("Connected to self");
 
                 this.logger.LogTrace("(-)[CONNECTED_TO_SELF]");

--- a/src/Stratis.Bitcoin/P2P/Peer/NetworkPeer.cs
+++ b/src/Stratis.Bitcoin/P2P/Peer/NetworkPeer.cs
@@ -534,7 +534,7 @@ namespace Stratis.Bitcoin.P2P.Peer
                 this.Disconnect("Connected to self");
 
                 this.logger.LogTrace("(-)[CONNECTED_TO_SELF]");
-                return;
+                throw new OperationCanceledException();
             }
 
             using (CancellationTokenSource cancellationSource = CancellationTokenSource.CreateLinkedTokenSource(this.Connection.CancellationSource.Token, cancellation))

--- a/src/Stratis.Bitcoin/P2P/Peer/NetworkPeerServer.cs
+++ b/src/Stratis.Bitcoin/P2P/Peer/NetworkPeerServer.cs
@@ -50,24 +50,6 @@ namespace Stratis.Bitcoin.P2P.Peer
         /// <summary>Cancellation that is triggered on shutdown to stop all pending operations.</summary>
         private readonly CancellationTokenSource serverCancel;
 
-        /// <summary>Nonce for server's version payload.</summary>
-        private ulong nonce;
-        /// <summary>Nonce for server's version payload.</summary>
-        public ulong Nonce
-        {
-            get
-            {
-                if (this.nonce == 0)
-                    this.nonce = RandomUtils.GetUInt64();
-
-                return this.nonce;
-            }
-            set
-            {
-                this.nonce = value;
-            }
-        }
-
         /// <summary>List of active clients' connections mapped by their unique identifiers.</summary>
         private readonly ConcurrentDictionary<int, NetworkPeerConnection> connectionsById;
 
@@ -297,7 +279,6 @@ namespace Stratis.Bitcoin.P2P.Peer
         {
             IPEndPoint myExternal = this.ExternalEndpoint;
             NetworkPeerConnectionParameters param2 = this.InboundNetworkPeerConnectionParameters.Clone();
-            param2.Nonce = this.Nonce;
             param2.Version = this.Version;
             param2.AddressFrom = myExternal;
             return param2;

--- a/src/Stratis.Bitcoin/Utilities/AsyncQueue.cs
+++ b/src/Stratis.Bitcoin/Utilities/AsyncQueue.cs
@@ -20,6 +20,20 @@ namespace Stratis.Bitcoin.Utilities
     public class AsyncQueue<T> : IDisposable
     {
         /// <summary>
+        /// Execution context holding information about the current status of the execution
+        /// in order to recognize if <see cref="Dispose"/> was called within the callback method.
+        /// </summary>
+        private class AsyncContext
+        {
+            /// <summary>
+            /// Set to <c>true</c> if <see cref="Dispose"/> was called from within the callback routine,
+            /// set to <c>false</c> otherwise.
+            /// </summary>
+            /// <seealso cref="callbackExecutionInProgress"/>
+            public bool DisposeRequested { get; set; }
+        }
+
+        /// <summary>
         /// Represents a callback method to be executed when a new item is added to the queue.
         /// </summary>
         /// <param name="item">Newly added item.</param>
@@ -57,20 +71,13 @@ namespace Stratis.Bitcoin.Utilities
         private readonly bool callbackMode;
 
         /// <summary>
-        /// Set to <c>true</c> if the queue is operating in callback mode and the current async execution context is the one that executes the callbacks,
-        /// set to <c>false</c> otherwise.
+        /// Async context to allow to recognize whether <see cref="Dispose"/> was called from within the callback routine.
+        /// <para>
+        /// Is not <c>null</c> if the queue is operating in callback mode and the current async execution context is the one that executes the callbacks,
+        /// set to <c>null</c> otherwise.
+        /// </para>
         /// </summary>
-        /// <remarks>
-        /// This allows <see cref="Dispose"/> to be called from within the callback routine.
-        /// </remarks>
-        private readonly AsyncLocal<bool> callbackExecutionInProgress;
-
-        /// <summary>
-        /// Set to <c>true</c> if <see cref="Dispose"/> was called from within the callback routine,
-        /// set to <c>false</c> otherwise.
-        /// </summary>
-        /// <seealso cref="callbackExecutionInProgress"/>
-        private readonly AsyncLocal<bool> disposeRequested;
+        private readonly AsyncLocal<AsyncContext> asyncContext;
 
         /// <summary>
         /// Initializes the queue either in blocking dequeue mode or in callback mode.
@@ -84,9 +91,8 @@ namespace Stratis.Bitcoin.Utilities
             this.signal = new AsyncManualResetEvent();
             this.onEnqueueAsync = onEnqueueAsync;
             this.cancellationTokenSource = new CancellationTokenSource();
+            this.asyncContext = new AsyncLocal<AsyncContext>();
             this.ConsumerTask = this.callbackMode ? this.ConsumerAsync() : null;
-            this.callbackExecutionInProgress = new AsyncLocal<bool>() { Value = false };
-            this.disposeRequested = new AsyncLocal<bool>() { Value = false };
         }
 
         /// <summary>
@@ -111,6 +117,9 @@ namespace Stratis.Bitcoin.Utilities
         /// </summary>
         private async Task ConsumerAsync()
         {
+            // Set the context, so that Dispose called from callback will recognize it.
+            this.asyncContext.Value = new AsyncContext();
+
             bool callDispose = false;
             CancellationToken cancellationToken = this.cancellationTokenSource.Token;
             while (!callDispose && !cancellationToken.IsCancellationRequested)
@@ -124,13 +133,9 @@ namespace Stratis.Bitcoin.Utilities
                     T item;
                     while (this.TryDequeue(out item) && !cancellationToken.IsCancellationRequested)
                     {
-                        this.callbackExecutionInProgress.Value = true;
-
                         await this.onEnqueueAsync(item, cancellationToken).ConfigureAwait(false);
 
-                        this.callbackExecutionInProgress.Value = false;
-
-                        if (this.disposeRequested.Value)
+                        if (this.asyncContext.Value.DisposeRequested)
                         {
                             callDispose = true;
                             break;
@@ -219,11 +224,11 @@ namespace Stratis.Bitcoin.Utilities
         /// <inheritdoc/>
         public void Dispose()
         {
-            if (this.callbackExecutionInProgress.Value)
+            if (this.asyncContext.Value != null)
             {
                 // We can't dispose now as we would end up in deadlock because we are called from within the callback.
                 // We just mark that dispose was requested and process with the dispose once we return from the callback.
-                this.disposeRequested.Value = true;
+                this.asyncContext.Value.DisposeRequested = true;
                 return;
             }
 

--- a/src/Stratis.Bitcoin/Utilities/AsyncQueue.cs
+++ b/src/Stratis.Bitcoin/Utilities/AsyncQueue.cs
@@ -29,7 +29,6 @@ namespace Stratis.Bitcoin.Utilities
             /// Set to <c>true</c> if <see cref="Dispose"/> was called from within the callback routine,
             /// set to <c>false</c> otherwise.
             /// </summary>
-            /// <seealso cref="callbackExecutionInProgress"/>
             public bool DisposeRequested { get; set; }
         }
 
@@ -162,7 +161,7 @@ namespace Stratis.Bitcoin.Utilities
         public async Task<T> DequeueAsync(CancellationToken cancellation = default(CancellationToken))
         {
             if (this.callbackMode)
-                throw new InvalidOperationException($"{nameof(DequeueAsync)} called on queue in callback mode.");
+                throw new InvalidOperationException($"{nameof(this.DequeueAsync)} called on queue in callback mode.");
 
             // Increment the counter so that the queue's cancellation source is not disposed when we are using it.
             Interlocked.Increment(ref this.unfinishedDequeueCount);
@@ -178,7 +177,7 @@ namespace Stratis.Bitcoin.Utilities
                     return item;
 
                 // If the queue is empty, we need to wait until there is an item available.
-                using (var cancellationSource = CancellationTokenSource.CreateLinkedTokenSource(cancellation, this.cancellationTokenSource.Token))
+                using (CancellationTokenSource cancellationSource = CancellationTokenSource.CreateLinkedTokenSource(cancellation, this.cancellationTokenSource.Token))
                 {
                     while (true)
                     {


### PR DESCRIPTION
Here we fix the second part of #1084. The nonce is now reused for all incoming peers as it should.
And there is a fix of async queue included. The AsyncLocal structure was not used properly as I missed the copy-on-write property before.