### PR TITLE
Move Max tip age to Network

### DIFF
--- a/src/NBitcoin/Network.cs
+++ b/src/NBitcoin/Network.cs
@@ -262,6 +262,9 @@ namespace NBitcoin
             }
         }
 
+        /// <summary>Maximum tip age in seconds to consider node in initial block download.</summary>
+        public int MaxTipAge { get; private set; }
+
         public long MinTxFee { get; private set; }
 
         public long FallbackFee { get; private set; }
@@ -363,6 +366,7 @@ namespace NBitcoin
 
             NetworksContainer.TryAdd(network.Name.ToLowerInvariant(), network);
 
+            network.MaxTipAge = builder.MaxTipAge;
             network.MinTxFee = builder.MinTxFee;
             network.FallbackFee = builder.FallbackFee;
             network.MinRelayTxFee = builder.MinRelayTxFee;

--- a/src/NBitcoin/NetworkBuilder.cs
+++ b/src/NBitcoin/NetworkBuilder.cs
@@ -21,6 +21,7 @@ namespace NBitcoin
         internal List<NetworkAddress> FixedSeeds;
         internal Block Genesis;
         internal long MinTxFee;
+        internal int MaxTipAge;
         internal long FallbackFee;
         internal long MinRelayTxFee;
 
@@ -69,6 +70,17 @@ namespace NBitcoin
             return this;
         }
 
+        /// <summary>
+        /// Sets the maximum tip age in seconds to consider node in initial block download.
+        /// </summary>
+        /// <param name="maxTipAge">Maximum tip age in seconds to consider node in initial block download.</param>
+        /// <returns>A <see cref="NetworkBuilder"/>.</returns>
+        public NetworkBuilder SetMaxTipAge(int maxTipAge)
+        {
+            this.MaxTipAge = maxTipAge;
+            return this;
+        }
+
         public void CopyFrom(Network network)
         {
             if(network == null)
@@ -88,7 +100,8 @@ namespace NBitcoin
                 .SetMagic(this.Magic)
                 .SetPort(network.DefaultPort)
                 .SetRPCPort(network.RPCPort)
-                .SetTxFees(network.MinTxFee, network.FallbackFee, network.MinRelayTxFee);
+                .SetTxFees(network.MinTxFee, network.FallbackFee, network.MinRelayTxFee)
+                .SetMaxTipAge(network.MaxTipAge);
         }
 
         public NetworkBuilder AddAlias(string alias)

--- a/src/NBitcoin/Networks.cs
+++ b/src/NBitcoin/Networks.cs
@@ -26,6 +26,9 @@ namespace NBitcoin
             Block.BlockSignature = saveSig;
         }
 
+        /// <summary> Default value for Maximum tip age in seconds to consider node in initial block download. </summary>
+        public const int DefaultMaxTipAge = 24 * 60 * 60;
+
         /// <summary> The name of the root folder containing the different Bitcoin blockchains (Main, TestNet, RegTest). </summary>
         public const string BitcoinRootFolderName = "bitcoin";
 
@@ -137,6 +140,8 @@ namespace NBitcoin
                 addr.Endpoint = Utils.ParseIpEndpoint(pnSeed[i], network.DefaultPort);
                 network.fixedSeeds.Add(addr);
             }
+
+            network.MaxTipAge = DefaultMaxTipAge;
             network.MinTxFee = 1000;
             network.FallbackFee = 20000;
             network.MinRelayTxFee = 1000;
@@ -213,6 +218,7 @@ namespace NBitcoin
             network.bech32Encoders[(int)Bech32Type.WITNESS_PUBKEY_ADDRESS] = encoder;
             network.bech32Encoders[(int)Bech32Type.WITNESS_SCRIPT_ADDRESS] = encoder;
 
+            network.MaxTipAge = DefaultMaxTipAge;
             network.MinTxFee = 1000;
             network.FallbackFee = 20000;
             network.MinRelayTxFee = 1000;
@@ -277,6 +283,7 @@ namespace NBitcoin
             network.bech32Encoders[(int)Bech32Type.WITNESS_PUBKEY_ADDRESS] = encoder;
             network.bech32Encoders[(int)Bech32Type.WITNESS_SCRIPT_ADDRESS] = encoder;
 
+            network.MaxTipAge = DefaultMaxTipAge;
             network.MinTxFee = 1000;
             network.FallbackFee = 20000;
             network.MinRelayTxFee = 1000;
