### PR TITLE
 Removing the ContextualCheckBlock method from the validator

### DIFF
--- a/src/Stratis.Bitcoin.Features.Consensus/ConsensusFeature.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/ConsensusFeature.cs
@@ -256,7 +256,7 @@ namespace Stratis.Bitcoin.Features.Consensus
                     new BlockHeaderPowContextualRule(),
 
                     // rules that are inside the method ContextualCheckBlock
-                    new Bip113ActivationRule(),
+                    new TransactionLocktimeActivationRule(),
                     new HeightInCoinbaseActivationRule(),
                     new WitnessCommitmentsRule(),
                     new BlockSizeRule(),
@@ -288,7 +288,7 @@ namespace Stratis.Bitcoin.Features.Consensus
                     new BlockHeaderPosContextualRule(),
 
                     // rules that are inside the method ContextualCheckBlock
-                    new Bip113ActivationRule(),
+                    new TransactionLocktimeActivationRule(),
                     new HeightInCoinbaseActivationRule(), 
                     new WitnessCommitmentsRule(),
                     new BlockSizeRule(),

--- a/src/Stratis.Bitcoin.Features.Consensus/ConsensusFeature.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/ConsensusFeature.cs
@@ -257,7 +257,7 @@ namespace Stratis.Bitcoin.Features.Consensus
 
                     // rules that are inside the method ContextualCheckBlock
                     new Bip113ActivationRule(),
-                    new Bip34ActivationRule(),
+                    new HeightInCoinbaseActivationRule(),
                     new WitnessCommitmentsRule(),
                     new BlockSizeRule(),
 
@@ -289,7 +289,7 @@ namespace Stratis.Bitcoin.Features.Consensus
 
                     // rules that are inside the method ContextualCheckBlock
                     new Bip113ActivationRule(),
-                    new Bip34ActivationRule(),
+                    new HeightInCoinbaseActivationRule(), 
                     new WitnessCommitmentsRule(),
                     new BlockSizeRule(),
 

--- a/src/Stratis.Bitcoin.Features.Consensus/ConsensusFeature.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/ConsensusFeature.cs
@@ -256,9 +256,9 @@ namespace Stratis.Bitcoin.Features.Consensus
                     new BlockHeaderPowContextualRule(),
 
                     // rules that are inside the method ContextualCheckBlock
-                    new TransactionLocktimeActivationRule(),
-                    new CoinbaseHeighActivationRule(),
-                    new WitnessCommitmentsRule(),
+                    new TransactionLocktimeActivationRule(), // implements BIP113
+                    new CoinbaseHeighActivationRule(), // implements BIP34
+                    new WitnessCommitmentsRule(), // BIP141, BIP144
                     new BlockSizeRule(),
 
                     // rules that are inside the method CheckBlock
@@ -288,9 +288,9 @@ namespace Stratis.Bitcoin.Features.Consensus
                     new BlockHeaderPosContextualRule(),
 
                     // rules that are inside the method ContextualCheckBlock
-                    new TransactionLocktimeActivationRule(),
-                    new CoinbaseHeighActivationRule(), 
-                    new WitnessCommitmentsRule(),
+                    new TransactionLocktimeActivationRule(), // implements BIP113
+                    new CoinbaseHeighActivationRule(), // implements BIP34
+                    new WitnessCommitmentsRule(), // BIP141, BIP144 
                     new BlockSizeRule(),
 
                     new PosBlockContextRule(), // TODO: this rule needs to be implemented

--- a/src/Stratis.Bitcoin.Features.Consensus/ConsensusFeature.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/ConsensusFeature.cs
@@ -257,7 +257,7 @@ namespace Stratis.Bitcoin.Features.Consensus
 
                     // rules that are inside the method ContextualCheckBlock
                     new TransactionLocktimeActivationRule(),
-                    new HeightInCoinbaseActivationRule(),
+                    new CoinbaseHeighActivationRule(),
                     new WitnessCommitmentsRule(),
                     new BlockSizeRule(),
 
