### PR TITLE
Tests consistency on Travis

### DIFF
--- a/src/Stratis.Bitcoin.Tests/Utilities/AsyncLoopTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Utilities/AsyncLoopTest.cs
@@ -118,13 +118,13 @@ namespace Stratis.Bitcoin.Tests.Utilities
             {
                 iterations++;
 
-                if (iterations == 3)
-                    asyncLoop.RepeatEvery = TimeSpan.FromMilliseconds(100);
+                if (iterations == 2)
+                    asyncLoop.RepeatEvery = TimeSpan.FromMilliseconds(200);
 
                 return Task.CompletedTask;
             });
 
-            Task loopRun = asyncLoop.Run(new CancellationTokenSource(1000).Token, TimeSpan.FromMilliseconds(300)).RunningTask;
+            Task loopRun = asyncLoop.Run(new CancellationTokenSource(5000).Token, TimeSpan.FromMilliseconds(1000)).RunningTask;
             
             await loopRun;
 

--- a/src/Stratis.Bitcoin.Tests/Utilities/ParallelAsyncTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Utilities/ParallelAsyncTest.cs
@@ -31,8 +31,8 @@ namespace Stratis.Bitcoin.Tests.Utilities
         public async void ForEachAsync_TestDegreeOfParallelism_Async()
         {
             int sum = 0;
-
-            var delayTask = new Task(async () => { await Task.Delay(this.testCollection.Count * this.itemProcessingDelayMs).ConfigureAwait(false); });
+            
+            Stopwatch watch = Stopwatch.StartNew();
 
             await this.testCollection.ForEachAsync(2, CancellationToken.None, async (item, cancellation) =>
             {
@@ -40,7 +40,8 @@ namespace Stratis.Bitcoin.Tests.Utilities
                 await Task.Delay(this.itemProcessingDelayMs).ConfigureAwait(false);
             }).ConfigureAwait(false);
 
-            Assert.False(delayTask.IsCompleted);
+            watch.Stop();
+            Assert.True(watch.Elapsed.TotalMilliseconds < this.testCollection.Count * this.itemProcessingDelayMs);
             Assert.Equal(this.testCollectionSum, sum);
         }
 
@@ -48,17 +49,17 @@ namespace Stratis.Bitcoin.Tests.Utilities
         public async void ForEachAsync_TestDegreeOfParallelism2_Async()
         {
             int sum = 0;
-            
-            var delayTask = new Task(async () => { await Task.Delay(this.testCollection.Count * this.itemProcessingDelayMs).ConfigureAwait(false); });
-            
+
+            Stopwatch watch = Stopwatch.StartNew();
+
             await this.testCollection.ForEachAsync(this.testCollection.Count, CancellationToken.None, async (item, cancellation) =>
             {
                 Interlocked.Add(ref sum, item);
                 await Task.Delay(this.itemProcessingDelayMs).ConfigureAwait(false);
             }).ConfigureAwait(false);
-
-            // We expect ForEachAsync task to be finished well before the delay task.
-            Assert.False(delayTask.IsCompleted);
+            
+            watch.Stop();
+            Assert.True(watch.Elapsed.TotalMilliseconds < this.testCollection.Count * this.itemProcessingDelayMs);
             Assert.Equal(this.testCollectionSum, sum);
         }
 

--- a/src/Stratis.Bitcoin.Tests/Utilities/ParallelAsyncTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Utilities/ParallelAsyncTest.cs
@@ -29,17 +29,15 @@ namespace Stratis.Bitcoin.Tests.Utilities
         {
             int sum = 0;
 
-            Stopwatch watch = Stopwatch.StartNew();
+            var delayTask = new Task(async () => { await Task.Delay(this.testCollection.Count * this.itemProcessingDelayMs / 2).ConfigureAwait(false); });
 
             await this.testCollection.ForEachAsync(2, CancellationToken.None, async (item, cancellation) =>
             {
-                await Task.Delay(this.itemProcessingDelayMs).ConfigureAwait(false);
                 sum += item;
+                await Task.Delay(this.itemProcessingDelayMs).ConfigureAwait(false);
             }).ConfigureAwait(false);
 
-            watch.Stop();
-
-            Assert.True(watch.Elapsed.TotalMilliseconds < this.testCollection.Count * this.itemProcessingDelayMs);
+            Assert.False(delayTask.IsCompleted);
             Assert.Equal(this.testCollectionSum, sum);
         }
 