@@ -352,6 +359,7 @@ namespace NBitcoin
                 .SetPort(16178)
                 .SetRPCPort(16174)
                 .SetTxFees(10000, 60000, 10000)
+                .SetMaxTipAge(DefaultMaxTipAge)
 
                 .AddDNSSeeds(new[]
                 {
@@ -434,6 +442,7 @@ namespace NBitcoin
                 .SetGenesis(genesis)
                 .SetPort(26178)
                 .SetRPCPort(26174)
+                .SetMaxTipAge(DefaultMaxTipAge)
                 .SetTxFees(10000, 60000, 10000)
                 .SetBase58Bytes(Base58Type.PUBKEY_ADDRESS, new byte[] { (65) })
                 .SetBase58Bytes(Base58Type.SCRIPT_ADDRESS, new byte[] { (196) })
@@ -497,6 +506,7 @@ namespace NBitcoin
                 .SetGenesis(genesis)
                 .SetPort(18444)
                 .SetRPCPort(18442)
+                .SetMaxTipAge(DefaultMaxTipAge)
                 .SetBase58Bytes(Base58Type.PUBKEY_ADDRESS, new byte[] { (65) })
                 .SetBase58Bytes(Base58Type.SCRIPT_ADDRESS, new byte[] { (196) })
                 .SetBase58Bytes(Base58Type.SECRET_KEY, new byte[] { (65 + 128) })

--- a/src/NBitcoin/Networks.cs
+++ b/src/NBitcoin/Networks.cs
@@ -26,8 +26,11 @@ namespace NBitcoin
             Block.BlockSignature = saveSig;
         }
 
-        /// <summary> Default value for Maximum tip age in seconds to consider node in initial block download. </summary>
-        public const int DefaultMaxTipAgeInSeconds = 24 * 60 * 60;
+        /// <summary> Bitcoin default value for the maximum tip age in seconds to consider the node in initial block download (24 hours). </summary>
+        public const int BitcoinDefaultMaxTipAgeInSeconds = 24 * 60 * 60;
+
+        /// <summary> Stratis default value for the maximum tip age in seconds to consider the node in initial block download (2 hours). </summary>
+        public const int StratisDefaultMaxTipAgeInSeconds = 2 * 60 * 60;
 
         /// <summary> The name of the root folder containing the different Bitcoin blockchains (Main, TestNet, RegTest). </summary>
         public const string BitcoinRootFolderName = "bitcoin";
@@ -141,7 +144,7 @@ namespace NBitcoin
                 network.fixedSeeds.Add(addr);
             }
 
-            network.MaxTipAge = DefaultMaxTipAgeInSeconds;
+            network.MaxTipAge = BitcoinDefaultMaxTipAgeInSeconds;
             network.MinTxFee = 1000;
             network.FallbackFee = 20000;
             network.MinRelayTxFee = 1000;
@@ -218,7 +221,7 @@ namespace NBitcoin
             network.bech32Encoders[(int)Bech32Type.WITNESS_PUBKEY_ADDRESS] = encoder;
             network.bech32Encoders[(int)Bech32Type.WITNESS_SCRIPT_ADDRESS] = encoder;
 
-            network.MaxTipAge = DefaultMaxTipAgeInSeconds;
+            network.MaxTipAge = BitcoinDefaultMaxTipAgeInSeconds;
             network.MinTxFee = 1000;
             network.FallbackFee = 20000;
             network.MinRelayTxFee = 1000;
@@ -283,7 +286,7 @@ namespace NBitcoin
             network.bech32Encoders[(int)Bech32Type.WITNESS_PUBKEY_ADDRESS] = encoder;
             network.bech32Encoders[(int)Bech32Type.WITNESS_SCRIPT_ADDRESS] = encoder;
 
-            network.MaxTipAge = DefaultMaxTipAgeInSeconds;
+            network.MaxTipAge = BitcoinDefaultMaxTipAgeInSeconds;
             network.MinTxFee = 1000;
             network.FallbackFee = 20000;
             network.MinRelayTxFee = 1000;
@@ -359,7 +362,7 @@ namespace NBitcoin
                 .SetPort(16178)
                 .SetRPCPort(16174)
                 .SetTxFees(10000, 60000, 10000)
