### PR TITLE
Add a LoadConfiguration method to features

### DIFF
--- a/src/Stratis.Bitcoin.Features.Api/ApiFeature.cs
+++ b/src/Stratis.Bitcoin.Features.Api/ApiFeature.cs
@@ -40,9 +40,14 @@ namespace Stratis.Bitcoin.Features.Api
             this.fullNodeBuilder = fullNodeBuilder;
             this.fullNode = fullNode;
             this.apiFeatureOptions = apiFeatureOptions;
-            apiSettings.Load(fullNode.Settings);
             this.apiSettings = apiSettings;
             this.logger = loggerFactory.CreateLogger(this.GetType().FullName);
+        }
+
+        /// <inheritdoc />
+        public override void LoadConfiguration()
+        {
+            this.apiSettings.Load(this.fullNode.Settings);
         }
 
         public override void Initialize()

--- a/src/Stratis.Bitcoin.Features.BlockStore/BlockStoreFeature.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/BlockStoreFeature.cs
@@ -83,8 +83,13 @@ namespace Stratis.Bitcoin.Features.BlockStore
             this.nodeSettings = nodeSettings;
             this.logger = loggerFactory.CreateLogger(this.GetType().FullName);
             this.loggerFactory = loggerFactory;
-            storeSettings.Load(nodeSettings);
             this.storeSettings = storeSettings;
+        }
+
+        /// <inheritdoc />
+        public override void LoadConfiguration()
+        {
+            this.storeSettings.Load(this.nodeSettings);
         }
 
         public virtual BlockStoreBehavior BlockStoreBehaviorFactory()

--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/ConsensusSettingsTest.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/ConsensusSettingsTest.cs
@@ -11,10 +11,9 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests
         public void LoadConfigWithAssumeValidHexLoads()
         {
             uint256 validHexBlock = new uint256("00000000229d9fb87182d73870d53f9fdd9b76bfc02c059e6d9a6c7a3507031d");
-            LoggerFactory loggerFactory = new LoggerFactory();
             Network network = Network.TestNet;
             NodeSettings nodeSettings = new NodeSettings(network, args:new string[] { $"-assumevalid={validHexBlock.ToString()}" });
-            ConsensusSettings settings = new ConsensusSettings(nodeSettings, loggerFactory).LoadFromConfig();
+            ConsensusSettings settings = new ConsensusSettings().Load(nodeSettings);
             Assert.Equal(validHexBlock, settings.BlockAssumedValid);
         }
 
@@ -24,7 +23,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests
             LoggerFactory loggerFactory = new LoggerFactory();
             Network network = Network.TestNet;
             NodeSettings nodeSettings = new NodeSettings(network, args:new string[] { "-assumevalid=0" });
-            ConsensusSettings settings = new ConsensusSettings(nodeSettings, loggerFactory).LoadFromConfig();
+            ConsensusSettings settings = new ConsensusSettings().Load(nodeSettings);
             Assert.Null(settings.BlockAssumedValid);
         }
 
@@ -34,28 +33,26 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests
             LoggerFactory loggerFactory = new LoggerFactory();
             Network network = Network.TestNet;
             NodeSettings nodeSettings = new NodeSettings(network, args:new string[] { "-assumevalid=xxx" });
-            Assert.Throws<ConfigurationException>(() => new ConsensusSettings(nodeSettings, loggerFactory).LoadFromConfig());
+            Assert.Throws<ConfigurationException>(() => new ConsensusSettings().Load(nodeSettings));
         }
 
         [Fact]
         public void LoadConfigWithDefaultsSetsToNetworkDefault()
         {
-            LoggerFactory loggerFactory = new LoggerFactory();
-
             Network network = Network.StratisMain;
-            ConsensusSettings settings = new ConsensusSettings(NodeSettings.Default(network), loggerFactory).LoadFromConfig();
+            ConsensusSettings settings = new ConsensusSettings().Load(NodeSettings.Default(network));
             Assert.Equal(network.Consensus.DefaultAssumeValid, settings.BlockAssumedValid);
 
             network = Network.StratisTest;
-            settings = new ConsensusSettings(NodeSettings.Default(network), loggerFactory).LoadFromConfig();
+            settings = new ConsensusSettings().Load(NodeSettings.Default(network));
             Assert.Equal(network.Consensus.DefaultAssumeValid, settings.BlockAssumedValid);
 
             network = Network.Main;
-            settings = new ConsensusSettings(NodeSettings.Default(network), loggerFactory).LoadFromConfig();
+            settings = new ConsensusSettings().Load(NodeSettings.Default(network));
             Assert.Equal(network.Consensus.DefaultAssumeValid, settings.BlockAssumedValid);
 
             network = Network.TestNet;
-            settings = new ConsensusSettings(NodeSettings.Default(network), loggerFactory).LoadFromConfig();
+            settings = new ConsensusSettings().Load(NodeSettings.Default(network));
             Assert.Equal(network.Consensus.DefaultAssumeValid, settings.BlockAssumedValid);
         }
     }

--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/ConsensusSettingsTest.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/ConsensusSettingsTest.cs
@@ -14,7 +14,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests
             LoggerFactory loggerFactory = new LoggerFactory();
             Network network = Network.TestNet;
             NodeSettings nodeSettings = new NodeSettings(network, args:new string[] { $"-assumevalid={validHexBlock.ToString()}" });
-            ConsensusSettings settings = new ConsensusSettings(nodeSettings, loggerFactory);
+            ConsensusSettings settings = new ConsensusSettings(nodeSettings, loggerFactory).LoadFromConfig();
             Assert.Equal(validHexBlock, settings.BlockAssumedValid);
         }
 
@@ -24,7 +24,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests
             LoggerFactory loggerFactory = new LoggerFactory();
             Network network = Network.TestNet;
             NodeSettings nodeSettings = new NodeSettings(network, args:new string[] { "-assumevalid=0" });
-            ConsensusSettings settings = new ConsensusSettings(nodeSettings, loggerFactory);
+            ConsensusSettings settings = new ConsensusSettings(nodeSettings, loggerFactory).LoadFromConfig();
             Assert.Null(settings.BlockAssumedValid);
         }
 
@@ -34,7 +34,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests
             LoggerFactory loggerFactory = new LoggerFactory();
             Network network = Network.TestNet;
             NodeSettings nodeSettings = new NodeSettings(network, args:new string[] { "-assumevalid=xxx" });
-            Assert.Throws<ConfigurationException>(() => new ConsensusSettings(nodeSettings, loggerFactory));
+            Assert.Throws<ConfigurationException>(() => new ConsensusSettings(nodeSettings, loggerFactory).LoadFromConfig());
         }
 
         [Fact]
@@ -43,19 +43,19 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests
             LoggerFactory loggerFactory = new LoggerFactory();
 
             Network network = Network.StratisMain;
