### PR TITLE
Peer discovery fix

### DIFF
--- a/src/Stratis.Bitcoin.Tests/Utilities/ParallelAsyncTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Utilities/ParallelAsyncTest.cs
@@ -31,7 +31,7 @@ namespace Stratis.Bitcoin.Tests.Utilities
 
             Stopwatch watch = Stopwatch.StartNew();
 
-            await this.testCollection.ForEachAsync(2, CancellationToken.None, async item =>
+            await this.testCollection.ForEachAsync(2, CancellationToken.None, async (item, cancellation) =>
             {
                 await Task.Delay(this.itemProcessingDelayMs).ConfigureAwait(false);
                 sum += item;
@@ -50,7 +50,7 @@ namespace Stratis.Bitcoin.Tests.Utilities
 
             Stopwatch watch = Stopwatch.StartNew();
 
-            await this.testCollection.ForEachAsync(this.testCollection.Count, CancellationToken.None, async item =>
+            await this.testCollection.ForEachAsync(this.testCollection.Count, CancellationToken.None, async (item, cancellation) =>
             {
                 await Task.Delay(this.itemProcessingDelayMs).ConfigureAwait(false);
                 sum += item;
@@ -67,7 +67,7 @@ namespace Stratis.Bitcoin.Tests.Utilities
         {
             var emptyList = new List<int>();
 
-            await emptyList.ForEachAsync(2, CancellationToken.None, async item =>
+            await emptyList.ForEachAsync(2, CancellationToken.None, async (item, cancellation) =>
             {
                 await Task.Delay(this.itemProcessingDelayMs).ConfigureAwait(false);
             }).ConfigureAwait(false);

--- a/src/Stratis.Bitcoin.Tests/Utilities/ParallelAsyncTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Utilities/ParallelAsyncTest.cs
@@ -72,5 +72,25 @@ namespace Stratis.Bitcoin.Tests.Utilities
                 await Task.Delay(this.itemProcessingDelayMs).ConfigureAwait(false);
             }).ConfigureAwait(false);
         }
+
+
+        [Fact]
+        public async void ForEachAsync_CanBeCancelled_Async()
+        {
+            var tokenSource = new CancellationTokenSource();
+
+            int itemsProcessed = 0;
+
+            await this.testCollection.ForEachAsync(1, tokenSource.Token, async (item, cancellation) =>
+            {
+                await Task.Delay(this.itemProcessingDelayMs).ConfigureAwait(false);
+                itemsProcessed++;
+
+                if (itemsProcessed == 3)
+                    tokenSource.Cancel();
+            }).ConfigureAwait(false);
+            
+            Assert.Equal(3, itemsProcessed);
+        }
     }
 }

--- a/src/Stratis.Bitcoin.Tests/Utilities/ParallelAsyncTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Utilities/ParallelAsyncTest.cs
@@ -1,0 +1,76 @@
+﻿using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using Stratis.Bitcoin.Utilities;
+using Xunit;
+
+namespace Stratis.Bitcoin.Tests.Utilities
+{
+    public class ParallelAsyncTest
+    {
+        private readonly List<int> testCollection;
+        private readonly int itemProcessingDelayMs;
+        private readonly int testCollectionSum;
+
+        public ParallelAsyncTest()
+        {
+            this.testCollection = new List<int>() { 1, 2, 3, 4, 5, 6, 7, 8 };
+            this.itemProcessingDelayMs = 200;
+
+            this.testCollectionSum = 0;
+
+            foreach (int item in this.testCollection)
+                this.testCollectionSum += item;
+        }
+
+        [Fact]
+        public async void ForEachAsync_TestDegreeOfParallelism_Async()
+        {
+            int sum = 0;
+
+            Stopwatch watch = Stopwatch.StartNew();
+
+            await this.testCollection.ForEachAsync(2, CancellationToken.None, async item =>
+            {
+                await Task.Delay(this.itemProcessingDelayMs).ConfigureAwait(false);
+                sum += item;
+            }).ConfigureAwait(false);
+
+            watch.Stop();
+
+            Assert.True(watch.Elapsed.TotalMilliseconds < this.testCollection.Count * this.itemProcessingDelayMs);
+            Assert.Equal(this.testCollectionSum, sum);
+        }
+
+        [Fact]
+        public async void ForEachAsync_TestDegreeOfParallelism2_Async()
+        {
+            int sum = 0;
+
+            Stopwatch watch = Stopwatch.StartNew();
+
+            await this.testCollection.ForEachAsync(this.testCollection.Count, CancellationToken.None, async item =>
+            {
+                await Task.Delay(this.itemProcessingDelayMs).ConfigureAwait(false);
+                sum += item;
+            }).ConfigureAwait(false);
+
+            watch.Stop();
+
+            Assert.True(watch.Elapsed.TotalMilliseconds < this.itemProcessingDelayMs * 2);
+            Assert.Equal(this.testCollectionSum, sum);
+        }
+
+        [Fact]
+        public async void ForEachAsync_DoesNothingWithEmptyCollection_Async()
+        {
+            var emptyList = new List<int>();
+
+            await emptyList.ForEachAsync(2, CancellationToken.None, async item =>
+            {
+                await Task.Delay(this.itemProcessingDelayMs).ConfigureAwait(false);
+            }).ConfigureAwait(false);
+        }
+    }
+}

--- a/src/Stratis.Bitcoin/P2P/PeerDiscoveryLoop.cs
+++ b/src/Stratis.Bitcoin/P2P/PeerDiscoveryLoop.cs
@@ -108,7 +108,7 @@ namespace Stratis.Bitcoin.P2P
         /// <summary>
         /// See <see cref="DiscoverPeers"/>
         /// </summary>
-        private Task DiscoverPeersAsync()
+        private async Task DiscoverPeersAsync()
         {
             var peersToDiscover = new List<IPEndPoint>();
             peersToDiscover.AddRange(this.peerAddressManager.PeerSelector.SelectPeersForDiscovery(1000).Select(p => p.Endpoint));
@@ -120,15 +120,10 @@ namespace Stratis.Bitcoin.P2P
 
                 peersToDiscover = peersToDiscover.OrderBy(a => RandomUtils.GetInt32()).ToList();
                 if (peersToDiscover.Count == 0)
-                    return Task.CompletedTask;
+                    return;
             }
-
-            Parallel.ForEach(peersToDiscover, new ParallelOptions()
-            {
-                MaxDegreeOfParallelism = 2,
-                CancellationToken = this.nodeLifetime.ApplicationStopping,
-            },
-            async endPoint =>
+            
+            await peersToDiscover.ForEachAsync(5, this.nodeLifetime.ApplicationStopping, async endPoint =>
             {
                 using (var connectTokenSource = CancellationTokenSource.CreateLinkedTokenSource(this.nodeLifetime.ApplicationStopping))
                 {
@@ -161,9 +156,7 @@ namespace Stratis.Bitcoin.P2P
                         networkPeer?.Dispose("Discovery job done");
                     }
                 }
-            });
-
-            return Task.CompletedTask;
+            }).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/src/Stratis.Bitcoin/P2P/PeerDiscoveryLoop.cs
+++ b/src/Stratis.Bitcoin/P2P/PeerDiscoveryLoop.cs
@@ -123,9 +123,9 @@ namespace Stratis.Bitcoin.P2P
                     return;
             }
             
