### PR TITLE
[P2P] Reset connection attempts and throttle connection when there are no peers

### DIFF
--- a/src/Stratis.Bitcoin.Features.Dns.Tests/GivenAWhitelistManager.cs
+++ b/src/Stratis.Bitcoin.Features.Dns.Tests/GivenAWhitelistManager.cs
@@ -483,7 +483,7 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
             mockLoggerFactory.Setup(l => l.CreateLogger(It.IsAny<string>())).Returns(mockLogger.Object);
             ILoggerFactory loggerFactory = mockLoggerFactory.Object;
 
-            IPeerAddressManager peerAddressManager = new PeerAddressManager(peerFolder, loggerFactory);
+            IPeerAddressManager peerAddressManager = new PeerAddressManager(DateTimeProvider.Default, peerFolder, loggerFactory);
 
             foreach (Tuple<NetworkAddress, DateTimeOffset> testData in testDataSet)
             {

--- a/src/Stratis.Bitcoin.Features.MemoryPool.Tests/TestChainFactory.cs
+++ b/src/Stratis.Bitcoin.Features.MemoryPool.Tests/TestChainFactory.cs
@@ -79,7 +79,7 @@ namespace Stratis.Bitcoin.Features.MemoryPool.Tests
             CachedCoinView cachedCoinView = new CachedCoinView(new InMemoryCoinView(chain.Tip.HashBlock), DateTimeProvider.Default, loggerFactory);
             NetworkPeerFactory networkPeerFactory = new NetworkPeerFactory(network, dateTimeProvider, loggerFactory);
 
-            var peerAddressManager = new PeerAddressManager(nodeSettings.DataFolder, loggerFactory);
+            var peerAddressManager = new PeerAddressManager(DateTimeProvider.Default, nodeSettings.DataFolder, loggerFactory);
             var peerDiscovery = new PeerDiscovery(new AsyncLoopFactory(loggerFactory), loggerFactory, Network.Main, networkPeerFactory, new NodeLifetime(), nodeSettings, peerAddressManager);
             var connectionSettings = new ConnectionManagerSettings();
             connectionSettings.Load(nodeSettings);

--- a/src/Stratis.Bitcoin.IntegrationTests/MinerTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/MinerTests.cs
@@ -151,7 +151,7 @@ namespace Stratis.Bitcoin.IntegrationTests
                 PowConsensusValidator consensusValidator = new PowConsensusValidator(this.network, new Checkpoints(), dateTimeProvider, loggerFactory);
                 NetworkPeerFactory networkPeerFactory = new NetworkPeerFactory(this.network, dateTimeProvider, loggerFactory);
 
-                var peerAddressManager = new PeerAddressManager(nodeSettings.DataFolder, loggerFactory);
+                var peerAddressManager = new PeerAddressManager(DateTimeProvider.Default, nodeSettings.DataFolder, loggerFactory);
                 var peerDiscovery = new PeerDiscovery(new AsyncLoopFactory(loggerFactory), loggerFactory, Network.Main, networkPeerFactory, new NodeLifetime(), nodeSettings, peerAddressManager);
                 var connectionSettings = new ConnectionManagerSettings();
                 connectionSettings.Load(nodeSettings);
@@ -354,7 +354,7 @@ namespace Stratis.Bitcoin.IntegrationTests
                 tx.Outputs[0].Value -= context.LOWFEE;
                 context.hash = tx.GetHash();
                 bool spendsCoinbase = (i == 0); // only first tx spends coinbase
-                                                               // If we don't set the # of sig ops in the CTxMemPoolEntry, template creation fails
+                                                // If we don't set the # of sig ops in the CTxMemPoolEntry, template creation fails
                 context.mempool.AddUnchecked(context.hash, context.entry.Fee(context.LOWFEE).Time(context.date.GetTime()).SpendsCoinbase(spendsCoinbase).FromTx(tx));
                 tx = tx.Clone();
                 tx.Inputs[0].PrevOut.Hash = context.hash;
@@ -370,7 +370,7 @@ namespace Stratis.Bitcoin.IntegrationTests
                 tx.Outputs[0].Value -= context.LOWFEE;
                 context.hash = tx.GetHash();
                 bool spendsCoinbase = (i == 0); // only first tx spends coinbase
-                                                               // If we do set the # of sig ops in the CTxMemPoolEntry, template creation passes
+                                                // If we do set the # of sig ops in the CTxMemPoolEntry, template creation passes
                 context.mempool.AddUnchecked(context.hash, context.entry.Fee(context.LOWFEE).Time(context.date.GetTime()).SpendsCoinbase(spendsCoinbase).SigOpsCost(80).FromTx(tx));
                 tx = tx.Clone();
                 tx.Inputs[0].PrevOut.Hash = context.hash;

--- a/src/Stratis.Bitcoin.IntegrationTests/P2P/PeerConnectionTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/P2P/PeerConnectionTests.cs
@@ -103,7 +103,7 @@ namespace Stratis.Bitcoin.IntegrationTests.P2P
             this.connectionSetting = new ConnectionManagerSettings();
             this.connectionSetting.Load(this.nodeSettings);
 
-            this.peerAddressManager = new PeerAddressManager(this.nodeSettings.DataFolder, this.loggerFactory);
+            this.peerAddressManager = new PeerAddressManager(DateTimeProvider.Default, this.nodeSettings.DataFolder, this.loggerFactory);
             var peerAddressManagerBehaviour = new PeerAddressManagerBehaviour(DateTimeProvider.Default, this.peerAddressManager)
             {
                 PeersToDiscover = 10

--- a/src/Stratis.Bitcoin.Tests/P2P/PeerAddressManagerBehaviourTests.cs
+++ b/src/Stratis.Bitcoin.Tests/P2P/PeerAddressManagerBehaviourTests.cs
@@ -35,7 +35,7 @@ namespace Stratis.Bitcoin.Tests.P2P
             var networkAddress = new NetworkAddress(ipAddress, 80);
 
             var peerFolder = AssureEmptyDirAsDataFolder(Path.Combine(AppContext.BaseDirectory, "PeerAddressManagerBehaviourTests"));
-            var addressManager = new PeerAddressManager(peerFolder, this.loggerFactory);
+            var addressManager = new PeerAddressManager(DateTimeProvider.Default, peerFolder, this.loggerFactory);
             addressManager.AddPeer(networkAddress, IPAddress.Loopback);
 
             var networkPeer = new NetworkPeer(networkAddress.Endpoint, this.network, new NetworkPeerConnectionParameters(), this.networkPeerFactory, DateTimeProvider.Default, this.extendedLoggerFactory);
@@ -60,7 +60,7 @@ namespace Stratis.Bitcoin.Tests.P2P
             var networkAddress = new NetworkAddress(ipAddress, 80);
 
             var peerFolder = AssureEmptyDirAsDataFolder(Path.Combine(AppContext.BaseDirectory, "PeerAddressManagerBehaviourTests"));
-            var addressManager = new PeerAddressManager(peerFolder, this.loggerFactory);
+            var addressManager = new PeerAddressManager(DateTimeProvider.Default, peerFolder, this.loggerFactory);
             addressManager.AddPeer(networkAddress, IPAddress.Loopback);
 
             var networkPeer = new NetworkPeer(networkAddress.Endpoint, this.network, new NetworkPeerConnectionParameters(), this.networkPeerFactory, DateTimeProvider.Default, this.extendedLoggerFactory);

--- a/src/Stratis.Bitcoin.Tests/P2P/PeerAddressManagerTests.cs
+++ b/src/Stratis.Bitcoin.Tests/P2P/PeerAddressManagerTests.cs
@@ -76,7 +76,7 @@ namespace Stratis.Bitcoin.Tests.P2P
 
             var peerFolder = AssureEmptyDirAsDataFolder(Path.Combine(AppContext.BaseDirectory, "PeerAddressManager"));
 
-            var addressManager = new PeerAddressManager(peerFolder, this.loggerFactory);
+            var addressManager = new PeerAddressManager(DateTimeProvider.Default, peerFolder, this.loggerFactory);
             addressManager.AddPeer(networkAddress, IPAddress.Loopback);
 
             var applicableDate = DateTime.UtcNow.Date;
@@ -101,7 +101,7 @@ namespace Stratis.Bitcoin.Tests.P2P
         }
 
         [Fact]
-        public void PeerAddressManager_AttemptThresholdReach_ResetAttempts()
+        public void PeerAddressManager_AttemptThresholdReached_ResetAttempts()
         {
             var ipAddress = IPAddress.Parse("::ffff:192.168.0.1");
             var networkAddress = new NetworkAddress(ipAddress, 80);
@@ -113,20 +113,62 @@ namespace Stratis.Bitcoin.Tests.P2P
 
             var applicableDate = DateTimeProvider.Default.GetUtcNow();
 
+            //Ensure that there was 10 failed attempts
             for (int i = 0; i < 10; i++)
             {
                 addressManager.PeerAttempted(networkAddress.Endpoint, applicableDate.AddHours(-i));
             }
 
-            addressManager.PeerAttempted(networkAddress.Endpoint, applicableDate);
+            //Ensure that the last attempt was more than 12 hours ago
+            addressManager.PeerAttempted(networkAddress.Endpoint, applicableDate.AddHours(-13));
+
+            //This call should now reset the counts
+            var resetTimestamp = DateTimeProvider.Default.GetUtcNow();
+            addressManager.PeerAttempted(networkAddress.Endpoint, resetTimestamp);
 
             var savedPeer = addressManager.FindPeer(networkAddress.Endpoint);
 
-            Assert.Equal("::ffff:192.168.0.1", savedPeer.EndPoint.Address.ToString());
-            Assert.Equal(80, savedPeer.EndPoint.Port);
-            Assert.Equal(0, savedPeer.ConnectionAttempts);
+            Assert.Equal(1, savedPeer.ConnectionAttempts);
+            Assert.Equal(resetTimestamp, savedPeer.LastAttempt);
             Assert.Null(savedPeer.LastConnectionSuccess);
             Assert.Null(savedPeer.LastConnectionHandshake);
+            Assert.Null(savedPeer.LastSeen);
+            Assert.Equal("127.0.0.1", savedPeer.Loopback.ToString());
+        }
+
+        [Fact]
+        public void PeerAddressManager_AttemptThresholdTimeNotReached_()
+        {
+            var ipAddress = IPAddress.Parse("::ffff:192.168.0.1");
+            var networkAddress = new NetworkAddress(ipAddress, 80);
+
+            var peerFolder = AssureEmptyDirAsDataFolder(Path.Combine(AppContext.BaseDirectory, "PeerAddressManager"));
+
+            var addressManager = new PeerAddressManager(DateTimeProvider.Default, peerFolder, this.loggerFactory);
+            addressManager.AddPeer(networkAddress, IPAddress.Loopback);
+
+            var applicableDate = DateTimeProvider.Default.GetUtcNow();
+
+            //Ensure that there was 10 failed attempts
+            for (int i = 0; i < 10; i++)
+            {
+                addressManager.PeerAttempted(networkAddress.Endpoint, applicableDate.AddHours(-i));
+            }
+
+            //Ensure that the last attempt was more than 12 hours ago
+            addressManager.PeerAttempted(networkAddress.Endpoint, applicableDate.AddHours(-13));
+
+            //This call should now reset the counts
+            var resetTimestamp = DateTimeProvider.Default.GetUtcNow();
+            addressManager.PeerAttempted(networkAddress.Endpoint, resetTimestamp);
+
+            var savedPeer = addressManager.FindPeer(networkAddress.Endpoint);
+
+            Assert.Equal(1, savedPeer.ConnectionAttempts);
+            Assert.Equal(resetTimestamp, savedPeer.LastAttempt);
+            Assert.Null(savedPeer.LastConnectionSuccess);
+            Assert.Null(savedPeer.LastConnectionHandshake);
+            Assert.Null(savedPeer.LastSeen);
             Assert.Equal("127.0.0.1", savedPeer.Loopback.ToString());
         }
     }