-            ConsensusSettings settings = new ConsensusSettings(NodeSettings.Default(network), loggerFactory);
+            ConsensusSettings settings = new ConsensusSettings(NodeSettings.Default(network), loggerFactory).LoadFromConfig();
             Assert.Equal(network.Consensus.DefaultAssumeValid, settings.BlockAssumedValid);
 
             network = Network.StratisTest;
-            settings = new ConsensusSettings(NodeSettings.Default(network), loggerFactory);
+            settings = new ConsensusSettings(NodeSettings.Default(network), loggerFactory).LoadFromConfig();
             Assert.Equal(network.Consensus.DefaultAssumeValid, settings.BlockAssumedValid);
 
             network = Network.Main;
-            settings = new ConsensusSettings(NodeSettings.Default(network), loggerFactory);
+            settings = new ConsensusSettings(NodeSettings.Default(network), loggerFactory).LoadFromConfig();
             Assert.Equal(network.Consensus.DefaultAssumeValid, settings.BlockAssumedValid);
 
             network = Network.TestNet;
-            settings = new ConsensusSettings(NodeSettings.Default(network), loggerFactory);
+            settings = new ConsensusSettings(NodeSettings.Default(network), loggerFactory).LoadFromConfig();
             Assert.Equal(network.Consensus.DefaultAssumeValid, settings.BlockAssumedValid);
         }
     }

--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/InitialBlockDownloadTest.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/InitialBlockDownloadTest.cs
@@ -18,7 +18,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests
         public InitialBlockDownloadTest()
         {
             this.network = Network.Main;
-            this.consensusSettings = new ConsensusSettings(NodeSettings.Default(), new ExtendedLoggerFactory());
+            this.consensusSettings = new ConsensusSettings().Load(NodeSettings.Default());
             this.checkpoints = new Checkpoints(this.network, this.consensusSettings);
             this.nodeSettings = new NodeSettings(this.network);
             this.chainState = new ChainState(new InvalidBlockHashStore(DateTimeProvider.Default));

--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/MerkeRootComputationTest.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/MerkeRootComputationTest.cs
@@ -50,10 +50,10 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests
 
         private uint256 ComputeMerkleRoot(List<uint256> leaves, out bool mutated)
         {
-            LoggerFactory loggerFactory = new LoggerFactory();
-            ConsensusSettings consensusSettings = new ConsensusSettings(NodeSettings.Default(), loggerFactory);
+            NodeSettings nodeSettings = NodeSettings.Default();
+            ConsensusSettings consensusSettings = new ConsensusSettings().Load(nodeSettings);
             Network.Main.Consensus.Options = new PosConsensusOptions();
-            var consensusValidator = new PowConsensusValidator(Network.Main, new Checkpoints(Network.Main, consensusSettings), DateTimeProvider.Default, loggerFactory);
+            var consensusValidator = new PowConsensusValidator(Network.Main, new Checkpoints(Network.Main, consensusSettings), DateTimeProvider.Default, nodeSettings.LoggerFactory);
 
             return consensusValidator.ComputeMerkleRoot(leaves, out mutated);
         }

--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/TestRulesContext.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/TestRulesContext.cs
@@ -62,12 +62,12 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules
                 testRulesContext.NodeSettings.DataDir = dataDir;
             }
 
-            testRulesContext.LoggerFactory = new ExtendedLoggerFactory();
+            testRulesContext.LoggerFactory = testRulesContext.NodeSettings.LoggerFactory;
             testRulesContext.LoggerFactory.AddConsoleWithFilters();
             testRulesContext.DateTimeProvider = DateTimeProvider.Default;
             network.Consensus.Options = new PowConsensusOptions();
 
-            ConsensusSettings consensusSettings = new ConsensusSettings(testRulesContext.NodeSettings, testRulesContext.LoggerFactory);
+            ConsensusSettings consensusSettings = new ConsensusSettings().Load(testRulesContext.NodeSettings);
             testRulesContext.Checkpoints = new Checkpoints();
             testRulesContext.Chain = new ConcurrentChain(network);
 

--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/TestChainFactory.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/TestChainFactory.cs
@@ -77,12 +77,11 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests
             testChainContext.ConnectionSettings = new ConnectionManagerSettings();
             testChainContext.ConnectionSettings.Load(testChainContext.NodeSettings);
 
-            testChainContext.LoggerFactory = new ExtendedLoggerFactory();
-            testChainContext.LoggerFactory.AddConsoleWithFilters();
+            testChainContext.LoggerFactory = testChainContext.NodeSettings.LoggerFactory;
             testChainContext.DateTimeProvider = DateTimeProvider.Default;
             network.Consensus.Options = new PowConsensusOptions();
 
-            ConsensusSettings consensusSettings = new ConsensusSettings(testChainContext.NodeSettings, testChainContext.LoggerFactory);
+            ConsensusSettings consensusSettings = new ConsensusSettings().Load(testChainContext.NodeSettings);
             testChainContext.Checkpoints = new Checkpoints();
 
             PowConsensusValidator consensusValidator = new PowConsensusValidator(network, testChainContext.Checkpoints, testChainContext.DateTimeProvider, testChainContext.LoggerFactory);

--- a/src/Stratis.Bitcoin.Features.Consensus/ConsensusFeature.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/ConsensusFeature.cs
@@ -9,6 +9,7 @@ using Stratis.Bitcoin.Base.Deployments;
 using Stratis.Bitcoin.BlockPulling;
 using Stratis.Bitcoin.Builder;
 using Stratis.Bitcoin.Builder.Feature;
+using Stratis.Bitcoin.Configuration;
 using Stratis.Bitcoin.Configuration.Logging;
 using Stratis.Bitcoin.Connection;
 using Stratis.Bitcoin.Features.Consensus.CoinViews;
@@ -45,7 +46,11 @@ namespace Stratis.Bitcoin.Features.Consensus
         private readonly StakeChainStore stakeChain;
 
         private readonly IRuleRegistration ruleRegistration;
+
+        private readonly NodeSettings nodeSettings;
+
         private readonly ConsensusSettings consensusSettings;
+
         private readonly IConsensusRules consensusRules;
 
         /// <summary>Instance logger.</summary>
@@ -71,6 +76,7 @@ namespace Stratis.Bitcoin.Features.Consensus
             ConsensusStats consensusStats,
             IRuleRegistration ruleRegistration,
             IConsensusRules consensusRules,