-                .SetMaxTipAge(DefaultMaxTipAgeInSeconds)
+                .SetMaxTipAge(StratisDefaultMaxTipAgeInSeconds)
 
                 .AddDNSSeeds(new[]
                 {
@@ -442,7 +445,7 @@ namespace NBitcoin
                 .SetGenesis(genesis)
                 .SetPort(26178)
                 .SetRPCPort(26174)
-                .SetMaxTipAge(DefaultMaxTipAgeInSeconds)
+                .SetMaxTipAge(StratisDefaultMaxTipAgeInSeconds)
                 .SetTxFees(10000, 60000, 10000)
                 .SetBase58Bytes(Base58Type.PUBKEY_ADDRESS, new byte[] { (65) })
                 .SetBase58Bytes(Base58Type.SCRIPT_ADDRESS, new byte[] { (196) })
@@ -506,7 +509,7 @@ namespace NBitcoin
                 .SetGenesis(genesis)
                 .SetPort(18444)
                 .SetRPCPort(18442)
-                .SetMaxTipAge(DefaultMaxTipAgeInSeconds)
+                .SetMaxTipAge(StratisDefaultMaxTipAgeInSeconds)
                 .SetBase58Bytes(Base58Type.PUBKEY_ADDRESS, new byte[] { (65) })
                 .SetBase58Bytes(Base58Type.SCRIPT_ADDRESS, new byte[] { (196) })
                 .SetBase58Bytes(Base58Type.SECRET_KEY, new byte[] { (65 + 128) })

--- a/src/NBitcoin/Networks.cs
+++ b/src/NBitcoin/Networks.cs
@@ -27,7 +27,7 @@ namespace NBitcoin
         }
 
         /// <summary> Default value for Maximum tip age in seconds to consider node in initial block download. </summary>
-        public const int DefaultMaxTipAge = 24 * 60 * 60;
+        public const int DefaultMaxTipAgeInSeconds = 24 * 60 * 60;
 
         /// <summary> The name of the root folder containing the different Bitcoin blockchains (Main, TestNet, RegTest). </summary>
         public const string BitcoinRootFolderName = "bitcoin";
@@ -141,7 +141,7 @@ namespace NBitcoin
                 network.fixedSeeds.Add(addr);
             }
 
-            network.MaxTipAge = DefaultMaxTipAge;
+            network.MaxTipAge = DefaultMaxTipAgeInSeconds;
             network.MinTxFee = 1000;
             network.FallbackFee = 20000;
             network.MinRelayTxFee = 1000;
@@ -218,7 +218,7 @@ namespace NBitcoin
             network.bech32Encoders[(int)Bech32Type.WITNESS_PUBKEY_ADDRESS] = encoder;
             network.bech32Encoders[(int)Bech32Type.WITNESS_SCRIPT_ADDRESS] = encoder;
 
-            network.MaxTipAge = DefaultMaxTipAge;
+            network.MaxTipAge = DefaultMaxTipAgeInSeconds;
             network.MinTxFee = 1000;
             network.FallbackFee = 20000;
             network.MinRelayTxFee = 1000;
@@ -283,7 +283,7 @@ namespace NBitcoin
             network.bech32Encoders[(int)Bech32Type.WITNESS_PUBKEY_ADDRESS] = encoder;
             network.bech32Encoders[(int)Bech32Type.WITNESS_SCRIPT_ADDRESS] = encoder;
 
-            network.MaxTipAge = DefaultMaxTipAge;
+            network.MaxTipAge = DefaultMaxTipAgeInSeconds;
             network.MinTxFee = 1000;
             network.FallbackFee = 20000;
             network.MinRelayTxFee = 1000;
@@ -359,7 +359,7 @@ namespace NBitcoin
                 .SetPort(16178)
                 .SetRPCPort(16174)
                 .SetTxFees(10000, 60000, 10000)
