### PR TITLE
Wallet performance improvements numero uno

### DIFF
--- a/src/Stratis.Bitcoin.Features.Wallet.Tests/WalletManagerTest.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet.Tests/WalletManagerTest.cs
@@ -2304,6 +2304,8 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
         [Fact]
         public void RemoveBlocksRemovesTransactionsWithHigherBlockHeightAndUpdatesLastSyncedBlockHeight()
         {
+            var trxId = uint256.Parse("21e74d1daed6dec93d58396a3406803c5fc8d220b59f4b4dd185cab5f7a9a22e");
+            int trxCount = 0;
             var concurrentchain = new ConcurrentChain(Network.Main);
             var chainedBlock = WalletTestsHelpers.AppendBlock(null, concurrentchain).ChainedBlock;
             chainedBlock = WalletTestsHelpers.AppendBlock(chainedBlock, concurrentchain).ChainedBlock;
@@ -2320,15 +2322,21 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
             // reorg at block 3
 
             // Trx at block 0 is not spent
+            wallet.AccountsRoot.ElementAt(0).Accounts.ElementAt(0).ExternalAddresses.ElementAt(0).Transactions.First().Id = trxId >> trxCount++; ;
             wallet.AccountsRoot.ElementAt(0).Accounts.ElementAt(0).ExternalAddresses.ElementAt(0).Transactions.First().SpendingDetails = null;
+            wallet.AccountsRoot.ElementAt(0).Accounts.ElementAt(0).InternalAddresses.ElementAt(0).Transactions.First().Id = trxId >> trxCount++;
             wallet.AccountsRoot.ElementAt(0).Accounts.ElementAt(0).InternalAddresses.ElementAt(0).Transactions.First().SpendingDetails = null;
 
             // Trx at block 2 is spent in block 3, after reorg it will not be spendable.
+            wallet.AccountsRoot.ElementAt(0).Accounts.ElementAt(0).ExternalAddresses.ElementAt(1).Transactions.First().SpendingDetails.TransactionId = trxId >> trxCount++;
             wallet.AccountsRoot.ElementAt(0).Accounts.ElementAt(0).ExternalAddresses.ElementAt(1).Transactions.First().SpendingDetails.BlockHeight = 3;
+            wallet.AccountsRoot.ElementAt(0).Accounts.ElementAt(0).InternalAddresses.ElementAt(1).Transactions.First().SpendingDetails.TransactionId = trxId >> trxCount++;
             wallet.AccountsRoot.ElementAt(0).Accounts.ElementAt(0).InternalAddresses.ElementAt(1).Transactions.First().SpendingDetails.BlockHeight = 3;
 
             // Trx at block 3 is spent at block 5, after reorg it will be spendable.
+            wallet.AccountsRoot.ElementAt(0).Accounts.ElementAt(0).ExternalAddresses.ElementAt(2).Transactions.First().SpendingDetails.TransactionId = trxId >> trxCount++; ;
             wallet.AccountsRoot.ElementAt(0).Accounts.ElementAt(0).ExternalAddresses.ElementAt(2).Transactions.First().SpendingDetails.BlockHeight = 5;
+            wallet.AccountsRoot.ElementAt(0).Accounts.ElementAt(0).InternalAddresses.ElementAt(2).Transactions.First().SpendingDetails.TransactionId = trxId >> trxCount++; ;
             wallet.AccountsRoot.ElementAt(0).Accounts.ElementAt(0).InternalAddresses.ElementAt(2).Transactions.First().SpendingDetails.BlockHeight = 5;
 
             var walletManager = new WalletManager(this.LoggerFactory.Object, Network.Main, new Mock<ConcurrentChain>().Object, NodeSettings.Default(), new Mock<WalletSettings>().Object,

--- a/src/Stratis.Bitcoin.Features.Wallet.Tests/WalletManagerTest.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet.Tests/WalletManagerTest.cs
@@ -1577,7 +1577,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
             var walletManager = new WalletManager(this.LoggerFactory.Object, Network.Main, chainInfo.chain, NodeSettings.Default(), new Mock<WalletSettings>().Object,
                 dataFolder, walletFeePolicy.Object, new Mock<IAsyncLoopFactory>().Object, new NodeLifetime(), DateTimeProvider.Default);
             walletManager.Wallets.Add(wallet);
-
+            walletManager.LoadKeysLookupLock();
             walletManager.ProcessTransaction(transaction);
 
             var spentAddressResult = wallet.AccountsRoot.ElementAt(0).Accounts.ElementAt(0).ExternalAddresses.ElementAt(0);
@@ -1668,7 +1668,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
             var walletManager = new WalletManager(this.LoggerFactory.Object, Network.Main, chainInfo.chain, NodeSettings.Default(), new Mock<WalletSettings>().Object,
                 dataFolder, walletFeePolicy.Object, new Mock<IAsyncLoopFactory>().Object, new NodeLifetime(), DateTimeProvider.Default);
             walletManager.Wallets.Add(wallet);
-
+            walletManager.LoadKeysLookupLock();
             walletManager.ProcessTransaction(transaction);
 
             var spentAddressResult = wallet.AccountsRoot.ElementAt(0).Accounts.ElementAt(0).ExternalAddresses.ElementAt(0);
@@ -1752,6 +1752,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
             var walletManager = new WalletManager(this.LoggerFactory.Object, Network.Main, chainInfo.chain, NodeSettings.Default(), new Mock<WalletSettings>().Object,
                 dataFolder, walletFeePolicy.Object, new Mock<IAsyncLoopFactory>().Object, new NodeLifetime(), DateTimeProvider.Default);
             walletManager.Wallets.Add(wallet);
+            walletManager.LoadKeysLookupLock();
 
             walletManager.ProcessTransaction(transaction);
 
@@ -1843,6 +1844,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
             var walletManager = new WalletManager(this.LoggerFactory.Object, Network.Main, chainInfo.chain, NodeSettings.Default(), new Mock<WalletSettings>().Object,
                 dataFolder, walletFeePolicy.Object, new Mock<IAsyncLoopFactory>().Object, new NodeLifetime(), DateTimeProvider.Default);
             walletManager.Wallets.Add(wallet);
+            walletManager.LoadKeysLookupLock();
 
             var block = WalletTestsHelpers.AppendTransactionInNewBlockToChain(chainInfo.chain, transaction);
 
@@ -1938,6 +1940,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
             var walletManager = new WalletManager(this.LoggerFactory.Object, Network.Main, chainInfo.chain, NodeSettings.Default(), new Mock<WalletSettings>().Object,
                 dataFolder, walletFeePolicy.Object, new Mock<IAsyncLoopFactory>().Object, new NodeLifetime(), DateTimeProvider.Default);
             walletManager.Wallets.Add(wallet);
+            walletManager.LoadKeysLookupLock();
 
             var block = WalletTestsHelpers.AppendTransactionInNewBlockToChain(chainInfo.chain, transaction);
 
@@ -2331,7 +2334,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
             var walletManager = new WalletManager(this.LoggerFactory.Object, Network.Main, new Mock<ConcurrentChain>().Object, NodeSettings.Default(), new Mock<WalletSettings>().Object,
                 CreateDataFolder(this), new Mock<IWalletFeePolicy>().Object, new Mock<IAsyncLoopFactory>().Object, new NodeLifetime(), DateTimeProvider.Default);
             walletManager.Wallets.Add(wallet);
-
+            walletManager.LoadKeysLookupLock();
             walletManager.RemoveBlocks(chainedBlock);
 
             Assert.Equal(chainedBlock.GetLocator().Blocks, wallet.BlockLocator);
@@ -2430,7 +2433,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
             var walletManager = new WalletManager(this.LoggerFactory.Object, Network.Main, chainInfo.chain, NodeSettings.Default(), new Mock<WalletSettings>().Object,
                 dataFolder, walletFeePolicy.Object, new Mock<IAsyncLoopFactory>().Object, new NodeLifetime(), DateTimeProvider.Default);
             walletManager.Wallets.Add(wallet);
-
+            walletManager.LoadKeysLookupLock();
             walletManager.WalletTipHash = block.Header.GetHash();
 
             var chainedBlock = chainInfo.chain.GetBlock(block.GetHash());

--- a/src/Stratis.Bitcoin.Features.Wallet/Controllers/WalletController.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Controllers/WalletController.cs
@@ -869,8 +869,8 @@ namespace Stratis.Bitcoin.Features.Wallet.Controllers
                     wallet.SetLastBlockDetailsByCoinType(this.coinType, chainedBlock);
                     this.walletManager.SaveWallet(wallet);
 
-                    // Start the syncing process.
-                    this.walletSyncManager.SyncFromHeight(chainedBlock.Height);
+                    // Start the syncing process from the block before the earliest transaction was seen.
+                    this.walletSyncManager.SyncFromHeight(chainedBlock.Height - 1);
                 }
 
                 IEnumerable<RemovedTransactionModel> model = result.Select(r => new RemovedTransactionModel

--- a/src/Stratis.Bitcoin.Features.Wallet/Interfaces/IWalletManager.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Interfaces/IWalletManager.cs
@@ -157,7 +157,8 @@ namespace Stratis.Bitcoin.Features.Wallet.Interfaces
         /// <param name="blockHeight">The height of the block this transaction came from. Null if it was not a transaction included in a block.</param>
         /// <param name="block">The block in which this transaction was included.</param>
         /// <param name="isPropagated">Transaction propagation state.</param>
-        void ProcessTransaction(Transaction transaction, int? blockHeight = null, Block block = null, bool isPropagated = true);
+        /// <returns>A value indicating whether this transaction affects the wallet.</returns>
+        bool ProcessTransaction(Transaction transaction, int? blockHeight = null, Block block = null, bool isPropagated = true);
 
         /// <summary>
         /// Saves the wallet into the file system.

--- a/src/Stratis.Bitcoin.Features.Wallet/WalletManager.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/WalletManager.cs
@@ -796,8 +796,7 @@ namespace Stratis.Bitcoin.Features.Wallet
                 // Check the inputs - include those that have a reference to a transaction containing one of our scripts and the same index.
                 foreach (TxIn input in transaction.Inputs)
                 {
-                    this.outpointLookup.TryGetValue(input.PrevOut, out TransactionData tTx);
-                    if (tTx == null)
+                    if (!this.outpointLookup.TryGetValue(input.PrevOut, out TransactionData tTx))
                     {
                         continue;
                     }
@@ -1226,7 +1225,6 @@ namespace Stratis.Bitcoin.Features.Wallet
                         {
                             this.outpointLookup[new OutPoint(unspentTransaction.Id, unspentTransaction.Index)] = unspentTransaction;
                         }
-                        
                     }
                 }
             }

