### PR TITLE
Time sync warnings

### DIFF
--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/TimeSyncBehaviorTest.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/TimeSyncBehaviorTest.cs
@@ -131,7 +131,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests
                 bool used = state.AddTimeData(peerAddress, timeOffsetSample, isInbound);
                 Assert.Equal(isUsed, used);
 
-                Assert.Equal(isWarningOn, state.WarningLoopStarted);
+                Assert.Equal(isWarningOn, state.IsSystemTimeOutOfSync);
                 Assert.Equal(isSyncOff, state.SwitchedOffLimitReached);
                 Assert.Equal(isSyncOff, state.SwitchedOff);
 

--- a/src/Stratis.Bitcoin.Features.Miner.Tests/Controllers/MinerControllerTest.cs
+++ b/src/Stratis.Bitcoin.Features.Miner.Tests/Controllers/MinerControllerTest.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Mvc;
 using Moq;
 using NBitcoin;
 using Newtonsoft.Json;
+using Stratis.Bitcoin.Base;
 using Stratis.Bitcoin.Features.Miner.Controllers;
 using Stratis.Bitcoin.Features.Miner.Interfaces;
 using Stratis.Bitcoin.Features.Miner.Models;
@@ -21,12 +22,14 @@ namespace Stratis.Bitcoin.Features.Miner.Tests.Controllers
         private Mock<IFullNode> fullNode;
         private Mock<IPosMinting> posMinting;
         private Mock<IWalletManager> walletManager;
+        private Mock<ITimeSyncBehaviorState> timeSyncBehaviorState;
 
         public MinerControllerTest()
         {
             this.fullNode = new Mock<IFullNode>();
             this.posMinting = new Mock<IPosMinting>();
             this.walletManager = new Mock<IWalletManager>();
+            this.timeSyncBehaviorState = new Mock<ITimeSyncBehaviorState>();
 
             this.controller = new MinerController(this.fullNode.Object, this.LoggerFactory.Object, this.walletManager.Object, this.posMinting.Object);
         }
@@ -167,12 +170,43 @@ namespace Stratis.Bitcoin.Features.Miner.Tests.Controllers
                 .Returns(this.walletManager.Object);
 
             this.fullNode.Setup(f => f.NodeFeature<MiningFeature>(true))
-                .Returns(new MiningFeature(Network.Main, new MinerSettings(), Configuration.NodeSettings.Default(), this.LoggerFactory.Object, null, this.posMinting.Object, this.walletManager.Object));
+                .Returns(new MiningFeature(Network.Main, new MinerSettings(), Configuration.NodeSettings.Default(), this.LoggerFactory.Object, this.timeSyncBehaviorState.Object, null, this.posMinting.Object, this.walletManager.Object));
 
             var result = this.controller.StartStaking(new StartStakingRequest() { Name = "myWallet", Password = "password1" });
 
             Assert.IsType<OkResult>(result);
             this.posMinting.Verify(p => p.Stake(It.Is<PosMinting.WalletSecret>(s => s.WalletName == "myWallet" && s.WalletPassword == "password1")), Times.Exactly(1));
+        }
+
+        /// <summary>
+        /// Tests that if the system time is out of symc with the rest of the network, staking doesn't start.
+        /// </summary>
+        [Fact]
+        public void StartStaking_InvalidTimeSyncState_ReturnsBadRequest()
+        {
+            var wallet = WalletTestsHelpers.GenerateBlankWallet("myWallet", "password1");
+            this.walletManager.Setup(w => w.GetWallet("myWallet"))
+                .Returns(wallet);
+
+            this.fullNode.Setup(f => f.NodeService<IWalletManager>(false))
+                .Returns(this.walletManager.Object);
+            
+            this.timeSyncBehaviorState.Setup(ts => ts.IsSystemTimeOutOfSync()).Returns(true);
+
+            this.fullNode.Setup(f => f.NodeFeature<MiningFeature>(true))
+                .Returns(new MiningFeature(Network.Main, new MinerSettings(), Configuration.NodeSettings.Default(), this.LoggerFactory.Object, this.timeSyncBehaviorState.Object, null, this.posMinting.Object, this.walletManager.Object));
+
+            var result = this.controller.StartStaking(new StartStakingRequest() { Name = "myWallet", Password = "password1" });
+
+            ErrorResult errorResult = Assert.IsType<ErrorResult>(result);
+            ErrorResponse errorResponse = Assert.IsType<ErrorResponse>(errorResult.Value);
+            Assert.Single(errorResponse.Errors);
+
+            ErrorModel error = errorResponse.Errors[0];
+            Assert.Equal(400, error.Status);
+            Assert.Contains("Staking cannot start", error.Message);
+
+            this.posMinting.Verify(pm => pm.Stake(It.IsAny<PosMinting.WalletSecret>()), Times.Never);
         }
     }
 }

