### PR TITLE
Minor block store improvement

### DIFF
--- a/src/Stratis.Bitcoin.Features.BlockStore/BlockStoreLoop.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/BlockStoreLoop.cs
@@ -264,6 +264,9 @@ namespace Stratis.Bitcoin.Features.BlockStore
                 var result = await this.stepChain.ExecuteAsync(nextChainedBlock, disposeMode, cancellationToken).ConfigureAwait(false);
                 if (result == StepResult.Stop)
                     break;
+
+                if (result == StepResult.Continue)
+                    await Task.Delay(100);
             }
 
             this.logger.LogTrace("(-)");


### PR DESCRIPTION
Added `await Task.Delay(100);` at the `DownloadAndStoreBlocksAsync`:
without that we're sometimes ending up with a while() loop that will have around 3000 iterations per second that are just actively waiting for the block download. That causes a lot of the CPU consumption during the IBD (around 20% CPU consumption reduction with that delay in place). 