--- a/src/Stratis.Bitcoin.Features.Wallet/WalletManager.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/WalletManager.cs
@@ -164,13 +164,13 @@ namespace Stratis.Bitcoin.Features.Wallet
             foreach (Wallet wallet in wallets)
                 this.Wallets.Add(wallet);
 
-            // load data in memory for faster lookups
+            // Load data in memory for faster lookups.
             this.LoadKeysLookupLock();
 
-            // find the last chain block received by the wallet manager.
+            // Find the last chain block received by the wallet manager.
             this.WalletTipHash = this.LastReceivedBlockHash();
 
-            // save the wallets file every 5 minutes to help against crashes.
+            // Save the wallets file every 5 minutes to help against crashes.
             this.asyncLoop = this.asyncLoopFactory.Run("wallet persist job", token =>
             {
                 this.logger.LogTrace("()");
@@ -220,7 +220,7 @@ namespace Stratis.Bitcoin.Features.Wallet
                 : new Mnemonic(mnemonicList);
             ExtKey extendedKey = HdOperations.GetHdPrivateKey(mnemonic, passphrase);
 
-            // Create a wallet file .
+            // Create a wallet file.
             string encryptedSeed = extendedKey.PrivateKey.GetEncryptedBitcoinSecret(password, this.network).ToWif();
             Wallet wallet = this.GenerateWalletFile(name, encryptedSeed, extendedKey.ChainCode);
 
@@ -380,7 +380,7 @@ namespace Stratis.Bitcoin.Features.Wallet
                 account = wallet.AddNewAccount(password, this.coinType, this.dateTimeProvider.GetTimeOffset());
             }
 
-            // save the changes to the file
+            // Save the changes to the file.
             this.SaveWallet(wallet);
 
             this.logger.LogTrace("(-)");
@@ -468,10 +468,10 @@ namespace Stratis.Bitcoin.Features.Wallet
 
             lock (this.lockObject)
             {
-                // get address to send the change to
+                // Get an address to send the change to.
                 changeAddress = account.GetFirstUnusedChangeAddress();
 
-                // no more change addresses left. create a new one.
+                // No more change addresses left so create a new one.
                 if (changeAddress == null)
                 {
                     changeAddress = account.CreateAddresses(this.network, 1, isChange: true).Single();
@@ -733,8 +733,8 @@ namespace Stratis.Bitcoin.Features.Wallet
                     throw new WalletException("Reorg");
                 }
 
-                // The block coming in to the wallet should
-                // never be ahead of the wallet, if the block is behind let it pass.
+                // The block coming in to the wallet should never be ahead of the wallet. 
+                // If the block is behind, let it pass.
                 if (chainedBlock.Height > current.Height)
                 {
                     this.logger.LogTrace("(-)[BLOCK_TOO_FAR]");
@@ -851,7 +851,7 @@ namespace Stratis.Bitcoin.Features.Wallet
             uint256 transactionHash = transaction.GetHash();
 
             this.logger.LogTrace("({0}:'{1}',{2}:{3})", nameof(transaction), transactionHash, nameof(blockHeight), blockHeight);
-            
+
             // Get the collection of transactions to add to.
             Script script = utxo.ScriptPubKey;
             this.keysLookup.TryGetValue(script, out HdAddress address);
@@ -879,7 +879,7 @@ namespace Stratis.Bitcoin.Features.Wallet
                     IsPropagated = isPropagated
                 };
 
-                // add the Merkle proof to the (non-spending) transaction
+                // Add the Merkle proof to the (non-spending) transaction.
                 if (block != null)
                 {
                     newTransaction.MerkleProof = new MerkleBlock(block, new[] { transactionHash }).PartialMerkleTree;
@@ -976,7 +976,7 @@ namespace Stratis.Bitcoin.Features.Wallet
                         case TxOutType.TX_SEGWIT:
                             break;
                     }
-                   
+
                     payments.Add(new PaymentDetails
                     {
                         DestinationScriptPubKey = paidToOutput.ScriptPubKey,
@@ -1115,13 +1115,13 @@ namespace Stratis.Bitcoin.Features.Wallet
             Guard.NotNull(chainedBlock, nameof(chainedBlock));
             this.logger.LogTrace("({0}:'{1}',{2}:'{3}')", nameof(wallet), wallet.Name, nameof(chainedBlock), chainedBlock);
 
-            // the block locator will help when the wallet
-            // needs to rewind this will be used to find the fork
+            // The block locator will help when the wallet
+            // needs to rewind this will be used to find the fork.
             wallet.BlockLocator = chainedBlock.GetLocator().Blocks;
 
             lock (this.lockObject)
             {
-                // update the wallets with the last processed block height
+                // Update the wallets with the last processed block height.
                 foreach (AccountRoot accountRoot in wallet.AccountsRoot.Where(a => a.CoinType == this.coinType))
                 {
                     accountRoot.LastBlockSyncedHeight = chainedBlock.Height;
@@ -1174,7 +1174,7 @@ namespace Stratis.Bitcoin.Features.Wallet
                 AccountsRoot = new List<AccountRoot> { new AccountRoot() { Accounts = new List<HdAccount>(), CoinType = this.coinType } },
             };
 
-            // create a folder if none exists and persist the file
+            // Create a folder if none exists and persist the file.
             this.fileStorage.SaveToFile(walletFile, $"{name}.{WalletFileExtension}");
 
             this.logger.LogTrace("(-)");
@@ -1207,7 +1207,6 @@ namespace Stratis.Bitcoin.Features.Wallet
         {
             lock (this.lockObject)
             {
-                //var lookup = new Dictionary<Script, HdAddress>();
                 foreach (Wallet wallet in this.Wallets)
                 {
                     IEnumerable<HdAddress> addresses = wallet.GetAllAddressesByCoinType(this.coinType);
@@ -1309,7 +1308,7 @@ namespace Stratis.Bitcoin.Features.Wallet
                             if (!transaction.IsConfirmed() && idsToRemove.Contains(transaction.Id))
                             {
                                 result.Add((transaction.Id, transaction.CreationTime));
-                                address.Transactions = address.Transactions.Except(new[] {transaction}).ToList();
+                                address.Transactions = address.Transactions.Except(new[] { transaction }).ToList();
                                 i--;
                             }
 
@@ -1383,7 +1382,7 @@ namespace Stratis.Bitcoin.Features.Wallet
                 },
                 (ex) =>
                 {
-                    // in case of an exception while waiting for the chain to be at a certain height, we just cut our losses and
+                    // In case of an exception while waiting for the chain to be at a certain height, we just cut our losses and
                     // sync from the current height.
                     this.logger.LogError($"Exception occurred while waiting for chain to download: {ex.Message}");
 


### PR DESCRIPTION
- Improved performance of when and how the lookup dictionary for addresses is loaded
- Added look-up on unspent outputs
- Changed from saving the wallet after every change to saving the wallet when
 1. a transaction is received from the network
 2. a block is done being processed and had some transactions affecting the wallet within it

- no benchmarking was done but the gain in speed is noticeable.

Kudos to @noescape00 for creating blocks with crazy transactions.
For reference, take a look at these blocks on Stratis Testnet:
333235
333445
333449
333946
334042
334044
334046
334048
334051
334052
334055
334056
334081
334084
334088
334094
334100

@dangershony 