@@ -47,18 +45,17 @@ namespace Stratis.Bitcoin.Tests.Utilities
         public async void ForEachAsync_TestDegreeOfParallelism2_Async()
         {
             int sum = 0;
-
-            Stopwatch watch = Stopwatch.StartNew();
-
+            
+            var delayTask = new Task(async () => { await Task.Delay(this.testCollection.Count * this.itemProcessingDelayMs).ConfigureAwait(false); });
+            
             await this.testCollection.ForEachAsync(this.testCollection.Count, CancellationToken.None, async (item, cancellation) =>
             {
-                await Task.Delay(this.itemProcessingDelayMs).ConfigureAwait(false);
                 sum += item;
+                await Task.Delay(this.itemProcessingDelayMs).ConfigureAwait(false);
             }).ConfigureAwait(false);
 
-            watch.Stop();
-
-            Assert.True(watch.Elapsed.TotalMilliseconds < this.itemProcessingDelayMs * 2);
+            // We expect ForEachAsync task to be finished well before the delay task.
+            Assert.False(delayTask.IsCompleted);
             Assert.Equal(this.testCollectionSum, sum);
         }
 
@@ -72,8 +69,7 @@ namespace Stratis.Bitcoin.Tests.Utilities
                 await Task.Delay(this.itemProcessingDelayMs).ConfigureAwait(false);
             }).ConfigureAwait(false);
         }
-
-
+        
         [Fact]
         public async void ForEachAsync_CanBeCancelled_Async()
         {

--- a/src/Stratis.Bitcoin.Tests/Utilities/ParallelAsyncTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Utilities/ParallelAsyncTest.cs
@@ -15,8 +15,11 @@ namespace Stratis.Bitcoin.Tests.Utilities
 
         public ParallelAsyncTest()
         {
-            this.testCollection = new List<int>() { 1, 2, 3, 4, 5, 6, 7, 8 };
-            this.itemProcessingDelayMs = 200;
+            this.testCollection = new List<int>();
+            for (int i=0; i < 100; ++i)
+                this.testCollection.Add(i);
+
+            this.itemProcessingDelayMs = 50;
 
             this.testCollectionSum = 0;
 
@@ -29,11 +32,11 @@ namespace Stratis.Bitcoin.Tests.Utilities
         {
             int sum = 0;
 
-            var delayTask = new Task(async () => { await Task.Delay(this.testCollection.Count * this.itemProcessingDelayMs / 2).ConfigureAwait(false); });
+            var delayTask = new Task(async () => { await Task.Delay(this.testCollection.Count * this.itemProcessingDelayMs).ConfigureAwait(false); });
 
             await this.testCollection.ForEachAsync(2, CancellationToken.None, async (item, cancellation) =>
             {
-                sum += item;
+                Interlocked.Add(ref sum, item);
                 await Task.Delay(this.itemProcessingDelayMs).ConfigureAwait(false);
             }).ConfigureAwait(false);
 
@@ -50,7 +53,7 @@ namespace Stratis.Bitcoin.Tests.Utilities
             
             await this.testCollection.ForEachAsync(this.testCollection.Count, CancellationToken.None, async (item, cancellation) =>
             {
-                sum += item;
+                Interlocked.Add(ref sum, item);
                 await Task.Delay(this.itemProcessingDelayMs).ConfigureAwait(false);
             }).ConfigureAwait(false);
 
@@ -79,7 +82,7 @@ namespace Stratis.Bitcoin.Tests.Utilities
 
             await this.testCollection.ForEachAsync(1, tokenSource.Token, async (item, cancellation) =>
             {
-                itemsProcessed++;
+                Interlocked.Increment(ref itemsProcessed);
 
                 await Task.Delay(this.itemProcessingDelayMs).ConfigureAwait(false);
 

--- a/src/Stratis.Bitcoin.Tests/Utilities/ParallelAsyncTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Utilities/ParallelAsyncTest.cs
@@ -79,8 +79,9 @@ namespace Stratis.Bitcoin.Tests.Utilities
 
             await this.testCollection.ForEachAsync(1, tokenSource.Token, async (item, cancellation) =>
             {
-                await Task.Delay(this.itemProcessingDelayMs).ConfigureAwait(false);
                 itemsProcessed++;
+
+                await Task.Delay(this.itemProcessingDelayMs).ConfigureAwait(false);
 
                 if (itemsProcessed == 3)
                     tokenSource.Cancel();


### PR DESCRIPTION
Removed StopWatch usages from the ParallelAsync tests & changed timings for AsyncLoopRepeatEveryIntervalCanBeChangedWhileRunningAsync & fixed race condition. 