### PR TITLE
Appropriate level of exceptions handling in NetworkPeerServer

### DIFF
--- a/src/Stratis.Bitcoin/P2P/Peer/NetworkPeerServer.cs
+++ b/src/Stratis.Bitcoin/P2P/Peer/NetworkPeerServer.cs
@@ -180,7 +180,7 @@ namespace Stratis.Bitcoin.P2P.Peer
             }
             catch (Exception e)
             {
-                this.logger.LogError("Exception occurred: {0}", e.ToString());
+                this.logger.LogDebug("Exception occurred: {0}", e.ToString());
             }
 
             this.logger.LogTrace("(-)");

--- a/src/Stratis.Bitcoin/P2P/PeerConnectorDiscovery.cs
+++ b/src/Stratis.Bitcoin/P2P/PeerConnectorDiscovery.cs
@@ -128,7 +128,7 @@ namespace Stratis.Bitcoin.P2P
                 await Task.Delay(2000, this.nodeLifetime.ApplicationStopping).ConfigureAwait(false);
             }
             else
-                await ConnectAsync(peer).ConfigureAwait(false);
+                await this.ConnectAsync(peer).ConfigureAwait(false);
         }
     }
 }


### PR DESCRIPTION
Error on a lower level was handled using LogError while handling was also implemented on a higher level with LogTrace. 
Removed low level handling with LogError. 

Fix: #1141