+            NodeSettings nodeSettings,
             ConsensusSettings consensusSettings,
             StakeChainStore stakeChain = null)
         {
@@ -87,6 +93,7 @@ namespace Stratis.Bitcoin.Features.Consensus
             this.loggerFactory = loggerFactory;
             this.consensusStats = consensusStats;
             this.ruleRegistration = ruleRegistration;
+            this.nodeSettings = nodeSettings;
             this.consensusSettings = consensusSettings;
             this.consensusRules = consensusRules;
 
@@ -108,7 +115,7 @@ namespace Stratis.Bitcoin.Features.Consensus
         /// <inheritdoc />
         public override void LoadConfiguration()
         {
-            this.consensusSettings.LoadFromConfig();
+            this.consensusSettings.Load(nodeSettings);
         }
 
         /// <inheritdoc />

--- a/src/Stratis.Bitcoin.Features.Consensus/ConsensusFeature.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/ConsensusFeature.cs
@@ -45,6 +45,7 @@ namespace Stratis.Bitcoin.Features.Consensus
         private readonly StakeChainStore stakeChain;
 
         private readonly IRuleRegistration ruleRegistration;
+        private readonly ConsensusSettings consensusSettings;
         private readonly IConsensusRules consensusRules;
 
         /// <summary>Instance logger.</summary>
@@ -70,6 +71,7 @@ namespace Stratis.Bitcoin.Features.Consensus
             ConsensusStats consensusStats,
             IRuleRegistration ruleRegistration,
             IConsensusRules consensusRules,
+            ConsensusSettings consensusSettings,
             StakeChainStore stakeChain = null)
         {
             this.dBreezeCoinView = dBreezeCoinView;
@@ -85,6 +87,7 @@ namespace Stratis.Bitcoin.Features.Consensus
             this.loggerFactory = loggerFactory;
             this.consensusStats = consensusStats;
             this.ruleRegistration = ruleRegistration;
+            this.consensusSettings = consensusSettings;
             this.consensusRules = consensusRules;
 
             this.chainState.MaxReorgLength = network.Consensus.Option<PowConsensusOptions>().MaxReorgLength;
@@ -100,6 +103,12 @@ namespace Stratis.Bitcoin.Features.Consensus
                                      " Consensus.Hash: ".PadRight(LoggingConfiguration.ColumnLength - 1) +
                                      this.chainState.ConsensusTip.HashBlock);
             }
+        }
+
+        /// <inheritdoc />
+        public override void LoadConfiguration()
+        {
+            this.consensusSettings.LoadFromConfig();
         }
 
         /// <inheritdoc />

--- a/src/Stratis.Bitcoin.Features.Consensus/ConsensusSettings.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/ConsensusSettings.cs
@@ -34,15 +34,13 @@ namespace Stratis.Bitcoin.Features.Consensus
         {
             this.nodeSettings = nodeSettings;
             this.logger = loggerFactory.CreateLogger(this.GetType().FullName);
-
-            this.LoadFromConfig();
         }
 
         /// <summary>
         /// Load the consensus settings from the config settings.
         /// </summary>
         /// <returns>These consensus config settings.</returns>