-                .SetMaxTipAge(DefaultMaxTipAge)
+                .SetMaxTipAge(DefaultMaxTipAgeInSeconds)
 
                 .AddDNSSeeds(new[]
                 {
@@ -442,7 +442,7 @@ namespace NBitcoin
                 .SetGenesis(genesis)
                 .SetPort(26178)
                 .SetRPCPort(26174)
-                .SetMaxTipAge(DefaultMaxTipAge)
+                .SetMaxTipAge(DefaultMaxTipAgeInSeconds)
                 .SetTxFees(10000, 60000, 10000)
                 .SetBase58Bytes(Base58Type.PUBKEY_ADDRESS, new byte[] { (65) })
                 .SetBase58Bytes(Base58Type.SCRIPT_ADDRESS, new byte[] { (196) })
@@ -506,7 +506,7 @@ namespace NBitcoin
                 .SetGenesis(genesis)
                 .SetPort(18444)
                 .SetRPCPort(18442)
-                .SetMaxTipAge(DefaultMaxTipAge)
+                .SetMaxTipAge(DefaultMaxTipAgeInSeconds)
                 .SetBase58Bytes(Base58Type.PUBKEY_ADDRESS, new byte[] { (65) })
                 .SetBase58Bytes(Base58Type.SCRIPT_ADDRESS, new byte[] { (196) })
                 .SetBase58Bytes(Base58Type.SECRET_KEY, new byte[] { (65 + 128) })

--- a/src/Stratis.Bitcoin/Configuration/NodeSettings.cs
+++ b/src/Stratis.Bitcoin/Configuration/NodeSettings.cs
@@ -35,9 +35,6 @@ namespace Stratis.Bitcoin.Configuration
         /// <summary>Version of the protocol the current implementation supports.</summary>
         public const ProtocolVersion SupportedProtocolVersion = ProtocolVersion.SENDHEADERS_VERSION;
 
-        /// <summary>Default value for Maximum tip age in seconds to consider node in initial block download.</summary>
-        public const int DefaultMaxTipAge = 24 * 60 * 60;
-
         /// <summary>
         /// Initializes a new instance of the object.
         /// </summary>
@@ -220,7 +217,7 @@ namespace Stratis.Bitcoin.Configuration
             this.Logger.LogDebug("Configuration file set to '{0}'.", this.ConfigurationFile);
 
             this.RequireStandard = config.GetOrDefault("acceptnonstdtxn", !(this.Network.IsTest()));
-            this.MaxTipAge = config.GetOrDefault("maxtipage", DefaultMaxTipAge);
+            this.MaxTipAge = config.GetOrDefault("maxtipage", this.Network.MaxTipAge);
             this.Logger.LogDebug("Network: IsTest='{0}', IsBitcoin='{1}'.", this.Network.IsTest(), this.Network.IsBitcoin());
             this.MinTxFeeRate = new FeeRate(config.GetOrDefault("mintxfee", this.Network.MinTxFee));
             this.Logger.LogDebug("MinTxFeeRate set to {0}.", this.MinTxFeeRate);
@@ -384,7 +381,7 @@ namespace Stratis.Bitcoin.Configuration
                 builder.AppendLine($"-testnet                  Use the testnet chain.");
                 builder.AppendLine($"-regtest                  Use the regtestnet chain.");
                 builder.AppendLine($"-acceptnonstdtxn=<0 or 1> Accept non-standard transactions. Default {defaults.RequireStandard}.");
-                builder.AppendLine($"-maxtipage=<number>       Max tip age. Default {DefaultMaxTipAge}.");
+                builder.AppendLine($"-maxtipage=<number>       Max tip age. Default {network.MaxTipAge}.");
                 builder.AppendLine($"-connect=<ip:port>        Specified node to connect to. Can be specified multiple times.");
                 builder.AppendLine($"-addnode=<ip:port>        Add a node to connect to and attempt to keep the connection open. Can be specified multiple times.");
                 builder.AppendLine($"-whitebind=<ip:port>      Bind to given address and whitelist peers connecting to it. Use [host]:port notation for IPv6. Can be specified multiple times.");

--- a/src/Stratis.Bitcoin/Configuration/NodeSettings.cs
+++ b/src/Stratis.Bitcoin/Configuration/NodeSettings.cs
@@ -361,11 +361,11 @@ namespace Stratis.Bitcoin.Configuration
         /// Checks whether to show a help and possibly shows the help.
         /// </summary>
         /// <param name="args">Application command line arguments.</param>
-        /// <param name="mainNet">Main network description to extract port values from.</param>
+        /// <param name="network">The network to extract values from.</param>
         /// <returns><c>true</c> if the help was displayed, <c>false</c> otherwise.</returns>
-        public static bool PrintHelp(string[] args, Network mainNet)
+        public static bool PrintHelp(string[] args, Network network)
         {
-            Guard.NotNull(mainNet, nameof(mainNet));
+            Guard.NotNull(network, nameof(network));
 
             if (args != null && args.Length == 1 && (args[0].StartsWith("-help") || args[0].StartsWith("--help")))
             {


### PR DESCRIPTION
This is for https://github.com/stratisproject/StratisBitcoinFullNode/issues/605
Should we change the default max tip age value for Stratis?
If yes, to what?
I think 2 hours is ok (~120 blocks).
@dangershony @Aprogiena 