--- a/src/Stratis.Bitcoin.Tests/P2P/PeerAddressManagerTests.cs
+++ b/src/Stratis.Bitcoin.Tests/P2P/PeerAddressManagerTests.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Net;
 using NBitcoin.Protocol;
 using Stratis.Bitcoin.P2P;
+using Stratis.Bitcoin.Utilities;
 using Xunit;
 
 namespace Stratis.Bitcoin.Tests.P2P
@@ -16,7 +17,7 @@ namespace Stratis.Bitcoin.Tests.P2P
             var networkAddress = new NetworkAddress(ipAddress, 80);
 
             var peerFolder = AssureEmptyDirAsDataFolder(Path.Combine(AppContext.BaseDirectory, "PeerAddressManager"));
-            var addressManager = new PeerAddressManager(peerFolder, this.loggerFactory);
+            var addressManager = new PeerAddressManager(DateTimeProvider.Default, peerFolder, this.loggerFactory);
             addressManager.AddPeer(networkAddress, IPAddress.Loopback);
 
             var applicableDate = DateTime.UtcNow.Date;
@@ -45,7 +46,7 @@ namespace Stratis.Bitcoin.Tests.P2P
 
             var peerFolder = AssureEmptyDirAsDataFolder(Path.Combine(AppContext.BaseDirectory, "PeerAddressManager"));
 
-            var addressManager = new PeerAddressManager(peerFolder, this.loggerFactory);
+            var addressManager = new PeerAddressManager(DateTimeProvider.Default, peerFolder, this.loggerFactory);
             addressManager.AddPeer(networkAddress, IPAddress.Loopback);
 
             var applicableDate = DateTime.UtcNow.Date;

--- a/src/Stratis.Bitcoin.Tests/P2P/PeerAddressManagerTests.cs
+++ b/src/Stratis.Bitcoin.Tests/P2P/PeerAddressManagerTests.cs
@@ -137,7 +137,7 @@ namespace Stratis.Bitcoin.Tests.P2P
         }
 
         [Fact]
