### PR TITLE
New Integration test - WalletCanSendOneTransactionWithManyOutputs

### DIFF
--- a/src/Stratis.Bitcoin.IntegrationTests/EnvironmentMockUpHelpers/CoreNode.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/EnvironmentMockUpHelpers/CoreNode.cs
@@ -515,6 +515,7 @@ namespace Stratis.Bitcoin.IntegrationTests.EnvironmentMockUpHelpers
             return this.FullNode.Services.ServiceProvider.GetService<IPowMining>().GenerateBlocks(new ReserveScript { ReserveFullNodeScript = this.MinerSecret.ScriptPubKey }, (ulong)blockCount, uint.MaxValue);
         }
 
+        [Obsolete("Please use GenerateStratisWithMiner instead.")]
         public Block[] GenerateStratis(int blockCount, List<Transaction> passedTransactions = null, bool broadcast = true)
         {
             var fullNode = (this.runner as StratisBitcoinPowRunner).FullNode;

--- a/src/Stratis.Bitcoin.IntegrationTests/WalletTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/WalletTests.cs
@@ -95,7 +95,7 @@ namespace Stratis.Bitcoin.IntegrationTests
         }
 
         [Fact]
-        public void WalletCanReceiveManyTransactionInputs()
+        public void WalletCanSendOneTransactionWithManyOutputs()
         { 
             using (NodeBuilder builder = NodeBuilder.Create())
             {
@@ -130,18 +130,12 @@ namespace Stratis.Bitcoin.IntegrationTests
                 IEnumerable<HdAddress> recevierAddresses = stratisReceiver.FullNode.WalletManager()
                     .GetUnusedAddresses(new WalletAccountReference("mywallet", "account 0"), 50);
 
-                var recipients = new List<Recipient>();
-
-                foreach (HdAddress address in recevierAddresses)
-                {
-                    var tx = new Transaction();
-                    tx.Outputs.Add(new TxOut(Money.COIN, address.ScriptPubKey));
-                    recipients.Add(new Recipient
+                List<Recipient> recipients = recevierAddresses.Select(address => new Recipient
                     {
                         ScriptPubKey = address.ScriptPubKey,
                         Amount = Money.COIN
-                    });
-                }
+                    })
+                    .ToList();
 
                 var transactionBuildContext = new TransactionBuildContext(
                     new WalletAccountReference("mywallet", "account 0"), recipients, "123456")

--- a/src/Stratis.Bitcoin.IntegrationTests/WalletTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/WalletTests.cs
@@ -128,6 +128,11 @@ namespace Stratis.Bitcoin.IntegrationTests
                 stratisSender.CreateRPCClient().AddNode(stratisReceiver.Endpoint, true);
                 TestHelper.WaitLoop(() => TestHelper.AreNodesSynced(stratisReceiver, stratisSender));
 
+                // Get 50 unused addresses from stratis stratisReceiver
+                // For each address send 1 coin
+                // Send transaction 
+                // Broadcast message
+
                 // send coins to the receiver
                 var sendto = stratisReceiver.FullNode.WalletManager().GetUnusedAddress(new WalletAccountReference("mywallet", "account 0"));
 

--- a/src/Stratis.Bitcoin.IntegrationTests/WalletTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/WalletTests.cs
@@ -93,6 +93,68 @@ namespace Stratis.Bitcoin.IntegrationTests
         }
 
         [Fact]
