### PR TITLE
Add PrintHelp method to Dns feature

### DIFF
--- a/src/Stratis.Bitcoin.Features.Dns/DnsFeature.cs
+++ b/src/Stratis.Bitcoin.Features.Dns/DnsFeature.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
+using NBitcoin;
 using Stratis.Bitcoin.Builder.Feature;
 using Stratis.Bitcoin.Configuration;
 using Stratis.Bitcoin.Utilities;
@@ -174,6 +175,15 @@ namespace Stratis.Bitcoin.Features.Dns
             }
 
             this.logger.LogTrace("(-)");
+        }
+
+        /// <summary>
+        /// Prints command-line help.
+        /// </summary>
+        /// <param name="network">The network to extract values from.</param>
+        public static void PrintHelp(Network network)
+        {
+            DnsSettings.PrintHelp(network);
         }
 
         /// <summary>

--- a/src/Stratis.Bitcoin.Features.Dns/DnsSettings.cs
+++ b/src/Stratis.Bitcoin.Features.Dns/DnsSettings.cs
@@ -90,9 +90,6 @@ namespace Stratis.Bitcoin.Features.Dns
 
             this.callback?.Invoke(this);
 
-            if (string.IsNullOrWhiteSpace(this.DnsHostName) || string.IsNullOrWhiteSpace(this.DnsNameServer) || string.IsNullOrWhiteSpace(this.DnsMailBox))
-                throw new ConfigurationException("When running as a DNS Seed service, the -dnshostname, -dnsnameserver and -dnsmailbox arguments must be specified on the command line.");
-
             logger.LogTrace("(-)");
 
             return this;

--- a/src/Stratis.Bitcoin.Features.Dns/DnsSettings.cs
+++ b/src/Stratis.Bitcoin.Features.Dns/DnsSettings.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Text;
 using Microsoft.Extensions.Logging;
+using NBitcoin;
 using Stratis.Bitcoin.Configuration;
 
 namespace Stratis.Bitcoin.Features.Dns
@@ -88,9 +90,28 @@ namespace Stratis.Bitcoin.Features.Dns
 
             this.callback?.Invoke(this);
 
+            if (string.IsNullOrWhiteSpace(this.DnsHostName) || string.IsNullOrWhiteSpace(this.DnsNameServer) || string.IsNullOrWhiteSpace(this.DnsMailBox))
+                throw new ConfigurationException("When running as a DNS Seed service, the -dnshostname, -dnsnameserver and -dnsmailbox arguments must be specified on the command line.");
+
             logger.LogTrace("(-)");
 
             return this;
+        }
+
+        /// <summary>Prints the help information on how to configure the DNS settings to the logger.</summary>
+        /// <param name="network">The network to use.</param>
+        public static void PrintHelp(Network network)
+        {
+            var builder = new StringBuilder();
+
+            builder.AppendLine($"-dnslistenport=<0-65535>  The DNS listen port. Defaults to '{ DefaultDnsListenPort }'.");
+            builder.AppendLine($"-dnsfullnode=<0 or 1>     Enables running the DNS Seed service as a full node.");
+            builder.AppendLine($"-dnspeerblacklistthresholdinseconds=<seconds>  The number of seconds since a peer last connected before being blacklisted from the DNS nodes. Default: {DefaultDnsPeerBlacklistThresholdInSeconds }.");
+            builder.AppendLine($"-dnshostname=<string>     The host name for the node when running as a DNS Seed service.");
+            builder.AppendLine($"-dnsnameserver=<string>   The DNS Seed Service nameserver.");
+            builder.AppendLine($"-dnsmailbox=<string>      The e-mail address used as the administrative point of contact for the domain.");
+
+            NodeSettings.Default().Logger.LogInformation(builder.ToString());
         }
     }
 }

--- a/src/Stratis.Bitcoin/Builder/FullNodeFeatureExecutor.cs
+++ b/src/Stratis.Bitcoin/Builder/FullNodeFeatureExecutor.cs
@@ -54,25 +54,7 @@ namespace Stratis.Bitcoin.Builder
             try
             {
                 this.Execute(service => service.ValidateDependencies(this.node.Services));
-            }
-            catch (Exception ex)
-            {
-                this.logger.LogError("An error occurred starting the application: {0}", ex);
-                throw;
-            }
-
-            try
-            {
                 this.Execute(service => service.LoadConfiguration());
-            }
-            catch (Exception ex)
-            {
-                // Suppress over-reporting (stack traces etc.) of configuration errors
-                throw;
-            }
-
-            try
-            {
                 this.Execute(service => service.Initialize());
             }
             catch (Exception ex)

--- a/src/Stratis.Bitcoin/Builder/FullNodeFeatureExecutor.cs
+++ b/src/Stratis.Bitcoin/Builder/FullNodeFeatureExecutor.cs
@@ -54,7 +54,25 @@ namespace Stratis.Bitcoin.Builder
             try
             {
                 this.Execute(service => service.ValidateDependencies(this.node.Services));
+            }
+            catch (Exception ex)
+            {
+                this.logger.LogError("An error occurred starting the application: {0}", ex);
+                throw;
+            }
+
+            try
+            {
                 this.Execute(service => service.LoadConfiguration());
+            }
+            catch (Exception ex)
+            {
+                // Suppress over-reporting (stack traces etc.) of configuration errors
+                throw;
+            }
+
+            try
+            {
                 this.Execute(service => service.Initialize());
             }
             catch (Exception ex)

--- a/src/Stratis.StratisDnsD/Program.cs
+++ b/src/Stratis.StratisDnsD/Program.cs
@@ -42,17 +42,10 @@ namespace Stratis.StratisDnsD
             try
             {
                 Network network = args.Contains("-testnet") ? Network.StratisTest : Network.StratisMain;
-                NodeSettings nodeSettings = new NodeSettings(network, ProtocolVersion.ALT_PROTOCOL_VERSION, args:args);
-                DnsSettings dnsSettings = new DnsSettings().Load(nodeSettings);
-
-                // Verify that the DNS host, nameserver and mailbox arguments are set.
-                if (string.IsNullOrWhiteSpace(dnsSettings.DnsHostName) || string.IsNullOrWhiteSpace(dnsSettings.DnsNameServer) || string.IsNullOrWhiteSpace(dnsSettings.DnsMailBox))
-                {
-                    throw new ArgumentException("When running as a DNS Seed service, the -dnshostname, -dnsnameserver and -dnsmailbox arguments must be specified on the command line.");
-                }
+                NodeSettings nodeSettings = new NodeSettings(network, ProtocolVersion.ALT_PROTOCOL_VERSION, args:args, loadConfiguration:false);
 
                 // Run as a full node with DNS or just a DNS service?
-                if (dnsSettings.DnsFullNode)
+                if (args.Contains("-dnsfullnode"))
                 {
                     // Build the Dns full node.
                     IFullNode node = new FullNodeBuilder()


### PR DESCRIPTION
This PR adds a PrintHelp method to the Dns feature to print command-line help for the Dns feature when required.