### PR TITLE
Bugfix: Prevent mining if node is not fully synced

### DIFF
--- a/src/Stratis.Bitcoin.Features.BlockStore.Tests/BlockRepositoryInMemory.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore.Tests/BlockRepositoryInMemory.cs
@@ -14,6 +14,9 @@ namespace Stratis.Bitcoin.Features.BlockStore.Tests
         public bool TxIndex { get; private set; }
         public BlockStoreRepositoryPerformanceCounter PerformanceCounter { get; private set; }
 
+        /// <inheritdoc />
+        public ChainedBlock HighestPersistedBlock { get { throw new NotImplementedException(); } }
+
         public BlockRepositoryInMemory()
         {
             this.InitializeAsync();

--- a/src/Stratis.Bitcoin.Features.BlockStore/BlockRepository.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/BlockRepository.cs
@@ -78,6 +78,9 @@ namespace Stratis.Bitcoin.Features.BlockStore
         BlockStoreRepositoryPerformanceCounter PerformanceCounter { get; }
 
         bool TxIndex { get; }
+
+        /// <summary>Represents the last block stored to disk.</summary>
+        ChainedBlock HighestPersistedBlock { get; }
     }
 
     public class BlockRepository : IBlockRepository
@@ -103,7 +106,7 @@ namespace Stratis.Bitcoin.Features.BlockStore
         /// <summary>Provider of time functions.</summary>
         protected readonly IDateTimeProvider dateTimeProvider;
 
-        /// <summary>Represents the last block stored to disk.</summary>
+        /// <inheritdoc />
         public ChainedBlock HighestPersistedBlock { get; internal set; }
 
         public BlockRepository(Network network, DataFolder dataFolder, IDateTimeProvider dateTimeProvider, ILoggerFactory loggerFactory)

--- a/src/Stratis.Bitcoin.Features.BlockStore/BlockStoreFeature.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/BlockStoreFeature.cs
@@ -94,7 +94,7 @@ namespace Stratis.Bitcoin.Features.BlockStore
 
         public void AddNodeStats(StringBuilder benchLogs)
         {
-            var highestBlock = (this.blockRepository as BlockRepository)?.HighestPersistedBlock;
+            var highestBlock = this.blockRepository.HighestPersistedBlock;
 
             if (highestBlock != null)
                 benchLogs.AppendLine($"{this.name}.Height: ".PadRight(LoggingConfiguration.ColumnLength + 1) +

--- a/src/Stratis.Bitcoin.Features.Miner/PosMinting.cs
+++ b/src/Stratis.Bitcoin.Features.Miner/PosMinting.cs
@@ -9,7 +9,6 @@ using NBitcoin.Crypto;
 using NBitcoin.Protocol;
 using Stratis.Bitcoin.Base;
 using Stratis.Bitcoin.Connection;
-using Stratis.Bitcoin.Features.BlockStore;
 using Stratis.Bitcoin.Features.Consensus;
 using Stratis.Bitcoin.Features.Consensus.CoinViews;
 using Stratis.Bitcoin.Features.Consensus.Interfaces;
@@ -259,9 +258,6 @@ namespace Stratis.Bitcoin.Features.Miner
         /// <summary>Memory pool of pending transactions.</summary>
         protected readonly ITxMempool mempool;
 
-        /// <summary>Contains logic for interacting with the blocks stored in the database.</summary>
-        private readonly IBlockRepository blockRepository;
-
         /// <summary>Information about node's staking for RPC "getstakinginfo" command.</summary>
         /// <remarks>This object does not need a synchronized access because there is no execution logic
         /// that depends on the reported information.</remarks>
@@ -320,7 +316,6 @@ namespace Stratis.Bitcoin.Features.Miner
         public PosMinting(
             IConsensusLoop consensusLoop,
             ConcurrentChain chain,
-            IBlockRepository blockRepository,
             Network network,
             IConnectionManager connection,
             IDateTimeProvider dateTimeProvider,
@@ -338,7 +333,6 @@ namespace Stratis.Bitcoin.Features.Miner
         {
             this.consensusLoop = consensusLoop;
             this.chain = chain;
-            this.blockRepository = blockRepository;
             this.network = network;
             this.connection = connection;
             this.dateTimeProvider = dateTimeProvider;
@@ -453,22 +447,9 @@ namespace Stratis.Bitcoin.Features.Miner
 
             while (!this.stakeCancellationTokenSource.Token.IsCancellationRequested)
             {
-                bool readyToMine = !this.initialBlockDownloadState.IsInitialBlockDownload();
-
-                // If not in IBD- check if fully synced.
-                if (readyToMine)
-                {
-                    // Most advanced peer's pending tip.
-                    ChainedBlock chainedBlock = this.connection.ConnectedPeers
-                        .Select(x => x.Behavior<ChainHeadersBehavior>().PendingTip)
-                        .Where(x => x != null).OrderByDescending(x => x.Height)
-                        .FirstOrDefault();
-
-                    if ((chainedBlock == null) || (this.blockRepository.HighestPersistedBlock.Height < chainedBlock.Height))
-                        readyToMine = false;
-                }
-
-                if (!readyToMine)
+                // Prevent mining if not fully synced.
+                if (this.initialBlockDownloadState.IsInitialBlockDownload() || 
+                    this.consensusLoop.Tip != this.chain.Tip)
                 {
                     this.logger.LogTrace("Waiting for synchronization before mining can be started...");
 

--- a/src/Stratis.Bitcoin.IntegrationTests/EnvironmentMockUpHelpers/NodeBuilder.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/EnvironmentMockUpHelpers/NodeBuilder.cs
@@ -56,7 +56,7 @@ namespace Stratis.Bitcoin.IntegrationTests.EnvironmentMockUpHelpers
 
         public static ChainedBlock HighestPersistedBlock(this FullNode fullNode)
         {
-            return (fullNode.NodeService<IBlockRepository>() as BlockRepository).HighestPersistedBlock;
+            return fullNode.NodeService<IBlockRepository>().HighestPersistedBlock;
         }
     }
 


### PR DESCRIPTION
Disable mining until the moment we're not in IBD and our block repository is  at the same height with the peer that has highest PendingTip.Height of all peers that we're connected to.

Fix: #896 