+        public void WalletCanReceiveManyInputs()
+        {
+            using (NodeBuilder builder = NodeBuilder.Create())
+            {
+                var stratisSender = builder.CreateStratisPowNode();
+                var stratisReceiver = builder.CreateStratisPowNode();
+
+                builder.StartAll();
+                stratisSender.NotInIBD();
+                stratisReceiver.NotInIBD();
+
+                stratisSender.FullNode.WalletManager().CreateWallet("123456", "mywallet");
+                stratisReceiver.FullNode.WalletManager().CreateWallet("123456", "mywallet");
+
+                var addr = stratisSender.FullNode.WalletManager().GetUnusedAddress(new WalletAccountReference("mywallet", "account 0"));
+                var wallet = stratisSender.FullNode.WalletManager().GetWalletByName("mywallet");
+                var key = wallet.GetExtendedPrivateKeyForAddress("123456", addr).PrivateKey;
+
+                stratisSender.SetDummyMinerSecret(new BitcoinSecret(key, stratisSender.FullNode.Network));
+                var maturity = (int)stratisSender.FullNode.Network.Consensus.Option<PowConsensusOptions>().CoinbaseMaturity;
+                stratisSender.GenerateStratis(maturity + 5);
+
+                // wait for block repo for block sync to work
+                TestHelper.WaitLoop(() => TestHelper.IsNodeSynced(stratisSender));
+
+                // the mining should add coins to the wallet
+                var total = stratisSender.FullNode.WalletManager().GetSpendableTransactionsInWallet("mywallet").Sum(s => s.Transaction.Amount);
+                Assert.Equal(Money.COIN * 105 * 50, total);
+
+                // sync both nodes
+                stratisSender.CreateRPCClient().AddNode(stratisReceiver.Endpoint, true);
+                TestHelper.WaitLoop(() => TestHelper.AreNodesSynced(stratisReceiver, stratisSender));
+
+                // send coins to the receiver
+                var sendto = stratisReceiver.FullNode.WalletManager().GetUnusedAddress(new WalletAccountReference("mywallet", "account 0"));
+                var trx = stratisSender.FullNode.WalletTransactionHandler().BuildTransaction(CreateContext(
+                    new WalletAccountReference("mywallet", "account 0"), "123456", sendto.ScriptPubKey, Money.COIN * 100, FeeType.Medium, 101));
+
+                // broadcast to the other node
+                stratisSender.FullNode.NodeService<WalletController>().SendTransaction(new SendTransactionRequest(trx.ToHex()));
+
+                // wait for the trx to arrive
+                TestHelper.WaitLoop(() => stratisReceiver.CreateRPCClient().GetRawMempool().Length > 0);
+                TestHelper.WaitLoop(() => stratisReceiver.FullNode.WalletManager().GetSpendableTransactionsInWallet("mywallet").Any());
+
+                var receivetotal = stratisReceiver.FullNode.WalletManager().GetSpendableTransactionsInWallet("mywallet").Sum(s => s.Transaction.Amount);
+                Assert.Equal(Money.COIN * 100, receivetotal);
+                Assert.Null(stratisReceiver.FullNode.WalletManager().GetSpendableTransactionsInWallet("mywallet").First().Transaction.BlockHeight);
+
+                // generate two new blocks do the trx is confirmed
+                stratisSender.GenerateStratis(1, new List<Transaction>(new[] { trx.Clone() }));
+                stratisSender.GenerateStratis(1);
+
+                // wait for block repo for block sync to work
+                TestHelper.WaitLoop(() => TestHelper.IsNodeSynced(stratisSender));
+                TestHelper.WaitLoop(() => TestHelper.AreNodesSynced(stratisReceiver, stratisSender));
+
+                TestHelper.WaitLoop(() => maturity + 6 == stratisReceiver.FullNode.WalletManager().GetSpendableTransactionsInWallet("mywallet").First().Transaction.BlockHeight);
+            }
+        }
+
+        [Fact]
         public void CanMineAndSendToAddress()
         {
             using (NodeBuilder builder = NodeBuilder.Create())

--- a/src/Stratis.Bitcoin.IntegrationTests/WalletTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/WalletTests.cs
@@ -115,7 +115,7 @@ namespace Stratis.Bitcoin.IntegrationTests
 
                 stratisSender.SetDummyMinerSecret(new BitcoinSecret(key, stratisSender.FullNode.Network));
                 int maturity = (int)stratisSender.FullNode.Network.Consensus.Option<PowConsensusOptions>().CoinbaseMaturity;
-                stratisSender.GenerateStratis(maturity + 51);
+                stratisSender.GenerateStratisWithMiner(maturity + 51);
 
                 // Wait for block repo for block sync to work.
                 TestHelper.WaitLoop(() => TestHelper.IsNodeSynced(stratisSender));

--- a/src/Stratis.Bitcoin.IntegrationTests/WalletTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/WalletTests.cs
@@ -145,6 +145,7 @@ namespace Stratis.Bitcoin.IntegrationTests
                     };
 
                 Transaction transaction = stratisSender.FullNode.WalletTransactionHandler().BuildTransaction(transactionBuildContext);
+                Assert.Equal(51, transaction.Outputs.Count);
 
                 // Broadcast to the other node.
                 stratisSender.FullNode.NodeService<WalletController>().SendTransaction(new SendTransactionRequest(transaction.ToHex()));
@@ -156,9 +157,8 @@ namespace Stratis.Bitcoin.IntegrationTests
                 Assert.Equal(Money.COIN * 50, stratisReceiver.FullNode.WalletManager().GetSpendableTransactionsInWallet("mywallet").Sum(s => s.Transaction.Amount));
                 Assert.Null(stratisReceiver.FullNode.WalletManager().GetSpendableTransactionsInWallet("mywallet").First().Transaction.BlockHeight);  
 
-                // Generate two new blocks do the trx is confirmed.
-                stratisSender.GenerateStratis(1, new List<Transaction> { transaction.Clone() });
-                stratisSender.GenerateStratis(1);
+                // Generate new blocks so the trx is confirmed.
+                stratisSender.GenerateStratisWithMiner(1);
 
                 // Wait for block repo for block sync to work.
                 TestHelper.WaitLoop(() => TestHelper.IsNodeSynced(stratisSender));


### PR DESCRIPTION
* Send one transaction from sender to receiver, with 50 transaction outputs.