-        private ConsensusSettings LoadFromConfig()
+        public ConsensusSettings LoadFromConfig()
         {
             TextFileConfiguration config = this.nodeSettings.ConfigReader;
             this.UseCheckpoints = config.GetOrDefault<bool>("checkpoints", true);

--- a/src/Stratis.Bitcoin.Features.Consensus/ConsensusSettings.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/ConsensusSettings.cs
@@ -10,12 +10,6 @@ namespace Stratis.Bitcoin.Features.Consensus
     /// </summary>
     public class ConsensusSettings
     {
-        /// <summary>Full node settings.</summary>
-        private readonly NodeSettings nodeSettings;
-
-        /// <summary>Current logger.</summary>
-        private readonly ILogger logger;
-
         /// <summary>Whether use of checkpoints is enabled or not.</summary>
         public bool UseCheckpoints { get; set; }
 
@@ -28,21 +22,20 @@ namespace Stratis.Bitcoin.Features.Consensus
         /// <summary>
         /// Constructs a new consensus settings object.
         /// </summary>
-        /// <param name="nodeSettings">Full node settings.</param>
-        /// <param name="loggerFactory">Logger factory.</param>
-        public ConsensusSettings(NodeSettings nodeSettings, ILoggerFactory loggerFactory)
+        public ConsensusSettings()
         {
-            this.nodeSettings = nodeSettings;
-            this.logger = loggerFactory.CreateLogger(this.GetType().FullName);
         }
 
         /// <summary>
         /// Load the consensus settings from the config settings.
         /// </summary>
+        /// <param name="nodeSettings">The node's settings.</param>
         /// <returns>These consensus config settings.</returns>
-        public ConsensusSettings LoadFromConfig()
+        public ConsensusSettings Load(NodeSettings nodeSettings)
         {
-            TextFileConfiguration config = this.nodeSettings.ConfigReader;
+            ILogger logger = nodeSettings.LoggerFactory.CreateLogger(typeof(ConsensusSettings).FullName);
+
+            TextFileConfiguration config = nodeSettings.ConfigReader;
             this.UseCheckpoints = config.GetOrDefault<bool>("checkpoints", true);
 
             if (config.GetAll("assumevalid").Any(i => i.Equals("0"))) // 0 means validate all blocks.
@@ -51,11 +44,11 @@ namespace Stratis.Bitcoin.Features.Consensus
             }
             else
             {
-                this.BlockAssumedValid = config.GetOrDefault<uint256>("assumevalid", this.nodeSettings.Network.Consensus.DefaultAssumeValid);
+                this.BlockAssumedValid = config.GetOrDefault<uint256>("assumevalid", nodeSettings.Network.Consensus.DefaultAssumeValid);
             }
 
-            this.logger.LogDebug("Checkpoints are {0}.", this.UseCheckpoints ? "enabled" : "disabled");
-            this.logger.LogDebug("Assume valid block is '{0}'.", this.BlockAssumedValid == null ? "disabled" : this.BlockAssumedValid.ToString());
+            logger.LogDebug("Checkpoints are {0}.", this.UseCheckpoints ? "enabled" : "disabled");
+            logger.LogDebug("Assume valid block is '{0}'.", this.BlockAssumedValid == null ? "disabled" : this.BlockAssumedValid.ToString());
 
             return this;
         }

--- a/src/Stratis.Bitcoin.Features.Dns.Tests/GivenADnsFeature.cs
+++ b/src/Stratis.Bitcoin.Features.Dns.Tests/GivenADnsFeature.cs
@@ -47,7 +47,7 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
             NodeSettings nodeSettings = NodeSettings.Default();
             DataFolder dataFolder = CreateDataFolder(this);
             IAsyncLoopFactory asyncLoopFactory = new Mock<IAsyncLoopFactory>().Object;
-            Action a = () => { new DnsFeature(dnsServer, null, loggerFactory, nodeLifetime, DnsSettings.Load(nodeSettings), nodeSettings, dataFolder, asyncLoopFactory); };
+            Action a = () => { new DnsFeature(dnsServer, null, loggerFactory, nodeLifetime, new DnsSettings().Load(nodeSettings), nodeSettings, dataFolder, asyncLoopFactory); };
 
             // Act and Assert.
             a.ShouldThrow<ArgumentNullException>().Which.Message.Should().Contain("whitelistManager");
@@ -64,7 +64,7 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
             NodeSettings nodeSettings = NodeSettings.Default();
             DataFolder dataFolder = CreateDataFolder(this);
             IAsyncLoopFactory asyncLoopFactory = new Mock<IAsyncLoopFactory>().Object;
-            Action a = () => { new DnsFeature(dnsServer, whitelistManager, null, nodeLifetime, DnsSettings.Load(nodeSettings), nodeSettings, dataFolder, asyncLoopFactory); };
+            Action a = () => { new DnsFeature(dnsServer, whitelistManager, null, nodeLifetime, new DnsSettings().Load(nodeSettings), nodeSettings, dataFolder, asyncLoopFactory); };
 
             // Act and Assert.
             a.ShouldThrow<ArgumentNullException>().Which.Message.Should().Contain("loggerFactory");
@@ -82,7 +82,7 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
             NodeSettings nodeSettings = NodeSettings.Default();
             DataFolder dataFolder = CreateDataFolder(this);
             IAsyncLoopFactory asyncLoopFactory = new Mock<IAsyncLoopFactory>().Object;
-            Action a = () => { new DnsFeature(dnsServer, whitelistManager, loggerFactory, null, DnsSettings.Load(nodeSettings), nodeSettings, dataFolder, asyncLoopFactory); };
+            Action a = () => { new DnsFeature(dnsServer, whitelistManager, loggerFactory, null, new DnsSettings().Load(nodeSettings), nodeSettings, dataFolder, asyncLoopFactory); };
 
             // Act and Assert.
             a.ShouldThrow<ArgumentNullException>().Which.Message.Should().Contain("nodeLifetime");
@@ -100,7 +100,7 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
             NodeSettings nodeSettings = NodeSettings.Default();
             DataFolder dataFolder = CreateDataFolder(this);
             IAsyncLoopFactory asyncLoopFactory = new Mock<IAsyncLoopFactory>().Object;
-            Action a = () => { new DnsFeature(dnsServer, whitelistManager, loggerFactory, nodeLifetime, DnsSettings.Load(nodeSettings), null, dataFolder, asyncLoopFactory); };
+            Action a = () => { new DnsFeature(dnsServer, whitelistManager, loggerFactory, nodeLifetime, new DnsSettings().Load(nodeSettings), null, dataFolder, asyncLoopFactory); };
 
             // Act and Assert.
             a.ShouldThrow<ArgumentNullException>().Which.Message.Should().Contain("nodeSettings");
@@ -138,7 +138,7 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
             IAsyncLoopFactory asyncLoopFactory = new Mock<IAsyncLoopFactory>().Object;
 
             // Act.
-            DnsFeature feature = new DnsFeature(dnsServer, whitelistManager, loggerFactory, nodeLifetime, DnsSettings.Load(nodeSettings), nodeSettings, dataFolder, asyncLoopFactory);
+            DnsFeature feature = new DnsFeature(dnsServer, whitelistManager, loggerFactory, nodeLifetime, new DnsSettings().Load(nodeSettings), nodeSettings, dataFolder, asyncLoopFactory);
 
             // Assert.
             feature.Should().NotBeNull();
@@ -172,7 +172,7 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
             IAsyncLoopFactory asyncLoopFactory = new AsyncLoopFactory(loggerFactory.Object);
 
             // Act.
-            DnsFeature feature = new DnsFeature(dnsServer.Object, whitelistManager.Object, loggerFactory.Object, nodeLifetime.Object, DnsSettings.Load(nodeSettings), nodeSettings, dataFolder, asyncLoopFactory);
+            DnsFeature feature = new DnsFeature(dnsServer.Object, whitelistManager.Object, loggerFactory.Object, nodeLifetime.Object, new DnsSettings().Load(nodeSettings), nodeSettings, dataFolder, asyncLoopFactory);
             feature.Initialize();
             bool waited = waitObject.Wait(5000);
 
@@ -218,7 +218,7 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
             IAsyncLoopFactory asyncLoopFactory = new AsyncLoopFactory(loggerFactory.Object);
 
             // Act.
-            DnsFeature feature = new DnsFeature(dnsServer.Object, whitelistManager, loggerFactory.Object, nodeLifetimeObject, DnsSettings.Load(nodeSettings), nodeSettings, dataFolder, asyncLoopFactory);
+            DnsFeature feature = new DnsFeature(dnsServer.Object, whitelistManager, loggerFactory.Object, nodeLifetimeObject, new DnsSettings().Load(nodeSettings), nodeSettings, dataFolder, asyncLoopFactory);
             feature.Initialize();
             nodeLifetimeObject.StopApplication();
             bool waited = source.Token.WaitHandle.WaitOne(5000);
@@ -263,7 +263,7 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
             IAsyncLoopFactory asyncLoopFactory = new AsyncLoopFactory(loggerFactory.Object);
 
             // Act.
-            DnsFeature feature = new DnsFeature(dnsServer.Object, whitelistManager, loggerFactory.Object, nodeLifetimeObject, DnsSettings.Load(nodeSettings), nodeSettings, dataFolder, asyncLoopFactory);
+            DnsFeature feature = new DnsFeature(dnsServer.Object, whitelistManager, loggerFactory.Object, nodeLifetimeObject, new DnsSettings().Load(nodeSettings), nodeSettings, dataFolder, asyncLoopFactory);
             feature.Initialize();
             bool waited = source.Token.WaitHandle.WaitOne(5000);
 
@@ -304,7 +304,7 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
             nodeSettings.DataDir = Directory.GetCurrentDirectory();
             DataFolder dataFolder = CreateDataFolder(this);
 
-            using (DnsFeature feature = new DnsFeature(dnsServer, whitelistManager, loggerFactory, nodeLifetimeObject, DnsSettings.Load(nodeSettings), nodeSettings, dataFolder, asyncLoopFactory))
+            using (DnsFeature feature = new DnsFeature(dnsServer, whitelistManager, loggerFactory, nodeLifetimeObject, new DnsSettings().Load(nodeSettings), nodeSettings, dataFolder, asyncLoopFactory))
             {
                 // Act.
                 feature.Initialize();

--- a/src/Stratis.Bitcoin.Features.Dns.Tests/GivenADnsSeedServer.cs
+++ b/src/Stratis.Bitcoin.Features.Dns.Tests/GivenADnsSeedServer.cs
@@ -35,7 +35,7 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
             IDateTimeProvider dateTimeProvider = new Mock<IDateTimeProvider>().Object;
             NodeSettings nodeSettings = NodeSettings.Default();
             DataFolder dataFolder = CreateDataFolder(this);
-            Action a = () => { new DnsSeedServer(null, masterFile, asyncLoopFactory, nodeLifetime, loggerFactory, dateTimeProvider, DnsSettings.Load(nodeSettings), dataFolder); };
+            Action a = () => { new DnsSeedServer(null, masterFile, asyncLoopFactory, nodeLifetime, loggerFactory, dateTimeProvider, new DnsSettings().Load(nodeSettings), dataFolder); };
 
             // Act and Assert.
             a.ShouldThrow<ArgumentNullException>().Which.Message.Should().Contain("client");
@@ -53,7 +53,7 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
             IDateTimeProvider dateTimeProvider = new Mock<IDateTimeProvider>().Object;
             NodeSettings nodeSettings = NodeSettings.Default();
             DataFolder dataFolder = CreateDataFolder(this);
-            Action a = () => { new DnsSeedServer(udpClient, null, asyncLoopFactory, nodeLifetime, loggerFactory, dateTimeProvider, DnsSettings.Load(nodeSettings), dataFolder); };
+            Action a = () => { new DnsSeedServer(udpClient, null, asyncLoopFactory, nodeLifetime, loggerFactory, dateTimeProvider, new DnsSettings().Load(nodeSettings), dataFolder); };
 
             // Act and Assert.
             a.ShouldThrow<ArgumentNullException>().Which.Message.Should().Contain("masterFile");
@@ -71,7 +71,7 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
             IDateTimeProvider dateTimeProvider = new Mock<IDateTimeProvider>().Object;
             NodeSettings nodeSettings = NodeSettings.Default();
             DataFolder dataFolder = CreateDataFolder(this);
-            Action a = () => { new DnsSeedServer(udpClient, masterFile, null, nodeLifetime, loggerFactory, dateTimeProvider, DnsSettings.Load(nodeSettings), dataFolder); };
+            Action a = () => { new DnsSeedServer(udpClient, masterFile, null, nodeLifetime, loggerFactory, dateTimeProvider, new DnsSettings().Load(nodeSettings), dataFolder); };
 
             // Act and Assert.
             a.ShouldThrow<ArgumentNullException>().Which.Message.Should().Contain("asyncLoopFactory");
@@ -89,7 +89,7 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
             IDateTimeProvider dateTimeProvider = new Mock<IDateTimeProvider>().Object;
             NodeSettings nodeSettings = NodeSettings.Default();
             DataFolder dataFolder = CreateDataFolder(this);
-            Action a = () => { new DnsSeedServer(udpClient, masterFile, asyncLoopFactory, null, loggerFactory, dateTimeProvider, DnsSettings.Load(nodeSettings), dataFolder); };
+            Action a = () => { new DnsSeedServer(udpClient, masterFile, asyncLoopFactory, null, loggerFactory, dateTimeProvider, new DnsSettings().Load(nodeSettings), dataFolder); };
 
             // Act and Assert.
             a.ShouldThrow<ArgumentNullException>().Which.Message.Should().Contain("nodeLifetime");
@@ -107,7 +107,7 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
             IDateTimeProvider dateTimeProvider = new Mock<IDateTimeProvider>().Object;
             NodeSettings nodeSettings = NodeSettings.Default();
             DataFolder dataFolder = CreateDataFolder(this);
-            Action a = () => { new DnsSeedServer(udpClient, masterFile, asyncLoopFactory, nodeLifetime, null, dateTimeProvider, DnsSettings.Load(nodeSettings), dataFolder); };
+            Action a = () => { new DnsSeedServer(udpClient, masterFile, asyncLoopFactory, nodeLifetime, null, dateTimeProvider, new DnsSettings().Load(nodeSettings), dataFolder); };
 
             // Act and Assert.
             a.ShouldThrow<ArgumentNullException>().Which.Message.Should().Contain("loggerFactory");
@@ -125,7 +125,7 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
             ILoggerFactory loggerFactory = new Mock<ILoggerFactory>().Object;
             NodeSettings nodeSettings = NodeSettings.Default();
             DataFolder dataFolder = CreateDataFolder(this);
-            Action a = () => { new DnsSeedServer(udpClient, masterFile, asyncLoopFactory, nodeLifetime, loggerFactory, null, DnsSettings.Load(nodeSettings), dataFolder); };
+            Action a = () => { new DnsSeedServer(udpClient, masterFile, asyncLoopFactory, nodeLifetime, loggerFactory, null, new DnsSettings().Load(nodeSettings), dataFolder); };
 
             // Act and Assert.
             a.ShouldThrow<ArgumentNullException>().Which.Message.Should().Contain("dateTimeProvider");
@@ -162,7 +162,7 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
             IDateTimeProvider dateTimeProvider = new Mock<IDateTimeProvider>().Object;
             NodeSettings nodeSettings = NodeSettings.Default();
             nodeSettings.DataDir = @"C:\";
-            Action a = () => { new DnsSeedServer(udpClient, masterFile, asyncLoopFactory, nodeLifetime, loggerFactory, dateTimeProvider, DnsSettings.Load(nodeSettings), null); };
+            Action a = () => { new DnsSeedServer(udpClient, masterFile, asyncLoopFactory, nodeLifetime, loggerFactory, dateTimeProvider, new DnsSettings().Load(nodeSettings), null); };
 
             // Act and Assert.
             a.ShouldThrow<ArgumentNullException>().Which.Message.Should().Contain("dataFolders");
@@ -183,7 +183,7 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
             DataFolder dataFolder = CreateDataFolder(this);
 
             // Act.
-            DnsSeedServer server = new DnsSeedServer(udpClient, masterFile, asyncLoopFactory, nodeLifetime, loggerFactory, dateTimeProvider, DnsSettings.Load(nodeSettings), dataFolder);
+            DnsSeedServer server = new DnsSeedServer(udpClient, masterFile, asyncLoopFactory, nodeLifetime, loggerFactory, dateTimeProvider, new DnsSettings().Load(nodeSettings), dataFolder);
 
             // Assert.
             server.Should().NotBeNull();

--- a/src/Stratis.Bitcoin.Features.Dns/DnsFeature.cs
+++ b/src/Stratis.Bitcoin.Features.Dns/DnsFeature.cs
@@ -109,7 +109,7 @@ namespace Stratis.Bitcoin.Features.Dns
         /// <inheritdoc />
         public override void LoadConfiguration()
         {
-            DnsSettings.Load(this.nodeSettings, this.dnsSettings);
+            this.dnsSettings.Load(this.nodeSettings);
         }
 
         /// <summary>

--- a/src/Stratis.Bitcoin.Features.Dns/DnsFeature.cs
+++ b/src/Stratis.Bitcoin.Features.Dns/DnsFeature.cs
@@ -43,6 +43,11 @@ namespace Stratis.Bitcoin.Features.Dns
         private readonly INodeLifetime nodeLifetime;
 
         /// <summary>
+        /// Defines the node settings for the node.
+        /// </summary>
+        private readonly NodeSettings nodeSettings;
+
+        /// <summary>
         /// Defines the DNS settings for the node.
         /// </summary>
         private readonly DnsSettings dnsSettings;
@@ -96,8 +101,15 @@ namespace Stratis.Bitcoin.Features.Dns
             this.logger = loggerFactory.CreateLogger(this.GetType().FullName);
             this.asyncLoopFactory = asyncLoopFactory;
             this.nodeLifetime = nodeLifetime;
-            this.dnsSettings = DnsSettings.Load(nodeSettings, dnsSettings);
+            this.nodeSettings = nodeSettings;
+            this.dnsSettings = dnsSettings;
             this.dataFolders = dataFolders;
+        }
+
+        /// <inheritdoc />
+        public override void LoadConfiguration()
+        {
+            DnsSettings.Load(this.nodeSettings, this.dnsSettings);
         }
 
         /// <summary>

--- a/src/Stratis.Bitcoin.Features.Dns/DnsSettings.cs
+++ b/src/Stratis.Bitcoin.Features.Dns/DnsSettings.cs
@@ -59,40 +59,38 @@ namespace Stratis.Bitcoin.Features.Dns
         /// </summary>
         /// <param name="nodeSettings">Application configuration.</param>
         /// <param name="dnsSettings">Existing DnsSettings object to add loaded values to.</param>
-        public static DnsSettings Load(NodeSettings nodeSettings, DnsSettings dnsSettings = null)
+        public DnsSettings Load(NodeSettings nodeSettings)
         {
             ILogger logger = nodeSettings.LoggerFactory.CreateLogger(typeof(DnsSettings).FullName);
 
             logger.LogTrace("()");
 
-            dnsSettings = dnsSettings ?? new DnsSettings();
-
             TextFileConfiguration config = nodeSettings.ConfigReader;
             
-            dnsSettings.DnsListenPort = config.GetOrDefault<int>("dnslistenport", DefaultDnsListenPort);
-            logger.LogDebug("DNS Seed Service listen port is {0}, if running as DNS Seed.", dnsSettings.DnsListenPort);
+            this.DnsListenPort = config.GetOrDefault<int>("dnslistenport", DefaultDnsListenPort);
+            logger.LogDebug("DNS Seed Service listen port is {0}, if running as DNS Seed.", this.DnsListenPort);
 
-            dnsSettings.DnsFullNode = config.GetOrDefault<bool>("dnsfullnode", false);
-            if (dnsSettings.DnsFullNode)
-                logger.LogDebug("DNS Seed Service is set to run as a full node, if running as DNS Seed.", dnsSettings.DnsListenPort);
+            this.DnsFullNode = config.GetOrDefault<bool>("dnsfullnode", false);
+            if (this.DnsFullNode)
+                logger.LogDebug("DNS Seed Service is set to run as a full node, if running as DNS Seed.", this.DnsListenPort);
 
-            dnsSettings.DnsPeerBlacklistThresholdInSeconds = config.GetOrDefault("dnspeerblacklistthresholdinseconds", DefaultDnsPeerBlacklistThresholdInSeconds);
-            logger.LogDebug("DnsPeerBlacklistThresholdInSeconds set to {0}.", dnsSettings.DnsPeerBlacklistThresholdInSeconds);
+            this.DnsPeerBlacklistThresholdInSeconds = config.GetOrDefault("dnspeerblacklistthresholdinseconds", DefaultDnsPeerBlacklistThresholdInSeconds);
+            logger.LogDebug("DnsPeerBlacklistThresholdInSeconds set to {0}.", this.DnsPeerBlacklistThresholdInSeconds);
 
-            dnsSettings.DnsHostName = config.GetOrDefault<string>("dnshostname", null);
-            logger.LogDebug("DNS Seed Service host name set to {0}.", dnsSettings.DnsHostName);
+            this.DnsHostName = config.GetOrDefault<string>("dnshostname", null);
+            logger.LogDebug("DNS Seed Service host name set to {0}.", this.DnsHostName);
 
-            dnsSettings.DnsNameServer = config.GetOrDefault<string>("dnsnameserver", null);
-            logger.LogDebug("DNS Seed Service nameserver set to {0}.", dnsSettings.DnsNameServer);
+            this.DnsNameServer = config.GetOrDefault<string>("dnsnameserver", null);
+            logger.LogDebug("DNS Seed Service nameserver set to {0}.", this.DnsNameServer);
 
-            dnsSettings.DnsMailBox = config.GetOrDefault<string>("dnsmailbox", null);
-            logger.LogDebug("DNS Seed Service mailbox set to {0}.", dnsSettings.DnsMailBox);
+            this.DnsMailBox = config.GetOrDefault<string>("dnsmailbox", null);
+            logger.LogDebug("DNS Seed Service mailbox set to {0}.", this.DnsMailBox);
 
-            dnsSettings.callback?.Invoke(dnsSettings);
+            this.callback?.Invoke(this);
 
             logger.LogTrace("(-)");
 
-            return dnsSettings;
+            return this;
         }
     }
 }