-        public void PeerAddressManager_AttemptThresholdTimeNotReached_()
+        public void PeerAddressManager_AttemptThresholdTimeNotReached_DoNotReset()
         {
             var ipAddress = IPAddress.Parse("::ffff:192.168.0.1");
             var networkAddress = new NetworkAddress(ipAddress, 80);
@@ -155,17 +155,14 @@ namespace Stratis.Bitcoin.Tests.P2P
                 addressManager.PeerAttempted(networkAddress.Endpoint, applicableDate.AddHours(-i));
             }
 
-            //Ensure that the last attempt was more than 12 hours ago
-            addressManager.PeerAttempted(networkAddress.Endpoint, applicableDate.AddHours(-13));
-
-            //This call should now reset the counts
-            var resetTimestamp = DateTimeProvider.Default.GetUtcNow();
-            addressManager.PeerAttempted(networkAddress.Endpoint, resetTimestamp);
+            //Capture the last attempt timestamp
+            var lastAttempt = DateTimeProvider.Default.GetUtcNow();
+            addressManager.PeerAttempted(networkAddress.Endpoint, lastAttempt);
 
             var savedPeer = addressManager.FindPeer(networkAddress.Endpoint);
 
-            Assert.Equal(1, savedPeer.ConnectionAttempts);
-            Assert.Equal(resetTimestamp, savedPeer.LastAttempt);
+            Assert.Equal(11, savedPeer.ConnectionAttempts);
+            Assert.Equal(lastAttempt, savedPeer.LastAttempt);
             Assert.Null(savedPeer.LastConnectionSuccess);
             Assert.Null(savedPeer.LastConnectionHandshake);
             Assert.Null(savedPeer.LastSeen);

--- a/src/Stratis.Bitcoin.Tests/P2P/PeerAddressManagerTests.cs
+++ b/src/Stratis.Bitcoin.Tests/P2P/PeerAddressManagerTests.cs
@@ -67,5 +67,35 @@ namespace Stratis.Bitcoin.Tests.P2P
             Assert.Equal(applicableDate, savedPeer.LastConnectionHandshake.Value.Date);
             Assert.Equal("127.0.0.1", savedPeer.Loopback.ToString());
         }
+
+        [Fact]
+        public void PeerAddressManager_AttemptThresholdReach_ResetAttempts()
+        {
+            var ipAddress = IPAddress.Parse("::ffff:192.168.0.1");
+            var networkAddress = new NetworkAddress(ipAddress, 80);
+
+            var peerFolder = AssureEmptyDirAsDataFolder(Path.Combine(AppContext.BaseDirectory, "PeerAddressManager"));
+
+            var addressManager = new PeerAddressManager(DateTimeProvider.Default, peerFolder, this.loggerFactory);
+            addressManager.AddPeer(networkAddress, IPAddress.Loopback);
+
+            var applicableDate = DateTimeProvider.Default.GetUtcNow();
+
+            for (int i = 0; i < 10; i++)
+            {
+                addressManager.PeerAttempted(networkAddress.Endpoint, applicableDate.AddHours(-i));
+            }
+
+            addressManager.PeerAttempted(networkAddress.Endpoint, applicableDate);
+
+            var savedPeer = addressManager.FindPeer(networkAddress.Endpoint);
+
+            Assert.Equal("::ffff:192.168.0.1", savedPeer.EndPoint.Address.ToString());
+            Assert.Equal(80, savedPeer.EndPoint.Port);
+            Assert.Equal(0, savedPeer.ConnectionAttempts);
+            Assert.Null(savedPeer.LastConnectionSuccess);
+            Assert.Null(savedPeer.LastConnectionHandshake);
+            Assert.Equal("127.0.0.1", savedPeer.Loopback.ToString());
+        }
     }
 }

