### PR TITLE
Fixed embedded IPv4 addresses not responding to DNS 'A' requests

### DIFF
--- a/src/Stratis.Bitcoin.Features.Dns/WhitelistManager.cs
+++ b/src/Stratis.Bitcoin.Features.Dns/WhitelistManager.cs
@@ -116,8 +116,8 @@ namespace Stratis.Bitcoin.Features.Dns
                 // Is this an IPv4 embedded address? If it is, make sure an 'A' record is added to the DNS master file, rather than an 'AAAA' record.
                 if (whitelistEntry.Endpoint.Address.IsIPv4MappedToIPv6)
                 {
-                    IPAddress ipv4Adress = whitelistEntry.Endpoint.Address.MapToIPv4();
-                    IPAddressResourceRecord resourceRecord = new IPAddressResourceRecord(domain, ipv4Adress);
+                    IPAddress ipv4Address = whitelistEntry.Endpoint.Address.MapToIPv4();
+                    IPAddressResourceRecord resourceRecord = new IPAddressResourceRecord(domain, ipv4Address);
                     masterFile.Add(resourceRecord);
                 }
                 else

--- a/src/Stratis.Bitcoin.Features.Dns/WhitelistManager.cs
+++ b/src/Stratis.Bitcoin.Features.Dns/WhitelistManager.cs
@@ -113,8 +113,18 @@ namespace Stratis.Bitcoin.Features.Dns
             {
                 Domain domain = new Domain(this.dnsHostName);
 
-                IPAddressResourceRecord resourceRecord = new IPAddressResourceRecord(domain, whitelistEntry.Endpoint.Address);
-                masterFile.Add(resourceRecord);
+                // Is this an IPv4 embedded address? If it is, make sure an 'A' record is added to the DNS master file, rather than an 'AAAA' record.
+                if (whitelistEntry.Endpoint.Address.IsIPv4MappedToIPv6)
+                {
+                    IPAddress ipv4Adress = whitelistEntry.Endpoint.Address.MapToIPv4();
+                    IPAddressResourceRecord resourceRecord = new IPAddressResourceRecord(domain, ipv4Adress);
+                    masterFile.Add(resourceRecord);
+                }
+                else
+                {
+                    IPAddressResourceRecord resourceRecord = new IPAddressResourceRecord(domain, whitelistEntry.Endpoint.Address);
+                    masterFile.Add(resourceRecord);
+                }
             }
 
             this.dnsServer.SwapMasterfile(masterFile);


### PR DESCRIPTION
Fixed issue with embedded IPv4 addresses (inside IPv6 address) that should be added as 'A' records to DNS master file, not 'AAAA'.
Fixed tests.