@@ -289,9 +289,11 @@ namespace Stratis.Bitcoin.Features.Consensus
 
                     // rules that are inside the method ContextualCheckBlock
                     new TransactionLocktimeActivationRule(),
-                    new HeightInCoinbaseActivationRule(), 
+                    new CoinbaseHeighActivationRule(), 
                     new WitnessCommitmentsRule(),
                     new BlockSizeRule(),
+
+                    new PosBlockContextRule(), // TODO: this rule needs to be implemented
 
                     // rules that are inside the method CheckBlock
                     new BlockMerkleRootRule(),

--- a/src/Stratis.Bitcoin.Features.Consensus/ConsensusLoop.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/ConsensusLoop.cs
@@ -453,8 +453,6 @@ namespace Stratis.Bitcoin.Features.Consensus
 
                 if (!context.SkipValidation)
                 {
-                    this.Validator.ContextualCheckBlock(context);
-
                     // Check the block itself.
                     this.Validator.CheckBlock(context);
                 }

--- a/src/Stratis.Bitcoin.Features.Consensus/Interfaces/IPowConsensusValidator.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/Interfaces/IPowConsensusValidator.cs
@@ -84,14 +84,6 @@ namespace Stratis.Bitcoin.Features.Consensus.Interfaces
         uint256 ComputeMerkleRoot(List<uint256> leaves, out bool mutated);
 
         /// <summary>
-        /// Context-dependent validity checks.
-        /// </summary>
-        /// <param name="context">Context that contains variety of information regarding blocks validation and execution.</param>
-        /// <exception cref="ConsensusErrors.BadTransactionNonFinal">Thrown if one or more transactions are not finalized.</exception>
-        /// <exception cref="ConsensusErrors.BadCoinbaseHeight">Thrown if coinbase doesn't start with serialized block height.</exception>
-        void ContextualCheckBlock(RuleContext context);
-
-        /// <summary>
         /// Validates the UTXO set is correctly spent.
         /// </summary>
         /// <param name="context">Context that contains variety of information regarding blocks validation and execution.</param>

--- a/src/Stratis.Bitcoin.Features.Consensus/PosConsensusValidator.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/PosConsensusValidator.cs
@@ -248,44 +248,6 @@ namespace Stratis.Bitcoin.Features.Consensus
             this.logger.LogTrace("(-)");
         }
 
-        /// <inheritdoc />
-        public override void ContextualCheckBlock(RuleContext context)
-        {
-            this.logger.LogTrace("()");
-
-            base.ContextualCheckBlock(context);
-
-            // TODO: fix this validation code
-
-            //// check proof-of-stake
-            //// Limited duplicity on stake: prevents block flood attack
-            //// Duplicate stake allowed only when there is orphan child block
-            //if (!fReindex && !fImporting && pblock->IsProofOfStake() && setStakeSeen.count(pblock->GetProofOfStake()) && !mapOrphanBlocksByPrev.count(hash))
-            //    return error("ProcessBlock() : duplicate proof-of-stake (%s, %d) for block %s", pblock->GetProofOfStake().first.ToString(), pblock->GetProofOfStake().second, hash.ToString());
-
-            //if (!BlockValidator.IsCanonicalBlockSignature(context.BlockResult.Block, false))
-            //{
-            //    //if (node != null && (int)node.Version >= CANONICAL_BLOCK_SIG_VERSION)
-            //    //node.Misbehaving(100);
-
-            //    //return false; //error("ProcessBlock(): bad block signature encoding");
-            //}
-
-            //if (!BlockValidator.IsCanonicalBlockSignature(context.BlockResult.Block, true))
-            //{
-            //    //if (pfrom && pfrom->nVersion >= CANONICAL_BLOCK_SIG_LOW_S_VERSION)
-            //    //{
-            //    //    pfrom->Misbehaving(100);
-            //    //    return error("ProcessBlock(): bad block signature encoding (low-s)");
-            //    //}
-
-            //    if (!BlockValidator.EnsureLowS(context.BlockResult.Block.BlockSignatur))
-            //        return false; // error("ProcessBlock(): EnsureLowS failed");
-            //}
-
-            this.logger.LogTrace("(-)[OK]");
-        }
-
         /// <summary>
         /// Checks whether the future drift should be reduced after provided timestamp.
         /// </summary>