--- a/src/Stratis.Bitcoin.Tests/P2P/PeerConnectorTests.cs
+++ b/src/Stratis.Bitcoin.Tests/P2P/PeerConnectorTests.cs
@@ -39,7 +39,7 @@ namespace Stratis.Bitcoin.Tests.P2P
         public void PeerConnectorAddNode_FindPeerToConnectTo_Returns_AddNodePeers()
         {
             var peerFolder = AssureEmptyDirAsDataFolder(Path.Combine(AppContext.BaseDirectory, "PeerConnectorTests"));
-            var peerAddressManager = new PeerAddressManager(peerFolder, this.extendedLoggerFactory);
+            var peerAddressManager = new PeerAddressManager(DateTimeProvider.Default, peerFolder, this.extendedLoggerFactory);
 
             var ipAddressOne = IPAddress.Parse("::ffff:192.168.0.1");
             var networkAddressAddNode = new NetworkAddress(ipAddressOne, 80);
@@ -67,7 +67,7 @@ namespace Stratis.Bitcoin.Tests.P2P
         public void PeerConnectorAddNode_CanAlwaysStart()
         {
             var peerFolder = AssureEmptyDirAsDataFolder(Path.Combine(AppContext.BaseDirectory, "PeerConnectorTests"));
-            var peerAddressManager = new PeerAddressManager(peerFolder, this.extendedLoggerFactory);
+            var peerAddressManager = new PeerAddressManager(DateTimeProvider.Default, peerFolder, this.extendedLoggerFactory);
 
             var nodeSettings = new NodeSettings();
             nodeSettings.LoadArguments(new string[] { });
@@ -82,7 +82,7 @@ namespace Stratis.Bitcoin.Tests.P2P
         public void PeerConnectorConnect_FindPeerToConnectTo_Returns_ConnectNodePeers()
         {
             var peerFolder = AssureEmptyDirAsDataFolder(Path.Combine(AppContext.BaseDirectory, "PeerConnectorTests"));
-            var peerAddressManager = new PeerAddressManager(peerFolder, this.extendedLoggerFactory);
+            var peerAddressManager = new PeerAddressManager(DateTimeProvider.Default, peerFolder, this.extendedLoggerFactory);
 
             var ipAddressOne = IPAddress.Parse("::ffff:192.168.0.1");
             var networkAddressAddNode = new NetworkAddress(ipAddressOne, 80);
@@ -116,7 +116,7 @@ namespace Stratis.Bitcoin.Tests.P2P
         public void PeerConnectorConnect_WithConnectPeersSpecified_CanStart()
         {
             var peerFolder = AssureEmptyDirAsDataFolder(Path.Combine(AppContext.BaseDirectory, "PeerConnectorTests"));
-            var peerAddressManager = new PeerAddressManager(peerFolder, this.extendedLoggerFactory);
+            var peerAddressManager = new PeerAddressManager(DateTimeProvider.Default, peerFolder, this.extendedLoggerFactory);
 
             var ipAddressThree = IPAddress.Parse("::ffff:192.168.0.3");
             var networkAddressConnectNode = new NetworkAddress(ipAddressThree, 80);
@@ -137,7 +137,7 @@ namespace Stratis.Bitcoin.Tests.P2P
         public void PeerConnectorConnect_WithNoConnectPeersSpecified_CanNotStart()
         {
             var peerFolder = AssureEmptyDirAsDataFolder(Path.Combine(AppContext.BaseDirectory, "PeerConnectorTests"));
-            var peerAddressManager = new PeerAddressManager(peerFolder, this.extendedLoggerFactory);
+            var peerAddressManager = new PeerAddressManager(DateTimeProvider.Default, peerFolder, this.extendedLoggerFactory);
             var nodeSettings = new NodeSettings();
             nodeSettings.LoadArguments(new string[] { });
 
@@ -152,7 +152,7 @@ namespace Stratis.Bitcoin.Tests.P2P
         public void PeerConnectorDiscovery_FindPeerToConnectTo_Returns_DiscoveredPeers()
         {
             var peerFolder = AssureEmptyDirAsDataFolder(Path.Combine(AppContext.BaseDirectory, "PeerConnectorTests"));
-            var peerAddressManager = new PeerAddressManager(peerFolder, this.extendedLoggerFactory);
+            var peerAddressManager = new PeerAddressManager(DateTimeProvider.Default, peerFolder, this.extendedLoggerFactory);
 
             var ipAddressOne = IPAddress.Parse("::ffff:192.168.0.1");
             var networkAddressAddNode = new NetworkAddress(ipAddressOne, 80);
@@ -187,7 +187,7 @@ namespace Stratis.Bitcoin.Tests.P2P
         public void PeerConnectorDiscover_WithNoConnectPeersSpecified_CanStart()
         {
             var peerFolder = AssureEmptyDirAsDataFolder(Path.Combine(AppContext.BaseDirectory, "PeerConnectorTests"));
-            var peerAddressManager = new PeerAddressManager(peerFolder, this.extendedLoggerFactory);
+            var peerAddressManager = new PeerAddressManager(DateTimeProvider.Default, peerFolder, this.extendedLoggerFactory);
 
             var nodeSettings = new NodeSettings();
             nodeSettings.LoadArguments(new string[] { });
@@ -214,7 +214,7 @@ namespace Stratis.Bitcoin.Tests.P2P
             connectionSettings.Connect.Add(networkAddressConnectNode.Endpoint);
 
             var peerFolder = AssureEmptyDirAsDataFolder(Path.Combine(AppContext.BaseDirectory, "PeerConnectorTests"));
-            var peerAddressManager = new PeerAddressManager(peerFolder, this.extendedLoggerFactory);
+            var peerAddressManager = new PeerAddressManager(DateTimeProvider.Default, peerFolder, this.extendedLoggerFactory);
 
             var connector = this.CreatePeerConnectorDiscovery(nodeSettings, connectionSettings, peerAddressManager);
             Assert.False(connector.CanStartConnect);
@@ -229,7 +229,7 @@ namespace Stratis.Bitcoin.Tests.P2P
         }
 
         private PeerConnectorConnectNode CreatePeerConnectorConnectNode(NodeSettings nodeSettings, ConnectionManagerSettings connectionSettings, IPeerAddressManager peerAddressManager)
-        {           
+        {
             var peerConnector = new PeerConnectorConnectNode(this.asyncLoopFactory, DateTimeProvider.Default, this.extendedLoggerFactory, this.network, this.networkPeerFactory, this.nodeLifetime, nodeSettings, connectionSettings, peerAddressManager);
             var connectionManager = CreateConnectionManager(nodeSettings, connectionSettings, peerAddressManager, peerConnector);
             peerConnector.Initialize(connectionManager);

--- a/src/Stratis.Bitcoin.Tests/P2P/PeerSelectorTests.cs
+++ b/src/Stratis.Bitcoin.Tests/P2P/PeerSelectorTests.cs
@@ -6,6 +6,7 @@ using System.Net;
 using NBitcoin.Protocol;
 using Stratis.Bitcoin.Configuration.Logging;
 using Stratis.Bitcoin.P2P;
+using Stratis.Bitcoin.Utilities;
 using Stratis.Bitcoin.Utilities.Extensions;
 using Xunit;
 
@@ -28,7 +29,7 @@ namespace Stratis.Bitcoin.Tests.P2P
             var networkAddress = new NetworkAddress(ipAddress, 80);
 
             var peerFolder = AssureEmptyDirAsDataFolder(Path.Combine(AppContext.BaseDirectory, "PeerAddressManager"));
-            var addressManager = new PeerAddressManager(peerFolder, this.extendedLoggerFactory);
+            var addressManager = new PeerAddressManager(DateTimeProvider.Default, peerFolder, this.extendedLoggerFactory);
             addressManager.AddPeer(networkAddress, IPAddress.Loopback);
 
             addressManager.PeerConnected(networkAddress.Endpoint, DateTime.UtcNow);
@@ -42,7 +43,7 @@ namespace Stratis.Bitcoin.Tests.P2P
             var peerOne = addressManager.FindPeer(networkAddress.Endpoint);
 
             Assert.Equal(0, peerOne.ConnectionAttempts);
-            Assert.Null(peerOne.LastConnectionAttempt);
+            Assert.Null(peerOne.LastAttempt);
             Assert.NotNull(peerOne.LastConnectionSuccess);
         }
 
@@ -72,7 +73,7 @@ namespace Stratis.Bitcoin.Tests.P2P
 
             var peerFolder = AssureEmptyDirAsDataFolder(Path.Combine(AppContext.BaseDirectory, "PeerAddressManager"));
 
-            var peerAddressManager = new PeerAddressManager(peerFolder, this.extendedLoggerFactory);
+            var peerAddressManager = new PeerAddressManager(DateTimeProvider.Default, peerFolder, this.extendedLoggerFactory);
             peerAddressManager.AddPeer(networkAddressOne, IPAddress.Loopback);
             peerAddressManager.AddPeer(networkAddressTwo, IPAddress.Loopback);
             peerAddressManager.AddPeer(networkAddressThree, IPAddress.Loopback);
@@ -107,14 +108,14 @@ namespace Stratis.Bitcoin.Tests.P2P
 
             var peerFolder = AssureEmptyDirAsDataFolder(Path.Combine(AppContext.BaseDirectory, "PeerAddressManager"));
 
-            var peerAddressManager = new PeerAddressManager(peerFolder, this.extendedLoggerFactory);
+            var peerAddressManager = new PeerAddressManager(DateTimeProvider.Default, peerFolder, this.extendedLoggerFactory);
             peerAddressManager.AddPeer(networkAddressOne, IPAddress.Loopback);
             peerAddressManager.AddPeer(networkAddressTwo, IPAddress.Loopback);
             peerAddressManager.AddPeer(networkAddressThree, IPAddress.Loopback);
 
             peerAddressManager.PeerAttempted(networkAddressOne.Endpoint, DateTime.UtcNow);
-            peerAddressManager.PeerAttempted(networkAddressTwo.Endpoint, DateTime.UtcNow.AddSeconds(-80));
-            peerAddressManager.PeerAttempted(networkAddressThree.Endpoint, DateTime.UtcNow.AddSeconds(-80));
+            peerAddressManager.PeerAttempted(networkAddressTwo.Endpoint, DateTime.UtcNow.AddHours(-2));
+            peerAddressManager.PeerAttempted(networkAddressThree.Endpoint, DateTime.UtcNow.AddHours(-2));
 
             var peers = peerAddressManager.PeerSelector.Attempted();
             Assert.Equal(2, peers.Count());
@@ -147,13 +148,13 @@ namespace Stratis.Bitcoin.Tests.P2P
 
             var peerFolder = AssureEmptyDirAsDataFolder(Path.Combine(AppContext.BaseDirectory, "PeerAddressManager"));
 
-            var peerAddressManager = new PeerAddressManager(peerFolder, this.extendedLoggerFactory);
+            var peerAddressManager = new PeerAddressManager(DateTimeProvider.Default, peerFolder, this.extendedLoggerFactory);
             peerAddressManager.AddPeer(networkAddressOne, IPAddress.Loopback);
             peerAddressManager.AddPeer(networkAddressTwo, IPAddress.Loopback);
             peerAddressManager.AddPeer(networkAddressThree, IPAddress.Loopback);
 
-            peerAddressManager.PeerAttempted(networkAddressOne.Endpoint, DateTime.UtcNow.AddSeconds(-80));
-            peerAddressManager.PeerAttempted(networkAddressTwo.Endpoint, DateTime.UtcNow.AddSeconds(-80));
+            peerAddressManager.PeerAttempted(networkAddressOne.Endpoint, DateTime.UtcNow.AddHours(-2));
+            peerAddressManager.PeerAttempted(networkAddressTwo.Endpoint, DateTime.UtcNow.AddHours(-2));
 
             for (int i = 0; i < 15; i++)
             {
@@ -191,7 +192,7 @@ namespace Stratis.Bitcoin.Tests.P2P
 
             var peerFolder = AssureEmptyDirAsDataFolder(Path.Combine(AppContext.BaseDirectory, "PeerAddressManager"));
 
-            var peerAddressManager = new PeerAddressManager(peerFolder, this.extendedLoggerFactory);
+            var peerAddressManager = new PeerAddressManager(DateTimeProvider.Default, peerFolder, this.extendedLoggerFactory);
             peerAddressManager.AddPeer(networkAddressOne, IPAddress.Loopback);
             peerAddressManager.AddPeer(networkAddressTwo, IPAddress.Loopback);
             peerAddressManager.AddPeer(networkAddressThree, IPAddress.Loopback);
@@ -231,7 +232,7 @@ namespace Stratis.Bitcoin.Tests.P2P
 
             var peerFolder = AssureEmptyDirAsDataFolder(Path.Combine(AppContext.BaseDirectory, "PeerAddressManager"));
 
-            var peerAddressManager = new PeerAddressManager(peerFolder, this.extendedLoggerFactory);
+            var peerAddressManager = new PeerAddressManager(DateTimeProvider.Default, peerFolder, this.extendedLoggerFactory);
             peerAddressManager.AddPeer(networkAddressOne, IPAddress.Loopback);
             peerAddressManager.AddPeer(networkAddressTwo, IPAddress.Loopback);
             peerAddressManager.AddPeer(networkAddressThree, IPAddress.Loopback);
@@ -276,7 +277,7 @@ namespace Stratis.Bitcoin.Tests.P2P
 
             var peerFolder = AssureEmptyDirAsDataFolder(Path.Combine(AppContext.BaseDirectory, "PeerAddressManager"));
 
-            var peerAddressManager = new PeerAddressManager(peerFolder, this.extendedLoggerFactory);
+            var peerAddressManager = new PeerAddressManager(DateTimeProvider.Default, peerFolder, this.extendedLoggerFactory);
             peerAddressManager.AddPeers(peersToAdd.ToArray(), IPAddress.Loopback);
 
             for (int i = 1; i <= 7; i++)
@@ -319,7 +320,7 @@ namespace Stratis.Bitcoin.Tests.P2P
 
             var peerFolder = AssureEmptyDirAsDataFolder(Path.Combine(AppContext.BaseDirectory, "PeerAddressManager"));
 
-            var peerAddressManager = new PeerAddressManager(peerFolder, this.extendedLoggerFactory);
+            var peerAddressManager = new PeerAddressManager(DateTimeProvider.Default, peerFolder, this.extendedLoggerFactory);
             peerAddressManager.AddPeers(peersToAdd.ToArray(), IPAddress.Loopback);
 
             for (int i = 1; i <= 7; i++)
@@ -363,13 +364,13 @@ namespace Stratis.Bitcoin.Tests.P2P
 
             var peerFolder = AssureEmptyDirAsDataFolder(Path.Combine(AppContext.BaseDirectory, "PeerAddressManager"));
 
-            var peerAddressManager = new PeerAddressManager(peerFolder, this.extendedLoggerFactory);
+            var peerAddressManager = new PeerAddressManager(DateTimeProvider.Default, peerFolder, this.extendedLoggerFactory);
             peerAddressManager.AddPeers(peersToAdd.ToArray(), IPAddress.Loopback);
 
             for (int i = 1; i <= 7; i++)
             {
                 var ipAddress = IPAddress.Parse(string.Format("::ffff:192.168.0.{0}", i));
-                peerAddressManager.PeerAttempted(new NetworkAddress(ipAddress, 80).Endpoint, DateTime.UtcNow.AddSeconds(-80));
+                peerAddressManager.PeerAttempted(new NetworkAddress(ipAddress, 80).Endpoint, DateTime.UtcNow.AddHours(-2));
             }
 
             var peers = peerAddressManager.PeerSelector.SelectPeersForGetAddrPayload(15);
@@ -406,7 +407,7 @@ namespace Stratis.Bitcoin.Tests.P2P
 
             var peerFolder = AssureEmptyDirAsDataFolder(Path.Combine(AppContext.BaseDirectory, "PeerAddressManager"));
 
-            var peerAddressManager = new PeerAddressManager(peerFolder, this.extendedLoggerFactory);
+            var peerAddressManager = new PeerAddressManager(DateTimeProvider.Default, peerFolder, this.extendedLoggerFactory);
             peerAddressManager.AddPeers(peersToAdd.ToArray(), IPAddress.Loopback);
 
             for (int i = 1; i <= 2; i++)

--- a/src/Stratis.Bitcoin/P2P/PeerAddress.cs
+++ b/src/Stratis.Bitcoin/P2P/PeerAddress.cs
@@ -15,13 +15,13 @@ namespace Stratis.Bitcoin.P2P
         /// <summary>
         /// The maximum amount of times a peer can be attempted within a give time frame.
         /// </summary>
-        internal static readonly int AttemptThreshold = 10;
+        internal static readonly int AttemptThreshold = 5;
 
         /// <summary>
         /// The amount of hours after which the peer's failed connection attempts
         /// will be reset.
         /// </summary>
-        internal static readonly int AttemptThresholdTime = 12;
+        internal static readonly int AttemptThresholdHours = 12;
 
         /// <summary>EndPoint of this peer.</summary>
         [JsonProperty(PropertyName = "endpoint")]
@@ -156,7 +156,7 @@ namespace Stratis.Bitcoin.P2P
         /// <para>
         /// This is reset when the amount of failed connection attempts reaches 
         /// the <see cref="PeerAddress.AttemptThreshold"/> and the last attempt was 
-        /// made more than <see cref="PeerAddress.AttemptThresholdTime"/> ago.
+        /// made more than <see cref="PeerAddress.AttemptThresholdHours"/> ago.
         /// </para>
         /// </summary>
         internal void ResetAttempts()

--- a/src/Stratis.Bitcoin/P2P/PeerAddress.cs
+++ b/src/Stratis.Bitcoin/P2P/PeerAddress.cs
@@ -15,13 +15,19 @@ namespace Stratis.Bitcoin.P2P
         /// <summary>
         /// The maximum amount of times a peer can be attempted within a give time frame.
         /// </summary>
-        internal static readonly int AttemptThreshold = 5;
+        internal const int AttemptThreshold = 5;
+
+        /// <summary>
+        /// The amount of hours we will wait before selecting an attempted peer again,
+        /// if it hasn't yet reached the <see cref="AttemptThreshold"/> amount of attempts.
+        /// </summary>
+        internal const int AttempThresholdHours = 1;
 
         /// <summary>
         /// The amount of hours after which the peer's failed connection attempts
-        /// will be reset.
+        /// will be reset to zero.
         /// </summary>
-        internal static readonly int AttemptThresholdHours = 12;
+        internal const int AttemptResetThresholdHours = 12;
 
         /// <summary>EndPoint of this peer.</summary>
         [JsonProperty(PropertyName = "endpoint")]
@@ -156,7 +162,7 @@ namespace Stratis.Bitcoin.P2P
         /// <para>
         /// This is reset when the amount of failed connection attempts reaches 
         /// the <see cref="PeerAddress.AttemptThreshold"/> and the last attempt was 
-        /// made more than <see cref="PeerAddress.AttemptThresholdHours"/> ago.
+        /// made more than <see cref="PeerAddress.AttemptResetThresholdHours"/> ago.
         /// </para>
         /// </summary>
         internal void ResetAttempts()

--- a/src/Stratis.Bitcoin/P2P/PeerAddress.cs
+++ b/src/Stratis.Bitcoin/P2P/PeerAddress.cs
@@ -21,7 +21,7 @@ namespace Stratis.Bitcoin.P2P
         /// The amount of hours after which the peer's failed connection attempts
         /// will be reset.
         /// </summary>
-        internal static readonly int AttempThresholdTime = 12;
+        internal static readonly int AttemptThresholdTime = 12;
 
         /// <summary>EndPoint of this peer.</summary>
         [JsonProperty(PropertyName = "endpoint")]
@@ -156,7 +156,7 @@ namespace Stratis.Bitcoin.P2P
         /// <para>
         /// This is reset when the amount of failed connection attempts reaches 
         /// the <see cref="PeerAddress.AttemptThreshold"/> and the last attempt was 
-        /// made more than <see cref="PeerAddress.AttempThresholdTime"/> ago.
+        /// made more than <see cref="PeerAddress.AttemptThresholdTime"/> ago.
         /// </para>
         /// </summary>
         internal void ResetAttempts()

--- a/src/Stratis.Bitcoin/P2P/PeerAddress.cs
+++ b/src/Stratis.Bitcoin/P2P/PeerAddress.cs
@@ -12,6 +12,12 @@ namespace Stratis.Bitcoin.P2P
     [JsonObject]
     public sealed class PeerAddress
     {
+        /// <summary>
+        /// The maximum amount of times a peer can be attempted within a
+        /// 12 hours period.
+        /// </summary>
+        internal static readonly int AttemptThreshold = 10;
+
         /// <summary>EndPoint of this peer.</summary>
         [JsonProperty(PropertyName = "endpoint")]
         [JsonConverter(typeof(IPEndPointConverter))]
@@ -62,7 +68,7 @@ namespace Stratis.Bitcoin.P2P
             get
             {
                 return
-                    (this.LastConnectionAttempt != null) &&
+                    (this.LastAttempt != null) &&
                     (this.LastConnectionSuccess == null) &&
                     (this.LastConnectionHandshake == null);
             }
@@ -77,7 +83,7 @@ namespace Stratis.Bitcoin.P2P
             get
             {
                 return
-                    (this.LastConnectionAttempt == null) &&
+                    (this.LastAttempt == null) &&
                     (this.LastConnectionSuccess != null) &&
                     (this.LastConnectionHandshake == null);
             }
@@ -92,7 +98,7 @@ namespace Stratis.Bitcoin.P2P
             get
             {
                 return
-                    (this.LastConnectionAttempt == null) &&
+                    (this.LastAttempt == null) &&
                     (this.LastConnectionSuccess == null) &&
                     (this.LastConnectionHandshake == null);
             }
@@ -107,7 +113,7 @@ namespace Stratis.Bitcoin.P2P
             get
             {
                 return
-                    (this.LastConnectionAttempt == null) &&
+                    (this.LastAttempt == null) &&
                     (this.LastConnectionSuccess != null) &&
                     (this.LastConnectionHandshake != null);
             }
@@ -120,7 +126,7 @@ namespace Stratis.Bitcoin.P2P
         /// </para>
         /// </summary>
         [JsonProperty(PropertyName = "lastConnectionAttempt", NullValueHandling = NullValueHandling.Ignore)]
-        public DateTimeOffset? LastConnectionAttempt { get; private set; }
+        public DateTimeOffset? LastAttempt { get; private set; }
 
         /// <summary>
         /// The last successful connection attempt.
@@ -132,12 +138,21 @@ namespace Stratis.Bitcoin.P2P
         public DateTimeOffset? LastConnectionSuccess { get; private set; }
 
         /// <summary>
-        /// Increments <see cref="ConnectionAttempts"/> and sets the <see cref="LastConnectionAttempt"/>.
+        /// Increments <see cref="ConnectionAttempts"/> and sets the <see cref="LastAttempt"/>.
         /// </summary>
-        internal void SetAttempted(DateTimeOffset peerAttemptedAt)
+        internal void ResetAttempts()
+        {
+            this.ConnectionAttempts = 0;
+        }
+
+        /// <summary>
+        /// Increments <see cref="ConnectionAttempts"/> and sets the <see cref="LastAttempt"/>.
+        /// </summary>
+        internal void SetAttempted(DateTime peerAttemptedAt)
         {
             this.ConnectionAttempts += 1;
-            this.LastConnectionAttempt = peerAttemptedAt;
+
+            this.LastAttempt = peerAttemptedAt;
             this.LastConnectionSuccess = null;
             this.LastConnectionHandshake = null;
         }
@@ -145,14 +160,14 @@ namespace Stratis.Bitcoin.P2P
         /// <summary>
         /// Sets the <see cref="LastConnectionSuccess"/>, <see cref="addressTime"/> and <see cref="NetworkAddress.Time"/> properties.
         /// <para>
-        /// Resets <see cref="ConnectionAttempts"/> and <see cref="LastConnectionAttempt"/>.
+        /// Resets <see cref="ConnectionAttempts"/> and <see cref="LastAttempt"/>.
         /// </para>
         /// </summary>
         internal void SetConnected(DateTimeOffset peerConnectedAt)
         {
             this.addressTime = peerConnectedAt;
 
-            this.LastConnectionAttempt = null;
+            this.LastAttempt = null;
             this.ConnectionAttempts = 0;
 
             this.LastConnectionSuccess = peerConnectedAt;

--- a/src/Stratis.Bitcoin/P2P/PeerAddress.cs
+++ b/src/Stratis.Bitcoin/P2P/PeerAddress.cs
@@ -13,10 +13,15 @@ namespace Stratis.Bitcoin.P2P
     public sealed class PeerAddress
     {
         /// <summary>
-        /// The maximum amount of times a peer can be attempted within a
-        /// 12 hours period.
+        /// The maximum amount of times a peer can be attempted within a give time frame.
         /// </summary>
         internal static readonly int AttemptThreshold = 10;
+
+        /// <summary>
+        /// The amount of hours after which the peer's failed connection attempts
+        /// will be reset.
+        /// </summary>
+        internal static readonly int AttempThresholdTime = 12;
 
         /// <summary>EndPoint of this peer.</summary>
         [JsonProperty(PropertyName = "endpoint")]
@@ -138,7 +143,12 @@ namespace Stratis.Bitcoin.P2P
         public DateTimeOffset? LastConnectionSuccess { get; private set; }
 
         /// <summary>
-        /// Increments <see cref="ConnectionAttempts"/> and sets the <see cref="LastAttempt"/>.
+        /// Resets the amount of <see cref="ConnectionAttempts"/>.
+        /// <para>
+        /// This is reset when the amount of failed connection attempts reaches 
+        /// the <see cref="PeerAddress.AttemptThreshold"/> and the last attempt was 
+        /// made more than <see cref="PeerAddress.AttempThresholdTime"/> ago.
+        /// </para>
         /// </summary>
         internal void ResetAttempts()
         {

--- a/src/Stratis.Bitcoin/P2P/PeerAddressManager.cs
+++ b/src/Stratis.Bitcoin/P2P/PeerAddressManager.cs
@@ -171,7 +171,7 @@ namespace Stratis.Bitcoin.P2P
             //1: The last attempt was more than the threshold time ago.
             //2: More than the threshold attempts was made.
             if (peer.Attempted &&
-                peer.LastAttempt < this.dateTimeProvider.GetUtcNow().AddHours(-PeerAddress.AttempThresholdTime) &&
+                peer.LastAttempt < this.dateTimeProvider.GetUtcNow().AddHours(-PeerAddress.AttemptThresholdTime) &&
                 peer.ConnectionAttempts >= PeerAddress.AttemptThreshold)
             {
                 peer.ResetAttempts();

--- a/src/Stratis.Bitcoin/P2P/PeerAddressManager.cs
+++ b/src/Stratis.Bitcoin/P2P/PeerAddressManager.cs
@@ -52,12 +52,12 @@ namespace Stratis.Bitcoin.P2P
         /// Increments <see cref="PeerAddress.ConnectionAttempts"/> of the peer as well as the <see cref="PeerAddress.LastConnectionSuccess"/>
         /// </para>
         /// </summary>
-        void PeerAttempted(IPEndPoint endpoint, DateTimeOffset peerAttemptedAt);
+        void PeerAttempted(IPEndPoint endpoint, DateTime peerAttemptedAt);
 
         /// <summary>
         /// A peer was successfully connected to.
         /// <para>
-        /// Resets the <see cref="PeerAddress.ConnectionAttempts"/> and <see cref="PeerAddress.LastConnectionAttempt"/> of the peer.
+        /// Resets the <see cref="PeerAddress.ConnectionAttempts"/> and <see cref="PeerAddress.LastAttempt"/> of the peer.
         /// Sets the peer's <see cref="PeerAddress.LastConnectionSuccess"/> to now.
         /// </para>
         /// </summary>
@@ -83,6 +83,9 @@ namespace Stratis.Bitcoin.P2P
     /// </summary>
     public sealed class PeerAddressManager : IPeerAddressManager
     {
+        /// <summary>Provider of time functions.</summary>
+        private readonly IDateTimeProvider dateTimeProvider;
+
         /// <summary>Instance logger.</summary>
         private readonly ILogger logger;
 
@@ -102,8 +105,9 @@ namespace Stratis.Bitcoin.P2P
         public IPeerSelector PeerSelector { get; private set; }
 
         /// <summary>Constructor used by dependency injection.</summary>
-        public PeerAddressManager(DataFolder peerFilePath, ILoggerFactory loggerFactory)
+        public PeerAddressManager(IDateTimeProvider dateTimeProvider, DataFolder peerFilePath, ILoggerFactory loggerFactory)
         {
+            this.dateTimeProvider = dateTimeProvider;
             this.loggerFactory = loggerFactory;
             this.logger = loggerFactory.CreateLogger(this.GetType().FullName);
             this.Peers = new ConcurrentDictionary<IPEndPoint, PeerAddress>();
@@ -152,11 +156,20 @@ namespace Stratis.Bitcoin.P2P
         }
 
         /// <inheritdoc/>
-        public void PeerAttempted(IPEndPoint endpoint, DateTimeOffset peerAttemptedAt)
+        public void PeerAttempted(IPEndPoint endpoint, DateTime peerAttemptedAt)
         {
             var peer = this.FindPeer(endpoint);
             if (peer == null)
                 return;
+
+            //Reset the attempted count if the last attempt was:
+            //1: More than 12 hours ago.
+            //2: More than 10 attempts was made.
+            if (peer.Attempted && peer.LastAttempt < this.dateTimeProvider.GetUtcNow().AddHours(-12) &&
+                peer.ConnectionAttempts >= PeerAddress.AttemptThreshold)
+            {
+                peer.ResetAttempts();
+            }
 
             peer.SetAttempted(peerAttemptedAt);
         }

--- a/src/Stratis.Bitcoin/P2P/PeerAddressManager.cs
+++ b/src/Stratis.Bitcoin/P2P/PeerAddressManager.cs
@@ -162,10 +162,11 @@ namespace Stratis.Bitcoin.P2P
             if (peer == null)
                 return;
 
-            //Reset the attempted count if the last attempt was:
-            //1: More than 12 hours ago.
-            //2: More than 10 attempts was made.
-            if (peer.Attempted && peer.LastAttempt < this.dateTimeProvider.GetUtcNow().AddHours(-12) &&
+            //Reset the attempted count if:
+            //1: The last attempt was more than the threshold time ago.
+            //2: More than the threshold attempts was made.
+            if (peer.Attempted &&
+                peer.LastAttempt < this.dateTimeProvider.GetUtcNow().AddHours(-PeerAddress.AttempThresholdTime) &&
                 peer.ConnectionAttempts >= PeerAddress.AttemptThreshold)
             {
                 peer.ResetAttempts();

--- a/src/Stratis.Bitcoin/P2P/PeerAddressManager.cs
+++ b/src/Stratis.Bitcoin/P2P/PeerAddressManager.cs
@@ -171,7 +171,7 @@ namespace Stratis.Bitcoin.P2P
             //1: The last attempt was more than the threshold time ago.
             //2: More than the threshold attempts was made.
             if (peer.Attempted &&
-                peer.LastAttempt < this.dateTimeProvider.GetUtcNow().AddHours(-PeerAddress.AttemptThresholdTime) &&
+                peer.LastAttempt < this.dateTimeProvider.GetUtcNow().AddHours(-PeerAddress.AttemptThresholdHours) &&
                 peer.ConnectionAttempts >= PeerAddress.AttemptThreshold)
             {
                 peer.ResetAttempts();

--- a/src/Stratis.Bitcoin/P2P/PeerAddressManager.cs
+++ b/src/Stratis.Bitcoin/P2P/PeerAddressManager.cs
@@ -171,7 +171,7 @@ namespace Stratis.Bitcoin.P2P
             //1: The last attempt was more than the threshold time ago.
             //2: More than the threshold attempts was made.
             if (peer.Attempted &&
-                peer.LastAttempt < this.dateTimeProvider.GetUtcNow().AddHours(-PeerAddress.AttemptThresholdHours) &&
+                peer.LastAttempt < this.dateTimeProvider.GetUtcNow().AddHours(-PeerAddress.AttemptResetThresholdHours) &&
                 peer.ConnectionAttempts >= PeerAddress.AttemptThreshold)
             {
                 peer.ResetAttempts();

--- a/src/Stratis.Bitcoin/P2P/PeerConnectorDiscovery.cs
+++ b/src/Stratis.Bitcoin/P2P/PeerConnectorDiscovery.cs
@@ -120,7 +120,7 @@ namespace Stratis.Bitcoin.P2P
                 break;
             }
 
-            //If the peer selector returns nothing, we need to wait a bit,
+            //If the peer selector returns nothing, we wait 2 seconds to
             //effectively override the connector's burst mode.
             if (peer == null)
             {

--- a/src/Stratis.Bitcoin/P2P/PeerDiscoveryLoop.cs
+++ b/src/Stratis.Bitcoin/P2P/PeerDiscoveryLoop.cs
@@ -96,7 +96,6 @@ namespace Stratis.Bitcoin.P2P
 
             this.peersToFind = this.currentParameters.PeerAddressManagerBehaviour().PeersToDiscover;
 
-            this.logger.LogInformation("Starting peer discovery...");
             this.asyncLoop = this.asyncLoopFactory.Run(nameof(this.DiscoverPeersAsync), async token =>
             {
                 if (this.peerAddressManager.Peers.Count < this.peersToFind)
@@ -133,6 +132,8 @@ namespace Stratis.Bitcoin.P2P
             {
                 using (var connectTokenSource = CancellationTokenSource.CreateLinkedTokenSource(this.nodeLifetime.ApplicationStopping))
                 {
+                    this.logger.LogTrace("Attempting to discover from : '{0}'", endPoint);
+
                     connectTokenSource.CancelAfter(TimeSpan.FromSeconds(5));
 
                     NetworkPeer networkPeer = null;

--- a/src/Stratis.Bitcoin/P2P/PeerSelector.cs
+++ b/src/Stratis.Bitcoin/P2P/PeerSelector.cs
@@ -253,7 +253,7 @@ namespace Stratis.Bitcoin.P2P
         /// <inheritdoc/>
         public IEnumerable<PeerAddress> Attempted()
         {
-            return this.peerAddresses.Values.Where(p => p.Attempted && p.ConnectionAttempts <= 10 && p.LastConnectionAttempt < DateTime.UtcNow.AddSeconds(-60));
+            return this.peerAddresses.Values.Where(p => p.Attempted && p.ConnectionAttempts < 10 && p.LastAttempt < DateTime.UtcNow.AddHours(-1));
         }
 
         /// <inheritdoc/>

--- a/src/Stratis.Bitcoin/P2P/PeerSelector.cs
+++ b/src/Stratis.Bitcoin/P2P/PeerSelector.cs
@@ -116,8 +116,6 @@ namespace Stratis.Bitcoin.P2P
         /// </summary>
         private IEnumerable<PeerAddress> SelectPreferredPeers()
         {
-            this.logger.LogTrace("()");
-
             // First check to see if there are handshaked peers. If so,
             // give them a 50% chance to be picked over all the other peers.
             var handshaked = this.Handshaked().ToList();
@@ -126,7 +124,7 @@ namespace Stratis.Bitcoin.P2P
                 int chance = this.random.Next(100);
                 if (chance <= 50)
                 {
-                    this.logger.LogTrace("(-)[RETURN_HANDSHAKED]");
+                    this.logger.LogTrace("[RETURN_HANDSHAKED]");
                     return handshaked;
                 }
             }
@@ -139,7 +137,7 @@ namespace Stratis.Bitcoin.P2P
                 int chance = this.random.Next(100);
                 if (chance <= 50)
                 {
-                    this.logger.LogTrace("(-)[RETURN_CONNECTED]");
+                    this.logger.LogTrace("[RETURN_CONNECTED]");
                     return connected;
                 }
             }
@@ -154,7 +152,7 @@ namespace Stratis.Bitcoin.P2P
             {
                 if (this.random.Next(2) == 0)
                 {
-                    this.logger.LogTrace("(-)[RETURN_ATTEMPTED]");
+                    this.logger.LogTrace("[RETURN_ATTEMPTED]");
                     return attempted;
                 }
                 else
@@ -167,20 +165,21 @@ namespace Stratis.Bitcoin.P2P
             // If there are only fresh peers, return them.
             if (fresh.Any() && !attempted.Any())
             {
-                this.logger.LogTrace("(-)[RETURN_ONLY_FRESH_EXIST]");
+                this.logger.LogTrace("[RETURN_FRESH_HC_FAILED]");
                 return fresh;
             }
 
             // If there are only attempted peers, return them.
             if (!fresh.Any() && attempted.Any())
             {
-                this.logger.LogTrace("(-)[RETURN_ONLY_ATTEMPTED_EXIST]");
+                this.logger.LogTrace("[RETURN_ATTEMPTED_HC_FAILED]");
                 return attempted;
             }
 
             // If all the selection criteria failed to return a set of peers,
             // then let the caller try again.
-            this.logger.LogTrace("(-)[RETURN_NO_PEERS]");
+            else
+                this.logger.LogTrace("[RETURN_NO_PEERS]");
 
             return new PeerAddress[] { };
         }

--- a/src/Stratis.Bitcoin/P2P/PeerSelector.cs
+++ b/src/Stratis.Bitcoin/P2P/PeerSelector.cs
@@ -252,7 +252,10 @@ namespace Stratis.Bitcoin.P2P
         /// <inheritdoc/>
         public IEnumerable<PeerAddress> Attempted()
         {
-            return this.peerAddresses.Values.Where(p => p.Attempted && p.ConnectionAttempts < 10 && p.LastAttempt < DateTime.UtcNow.AddHours(-1));
+            return this.peerAddresses.Values.Where(p =>
+                                p.Attempted &&
+                                p.ConnectionAttempts < PeerAddress.AttemptThreshold &&
+                                p.LastAttempt < DateTime.UtcNow.AddHours(-PeerAddress.AttempThresholdHours));
         }
 
         /// <inheritdoc/>


### PR DESCRIPTION
This fixes #1105.

Also, in the scenario where there are no connections, we will employ the burst connection mode BUT if there are no peers to be selected from, the peer connector will continuously try and find peers without any delay. Therefore we need to delay the connection for a bit before trying again. This was the scenario where the logs were being flooded with entries.