--- a/src/Stratis.Bitcoin.Features.Miner.Tests/Controllers/MinerControllerTest.cs
+++ b/src/Stratis.Bitcoin.Features.Miner.Tests/Controllers/MinerControllerTest.cs
@@ -191,7 +191,7 @@ namespace Stratis.Bitcoin.Features.Miner.Tests.Controllers
             this.fullNode.Setup(f => f.NodeService<IWalletManager>(false))
                 .Returns(this.walletManager.Object);
             
-            this.timeSyncBehaviorState.Setup(ts => ts.IsSystemTimeOutOfSync()).Returns(true);
+            this.timeSyncBehaviorState.Setup(ts => ts.IsSystemTimeOutOfSync).Returns(true);
 
             this.fullNode.Setup(f => f.NodeFeature<MiningFeature>(true))
                 .Returns(new MiningFeature(Network.Main, new MinerSettings(), Configuration.NodeSettings.Default(), this.LoggerFactory.Object, this.timeSyncBehaviorState.Object, null, this.posMinting.Object, this.walletManager.Object));

--- a/src/Stratis.Bitcoin.Features.Miner.Tests/MiningRPCControllerTest.cs
+++ b/src/Stratis.Bitcoin.Features.Miner.Tests/MiningRPCControllerTest.cs
@@ -135,7 +135,7 @@ namespace Stratis.Bitcoin.Features.Miner.Tests
         public void StartStaking_InvalidTimeSyncState_ThrowsException()
         {
             this.walletManager.Setup(w => w.GetWallet("myWallet")).Returns(this.fixture.wallet);
-            this.timeSyncBehaviorState.Setup(ts => ts.IsSystemTimeOutOfSync()).Returns(true);
+            this.timeSyncBehaviorState.Setup(ts => ts.IsSystemTimeOutOfSync).Returns(true);
 
             this.fullNode.Setup(f => f.NodeFeature<MiningFeature>(true))
                 .Returns(new MiningFeature(Network.Main, new MinerSettings(), Configuration.NodeSettings.Default(), this.LoggerFactory.Object, this.timeSyncBehaviorState.Object, this.powMining.Object, this.posMinting.Object, this.walletManager.Object));

--- a/src/Stratis.Bitcoin.Features.Miner.Tests/MiningRPCControllerTest.cs
+++ b/src/Stratis.Bitcoin.Features.Miner.Tests/MiningRPCControllerTest.cs
@@ -4,6 +4,8 @@ using System.Security;
 using Moq;
 using NBitcoin;
 using Newtonsoft.Json;
+using Stratis.Bitcoin.Base;
+using Stratis.Bitcoin.Configuration;
 using Stratis.Bitcoin.Features.Miner.Interfaces;
 using Stratis.Bitcoin.Features.Miner.Models;
 using Stratis.Bitcoin.Features.RPC;
@@ -21,6 +23,7 @@ namespace Stratis.Bitcoin.Features.Miner.Tests
         private Mock<IFullNode> fullNode;
         private Mock<IPosMinting> posMinting;
         private Mock<IWalletManager> walletManager;
+        private Mock<ITimeSyncBehaviorState> timeSyncBehaviorState;
         private MiningRPCControllerFixture fixture;
         private Mock<IPowMining> powMining;
 
@@ -31,7 +34,7 @@ namespace Stratis.Bitcoin.Features.Miner.Tests
             this.fullNode = new Mock<IFullNode>();
             this.posMinting = new Mock<IPosMinting>();
             this.walletManager = new Mock<IWalletManager>();
-
+            this.timeSyncBehaviorState = new Mock<ITimeSyncBehaviorState>();
             this.fullNode.Setup(f => f.NodeService<IWalletManager>(false))
                 .Returns(this.walletManager.Object);
 
@@ -129,13 +132,31 @@ namespace Stratis.Bitcoin.Features.Miner.Tests
         }
 
         [Fact]