-            await peersToDiscover.ForEachAsync(5, this.nodeLifetime.ApplicationStopping, async endPoint =>
+            await peersToDiscover.ForEachAsync(5, this.nodeLifetime.ApplicationStopping, async (endPoint, cancellation) =>
             {
-                using (var connectTokenSource = CancellationTokenSource.CreateLinkedTokenSource(this.nodeLifetime.ApplicationStopping))
+                using (var connectTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellation))
                 {
                     this.logger.LogTrace("Attempting to discover from : '{0}'", endPoint);
 

--- a/src/Stratis.Bitcoin/Utilities/ParallelAsync.cs
+++ b/src/Stratis.Bitcoin/Utilities/ParallelAsync.cs
@@ -33,7 +33,8 @@ namespace Stratis.Bitcoin.Utilities
                         unfinished.Remove(toRemove);
                 }
 
-                unfinished.Add(action(item, cancellationToken));
+                if (!cancellationToken.IsCancellationRequested)
+                    unfinished.Add(action(item, cancellationToken));
             }
 
             await Task.WhenAll(unfinished).ConfigureAwait(false);

--- a/src/Stratis.Bitcoin/Utilities/ParallelAsync.cs
+++ b/src/Stratis.Bitcoin/Utilities/ParallelAsync.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Stratis.Bitcoin.Utilities
+{
+    public static class ParallelAsync
+    {
+        /// <summary>
+        /// Executes a foreach operation on an IEnumerable in which iterations run in parallel.
+        /// </summary>
+        /// <typeparam name="TSource">Item type.</typeparam>
+        /// <param name="collection">Enumerated collection.</param>
+        /// <param name="maxDegreeOfParallelism">The maximum amount of items that can be processed simultaneously.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <param name="action">Action that is used for processing each item in the collection.</param>
+        public static async Task ForEachAsync<TSource>(this IEnumerable<TSource> collection, int maxDegreeOfParallelism, CancellationToken cancellationToken, Func<TSource, Task> action)
+        {
+            var unfinished = new List<Task>();
+
+            foreach (TSource item in collection)
+            {
+                if (cancellationToken.IsCancellationRequested)
+                    break;
+                
+                if (unfinished.Count >= maxDegreeOfParallelism)
+                {
+                    await Task.WhenAny(unfinished).ConfigureAwait(false);
+
+                    foreach (Task toRemove in unfinished.Where(x => x.IsCompleted).ToList())
+                        unfinished.Remove(toRemove);
+                }
+
+                unfinished.Add(action(item));
+            }
+
+            await Task.WhenAll(unfinished).ConfigureAwait(false);
+        }
+    }
+}

--- a/src/Stratis.Bitcoin/Utilities/ParallelAsync.cs
+++ b/src/Stratis.Bitcoin/Utilities/ParallelAsync.cs
@@ -9,7 +9,7 @@ namespace Stratis.Bitcoin.Utilities
     public static class ParallelAsync
     {
         /// <summary>
-        /// Executes a foreach operation on an IEnumerable in which iterations run in parallel.
+        /// Executes a foreach operation on an IEnumerable in which iterations run asynchronously.
         /// </summary>
         /// <typeparam name="TSource">Item type.</typeparam>
         /// <param name="collection">Enumerated collection.</param>

--- a/src/Stratis.Bitcoin/Utilities/ParallelAsync.cs
+++ b/src/Stratis.Bitcoin/Utilities/ParallelAsync.cs
@@ -16,7 +16,7 @@ namespace Stratis.Bitcoin.Utilities
         /// <param name="maxDegreeOfParallelism">The maximum amount of items that can be processed simultaneously.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <param name="action">Action that is used for processing each item in the collection.</param>
-        public static async Task ForEachAsync<TSource>(this IEnumerable<TSource> collection, int maxDegreeOfParallelism, CancellationToken cancellationToken, Func<TSource, Task> action)
+        public static async Task ForEachAsync<TSource>(this IEnumerable<TSource> collection, int maxDegreeOfParallelism, CancellationToken cancellationToken, Func<TSource, CancellationToken, Task> action)
         {
             var unfinished = new List<Task>();
 
@@ -33,7 +33,7 @@ namespace Stratis.Bitcoin.Utilities
                         unfinished.Remove(toRemove);
                 }
 
-                unfinished.Add(action(item));
+                unfinished.Add(action(item, cancellationToken));
             }
 
             await Task.WhenAll(unfinished).ConfigureAwait(false);


### PR DESCRIPTION
PeerDiscoveryLoop used to use Parallel.ForEach in order to perform the peer discovery. And since awaitable methods were used in the foreach iterations the whole Parallel.ForEach was not awaited (apparently Parallel.ForEach cannot be used with awaits inside the iteration code).

That caused running peer discovery for the same set of peers every 10 seconds without awaiting prev set to be processed => we get a peer discovery connection + connection drop every 10 seconds. 

In order to fix this I've introduced a `ParallelAsync.ForEachAsync` that works exactly the same as `Parallel.ForEach` except for it can work with async code properly. 

Fix: #1124