### PR TITLE
Fix for wrong height reward calculation

### DIFF
--- a/src/Stratis.Bitcoin.Features.Miner/PosMinting.cs
+++ b/src/Stratis.Bitcoin.Features.Miner/PosMinting.cs
@@ -783,8 +783,8 @@ namespace Stratis.Bitcoin.Features.Miner
             }
 
             this.logger.LogTrace("Worker #{0} found the kernel.", workersResult.KernelFoundIndex);
-			//Get reward for newly created block
-            long reward = fees + this.posConsensusValidator.GetProofOfStakeReward(chainTip.Height+1);
+	        //Get reward for newly created block
+	        long reward = fees + this.posConsensusValidator.GetProofOfStakeReward(chainTip.Height+1);
             if (reward <= 0)
             {
                 // TODO: This can't happen unless we remove reward for mined block.

--- a/src/Stratis.Bitcoin.Features.Miner/PosMinting.cs
+++ b/src/Stratis.Bitcoin.Features.Miner/PosMinting.cs
@@ -784,7 +784,7 @@ namespace Stratis.Bitcoin.Features.Miner
 
             this.logger.LogTrace("Worker #{0} found the kernel.", workersResult.KernelFoundIndex);
             // Get reward for newly created block.
-            long reward = fees + this.posConsensusValidator.GetProofOfStakeReward(chainTip.Height+1);
+            long reward = fees + this.posConsensusValidator.GetProofOfStakeReward(chainTip.Height + 1);
             if (reward <= 0)
             {
                 // TODO: This can't happen unless we remove reward for mined block.

--- a/src/Stratis.Bitcoin.Features.Miner/PosMinting.cs
+++ b/src/Stratis.Bitcoin.Features.Miner/PosMinting.cs
@@ -783,8 +783,8 @@ namespace Stratis.Bitcoin.Features.Miner
             }
 
             this.logger.LogTrace("Worker #{0} found the kernel.", workersResult.KernelFoundIndex);
-	        //Get reward for newly created block
-	        long reward = fees + this.posConsensusValidator.GetProofOfStakeReward(chainTip.Height+1);
+            // Get reward for newly created block.
+            long reward = fees + this.posConsensusValidator.GetProofOfStakeReward(chainTip.Height+1);
             if (reward <= 0)
             {
                 // TODO: This can't happen unless we remove reward for mined block.

--- a/src/Stratis.Bitcoin.Features.Miner/PosMinting.cs
+++ b/src/Stratis.Bitcoin.Features.Miner/PosMinting.cs
@@ -783,8 +783,8 @@ namespace Stratis.Bitcoin.Features.Miner
             }
 
             this.logger.LogTrace("Worker #{0} found the kernel.", workersResult.KernelFoundIndex);
-
-            long reward = fees + this.posConsensusValidator.GetProofOfStakeReward(chainTip.Height);
+			//Get reward for newly created block
+            long reward = fees + this.posConsensusValidator.GetProofOfStakeReward(chainTip.Height+1);
             if (reward <= 0)
             {
                 // TODO: This can't happen unless we remove reward for mined block.


### PR DESCRIPTION
Hi, it's my first commit to this repo, let me know if something wrong. This problem occurs when I'm tried to create a private PoW/PoS chain with different parameters.
Not sure if this is correct, but `PosMinting` calculate the reward for current blockchain height (let's say `N`), but when it validates reward in `PosConesnsusValidator` -> `CheckBlockReward` method - its uses newly created block height (`N+1`). As far as Stratis has a constant reward for PoS - 1 coin, it will work properly, but in case if reward depends on the block - it probably won't work