--- a/src/Stratis.Bitcoin.Features.MemoryPool.Tests/MempoolPersistenceTest.cs
+++ b/src/Stratis.Bitcoin.Features.MemoryPool.Tests/MempoolPersistenceTest.cs
@@ -270,8 +270,8 @@ namespace Stratis.Bitcoin.Features.MemoryPool.Tests
             var mempoolSettings = new MempoolSettings(settings);
             IDateTimeProvider dateTimeProvider = DateTimeProvider.Default;
             NodeSettings nodeSettings = NodeSettings.Default();
-            LoggerFactory loggerFactory = new LoggerFactory();
-            ConsensusSettings consensusSettings = new ConsensusSettings(nodeSettings, loggerFactory);
+            var loggerFactory = nodeSettings.LoggerFactory;
+            ConsensusSettings consensusSettings = new ConsensusSettings().Load(nodeSettings);
             txMemPool = new TxMempool(dateTimeProvider, new BlockPolicyEstimator(new MempoolSettings(nodeSettings), loggerFactory, nodeSettings), loggerFactory, nodeSettings);
             var mempoolLock = new MempoolSchedulerLock();
             var coins = new InMemoryCoinView(settings.Network.GenesisHash);

--- a/src/Stratis.Bitcoin.Features.MemoryPool.Tests/TestChainFactory.cs
+++ b/src/Stratis.Bitcoin.Features.MemoryPool.Tests/TestChainFactory.cs
@@ -65,11 +65,11 @@ namespace Stratis.Bitcoin.Features.MemoryPool.Tests
         {
             NodeSettings nodeSettings = new NodeSettings(network, args:new string[] { $"-datadir={dataDir}" });
 
-            var loggerFactory = new ExtendedLoggerFactory();
+            var loggerFactory = nodeSettings.LoggerFactory;
             IDateTimeProvider dateTimeProvider = DateTimeProvider.Default;
 
             network.Consensus.Options = new PowConsensusOptions();
-            ConsensusSettings consensusSettings = new ConsensusSettings(nodeSettings, loggerFactory);
+            ConsensusSettings consensusSettings = new ConsensusSettings().Load(nodeSettings);
             PowConsensusValidator consensusValidator = new PowConsensusValidator(network, new Checkpoints(), dateTimeProvider, loggerFactory);
             ConcurrentChain chain = new ConcurrentChain(network);
             CachedCoinView cachedCoinView = new CachedCoinView(new InMemoryCoinView(chain.Tip.HashBlock), DateTimeProvider.Default, loggerFactory);
@@ -93,7 +93,7 @@ namespace Stratis.Bitcoin.Features.MemoryPool.Tests
             MempoolSchedulerLock mempoolLock = new MempoolSchedulerLock();
 
             // Simple block creation, nothing special yet:
-            PowBlockAssembler blockAssembler = CreatePowBlockAssembler(network, consensus, chain, mempoolLock, mempool, dateTimeProvider, loggerFactory);
+            PowBlockAssembler blockAssembler = CreatePowBlockAssembler(network, consensus, chain, mempoolLock, mempool, dateTimeProvider, loggerFactory as LoggerFactory);
             BlockTemplate newBlock = blockAssembler.CreateNewBlock(scriptPubKey);
             chain.SetTip(newBlock.Block.Header);
             await consensus.ValidateAndExecuteBlockAsync(new RuleContext(new BlockValidationContext { Block = newBlock.Block }, network.Consensus, consensus.Tip) { CheckPow = false, CheckMerkleRoot = false });
@@ -133,7 +133,7 @@ namespace Stratis.Bitcoin.Features.MemoryPool.Tests
             }
 
             // Just to make sure we can still make simple blocks