+        public void StartStaking_InvalidTimeSyncState_ThrowsException()
+        {
+            this.walletManager.Setup(w => w.GetWallet("myWallet")).Returns(this.fixture.wallet);
+            this.timeSyncBehaviorState.Setup(ts => ts.IsSystemTimeOutOfSync()).Returns(true);
+
+            this.fullNode.Setup(f => f.NodeFeature<MiningFeature>(true))
+                .Returns(new MiningFeature(Network.Main, new MinerSettings(), Configuration.NodeSettings.Default(), this.LoggerFactory.Object, this.timeSyncBehaviorState.Object, this.powMining.Object, this.posMinting.Object, this.walletManager.Object));
+
+            var exception = Assert.Throws<ConfigurationException>(() =>
+            {
+                var result = this.controller.StartStaking("myWallet", "password1");
+            });
+
+            Assert.Contains("Staking cannot start", exception.Message);
+            this.posMinting.Verify(pm => pm.Stake(It.IsAny<PosMinting.WalletSecret>()), Times.Never);
+        }
+
+        [Fact]
         public void StartStaking_ValidWalletAndPassword_StartsStaking_ReturnsTrue()
         {            
             this.walletManager.Setup(w => w.GetWallet("myWallet"))
               .Returns(this.fixture.wallet);
 
             this.fullNode.Setup(f => f.NodeFeature<MiningFeature>(true))
-                .Returns(new MiningFeature(Network.Main, new MinerSettings(), Configuration.NodeSettings.Default(), this.LoggerFactory.Object, this.powMining.Object, this.posMinting.Object, this.walletManager.Object));
+                .Returns(new MiningFeature(Network.Main, new MinerSettings(), Configuration.NodeSettings.Default(), this.LoggerFactory.Object, this.timeSyncBehaviorState.Object, this.powMining.Object, this.posMinting.Object, this.walletManager.Object));
 
             var result = this.controller.StartStaking("myWallet", "password1");
 

--- a/src/Stratis.Bitcoin.Features.Miner/MiningFeature.cs
+++ b/src/Stratis.Bitcoin.Features.Miner/MiningFeature.cs
@@ -89,7 +89,7 @@ namespace Stratis.Bitcoin.Features.Miner
         public void StartStaking(string walletName, string walletPassword)
         {
             // Prevent mining if the system time is not in sync with that of other members on the network.
-            if (this.timeSyncBehaviorState.IsSystemTimeOutOfSync())
+            if (this.timeSyncBehaviorState.IsSystemTimeOutOfSync)
             {
                 var errorMessage = "Staking cannot start, your system time does not match that of other nodes on the network." + Environment.NewLine
                                     + "Please adjust your system time and restart the node.";

--- a/src/Stratis.Bitcoin.Features.Miner/MiningFeature.cs
+++ b/src/Stratis.Bitcoin.Features.Miner/MiningFeature.cs
@@ -2,6 +2,7 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using NBitcoin;
+using Stratis.Bitcoin.Base;
 using Stratis.Bitcoin.Builder;
 using Stratis.Bitcoin.Builder.Feature;
 using Stratis.Bitcoin.Configuration;
@@ -46,6 +47,9 @@ namespace Stratis.Bitcoin.Features.Miner
         /// <summary>POW mining loop.</summary>
         private IAsyncLoop powLoop;
 
+        /// <summary>State of time synchronization feature that stores collected data samples.</summary>
+        private readonly ITimeSyncBehaviorState timeSyncBehaviorState;
+
         /// <summary>
         /// Initializes the instance of the object.
         /// </summary>
@@ -53,6 +57,7 @@ namespace Stratis.Bitcoin.Features.Miner
         /// <param name="minerSettings">Settings relevant to mining or staking.</param>
         /// <param name="nodeSettings">The node's configuration settings.</param>
         /// <param name="loggerFactory">Factory to be used to create logger for the node.</param>
+        /// <param name="timeSyncBehaviorState">State of time synchronization feature that stores collected data samples.</param>
         /// <param name="powMining">POW miner.</param>
         /// <param name="posMinting">POS staker.</param>
         /// <param name="walletManager">Manager providing operations on wallets.</param>
@@ -61,6 +66,7 @@ namespace Stratis.Bitcoin.Features.Miner
             MinerSettings minerSettings,
             NodeSettings nodeSettings,
             ILoggerFactory loggerFactory,
+            ITimeSyncBehaviorState timeSyncBehaviorState,
             IPowMining powMining,
             IPosMinting posMinting = null,
             IWalletManager walletManager = null)
@@ -69,6 +75,7 @@ namespace Stratis.Bitcoin.Features.Miner
             this.minerSettings = minerSettings;
             this.minerSettings.Load(nodeSettings);
             this.powMining = powMining;
+            this.timeSyncBehaviorState = timeSyncBehaviorState;
             this.posMinting = posMinting;
             this.walletManager = walletManager;
             this.logger = loggerFactory.CreateLogger(this.GetType().FullName);
@@ -81,6 +88,15 @@ namespace Stratis.Bitcoin.Features.Miner
         /// <param name="walletPassword">The password of the wallet.</param>
         public void StartStaking(string walletName, string walletPassword)
         {
+            // Prevent mining if the system time is not in sync with that of other members on the network.
+            if (this.timeSyncBehaviorState.IsSystemTimeOutOfSync())
+            {
+                var errorMessage = "Staking cannot start, your system time does not match that of other nodes on the network." + Environment.NewLine
+                                    + "Please adjust your system time and restart the node.";
+                this.logger.LogError(errorMessage);
+                throw new ConfigurationException(errorMessage);
+            }
+
             if (!string.IsNullOrEmpty(walletName) && !string.IsNullOrEmpty(walletPassword))
             {
                 this.logger.LogInformation("Staking enabled on wallet '{0}'.", walletName);
@@ -93,7 +109,9 @@ namespace Stratis.Bitcoin.Features.Miner
             }
             else
             {
-                this.logger.LogWarning("Staking not started, wallet name or password were not provided.");
+                var errorMessage = "Staking not started, wallet name or password were not provided.";
+                this.logger.LogError(errorMessage);
+                throw new ConfigurationException(errorMessage);
             }
         }
 

--- a/src/Stratis.Bitcoin.Features.Miner/PosMinting.cs
+++ b/src/Stratis.Bitcoin.Features.Miner/PosMinting.cs
@@ -261,6 +261,9 @@ namespace Stratis.Bitcoin.Features.Miner
         /// <summary>Time in milliseconds between attempts to generate PoS blocks.</summary>
         private readonly int minerSleep;
 
+        /// <summary>Time in milliseconds between attempts to generate PoS blocks, when the system time is out of sync.</summary>
+        private readonly int systemTimeOutOfSyncSleep;
+
         /// <summary>A lock for managing asynchronous access to memory pool.</summary>
         protected readonly MempoolSchedulerLock mempoolLock;
 
@@ -365,6 +368,7 @@ namespace Stratis.Bitcoin.Features.Miner
             this.logger = loggerFactory.CreateLogger(this.GetType().FullName);
 
             this.minerSleep = 500; // GetArg("-minersleep", 500);
+            this.systemTimeOutOfSyncSleep = 7000;
             this.lastCoinStakeSearchTime = this.dateTimeProvider.GetAdjustedTimeAsUnixTimestamp();
             this.lastCoinStakeSearchPrevBlockHash = 0;
             this.targetReserveBalance = 0; // TOOD:settings.targetReserveBalance
@@ -469,7 +473,7 @@ namespace Stratis.Bitcoin.Features.Miner
                 {
                     this.logger.LogError("Staking cannot start, your system time does not match that of other nodes on the network." + Environment.NewLine
                                          + "Please adjust your system time and restart the node.");
-                    await Task.Delay(TimeSpan.FromMilliseconds(this.minerSleep), this.stakeCancellationTokenSource.Token).ConfigureAwait(false);
+                    await Task.Delay(TimeSpan.FromMilliseconds(this.systemTimeOutOfSyncSleep), this.stakeCancellationTokenSource.Token).ConfigureAwait(false);
                     continue;
                 }
 

--- a/src/Stratis.Bitcoin.Features.Miner/PosMinting.cs
+++ b/src/Stratis.Bitcoin.Features.Miner/PosMinting.cs
@@ -465,7 +465,7 @@ namespace Stratis.Bitcoin.Features.Miner
             while (!this.stakeCancellationTokenSource.Token.IsCancellationRequested)
             {
                 // Prevent mining if the system time is not in sync with that of other members on the network.
-                if (this.timeSyncBehaviorState.IsSystemTimeOutOfSync())
+                if (this.timeSyncBehaviorState.IsSystemTimeOutOfSync)
                 {
                     this.logger.LogError("Staking cannot start, your system time does not match that of other nodes on the network." + Environment.NewLine
                                          + "Please adjust your system time and restart the node.");

--- a/src/Stratis.Bitcoin.Features.RPC/RPCMiddleware.cs
+++ b/src/Stratis.Bitcoin.Features.RPC/RPCMiddleware.cs
@@ -7,6 +7,7 @@ using NBitcoin.DataEncoders;
 using NBitcoin.RPC;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using Stratis.Bitcoin.Configuration;
 using Stratis.Bitcoin.Utilities;
 
 namespace Stratis.Bitcoin.Features.RPC
@@ -51,6 +52,12 @@ namespace Stratis.Bitcoin.Features.RPC
             if (ex is ArgumentException || ex is FormatException)
             {
                 JObject response = CreateError(RPCErrorCode.RPC_MISC_ERROR, "Argument error: " + ex.Message);
+                httpContext.Response.ContentType = "application/json";
+                await httpContext.Response.WriteAsync(response.ToString(Formatting.Indented));
+            }
+            else if (ex is ConfigurationException)
+            {
+                JObject response = CreateError(RPCErrorCode.RPC_INTERNAL_ERROR, ex.Message);
                 httpContext.Response.ContentType = "application/json";
                 await httpContext.Response.WriteAsync(response.ToString(Formatting.Indented));
             }

--- a/src/Stratis.Bitcoin/Base/TimeSyncBehavior.cs
+++ b/src/Stratis.Bitcoin/Base/TimeSyncBehavior.cs
@@ -28,11 +28,8 @@ namespace Stratis.Bitcoin.Base
         /// <returns><c>true</c> if the sample was added to the mix, <c>false</c> otherwise.</returns>
         bool AddTimeData(IPAddress peerAddress, TimeSpan offsetSample, bool isInboundConnection);
 
-        /// <summary>
-        /// Gets a value indicating whether the system time is not in sync and needs adjustment.
-        /// </summary>
-        /// <returns><true/> if the system time is not in sync and needs adjustment, <c>false</c> otherwise.</returns>
-        bool IsSystemTimeOutOfSync();
+        /// <summary> A value indicating whether the system time is not in sync and needs adjustment. </summary>
+        bool IsSystemTimeOutOfSync { get; }
     }
 
     /// <summary>
@@ -258,12 +255,9 @@ namespace Stratis.Bitcoin.Base
             this.logger.LogTrace("(-):{0}", res);
             return res;
         }
-
+        
         /// <inheritdoc/>
-        public bool IsSystemTimeOutOfSync()
-        {
-            return this.isSystemTimeOutOfSync;
-        }
+        public bool IsSystemTimeOutOfSync => this.isSystemTimeOutOfSync;
 
         /// <summary>
         /// Calculates a new value for <see cref="timeOffset"/> based on existing samples.

--- a/src/Stratis.Bitcoin/Base/TimeSyncBehavior.cs
+++ b/src/Stratis.Bitcoin/Base/TimeSyncBehavior.cs
@@ -154,9 +154,6 @@ namespace Stratis.Bitcoin.Base
         /// <remarks>All access to this object has to be protected by <see cref="lockObject"/>.</remarks>
         private readonly HashSet<IPAddress> outboundSampleSources;
 
-        /// <summary><c>true</c> if the warning loop has been started, <c>false</c> otherwise.</summary>
-        public bool WarningLoopStarted { get; private set; }
-
         /// <summary><c>true</c> if the time sync with peers has been switched off, <c>false</c> otherwise.</summary>
         public bool SwitchedOff { get; private set; }
 
@@ -193,9 +190,6 @@ namespace Stratis.Bitcoin.Base
             this.outboundSampleSources = new HashSet<IPAddress>();
 
             this.timeOffset = TimeSpan.Zero;
-            this.WarningLoopStarted = false;
-            this.SwitchedOff = false;
-            this.SwitchedOffLimitReached = false;
         }
 
         /// <inheritdoc />
@@ -234,11 +228,10 @@ namespace Stratis.Bitcoin.Base
 
                         // If SwitchedOffLimitReached is set, timeOffset is set to zero,
                         // so we need to check both conditions here.
-                        if (!this.WarningLoopStarted
+                        if (!this.isSystemTimeOutOfSync
                             && ((Math.Abs(this.timeOffset.TotalSeconds) > TimeOffsetWarningThresholdSeconds) || this.SwitchedOffLimitReached))
                         {
                             startWarningLoopNow = true;
-                            this.WarningLoopStarted = true;
                             this.isSystemTimeOutOfSync = true;
                         }
 

--- a/src/Stratis.Bitcoin/Base/TimeSyncBehavior.cs
+++ b/src/Stratis.Bitcoin/Base/TimeSyncBehavior.cs
@@ -320,25 +320,27 @@ namespace Stratis.Bitcoin.Base
 
                     if (timeOffsetWrong)
                     {
-                        this.logger.LogCritical("\n"
-                            + "============================== W A R N I N G ! ==============================\n"
-                            + "Your system time is very different than the time of other network nodes.\n"
-                            + "To prevent problems, adjust your system time, or check -synctime command line argument.\n"
-                            + "Your time difference to the network median time is {0} seconds.\n"
-                            + "=============================================================================\n",
+                        this.logger.LogCritical(Environment.NewLine
+                            + "============================== W A R N I N G ! ==============================" + Environment.NewLine
+                            + "Your system time is very different from the time of other network nodes." + Environment.NewLine
+                            + "It differs from the network median time by {0} seconds." + Environment.NewLine
+                            + "To prevent problems, adjust your system time or check the -synctime command line argument," + Environment.NewLine
+                            + "and restart the node." + Environment.NewLine
+                            + "=============================================================================" + Environment.NewLine,
                               timeOffsetSeconds);
                     }
                 }
                 else
                 {
-                    this.logger.LogCritical("\n"
-                        + "============================== W A R N I N G ! ==============================\n"
-                        + "Your system time is VERY different than the time of other network nodes.\n"
-                        + "Your time difference to the network median time is over the allowed maximum of {0} seconds.\n"
-                        + "The time syncing feature has been as it is no longer considered safe.\n"
-                        + "It is likely that you will now reject new blocks or be unable to mine new block.\n"
-                        + "You need to adjust your system time or check -synctime command line argument.\n"
-                        + "=============================================================================\n",
+                    this.logger.LogCritical(Environment.NewLine
+                        + "============================== W A R N I N G ! ==============================" + Environment.NewLine
+                        + "Your system time is very different from the time of other network nodes." + Environment.NewLine
+                        + "Your time difference to the network median time is over the allowed maximum of {0} seconds." + Environment.NewLine
+                        + "The time syncing feature has been switched off as it is no longer considered safe." + Environment.NewLine
+                        + "It is likely that you will now reject new blocks or be unable to mine new blocks." + Environment.NewLine
+                        + "You need to adjust your system time or check the -synctime command line argument," + Environment.NewLine
+                        + "and restart the node." + Environment.NewLine
+                        + "=============================================================================" + Environment.NewLine,
                           MaxTimeOffsetSeconds);
                 }
 

--- a/src/Stratis.Bitcoin/Base/TimeSyncBehavior.cs
+++ b/src/Stratis.Bitcoin/Base/TimeSyncBehavior.cs
@@ -166,9 +166,9 @@ namespace Stratis.Bitcoin.Base
         /// <summary>Periodically shows a console warning to inform the user that the system time needs adjustment,
         /// otherwise the node may not perform correctly on the network.</summary>
         private IAsyncLoop warningLoop;
-
-        /// <summary> A value indicating whether the system time is not in sync and needs adjustment. </summary>
-        private bool isSystemTimeOutOfSync;
+        
+        /// <inheritdoc/>
+        public bool IsSystemTimeOutOfSync { get; private set; }
 
         /// <summary>
         /// Initializes a new instance of the object.
@@ -228,11 +228,11 @@ namespace Stratis.Bitcoin.Base
 
                         // If SwitchedOffLimitReached is set, timeOffset is set to zero,
                         // so we need to check both conditions here.
-                        if (!this.isSystemTimeOutOfSync
+                        if (!this.IsSystemTimeOutOfSync
                             && ((Math.Abs(this.timeOffset.TotalSeconds) > TimeOffsetWarningThresholdSeconds) || this.SwitchedOffLimitReached))
                         {
                             startWarningLoopNow = true;
-                            this.isSystemTimeOutOfSync = true;
+                            this.IsSystemTimeOutOfSync = true;
                         }
 
                         res = true;
@@ -249,9 +249,6 @@ namespace Stratis.Bitcoin.Base
             return res;
         }
         
-        /// <inheritdoc/>
-        public bool IsSystemTimeOutOfSync => this.isSystemTimeOutOfSync;
-
         /// <summary>
         /// Calculates a new value for <see cref="timeOffset"/> based on existing samples.
         /// </summary>

--- a/src/Stratis.Bitcoin/Base/TimeSyncBehavior.cs
+++ b/src/Stratis.Bitcoin/Base/TimeSyncBehavior.cs
@@ -27,6 +27,12 @@ namespace Stratis.Bitcoin.Base
         /// <c>false</c> if the sample comes from a peer that our node connected to.</param>
         /// <returns><c>true</c> if the sample was added to the mix, <c>false</c> otherwise.</returns>
         bool AddTimeData(IPAddress peerAddress, TimeSpan offsetSample, bool isInboundConnection);
+
+        /// <summary>
+        /// Gets a value indicating whether the system time is not in sync and needs adjustment.
+        /// </summary>
+        /// <returns><true/> if the system time is not in sync and needs adjustment, <c>false</c> otherwise.</returns>
+        bool IsSystemTimeOutOfSync();
     }
 
     /// <summary>
@@ -167,6 +173,9 @@ namespace Stratis.Bitcoin.Base
         /// otherwise the node may not perform correctly on the network.</summary>
         private IAsyncLoop warningLoop;
 
+        /// <summary> A value indicating whether the system time is not in sync and needs adjustment. </summary>
+        private bool isSystemTimeOutOfSync;
+
         /// <summary>
         /// Initializes a new instance of the object.
         /// </summary>
@@ -233,6 +242,7 @@ namespace Stratis.Bitcoin.Base
                         {
                             startWarningLoopNow = true;
                             this.WarningLoopStarted = true;
+                            this.isSystemTimeOutOfSync = true;
                         }
 
                         res = true;
@@ -247,6 +257,12 @@ namespace Stratis.Bitcoin.Base
 
             this.logger.LogTrace("(-):{0}", res);
             return res;
+        }
+
+        /// <inheritdoc/>
+        public bool IsSystemTimeOutOfSync()
+        {
+            return this.isSystemTimeOutOfSync;
         }
 
         /// <summary>


### PR DESCRIPTION
* Better warning messages when system time out of sync
* Added method to explicitly states that system time is out of sync
* Prevent staking if system time is out of sync.
  Show errors in API, RPC staking calls as well as when starting the node with -stake=true

For https://github.com/stratisproject/StratisBitcoinFullNode/issues/1097