### PR TITLE
Add PrintHelp method to Consensus feature

### DIFF
--- a/src/Stratis.Bitcoin.Features.Consensus/ConsensusFeature.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/ConsensusFeature.cs
@@ -138,6 +138,15 @@ namespace Stratis.Bitcoin.Features.Consensus
             this.consensusRules.Register(this.ruleRegistration);
         }
 
+        /// <summary>
+        /// Prints command-line help.
+        /// </summary>
+        /// <param name="network">The network to extract values from.</param>
+        public static void PrintHelp(Network network)
+        {
+            ConsensusSettings.PrintHelp(network);
+        }
+
         /// <inheritdoc />
         public override void Dispose()
         {

--- a/src/Stratis.Bitcoin.Features.Consensus/ConsensusSettings.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/ConsensusSettings.cs
@@ -1,4 +1,5 @@
 ﻿using System.Linq;
+using System.Text;
 using Microsoft.Extensions.Logging;
 using NBitcoin;
 using Stratis.Bitcoin.Configuration;
@@ -51,6 +52,18 @@ namespace Stratis.Bitcoin.Features.Consensus
             logger.LogDebug("Assume valid block is '{0}'.", this.BlockAssumedValid == null ? "disabled" : this.BlockAssumedValid.ToString());
 
             return this;
+        }
+
+        /// <summary>Prints the help information on how to configure the Consensus settings to the logger.</summary>
+        /// <param name="network">The network to use.</param>
+        public static void PrintHelp(Network network)
+        {
+            var builder = new StringBuilder();
+
+            builder.AppendLine($"-checkpoints=<0 or 1>     Use checkpoints. Default 1.");
+            builder.AppendLine($"-assumevalid=<hex>        If this block is in the chain assume that it and its ancestors are valid and potentially skip their script verification (0 to verify all). Defaults to { network.Consensus.DefaultAssumeValid }.");
+
+            NodeSettings.Default().Logger.LogInformation(builder.ToString());
         }
     }
 }

--- a/src/Stratis.Bitcoin/Configuration/NodeSettings.cs
+++ b/src/Stratis.Bitcoin/Configuration/NodeSettings.cs
@@ -394,12 +394,10 @@ namespace Stratis.Bitcoin.Configuration
             builder.AppendLine($"-whitebind=<ip:port>      Bind to given address and whitelist peers connecting to it. Use [host]:port notation for IPv6. Can be specified multiple times.");
             builder.AppendLine($"-externalip=<ip>          Specify your own public address.");
             builder.AppendLine($"-synctime=<0 or 1>        Sync with peers. Default 1.");
-            builder.AppendLine($"-checkpoints=<0 or 1>     Use checkpoints. Default 1.");
             builder.AppendLine($"-mintxfee=<number>        Minimum fee rate. Defaults to network specific value.");
             builder.AppendLine($"-fallbackfee=<number>     Fallback fee rate. Defaults to network specific value.");
             builder.AppendLine($"-minrelaytxfee=<number>   Minimum relay fee rate. Defaults to network specific value.");
             builder.AppendLine($"-bantime=<number>         Number of seconds to keep misbehaving peers from reconnecting (Default 24-hour ban).");
-            builder.AppendLine($"-assumevalid=<hex>        If this block is in the chain assume that it and its ancestors are valid and potentially skip their script verification(0 to verify all). Defaults to network specific value.");
 
             defaults.Logger.LogInformation(builder.ToString());
         }


### PR DESCRIPTION
This PR adds a PrintHelp method to the Consensus feature to display command-line help for the Consensus feature when required.