-            blockAssembler = CreatePowBlockAssembler(network, consensus, chain, mempoolLock, mempool, dateTimeProvider, loggerFactory);
+            blockAssembler = CreatePowBlockAssembler(network, consensus, chain, mempoolLock, mempool, dateTimeProvider, loggerFactory as LoggerFactory);
             newBlock = blockAssembler.CreateNewBlock(scriptPubKey);
 
             MempoolValidator mempoolValidator = new MempoolValidator(mempool, mempoolLock, consensusValidator, dateTimeProvider, new MempoolSettings(nodeSettings), chain, cachedCoinView, loggerFactory, nodeSettings);

--- a/src/Stratis.Bitcoin.Features.MemoryPool/MempoolFeature.cs
+++ b/src/Stratis.Bitcoin.Features.MemoryPool/MempoolFeature.cs
@@ -44,6 +44,9 @@ namespace Stratis.Bitcoin.Features.MemoryPool
         /// <summary>Settings for the memory pool component.</summary>
         private readonly MempoolSettings mempoolSettings;
 
+        /// <summary>Settings for the node.</summary>
+        private readonly NodeSettings nodeSettings;
+
         /// <summary>
         /// Constructs a memory pool feature.
         /// </summary>
@@ -72,7 +75,13 @@ namespace Stratis.Bitcoin.Features.MemoryPool
             this.mempoolManager = mempoolManager;
             this.mempoolLogger = loggerFactory.CreateLogger(this.GetType().FullName);
             this.mempoolSettings = mempoolSettings;
