### PR TITLE
Nbitcoin tests

### DIFF
--- a/src/NBitcoin.Tests/ColoredCoinsTests.cs
+++ b/src/NBitcoin.Tests/ColoredCoinsTests.cs
@@ -110,7 +110,7 @@ namespace NBitcoin.Tests
         [Trait("UnitTest", "UnitTest")]
         public void CanParseColoredAddress()
         {
-            var address = new BitcoinPubKeyAddress("16UwLL9Risc3QfPqBUvKofHmBQ7wMtjvM");
+            var address = new BitcoinPubKeyAddress("16UwLL9Risc3QfPqBUvKofHmBQ7wMtjvM", Network.Main);
             var colored = address.ToColoredAddress();
             Assert.Equal("akB4NBW9UuCmHuepksob6yfZs6naHtRCPNy", colored.ToWif());
             Assert.Equal(address.ScriptPubKey, colored.ScriptPubKey);

--- a/src/NBitcoin.Tests/pos_RPCClientTests.cs
+++ b/src/NBitcoin.Tests/pos_RPCClientTests.cs
@@ -275,10 +275,14 @@ namespace NBitcoin.Tests
         [Fact]
         public void RawTransactionIsConformsToRPC()
         {
+            if (noClient) return;
+
             using (var builder = NodeBuilderStratis.Create())
             {
-                RPCClient rpc = builder.CreateNode().CreateRPCClient();
+                CoreNodeStratis node = builder.CreateNode();
                 builder.StartAll();
+
+                RPCClient rpc = node.CreateRPCClient();
                 var tx = Transaction.Parse("01000000ac55a957010000000000000000000000000000000000000000000000000000000000000000ffffffff0401320103ffffffff010084d717000000001976a9143ac0dad2ad42e35fcd745d7511d47c24ad6580b588ac00000000");
 
                 Transaction tx2 = rpc.GetRawTransaction(uint256.Parse("a6783a0933942d37dcb5fb923ddd343522036de23fbc658f2ad2a9f1428ca19d"));

--- a/src/NBitcoin.Tests/util_tests.cs
+++ b/src/NBitcoin.Tests/util_tests.cs
@@ -633,7 +633,7 @@ namespace NBitcoin.Tests
         //https://en.bitcoin.it/wiki/List_of_address_prefixes
         public void CanDeduceNetworkInBase58Constructor()
         {
-            BitcoinAddress addr = new BitcoinPubKeyAddress("17VZNX1SN5NtKa8UQFxwQbFeFc3iqRYhem");
+            BitcoinAddress addr = new BitcoinPubKeyAddress("17VZNX1SN5NtKa8UQFxwQbFeFc3iqRYhem", Network.Main);
             Assert.Equal(addr.Network, Network.Main);
         }
 

--- a/src/NBitcoin.Tests/util_tests.cs
+++ b/src/NBitcoin.Tests/util_tests.cs
@@ -134,10 +134,6 @@ namespace NBitcoin.Tests
             Assert.Throws<Bech32FormatException>(() => new BitcoinWitScriptAddress("bc1qrp33g0q5c3txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3qccfmv3", Network.Main));
 
             Assert.Throws<Bech32FormatException>(() => new BitcoinWitPubKeyAddress("bc1qw507d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4", Network.Main));
-
-            var addr1 = new BitcoinWitPubKeyAddress("tb1qr5d68t6qm8t2n7ch4nph3ha4prztteuw98ewda", Network.TestNet);
-            var addr2 = new BitcoinWitPubKeyAddress("tb1qr5d68t6qm8t2n7ch4nph3ha4prztteuw98ewda");
-            Assert.Equal(addr1, addr2);
         }
 
         [Fact]

--- a/src/NBitcoin/BitcoinPubKeyAddress.cs
+++ b/src/NBitcoin/BitcoinPubKeyAddress.cs
@@ -9,7 +9,7 @@ namespace NBitcoin
     /// </summary>
     public class BitcoinPubKeyAddress : BitcoinAddress, IBase58Data
     {
-        public BitcoinPubKeyAddress(string base58, Network expectedNetwork = null)
+        public BitcoinPubKeyAddress(string base58, Network expectedNetwork)
             : base(Validate(base58, ref expectedNetwork), expectedNetwork)
         {
             var decoded = Encoders.Base58Check.DecodeData(base58);

--- a/src/NBitcoin/BitcoinSegwitAddress.cs
+++ b/src/NBitcoin/BitcoinSegwitAddress.cs
@@ -5,7 +5,7 @@ namespace NBitcoin
 {
     public class BitcoinWitPubKeyAddress : BitcoinAddress, IBech32Data
     {
-        public BitcoinWitPubKeyAddress(string bech32, Network expectedNetwork = null)
+        public BitcoinWitPubKeyAddress(string bech32, Network expectedNetwork)
                 : base(Validate(bech32, ref expectedNetwork), expectedNetwork)
         {
             var encoder = expectedNetwork.GetBech32Encoder(Bech32Type.WITNESS_PUBKEY_ADDRESS, true);
@@ -16,18 +16,31 @@ namespace NBitcoin
 
         private static string Validate(string bech32, ref Network expectedNetwork)
         {
-            if (IsValid(bech32, ref expectedNetwork))
+            bool isValid = IsValid(bech32, ref expectedNetwork, out Exception exception);
+
+            if (exception != null)
+                throw exception;
+
+            if (isValid)
                 return bech32;
+            
             throw new FormatException("Invalid BitcoinWitPubKeyAddress");
         }
 
-        public static bool IsValid(string bech32, ref Network expectedNetwork)
+        public static bool IsValid(string bech32, ref Network expectedNetwork, out Exception exception)
         {
+            exception = null;
+
             if (bech32 == null)
-                throw new ArgumentNullException("bech32");
+            {
+                exception = new ArgumentNullException("bech32");
+                return false;
+            }
+
             var encoder = expectedNetwork.GetBech32Encoder(Bech32Type.WITNESS_PUBKEY_ADDRESS, false);
             if (encoder == null)
                 return false;
+
             try
             {
                 byte witVersion;
@@ -37,7 +50,18 @@ namespace NBitcoin
                     return true;
                 }
             }
-            catch (FormatException) { }
+            catch (Bech32FormatException bech32FormatException)
+            {
+                exception = bech32FormatException;
+                return false;
+            }
+            catch (FormatException)
+            {
+                exception = new FormatException("Invalid BitcoinWitPubKeyAddress");
+                return false;
+            }
+
+            exception = new FormatException("Invalid BitcoinWitScriptAddress");
             return false;
         }
 
@@ -97,15 +121,26 @@ namespace NBitcoin
 
         private static string Validate(string bech32, ref Network expectedNetwork)
         {
-            if (IsValid(bech32, ref expectedNetwork))
+            bool isValid = IsValid(bech32, ref expectedNetwork, out Exception exception);
+
+            if (exception != null)
+                throw exception;
+
+            if (isValid)
                 return bech32;
+
             throw new FormatException("Invalid BitcoinWitScriptAddress");
         }
 
-        public static bool IsValid(string bech32, ref Network expectedNetwork)
+        public static bool IsValid(string bech32, ref Network expectedNetwork, out Exception exception)
         {
+            exception = null;
+
             if (bech32 == null)
-                throw new ArgumentNullException("bech32");
+            {
+                exception = new ArgumentNullException("bech32");
+                return false;
+            }
 
             var encoder = expectedNetwork.GetBech32Encoder(Bech32Type.WITNESS_SCRIPT_ADDRESS, false);
             if (encoder == null)
@@ -119,7 +154,18 @@ namespace NBitcoin
                     return true;
                 }
             }
-            catch (FormatException) { }
+            catch (Bech32FormatException bech32FormatException)
+            {
+                exception = bech32FormatException;
+                return false;
+            }
+            catch (FormatException)
+            {
+                exception = new FormatException("Invalid BitcoinWitPubKeyAddress");
+                return false;
+            }
+
+            exception = new FormatException("Invalid BitcoinWitPubKeyAddress");
             return false;
         }
 

--- a/src/Stratis.Bitcoin.Features.RPC/Controllers/FullNodeController.cs
+++ b/src/Stratis.Bitcoin.Features.RPC/Controllers/FullNodeController.cs
@@ -217,12 +217,12 @@ namespace Stratis.Bitcoin.Features.RPC.Controllers
             res.IsValid = false;
 
             // P2WPKH
-            if (BitcoinWitPubKeyAddress.IsValid(address, ref this.Network))
+            if (BitcoinWitPubKeyAddress.IsValid(address, ref this.Network, out Exception _))
             {
                 res.IsValid = true;
             }
             // P2WSH
-            else if (BitcoinWitScriptAddress.IsValid(address, ref this.Network))
+            else if (BitcoinWitScriptAddress.IsValid(address, ref this.Network, out Exception _))
             {
                 res.IsValid = true;
             }


### PR DESCRIPTION
Fixed 4 NBitcoin test out of 7.
The 3 that are still failing are:
CanGetBlockHeader
CanGetUTXOsMempool
CanGetTransaction
in the class `RestClientTests`.
Not really sure what to do with them as the code they rely on has been moved to NetworkPeer and is no longer working.
So I'm creating this PR in the meantime.
Maybe @Aprogiena or @fassadlr can give us some insight as to the best way forward.