### PR TITLE
Remove public TestNet, RegTest and GetNetwork from NodeSettings (Refactor)

### DIFF
--- a/src/Stratis.Bitcoin.Features.Consensus/ConsensusFeature.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/ConsensusFeature.cs
@@ -17,6 +17,7 @@ using Stratis.Bitcoin.Features.Consensus.Rules;
 using Stratis.Bitcoin.Features.Consensus.Rules.CommonRules;
 using Stratis.Bitcoin.Interfaces;
 using Stratis.Bitcoin.P2P.Protocol.Payloads;
+using Stratis.Bitcoin.Utilities;
 
 [assembly: InternalsVisibleTo("Stratis.Bitcoin.Features.Consensus.Tests")]
 
@@ -194,7 +195,7 @@ namespace Stratis.Bitcoin.Features.Consensus
                     {
                         fullNodeBuilder.Network.Consensus.Options = new PosConsensusOptions();
 
-                        if (fullNodeBuilder.NodeSettings.Testnet)
+                        if (fullNodeBuilder.Network.IsTest())
                         {
                             fullNodeBuilder.Network.Consensus.Option<PosConsensusOptions>().CoinbaseMaturity = 10;
                             fullNodeBuilder.Network.Consensus.Option<PosConsensusOptions>().StakeMinConfirmations = 10;

--- a/src/Stratis.Bitcoin.Tests/Builder/FullNodeBuilderExtensionsTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Builder/FullNodeBuilderExtensionsTest.cs
@@ -43,7 +43,7 @@ namespace Stratis.Bitcoin.Tests.Builder
         [Fact]
         public void UseDefaultNodeSettingsConfiguresNodeBuilderWithDefaultSettings()
         {
-            var nodeSettings = new NodeSettings();
+            var nodeSettings = NodeSettings.Default();
             nodeSettings.ConfigurationFile = "TestData/FullNodeBuilder/UseNodeSettingsConfFile";
             nodeSettings.DataDir = "TestData/FullNodeBuilder/UseNodeSettings";
 
@@ -60,7 +60,7 @@ namespace Stratis.Bitcoin.Tests.Builder
         [Fact]
         public void UseNodeSettingsUsingTestNetConfiguresNodeBuilderWithTestnetSettings()
         {
-            NodeSettings nodeSettings = new NodeSettings(args:new string[] { "-testnet" });
+            NodeSettings nodeSettings = NodeSettings.Default(Network.TestNet);
             nodeSettings.ConfigurationFile = "TestData/FullNodeBuilder/UseNodeSettingsConfFile";
             nodeSettings.DataDir = "TestData/FullNodeBuilder/UseNodeSettings";
 
@@ -77,7 +77,7 @@ namespace Stratis.Bitcoin.Tests.Builder
         [Fact]
         public void UseNodeSettingsUsingRegTestNetConfiguresNodeBuilderWithRegTestNet()
         {
-            NodeSettings nodeSettings = new NodeSettings(args:new string[] { "-regtest" });
+            NodeSettings nodeSettings = NodeSettings.Default(Network.RegTest);
             nodeSettings.ConfigurationFile = "TestData/FullNodeBuilder/UseNodeSettingsConfFile";
             nodeSettings.DataDir = "TestData/FullNodeBuilder/UseNodeSettings";
 

--- a/src/Stratis.Bitcoin.Tests/Builder/FullNodeBuilderExtensionsTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Builder/FullNodeBuilderExtensionsTest.cs
@@ -43,9 +43,10 @@ namespace Stratis.Bitcoin.Tests.Builder
         [Fact]
         public void UseDefaultNodeSettingsConfiguresNodeBuilderWithDefaultSettings()
         {
-            var nodeSettings = new NodeSettings(args: new string[] { "-testnet" });
+            var nodeSettings = new NodeSettings(loadConfiguration:false);
             nodeSettings.ConfigurationFile = "TestData/FullNodeBuilder/UseNodeSettingsConfFile";
             nodeSettings.DataDir = "TestData/FullNodeBuilder/UseNodeSettings";
+            nodeSettings.LoadConfiguration();
 
             FullNodeBuilderNodeSettingsExtension.UseNodeSettings(this.fullNodeBuilder, nodeSettings);
 

--- a/src/Stratis.Bitcoin.Tests/Builder/FullNodeBuilderExtensionsTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Builder/FullNodeBuilderExtensionsTest.cs
@@ -43,10 +43,9 @@ namespace Stratis.Bitcoin.Tests.Builder
         [Fact]
         public void UseDefaultNodeSettingsConfiguresNodeBuilderWithDefaultSettings()
         {
-            var nodeSettings = new NodeSettings(loadConfiguration:false);
+            var nodeSettings = new NodeSettings();
             nodeSettings.ConfigurationFile = "TestData/FullNodeBuilder/UseNodeSettingsConfFile";
             nodeSettings.DataDir = "TestData/FullNodeBuilder/UseNodeSettings";
-            nodeSettings.LoadConfiguration();
 
             FullNodeBuilderNodeSettingsExtension.UseNodeSettings(this.fullNodeBuilder, nodeSettings);
 

--- a/src/Stratis.Bitcoin.Tests/Builder/FullNodeBuilderExtensionsTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Builder/FullNodeBuilderExtensionsTest.cs
@@ -36,17 +36,16 @@ namespace Stratis.Bitcoin.Tests.Builder
             Assert.Equal(NodeSettings.Default().ConfigurationFile, this.fullNodeBuilder.NodeSettings.ConfigurationFile);
             Assert.Equal(NodeSettings.Default().DataDir, this.fullNodeBuilder.NodeSettings.DataDir);
             Assert.NotNull(this.fullNodeBuilder.Network);
-            Assert.Equal(NodeSettings.Default().GetNetwork(), this.fullNodeBuilder.Network);
+            Assert.Equal(NodeSettings.Default().Network, this.fullNodeBuilder.Network);
             Assert.Single(this.serviceCollectionDelegates);
         }
 
         [Fact]
         public void UseDefaultNodeSettingsConfiguresNodeBuilderWithDefaultSettings()
         {
-            var nodeSettings = NodeSettings.Default();
+            var nodeSettings = new NodeSettings(args: new string[] { "-testnet" });
             nodeSettings.ConfigurationFile = "TestData/FullNodeBuilder/UseNodeSettingsConfFile";
             nodeSettings.DataDir = "TestData/FullNodeBuilder/UseNodeSettings";
-            nodeSettings.Testnet = true;
 
             FullNodeBuilderNodeSettingsExtension.UseNodeSettings(this.fullNodeBuilder, nodeSettings);
 

--- a/src/Stratis.Bitcoin.Tests/Builder/FullNodeBuilderTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Builder/FullNodeBuilderTest.cs
@@ -122,7 +122,7 @@ namespace Stratis.Bitcoin.Tests.Builder
             this.fullNodeBuilder.ConfigureServiceProvider(e =>
             {
                 var settings = e.GetService<NodeSettings>();
-                settings.Testnet = true;
+                settings.Agent = "abc";
             });
 
             var result = this.fullNodeBuilder.Build();
@@ -141,7 +141,7 @@ namespace Stratis.Bitcoin.Tests.Builder
             {
                 e.AddSingleton(nodeSettings);
                 e.AddSingleton(nodeSettings.LoggerFactory);
-                e.AddSingleton(nodeSettings.GetNetwork());
+                e.AddSingleton(nodeSettings.Network);
                 e.AddSingleton<FullNode>();
             });
 
@@ -153,7 +153,7 @@ namespace Stratis.Bitcoin.Tests.Builder
             this.fullNodeBuilder.ConfigureServiceProvider(e =>
             {
                 var settings = e.GetService<NodeSettings>();
-                settings.Testnet = true;
+                settings.Agent = "abc";
             });
 
             var result = this.fullNodeBuilder.Build();
@@ -169,7 +169,7 @@ namespace Stratis.Bitcoin.Tests.Builder
                 this.fullNodeBuilder.ConfigureServices(e =>
                 {
                     e.AddSingleton<NodeSettings>();
-                    e.AddSingleton<Network>(NodeSettings.Default().GetNetwork());
+                    e.AddSingleton<Network>(NodeSettings.Default().Network);
                 });
 
                 this.fullNodeBuilder.Build();
@@ -190,7 +190,7 @@ namespace Stratis.Bitcoin.Tests.Builder
                 {
                     e.AddSingleton(nodeSettings);
                     e.AddSingleton(nodeSettings.LoggerFactory);
-                    e.AddSingleton(nodeSettings.GetNetwork());
+                    e.AddSingleton(nodeSettings.Network);
                     e.AddSingleton<FullNode>();
                 });
 

--- a/src/Stratis.Bitcoin.Tests/Builder/FullNodeBuilderTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Builder/FullNodeBuilderTest.cs
@@ -119,12 +119,6 @@ namespace Stratis.Bitcoin.Tests.Builder
                 e.AddFeature<DummyFeature>();
             });
 
-            this.fullNodeBuilder.ConfigureServiceProvider(e =>
-            {
-                var settings = e.GetService<NodeSettings>();
-                settings.Agent = "abc";
-            });
-
             var result = this.fullNodeBuilder.Build();
 
             Assert.NotNull(result);
@@ -148,12 +142,6 @@ namespace Stratis.Bitcoin.Tests.Builder
             this.fullNodeBuilder.ConfigureFeature(e =>
             {
                 e.AddFeature<DummyFeature>();
-            });
-
-            this.fullNodeBuilder.ConfigureServiceProvider(e =>
-            {
-                var settings = e.GetService<NodeSettings>();
-                settings.Agent = "abc";
             });
 
             var result = this.fullNodeBuilder.Build();

--- a/src/Stratis.Bitcoin/Builder/FullNodeBuilder.cs
+++ b/src/Stratis.Bitcoin/Builder/FullNodeBuilder.cs
@@ -91,7 +91,7 @@ namespace Stratis.Bitcoin.Builder
             : this(configureServicesDelegates, configureDelegates, featuresRegistrationDelegates, features)
         {
             this.NodeSettings = nodeSettings ?? NodeSettings.Default();
-            this.Network = this.NodeSettings.GetNetwork();
+            this.Network = this.NodeSettings.Network;
 
             this.ConfigureServices(service =>
             {

--- a/src/Stratis.Bitcoin/Builder/FullNodeBuilderNodeSettingsExtension.cs
+++ b/src/Stratis.Bitcoin/Builder/FullNodeBuilderNodeSettingsExtension.cs
@@ -19,7 +19,7 @@ namespace Stratis.Bitcoin.Builder
         {
             var nodeBuilder = builder as FullNodeBuilder;
             nodeBuilder.NodeSettings = nodeSettings;
-            nodeBuilder.Network = nodeSettings.GetNetwork();
+            nodeBuilder.Network = nodeSettings.Network;
 
             builder.ConfigureServices(service =>
             {


### PR DESCRIPTION
This PR removes unnecessary public methods and variables from `NodeSettings`.

Having the public / member `TestNet` and `RegTest` variables can allow contradictions to arise between the values of the variables and the current `this.Network` variable.