-            this.mempoolSettings.Load(nodeSettings);
+            this.nodeSettings = nodeSettings;
+        }
+
+        /// <inheritdoc />
+        public override void LoadConfiguration()
+        {
+            this.mempoolSettings.Load(this.nodeSettings);
         }
 
         public void AddFeatureStats(StringBuilder benchLogs)

--- a/src/Stratis.Bitcoin.Features.Miner/MiningFeature.cs
+++ b/src/Stratis.Bitcoin.Features.Miner/MiningFeature.cs
@@ -28,6 +28,9 @@ namespace Stratis.Bitcoin.Features.Miner
         /// <summary>Settings relevant to mining or staking.</summary>
         private readonly MinerSettings minerSettings;
 
+        /// <summary>Settings relevant to node.</summary>
+        private readonly NodeSettings nodeSettings;
+
         /// <summary>POW miner.</summary>
         private readonly IPowMining powMining;
 
@@ -67,11 +70,17 @@ namespace Stratis.Bitcoin.Features.Miner
         {
             this.network = network;
             this.minerSettings = minerSettings;
-            this.minerSettings.Load(nodeSettings);
+            this.nodeSettings = nodeSettings;
             this.powMining = powMining;
             this.posMinting = posMinting;
             this.walletManager = walletManager;
             this.logger = loggerFactory.CreateLogger(this.GetType().FullName);
+        }
+
+        /// <inheritdoc />
+        public override void LoadConfiguration()
+        {
+            this.minerSettings.Load(this.nodeSettings);
         }
 
         /// <summary>

--- a/src/Stratis.Bitcoin.Features.RPC/RPCFeature.cs
+++ b/src/Stratis.Bitcoin.Features.RPC/RPCFeature.cs
@@ -27,8 +27,13 @@ namespace Stratis.Bitcoin.Features.RPC
             this.fullNodeBuilder = fullNodeBuilder;
             this.fullNode = fullNode;
             this.logger = loggerFactory.CreateLogger(this.GetType().FullName);
-            rpcSettings.Load(nodeSettings);
             this.rpcSettings = rpcSettings;
+        }
+
+        /// <inheritdoc />
+        public override void LoadConfiguration()
+        {
+            this.rpcSettings.Load(this.fullNode.NodeService<NodeSettings>());
         }
 
         public override void Initialize()

--- a/src/Stratis.Bitcoin.Features.RPC/RPCFeature.cs
+++ b/src/Stratis.Bitcoin.Features.RPC/RPCFeature.cs
@@ -16,6 +16,8 @@ namespace Stratis.Bitcoin.Features.RPC
     {
         private readonly FullNode fullNode;
 
+        private readonly NodeSettings nodeSettings;
+
         private readonly ILogger logger;
 
         private readonly IFullNodeBuilder fullNodeBuilder;
@@ -26,6 +28,7 @@ namespace Stratis.Bitcoin.Features.RPC
         {
             this.fullNodeBuilder = fullNodeBuilder;
             this.fullNode = fullNode;
+            this.nodeSettings = nodeSettings;
             this.logger = loggerFactory.CreateLogger(this.GetType().FullName);
             this.rpcSettings = rpcSettings;
         }
@@ -33,7 +36,7 @@ namespace Stratis.Bitcoin.Features.RPC
         /// <inheritdoc />
         public override void LoadConfiguration()
         {
-            this.rpcSettings.Load(this.fullNode.NodeService<NodeSettings>());
+            this.rpcSettings.Load(this.nodeSettings);
         }
 
         public override void Initialize()

--- a/src/Stratis.Bitcoin.IntegrationTests/CoinViewTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/CoinViewTests.cs
@@ -343,7 +343,7 @@ namespace Stratis.Bitcoin.IntegrationTests
             };
 
             Network.Main.Consensus.Options = new PowConsensusOptions();
-            ConsensusSettings consensusSettings = new ConsensusSettings(NodeSettings.Default(), this.loggerFactory);
+            ConsensusSettings consensusSettings = new ConsensusSettings().Load(NodeSettings.Default());
             var validator = new PowConsensusValidator(Network.Main, new Checkpoints(Network.Main, consensusSettings), DateTimeProvider.Default, this.loggerFactory);
             //validator.CheckBlockHeader(context);
             validator.ContextualCheckBlock(context);

--- a/src/Stratis.Bitcoin.IntegrationTests/MinerTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/MinerTests.cs
@@ -142,11 +142,8 @@ namespace Stratis.Bitcoin.IntegrationTests
                 var loggerFactory = new ExtendedLoggerFactory();
                 loggerFactory.AddConsoleWithFilters();
 