--- a/src/Stratis.Bitcoin.Features.Consensus/PowConsensusValidator.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/PowConsensusValidator.cs
@@ -84,18 +84,6 @@ namespace Stratis.Bitcoin.Features.Consensus
                 }
             }
 
-            // Enforce rule that the coinbase starts with serialized block height.
-            if (deploymentFlags.EnforceBIP34)
-            {
-                var expect = new Script(Op.GetPushOp(height));
-                Script actual = block.Transactions[0].Inputs[0].ScriptSig;
-                if (!this.StartWith(actual.ToBytes(true), expect.ToBytes(true)))
-                {
-                    this.logger.LogTrace("(-)[BAD_COINBASE_HEIGHT]");
-                    ConsensusErrors.BadCoinbaseHeight.Throw();
-                }
-            }
-
             // Validation for witness commitments.
             // * We compute the witness hash (which is the hash including witnesses) of all the block's transactions, except the
             //   coinbase (where 0x0000....0000 is used instead).

--- a/src/Stratis.Bitcoin.Features.Consensus/PowConsensusValidator.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/PowConsensusValidator.cs
@@ -60,11 +60,6 @@ namespace Stratis.Bitcoin.Features.Consensus
         }
 
         /// <inheritdoc />
-        public virtual void ContextualCheckBlock(RuleContext context)
-        {
-        }
-
-        /// <inheritdoc />
         public virtual void ExecuteBlock(RuleContext context, TaskScheduler taskScheduler = null)
         {
             this.logger.LogTrace("()");

--- a/src/Stratis.Bitcoin.Features.Consensus/PowConsensusValidator.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/PowConsensusValidator.cs
@@ -62,23 +62,6 @@ namespace Stratis.Bitcoin.Features.Consensus
         /// <inheritdoc />
         public virtual void ContextualCheckBlock(RuleContext context)
         {
-            this.logger.LogTrace("()");
-
-            Block block = context.BlockValidationContext.Block;
-
-            // After the coinbase witness nonce and commitment are verified,
-            // we can check if the block weight passes (before we've checked the
-            // coinbase witness, it would be possible for the weight to be too
-            // large by filling up the coinbase witness, which doesn't change
-            // the block hash, so we couldn't mark the block as permanently
-            // failed).
-            if (this.GetBlockWeight(block) > this.ConsensusOptions.MaxBlockWeight)
-            {
-                this.logger.LogTrace("(-)[BAD_BLOCK_WEIGHT]");
-                ConsensusErrors.BadBlockWeight.Throw();
-            }
-
-            this.logger.LogTrace("(-)[OK]");
         }
 
         /// <inheritdoc />
@@ -429,14 +412,6 @@ namespace Stratis.Bitcoin.Features.Consensus
             // because we receive the wrong transactions for it.
             // Note that witness malleability is checked in ContextualCheckBlock, so no
             // checks that use witness data may be performed here.
-
-            // Size limits.
-            if ((block.Transactions.Count == 0) || (block.Transactions.Count > this.ConsensusOptions.MaxBlockBaseSize) ||
-                (this.GetSize(block, NetworkOptions.TemporaryOptions & ~NetworkOptions.Witness) > this.ConsensusOptions.MaxBlockBaseSize))
-            {
-                this.logger.LogTrace("(-)[BAD_BLOCK_LEN]");
-                ConsensusErrors.BadBlockLength.Throw();
-            }
 
             // First transaction must be coinbase, the rest must not be
             if ((block.Transactions.Count == 0) || !block.Transactions[0].IsCoinBase)

--- a/src/Stratis.Bitcoin.Features.Consensus/PowConsensusValidator.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/PowConsensusValidator.cs
@@ -65,60 +65,6 @@ namespace Stratis.Bitcoin.Features.Consensus
             this.logger.LogTrace("()");
 
             Block block = context.BlockValidationContext.Block;
-            DeploymentFlags deploymentFlags = context.Flags;
-
-            // Validation for witness commitments.
-            // * We compute the witness hash (which is the hash including witnesses) of all the block's transactions, except the
-            //   coinbase (where 0x0000....0000 is used instead).
-            // * The coinbase scriptWitness is a stack of a single 32-byte vector, containing a witness nonce (unconstrained).
-            // * We build a merkle tree with all those witness hashes as leaves (similar to the hashMerkleRoot in the block header).
-            // * There must be at least one output whose scriptPubKey is a single 36-byte push, the first 4 bytes of which are
-            //   {0xaa, 0x21, 0xa9, 0xed}, and the following 32 bytes are SHA256^2(witness root, witness nonce). In case there are
-            //   multiple, the last one is used.
-            bool haveWitness = false;
-            if (deploymentFlags.ScriptFlags.HasFlag(ScriptVerify.Witness))
-            {
-                int commitpos = this.GetWitnessCommitmentIndex(block);
-                if (commitpos != -1)
-                {
-                    uint256 hashWitness = this.BlockWitnessMerkleRoot(block, out bool unused);
-
-                    // The malleation check is ignored; as the transaction tree itself
-                    // already does not permit it, it is impossible to trigger in the
-                    // witness tree.
-                    WitScript witness = block.Transactions[0].Inputs[0].WitScript;
-                    if ((witness.PushCount != 1) || (witness.Pushes.First().Length != 32))
-                    {
-                        this.logger.LogTrace("(-)[BAD_WITNESS_NONCE_SIZE]");
-                        ConsensusErrors.BadWitnessNonceSize.Throw();
-                    }
-
-                    var hashed = new byte[64];
-                    Buffer.BlockCopy(hashWitness.ToBytes(), 0, hashed, 0, 32);
-                    Buffer.BlockCopy(witness.Pushes.First(), 0, hashed, 32, 32);
-                    hashWitness = Hashes.Hash256(hashed);
-
-                    if (!this.EqualsArray(hashWitness.ToBytes(), block.Transactions[0].Outputs[commitpos].ScriptPubKey.ToBytes(true).Skip(6).ToArray(), 32))
-                    {
-                        this.logger.LogTrace("(-)[WITNESS_MERKLE_MISMATCH]");
-                        ConsensusErrors.BadWitnessMerkleMatch.Throw();
-                    }
-
-                    haveWitness = true;
-                }
-            }
-
-            if (!haveWitness)
-            {
-                for (int i = 0; i < block.Transactions.Count; i++)
-                {
-                    if (block.Transactions[i].HasWitness)
-                    {
-                        this.logger.LogTrace("(-)[UNEXPECTED_WITNESS]");
-                        ConsensusErrors.UnexpectedWitness.Throw();
-                    }
-                }
-            }
 
             // After the coinbase witness nonce and commitment are verified,
             // we can check if the block weight passes (before we've checked the

--- a/src/Stratis.Bitcoin.Features.Consensus/PowConsensusValidator.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/PowConsensusValidator.cs
@@ -67,23 +67,6 @@ namespace Stratis.Bitcoin.Features.Consensus
             Block block = context.BlockValidationContext.Block;
             DeploymentFlags deploymentFlags = context.Flags;
 
-            int height = context.BestBlock == null ? 0 : context.BestBlock.Height + 1;
-
-            // Start enforcing BIP113 (Median Time Past) using versionbits logic.
-            DateTimeOffset lockTimeCutoff = deploymentFlags.LockTimeFlags.HasFlag(Transaction.LockTimeFlags.MedianTimePast) ?
-                context.BestBlock.MedianTimePast :
-                block.Header.BlockTime;
-
-            // Check that all transactions are finalized.
-            foreach (Transaction transaction in block.Transactions)
-            {
-                if (!transaction.IsFinal(lockTimeCutoff, height))
-                {
-                    this.logger.LogTrace("(-)[TX_NON_FINAL]");
-                    ConsensusErrors.BadTransactionNonFinal.Throw();
-                }
-            }
-
             // Validation for witness commitments.
             // * We compute the witness hash (which is the hash including witnesses) of all the block's transactions, except the
             //   coinbase (where 0x0000....0000 is used instead).

--- a/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/CoinbaseHeighRule.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/CoinbaseHeighRule.cs
@@ -10,8 +10,9 @@ namespace Stratis.Bitcoin.Features.Consensus.Rules.CommonRules
     /// </summary>
     /// <remarks>
     /// More info here https://github.com/bitcoin/bips/blob/master/bip-0034.mediawiki
-    /// </remarks>
-    public class HeightInCoinbaseRule : ConsensusRule
+    /// </remarks>    
+    /// <exception cref="ConsensusErrors.BadCoinbaseHeight">Thrown if coinbase doesn't start with serialized block height.</exception>
+    public class CoinbaseHeighRule : ConsensusRule
     {
         /// <inheritdoc />
         public override Task RunAsync(RuleContext context)
@@ -55,7 +56,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Rules.CommonRules
     /// With Bitcoin the BIP34 was activated at block 227,835 using the deployment flags, 
     /// this rule allows a chain to have BIP34 activated as a deployment rule.
     /// </summary>
-    public class HeightInCoinbaseActivationRule : HeightInCoinbaseRule
+    public class CoinbaseHeighActivationRule : CoinbaseHeighRule
     {
         /// <inheritdoc />
         public override Task RunAsync(RuleContext context)

--- a/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/HeightInCoinbaseRule.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/HeightInCoinbaseRule.cs
@@ -11,7 +11,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Rules.CommonRules
     /// <remarks>
     /// More info here https://github.com/bitcoin/bips/blob/master/bip-0034.mediawiki
     /// </remarks>
-    public class Bip34Rule : ConsensusRule
+    public class HeightInCoinbaseRule : ConsensusRule
     {
         /// <inheritdoc />
         public override Task RunAsync(RuleContext context)
@@ -55,7 +55,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Rules.CommonRules
     /// With Bitcoin the BIP34 was activated at block 227,835 using the deployment flags, 
     /// this rule allows a chain to have BIP34 activated as a deployment rule.
     /// </summary>
-    public class Bip34ActivationRule : Bip34Rule
+    public class HeightInCoinbaseActivationRule : HeightInCoinbaseRule
     {
         /// <inheritdoc />
         public override Task RunAsync(RuleContext context)

--- a/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/PosBlockContextRule.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/PosBlockContextRule.cs
@@ -5,7 +5,6 @@ namespace Stratis.Bitcoin.Features.Consensus.Rules.CommonRules
     /// <summary>
     /// Context checks on a POS block.
     /// </summary>
-    [ValidationRule(CanSkipValidation = false)]
     public class PosBlockContextRule : PosConsensusRule
     {
         /// <inheritdoc />

--- a/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/PosBlockContextRule.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/PosBlockContextRule.cs
@@ -8,7 +8,6 @@ namespace Stratis.Bitcoin.Features.Consensus.Rules.CommonRules
     public class PosBlockContextRule : PosConsensusRule
     {
         /// <inheritdoc />
-        /// <exception cref="ConsensusErrors.HighHash"> Thrown if block doesn't have a valid PoW header.</exception>
         public override Task RunAsync(RuleContext context)
         {
             // TODO: fix this validation code

--- a/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/PosBlockContextRule.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/PosBlockContextRule.cs
@@ -1,0 +1,46 @@
+﻿using System.Threading.Tasks;
+
+namespace Stratis.Bitcoin.Features.Consensus.Rules.CommonRules
+{
+    /// <summary>
+    /// Context checks on a POS block.
+    /// </summary>
+    [ValidationRule(CanSkipValidation = false)]
+    public class PosBlockContextRule : PosConsensusRule
+    {
+        /// <inheritdoc />
+        /// <exception cref="ConsensusErrors.HighHash"> Thrown if block doesn't have a valid PoW header.</exception>
+        public override Task RunAsync(RuleContext context)
+        {
+            // TODO: fix this validation code
+
+            //// check proof-of-stake
+            //// Limited duplicity on stake: prevents block flood attack
+            //// Duplicate stake allowed only when there is orphan child block
+            //if (!fReindex && !fImporting && pblock->IsProofOfStake() && setStakeSeen.count(pblock->GetProofOfStake()) && !mapOrphanBlocksByPrev.count(hash))
+            //    return error("ProcessBlock() : duplicate proof-of-stake (%s, %d) for block %s", pblock->GetProofOfStake().first.ToString(), pblock->GetProofOfStake().second, hash.ToString());
+
+            //if (!BlockValidator.IsCanonicalBlockSignature(context.BlockResult.Block, false))
+            //{
+            //    //if (node != null && (int)node.Version >= CANONICAL_BLOCK_SIG_VERSION)
+            //    //node.Misbehaving(100);
+
+            //    //return false; //error("ProcessBlock(): bad block signature encoding");
+            //}
+
+            //if (!BlockValidator.IsCanonicalBlockSignature(context.BlockResult.Block, true))
+            //{
+            //    //if (pfrom && pfrom->nVersion >= CANONICAL_BLOCK_SIG_LOW_S_VERSION)
+            //    //{
+            //    //    pfrom->Misbehaving(100);
+            //    //    return error("ProcessBlock(): bad block signature encoding (low-s)");
+            //    //}
+
+            //    if (!BlockValidator.EnsureLowS(context.BlockResult.Block.BlockSignatur))
+            //        return false; // error("ProcessBlock(): EnsureLowS failed");
+            //}
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/TransactionLocktimeActivationRule.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/TransactionLocktimeActivationRule.cs
@@ -12,6 +12,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Rules.CommonRules
     /// <remarks>
     /// More info here https://github.com/bitcoin/bips/blob/master/bip-0113.mediawiki
     /// </remarks>
+    /// <exception cref="ConsensusErrors.BadTransactionNonFinal">Thrown if one or more transactions are not finalized.</exception>
     public class TransactionLocktimeActivationRule : ConsensusRule
     {
         /// <inheritdoc />

--- a/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/TransactionLocktimeActivationRule.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/TransactionLocktimeActivationRule.cs
@@ -12,7 +12,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Rules.CommonRules
     /// <remarks>
     /// More info here https://github.com/bitcoin/bips/blob/master/bip-0113.mediawiki
     /// </remarks>
-    public class Bip113ActivationRule : ConsensusRule
+    public class TransactionLocktimeActivationRule : ConsensusRule
     {
         /// <inheritdoc />
         public override Task RunAsync(RuleContext context)

--- a/src/Stratis.Bitcoin.IntegrationTests/CoinViewTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/CoinViewTests.cs
@@ -13,6 +13,7 @@ using Stratis.Bitcoin.Base.Deployments;
 using Stratis.Bitcoin.Configuration;
 using Stratis.Bitcoin.Features.Consensus;
 using Stratis.Bitcoin.Features.Consensus.CoinViews;
+using Stratis.Bitcoin.Features.Consensus.Rules.CommonRules;
 using Stratis.Bitcoin.IntegrationTests.EnvironmentMockUpHelpers;
 using Stratis.Bitcoin.Utilities;
 using Xunit;
@@ -345,8 +346,7 @@ namespace Stratis.Bitcoin.IntegrationTests
             Network.Main.Consensus.Options = new PowConsensusOptions();
             ConsensusSettings consensusSettings = new ConsensusSettings().Load(NodeSettings.Default());
             var validator = new PowConsensusValidator(Network.Main, new Checkpoints(Network.Main, consensusSettings), DateTimeProvider.Default, this.loggerFactory);
-            //validator.CheckBlockHeader(context);
-            validator.ContextualCheckBlock(context);
+            new WitnessCommitmentsRule().RunAsync(context).GetAwaiter().GetResult();
             validator.CheckBlock(context);
         }
     }


### PR DESCRIPTION
Some rules have already been implemented this code will remove them from the validator class.