### PR TITLE
Block store high cpu usage fix

### DIFF
--- a/src/Stratis.Bitcoin.Features.BlockStore/LoopSteps/ProcessPendingStorageStep.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/LoopSteps/ProcessPendingStorageStep.cs
@@ -54,9 +54,11 @@ namespace Stratis.Bitcoin.Features.BlockStore.LoopSteps
             }
             
             // In case of IBD do not save every single block- persist them in batches.
-            if (this.BlockStoreLoop.PendingStorage.Count < BlockStoreLoop.PendingStorageBatchThreshold && !disposeMode && 
-                this.BlockStoreLoop.InitialBlockDownloadState.IsInitialBlockDownload())
-                return StepResult.Continue;
+            if (this.BlockStoreLoop.PendingStorage.Count < BlockStoreLoop.PendingStorageBatchThreshold &&
+                !disposeMode && this.BlockStoreLoop.InitialBlockDownloadState.IsInitialBlockDownload())
+            {
+                return StepResult.Stop;
+            }
 
             while (!context.CancellationToken.IsCancellationRequested)
             {

--- a/src/Stratis.Bitcoin.Features.BlockStore/LoopSteps/ProcessPendingStorageStep.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/LoopSteps/ProcessPendingStorageStep.cs
@@ -52,95 +52,25 @@ namespace Stratis.Bitcoin.Features.BlockStore.LoopSteps
                 this.logger.LogTrace("(-)[NOT_FOUND]:{0}", StepResult.Next);
                 return StepResult.Next;
             }
-
-            if (disposeMode)
-            {
-                StepResult lres = await this.ProcessWhenDisposingAsync(context);
-                this.logger.LogTrace("(-)[DISPOSE]:{0}", lres);
-                return lres;
-            }
-
-            if (this.BlockStoreLoop.InitialBlockDownloadState.IsInitialBlockDownload())
-            {
-                StepResult lres = await this.ProcessWhenInIBDAsync(context);
-                this.logger.LogTrace("(-)[IBD]:{0}", lres);
-                return lres;
-            }
-
-            StepResult res = await this.ProcessWhenNotInIBDAsync(context);
-            this.logger.LogTrace("(-):{0}", res);
-            return res;
-        }
-
-        /// <summary>
-        /// When the node disposes, process all the blocks in <see cref="BlockStoreLoop.PendingStorage"/> until
-        /// its empty
-        /// </summary>
-        private async Task<StepResult> ProcessWhenDisposingAsync(ProcessPendingStorageContext context)
-        {
-            this.logger.LogTrace("({0}:'{1}')", nameof(context.NextChainedBlock), context.NextChainedBlock);
-
-            while (this.BlockStoreLoop.PendingStorage.Count > 0)
-            {
-                StepResult result = this.PrepareNextBlockFromPendingStorage(context);
-                if (result == StepResult.Stop)
-                    break;
-            }
-
-            if (context.PendingBlockPairsToStore.Any())
-                await this.PushBlocksToRepositoryAsync(context);
-
-            this.logger.LogTrace("(-):{0}", StepResult.Stop);
-            return StepResult.Stop;
-        }
-
-        /// <summary>
-        /// When the node is in IBD wait for <see cref="BlockStoreLoop.PendingStorageBatchThreshold"/> to be true then continuously process all the blocks in <see cref="BlockStoreLoop.PendingStorage"/> until
-        /// a stop condition is found, the blocks will be pushed to the repository in batches of size <see cref="BlockStoreLoop.MaxPendingInsertBlockSize"/>.
-        /// </summary>
-        private async Task<StepResult> ProcessWhenInIBDAsync(ProcessPendingStorageContext context)
-        {
-            this.logger.LogTrace("({0}:'{1}',{2}.{3}:{4})", nameof(context.NextChainedBlock), context.NextChainedBlock, nameof(this.BlockStoreLoop.PendingStorage), nameof(this.BlockStoreLoop.PendingStorage.Count), this.BlockStoreLoop.PendingStorage.Count);
-
-            if (this.BlockStoreLoop.PendingStorage.Count < BlockStoreLoop.PendingStorageBatchThreshold)
+            
+            // In case of IBD do not save every single block- persist them in batches.
+            if (this.BlockStoreLoop.PendingStorage.Count < BlockStoreLoop.PendingStorageBatchThreshold && !disposeMode && 
+                this.BlockStoreLoop.InitialBlockDownloadState.IsInitialBlockDownload())
                 return StepResult.Continue;
 
-            while (context.CancellationToken.IsCancellationRequested == false)
+            while (!context.CancellationToken.IsCancellationRequested)
             {
                 StepResult result = this.PrepareNextBlockFromPendingStorage(context);
                 if (result == StepResult.Stop)
                     break;
 
                 if (context.PendingStorageBatchSize > BlockStoreLoop.MaxPendingInsertBlockSize)
-                    await this.PushBlocksToRepositoryAsync(context);
+                    await this.PushBlocksToRepositoryAsync(context).ConfigureAwait(false);
             }
 
             if (context.PendingBlockPairsToStore.Any())
-                await this.PushBlocksToRepositoryAsync(context);
+                await this.PushBlocksToRepositoryAsync(context).ConfigureAwait(false);
 
-            this.logger.LogTrace("(-):{0}", StepResult.Continue);
-            return StepResult.Continue;
-        }
-
-        /// <summary>
-        /// When the node is NOT in IBD, process and push the blocks in <see cref="BlockStoreLoop.PendingStorage"/> immediately
-        /// to the block repository without checking batch size.
-        /// </summary>
-        private async Task<StepResult> ProcessWhenNotInIBDAsync(ProcessPendingStorageContext context)
-        {
-            this.logger.LogTrace("({0}:'{1}')", nameof(context.NextChainedBlock), context.NextChainedBlock);
-
-            while (context.CancellationToken.IsCancellationRequested == false)
-            {
-                StepResult result = this.PrepareNextBlockFromPendingStorage(context);
-                if (result == StepResult.Stop)
-                    break;
-            }
-
-            if (context.PendingBlockPairsToStore.Any())
-                await this.PushBlocksToRepositoryAsync(context);
-
-            this.logger.LogTrace("(-):{0}", StepResult.Continue);
             return StepResult.Continue;
         }
 


### PR DESCRIPTION
### Why this is happening?

`ProcessPendingStorageStep.ProcessWhenInIBDAsync` will return `StepResult.Continue` if `PendingStorage` has less than 10 blocks in it. Every time `StepResult.Continue` is returned we are starting a new iteration in `BlockStoreLoop.DownloadAndStoreBlocksAsync` which will again bump into that threshold and restart until the moment 10 blocks are finally downloaded. And so it goes over and over again => the slower the peers are the longer it takes to download enough blocks to pass the threshold => more iterations we have. 

On average I have 300000 iterations of the `DownloadAndStoreBlocksAsync:while` loop before I have 30 blocks downloaded given that I'm connected to the slow peers. 

### Fix

Returning `StepResult.Stop` instead of  `StepResult.Continue` when the threshold is not met makes the loop have a 1 second break so for now this will do. 
But it's still a quick fix and in future we will need to refactor logic behind the BlockStoreLoop so we don't start a new iteration until we have a new block that we need to act upon.

ps

I've also refactored the ProcessPendingStorageStep a bit because it had 3 methods that were 80% copy paste of each other - merged them into 1.