-                NodeSettings nodeSettings = NodeSettings.Default();
-                var consensusSettings = new ConsensusSettings(nodeSettings, loggerFactory)
-                {
-                    UseCheckpoints = this.useCheckpoints
-                };
+                NodeSettings nodeSettings = new NodeSettings(args:new string[] { "-checkpoints" });
+                var consensusSettings = new ConsensusSettings().Load(nodeSettings);
 
                 PowConsensusValidator consensusValidator = new PowConsensusValidator(this.network, new Checkpoints(), dateTimeProvider, loggerFactory);
                 NetworkPeerFactory networkPeerFactory = new NetworkPeerFactory(this.network, dateTimeProvider, loggerFactory);

--- a/src/Stratis.Bitcoin.Tests/Builder/Feature/FeatureCollectionTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Builder/Feature/FeatureCollectionTest.cs
@@ -32,6 +32,11 @@ namespace Stratis.Bitcoin.Tests.Builder.Feature
 
         private class FeatureCollectionFullNodeFeature : IFullNodeFeature
         {
+            public void LoadConfiguration()
+            {
+                throw new NotImplementedException();
+            }
+
             public void Initialize()
             {
                 throw new NotImplementedException();

--- a/src/Stratis.Bitcoin.Tests/Builder/Feature/FeatureRegistrationTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Builder/Feature/FeatureRegistrationTest.cs
@@ -104,6 +104,11 @@ namespace Stratis.Bitcoin.Tests.Builder.Feature
 
         private class FeatureRegistrationFullNodeFeature : IFullNodeFeature
         {
+            public void LoadConfiguration()
+            {
+                throw new NotImplementedException();
+            }
+
             public void Initialize()
             {
                 throw new NotImplementedException();

--- a/src/Stratis.Bitcoin.Tests/Builder/Feature/FeaturesDependencyCheckingTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Builder/Feature/FeaturesDependencyCheckingTest.cs
@@ -19,6 +19,12 @@ namespace Stratis.Bitcoin.Tests.Builder.Feature
         private class FeatureA : IFullNodeFeature
         {
             /// <inheritdoc />
+            public void LoadConfiguration()
+            {
+                throw new NotImplementedException();
+            }
+
+            /// <inheritdoc />
             public void Initialize()
             {
                 throw new NotImplementedException();

--- a/src/Stratis.Bitcoin.Tests/Builder/Feature/FeaturesExtensionsTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Builder/Feature/FeaturesExtensionsTest.cs
@@ -19,6 +19,12 @@ namespace Stratis.Bitcoin.Tests.Builder.Feature
         private class FeatureA : IFullNodeFeature
         {
             /// <inheritdoc />
+            public void LoadConfiguration()
+            {
+                throw new NotImplementedException();
+            }
+
+            /// <inheritdoc />
             public void Initialize()
             {
                 throw new NotImplementedException();
@@ -41,6 +47,12 @@ namespace Stratis.Bitcoin.Tests.Builder.Feature
         /// </summary>
         private class FeatureB : IFullNodeFeature
         {
+            /// <inheritdoc />
+            public void LoadConfiguration()
+            {
+                throw new NotImplementedException();
+            }
+
             /// <inheritdoc />
             public void Initialize()
             {

--- a/src/Stratis.Bitcoin.Tests/Builder/FullNodeServiceProviderTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Builder/FullNodeServiceProviderTest.cs
@@ -56,6 +56,12 @@ namespace Stratis.Bitcoin.Tests.Builder
         private class TestFeatureStub : IFullNodeFeature
         {
             /// <inheritdoc />
+            public void LoadConfiguration()
+            {
+                throw new NotImplementedException();
+            }
+
+            /// <inheritdoc />
             public void Initialize()
             {
                 throw new NotImplementedException();
@@ -75,6 +81,12 @@ namespace Stratis.Bitcoin.Tests.Builder
 
         private class TestFeatureStub2 : IFullNodeFeature
         {
+            /// <inheritdoc />
+            public void LoadConfiguration()
+            {
+                throw new NotImplementedException();
+            }
+
             /// <inheritdoc />
             public void Initialize()
             {

--- a/src/Stratis.Bitcoin/Builder/Feature/FullNodeFeature.cs
+++ b/src/Stratis.Bitcoin/Builder/Feature/FullNodeFeature.cs
@@ -8,6 +8,11 @@ namespace Stratis.Bitcoin.Builder.Feature
     public interface IFullNodeFeature : IDisposable
     {
         /// <summary>
+        /// Called on all the features prior to calling Initialize on all the features.
+        /// </summary>
+        void LoadConfiguration();
+
+        /// <summary>
         /// Triggered when the FullNode host has fully started.
         /// </summary>
         void Initialize();
@@ -32,6 +37,11 @@ namespace Stratis.Bitcoin.Builder.Feature
     /// </summary>
     public abstract class FullNodeFeature : IFullNodeFeature
     {
+        /// <inheritdoc />
+        public virtual void LoadConfiguration()
+        {
+        }
+
         /// <inheritdoc />
         public abstract void Initialize();
 

--- a/src/Stratis.Bitcoin/Builder/FullNodeFeatureExecutor.cs
+++ b/src/Stratis.Bitcoin/Builder/FullNodeFeatureExecutor.cs
@@ -54,6 +54,7 @@ namespace Stratis.Bitcoin.Builder
             try
             {
                 this.Execute(service => service.ValidateDependencies(this.node.Services));
+                this.Execute(service => service.LoadConfiguration());
                 this.Execute(service => service.Initialize());
             }
             catch (Exception ex)

--- a/src/Stratis.StratisDnsD/Program.cs
+++ b/src/Stratis.StratisDnsD/Program.cs
@@ -43,7 +43,7 @@ namespace Stratis.StratisDnsD
             {
                 Network network = args.Contains("-testnet") ? Network.StratisTest : Network.StratisMain;
                 NodeSettings nodeSettings = new NodeSettings(network, ProtocolVersion.ALT_PROTOCOL_VERSION, args:args);
-                DnsSettings dnsSettings = DnsSettings.Load(nodeSettings);
+                DnsSettings dnsSettings = new DnsSettings().Load(nodeSettings);
 
                 // Verify that the DNS host, nameserver and mailbox arguments are set.
                 if (string.IsNullOrWhiteSpace(dnsSettings.DnsHostName) || string.IsNullOrWhiteSpace(dnsSettings.DnsNameServer) || string.IsNullOrWhiteSpace(dnsSettings.DnsMailBox))


### PR DESCRIPTION
This PR adds a `LoadConfiguration` method to features.

This change promotes a more structured approach to starting up features:

```
        /// <inheritdoc />
        public void Initialize()
        {
            try
            {
                this.Execute(service => service.ValidateDependencies(this.node.Services));
                this.Execute(service => service.LoadConfiguration()); // <================
                this.Execute(service => service.Initialize());
            }
            catch (Exception ex)
            {
                this.logger.LogError("An error occurred starting the application: {0}", ex);
                throw;
            }
        }
```

The alternative to this is to load configurations from the above `Initialize` method. However, since some `Initialize` methods may be looking at configurations from other features, it is better to load all configurations before calling the features' `Initialize` methods.