### PR TITLE
Consensus project tests part 1

### DIFF
--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/CoinViews/BackendPerformanceCounterTest.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/CoinViews/BackendPerformanceCounterTest.cs
@@ -1,0 +1,102 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Stratis.Bitcoin.Features.Consensus.CoinViews;
+using Stratis.Bitcoin.Utilities;
+using Xunit;
+
+namespace Stratis.Bitcoin.Features.Consensus.Tests.CoinViews
+{
+    public class BackendPerformanceCounterTest
+    {
+        private BackendPerformanceCounter performanceCounter;
+
+        public BackendPerformanceCounterTest()
+        {
+            this.performanceCounter = new BackendPerformanceCounter(DateTimeProvider.Default);
+        }
+
+        [Fact]
+        public void Constructor_InitializesTimeAndCount()
+        {
+            Assert.Equal(0, this.performanceCounter.InsertedEntities);
+            Assert.Equal(0, this.performanceCounter.QueriedEntities);
+            Assert.Equal(TimeSpan.FromTicks(0), this.performanceCounter.InsertTime);
+            Assert.Equal(TimeSpan.FromTicks(0), this.performanceCounter.QueryTime);
+
+            Assert.Equal(DateTime.UtcNow.Date, this.performanceCounter.Start.Date);
+        }
+
+        [Fact]
+        public void AddInsertedEntities_WithGivenEmount_IncrementsInsertedEntities()
+        {
+            this.performanceCounter.AddInsertedEntities(15);
+
+            Assert.Equal(15, this.performanceCounter.InsertedEntities);
+            Assert.Equal(0, this.performanceCounter.QueriedEntities);
+            Assert.Equal(TimeSpan.FromTicks(0), this.performanceCounter.InsertTime);
+            Assert.Equal(TimeSpan.FromTicks(0), this.performanceCounter.QueryTime);
+        }
+
+        [Fact]
+        public void AddQueriedEntities_WithGivenEmount_IncrementsQueriedEntities()
+        {
+            this.performanceCounter.AddQueriedEntities(15);
+
+            Assert.Equal(0, this.performanceCounter.InsertedEntities);
+            Assert.Equal(15, this.performanceCounter.QueriedEntities);
+            Assert.Equal(TimeSpan.FromTicks(0), this.performanceCounter.InsertTime);
+            Assert.Equal(TimeSpan.FromTicks(0), this.performanceCounter.QueryTime);
+        }
+
+        [Fact]
+        public void AddInsertTime_WithGivenEmount_IncrementsInsertTime()
+        {
+            this.performanceCounter.AddInsertTime(15);
+
+            Assert.Equal(0, this.performanceCounter.InsertedEntities);
+            Assert.Equal(0, this.performanceCounter.QueriedEntities);
+            Assert.Equal(TimeSpan.FromTicks(15), this.performanceCounter.InsertTime);
+            Assert.Equal(TimeSpan.FromTicks(0), this.performanceCounter.QueryTime);
+        }
+
+        [Fact]
+        public void AddQueryTime_WithGivenEmount_IncrementsQueryTime()
+        {
+            this.performanceCounter.AddQueryTime(15);
+
+            Assert.Equal(0, this.performanceCounter.InsertedEntities);
+            Assert.Equal(0, this.performanceCounter.QueriedEntities);
+            Assert.Equal(TimeSpan.FromTicks(0), this.performanceCounter.InsertTime);
+            Assert.Equal(TimeSpan.FromTicks(15), this.performanceCounter.QueryTime);
+        }
+
+        [Fact]
+        public void Snapshot_CreatesSnapshotWithCurrentPerformanceCount()
+        {
+            this.performanceCounter.AddInsertedEntities(15);
+            this.performanceCounter.AddQueriedEntities(7);
+            this.performanceCounter.AddInsertTime(3);
+            this.performanceCounter.AddQueryTime(1);
+
+            var snapshot1 = this.performanceCounter.Snapshot();
+
+            this.performanceCounter.AddInsertedEntities(50);
+            this.performanceCounter.AddQueriedEntities(9);
+            this.performanceCounter.AddInsertTime(6);
+            this.performanceCounter.AddQueryTime(67);
+
+            var snapshot2 = this.performanceCounter.Snapshot();
+
+            Assert.Equal(15, snapshot1.TotalInsertedEntities);
+            Assert.Equal(7, snapshot1.TotalQueriedEntities);
+            Assert.Equal(TimeSpan.FromTicks(3), snapshot1.TotalInsertTime);
+            Assert.Equal(TimeSpan.FromTicks(1), snapshot1.TotalQueryTime);
+
+            Assert.Equal(65, snapshot2.TotalInsertedEntities);
+            Assert.Equal(16, snapshot2.TotalQueriedEntities);
+            Assert.Equal(TimeSpan.FromTicks(9), snapshot2.TotalInsertTime);
+            Assert.Equal(TimeSpan.FromTicks(68), snapshot2.TotalQueryTime);
+        }
+    }
+}

--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/CoinViews/CachePerformanceCounterTest.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/CoinViews/CachePerformanceCounterTest.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Stratis.Bitcoin.Features.Consensus.CoinViews;
+using Stratis.Bitcoin.Utilities;
+using Xunit;
+
+namespace Stratis.Bitcoin.Features.Consensus.Tests.CoinViews
+{
+    public class CachePerformanceCounterTest
+    {
+        private CachePerformanceCounter performanceCounter;
+
+        public CachePerformanceCounterTest()
+        {
+            this.performanceCounter = new CachePerformanceCounter(DateTimeProvider.Default);
+        }
+
+        [Fact]
+        public void Constructor_InitializesTimeAndCount()
+        {
+            Assert.Equal(0, this.performanceCounter.HitCount);
+            Assert.Equal(0, this.performanceCounter.MissCount);
+
+            Assert.Equal(DateTime.UtcNow.Date, this.performanceCounter.Start.Date);
+        }
+
+        [Fact]
+        public void AddHitCount_WithGivenEmount_IncrementsHitCount()
+        {
+            this.performanceCounter.AddHitCount(15);
+
+            Assert.Equal(15, this.performanceCounter.HitCount);
+            Assert.Equal(0, this.performanceCounter.MissCount);
+        }
+
+        [Fact]
+        public void AddMissCount_WithGivenEmount_IncrementsMissCount()
+        {
+            this.performanceCounter.AddMissCount(15);
+
+            Assert.Equal(0, this.performanceCounter.HitCount);
+            Assert.Equal(15, this.performanceCounter.MissCount);
+        }
+
+        [Fact]
+        public void Snapshot_CreatesSnapshotWithCurrentPerformanceCount()
+        {
+            this.performanceCounter.AddHitCount(15);
+            this.performanceCounter.AddMissCount(7);
+
+            var snapshot1 = this.performanceCounter.Snapshot();
+
+            this.performanceCounter.AddHitCount(50);
+            this.performanceCounter.AddMissCount(9);
+
+            var snapshot2 = this.performanceCounter.Snapshot();
+
+            Assert.Equal(15, snapshot1.TotalHitCount);
+            Assert.Equal(7, snapshot1.TotalMissCount);
+
+            Assert.Equal(65, snapshot2.TotalHitCount);
+            Assert.Equal(16, snapshot2.TotalMissCount);
+        }
+    }
+}

--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/CoinViews/CoinViewStackTest.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/CoinViews/CoinViewStackTest.cs
@@ -1,0 +1,193 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NBitcoin;
+using Stratis.Bitcoin.Features.Consensus.CoinViews;
+using Stratis.Bitcoin.Utilities;
+using Xunit;
+
+namespace Stratis.Bitcoin.Features.Consensus.Tests.CoinViews
+{
+    public class CoinViewStackTest
+    {
+        [Fact]
+        public void Constructor_CoinViewWithoutBackedCoinViews_SetsCoinViewAsTopAndBottom()
+        {
+            var coinView = new NonBackedCoinView();
+
+            var stack = new CoinViewStack(coinView);
+
+            Assert.True(stack.Top is NonBackedCoinView);
+            Assert.True(stack.Bottom is NonBackedCoinView);
+        }
+
+        [Fact]
+        public void Constructor_CoinViewWithBackedCoinViews_SetsTopAndBottom()
+        {
+            var nonBackedCoinView = new NonBackedCoinView();
+            var backedCoinView2 = new BackedCoinView2(nonBackedCoinView);
+            var backedCoinView1 = new BackedCoinView1(backedCoinView2);
+
+            var stack = new CoinViewStack(backedCoinView1);
+
+            Assert.True(stack.Top is BackedCoinView1);
+            Assert.True(stack.Bottom is NonBackedCoinView);
+        }
+
+        [Fact]
+        public void GetElements_CoinViewWithBackedCoinViews_ReturnsStack()
+        {
+            var nonBackedCoinView = new NonBackedCoinView();
+            var backedCoinView2 = new BackedCoinView2(nonBackedCoinView);
+            var backedCoinView1 = new BackedCoinView1(backedCoinView2);
+
+            var stack = new CoinViewStack(backedCoinView1);
+
+            var coinViews = stack.GetElements().ToList();
+
+            Assert.Equal(3, coinViews.Count);
+            Assert.True(coinViews[0] is BackedCoinView1);
+            Assert.True(coinViews[1] is BackedCoinView2);
+            Assert.True(coinViews[2] is NonBackedCoinView);
+        }
+
+        [Fact]
+        public void GetElements_NullCoinViewWithinStack_ReturnsNonNullCoinViews()
+        {
+            var backedCoinView2 = new BackedCoinView2(null);
+            var backedCoinView1 = new BackedCoinView1(backedCoinView2);
+
+            var stack = new CoinViewStack(backedCoinView1);
+
+            var coinViews = stack.GetElements().ToList();
+
+            Assert.Equal(2, coinViews.Count);
+            Assert.True(coinViews[0] is BackedCoinView1);
+            Assert.True(coinViews[1] is BackedCoinView2);
+        }
+
+        [Fact]
+        public void Find_CoinViewTop_ReturnsCoinView()
+        {
+            var nonBackedCoinView = new NonBackedCoinView();
+            var backedCoinView2 = new BackedCoinView2(nonBackedCoinView, 3);
+            var backedCoinView1 = new BackedCoinView1(backedCoinView2, 4);
+
+            var stack = new CoinViewStack(backedCoinView1);
+
+            var coinView = stack.Find<BackedCoinView1>();
+
+            Assert.True(coinView is BackedCoinView1);
+            Assert.Equal(4, coinView.OutputCount);
+        }
+
+        [Fact]
+        public void Find_CoinViewWithinStack_ReturnsCoinView()
+        {
+            var nonBackedCoinView = new NonBackedCoinView();
+            var backedCoinView2 = new BackedCoinView2(nonBackedCoinView, 3);
+            var backedCoinView1 = new BackedCoinView1(backedCoinView2, 4);
+
+            var stack = new CoinViewStack(backedCoinView1);
+
+            var coinView = stack.Find<BackedCoinView2>();
+
+            Assert.True(coinView is BackedCoinView2);
+            Assert.Equal(3, coinView.OutputCount);
+        }
+
+        [Fact]
+        public void Find_CoinViewNotFound_ReturnsNull()
+        {
+            var nonBackedCoinView = new NonBackedCoinView();
+
+            var stack = new CoinViewStack(nonBackedCoinView);
+
+            var coinView = stack.Find<BackedCoinView2>();
+
+            Assert.Null(coinView);
+        }
+
+        private class NonBackedCoinView : CoinView
+        {
+            public NonBackedCoinView() : base()
+            {
+            }
+
+            public override Task<FetchCoinsResponse> FetchCoinsAsync(uint256[] txIds)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override Task<uint256> Rewind()
+            {
+                throw new NotImplementedException();
+            }
+
+            public override Task SaveChangesAsync(IEnumerable<UnspentOutputs> unspentOutputs, IEnumerable<TxOut[]> originalOutputs, uint256 oldBlockHash, uint256 nextBlockHash)
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        private class BackedCoinView1 : CoinView, IBackedCoinView
+        {
+            private BackedCoinView2 inner;
+
+            public BackedCoinView1(BackedCoinView2 inner, int outputCount = 0) : base()
+            {
+                this.inner = inner;
+                this.OutputCount = outputCount;
+            }
+
+            public int OutputCount { get; }
+            public CoinView Inner => this.inner;
+
+            public override Task<FetchCoinsResponse> FetchCoinsAsync(uint256[] txIds)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override Task<uint256> Rewind()
+            {
+                throw new NotImplementedException();
+            }
+
+            public override Task SaveChangesAsync(IEnumerable<UnspentOutputs> unspentOutputs, IEnumerable<TxOut[]> originalOutputs, uint256 oldBlockHash, uint256 nextBlockHash)
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        private class BackedCoinView2 : CoinView, IBackedCoinView
+        {
+            private NonBackedCoinView inner;
+
+            public BackedCoinView2(NonBackedCoinView inner, int outputCount = 0) : base()
+            {
+                this.inner = inner;
+                this.OutputCount = outputCount;
+            }
+
+            public int OutputCount { get; }
+            public CoinView Inner => this.inner;
+
+            public override Task<FetchCoinsResponse> FetchCoinsAsync(uint256[] txIds)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override Task<uint256> Rewind()
+            {
+                throw new NotImplementedException();
+            }
+
+            public override Task SaveChangesAsync(IEnumerable<UnspentOutputs> unspentOutputs, IEnumerable<TxOut[]> originalOutputs, uint256 oldBlockHash, uint256 nextBlockHash)
+            {
+                throw new NotImplementedException();
+            }
+        }
+    }
+}

--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/CoinViews/CoinViewTest.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/CoinViews/CoinViewTest.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using NBitcoin;
+using Stratis.Bitcoin.Features.Consensus.CoinViews;
+using Stratis.Bitcoin.Utilities;
+using Xunit;
+
+namespace Stratis.Bitcoin.Features.Consensus.Tests.CoinViews
+{
+    public class CoinViewTest
+    {
+        private TestCoinView coinView;
+
+        public CoinViewTest()
+        {
+            this.coinView = new TestCoinView();
+        }
+
+        [Fact]
+        public async Task GetBlockHashAsync_ReturnsBlockHashFromFetchCoinsAsyncMethodAsync()
+        {
+            var result = await this.coinView.GetBlockHashAsync();
+
+            Assert.Equal(new uint256(987263876253), result);
+        }
+
+        private class TestCoinView : CoinView
+        {
+            public TestCoinView() : base()
+            {
+            }
+
+            public override Task<FetchCoinsResponse> FetchCoinsAsync(uint256[] txIds)
+            {
+                var fetchCoinResponse = new FetchCoinsResponse(new UnspentOutputs[0], new uint256(987263876253));
+                return Task.FromResult(fetchCoinResponse);
+            }
+
+            public override Task<uint256> Rewind()
+            {
+                throw new NotImplementedException();
+            }
+
+            public override Task SaveChangesAsync(IEnumerable<UnspentOutputs> unspentOutputs, IEnumerable<TxOut[]> originalOutputs, uint256 oldBlockHash, uint256 nextBlockHash)
+            {
+                throw new NotImplementedException();
+            }
+        }
+    }
+}

--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/CoinViews/FetchCoinsResponseTest.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/CoinViews/FetchCoinsResponseTest.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using NBitcoin;
+using Stratis.Bitcoin.Features.Consensus.CoinViews;
+using Stratis.Bitcoin.Utilities;
+using Xunit;
+
+namespace Stratis.Bitcoin.Features.Consensus.Tests.CoinViews
+{
+    public class FetchCoinsResponseTest
+    {
+        [Fact]
+        public void Constructor_InitializesClass()
+        {
+            var blockHash = new uint256(124);
+            var unspentOutputs = new UnspentOutputs[] {
+                new UnspentOutputs(1, new Transaction()),
+                new UnspentOutputs(2, new Transaction())
+            };
+
+            var fetchCoinsResponse = new FetchCoinsResponse(unspentOutputs, blockHash);
+
+            Assert.Equal(2, fetchCoinsResponse.UnspentOutputs.Length);
+            Assert.Equal((uint)1, fetchCoinsResponse.UnspentOutputs[0].Height);
+            Assert.Equal((uint)2, fetchCoinsResponse.UnspentOutputs[1].Height);
+            Assert.Equal(blockHash, fetchCoinsResponse.BlockHash);
+        }
+    }
+}

--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/ConsensusSettingsTest.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/ConsensusSettingsTest.cs
@@ -39,21 +39,29 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests
         [Fact]
         public void LoadConfigWithDefaultsSetsToNetworkDefault()
         {
-            Network network = Network.StratisMain;
-            ConsensusSettings settings = new ConsensusSettings().Load(NodeSettings.Default(network));
-            Assert.Equal(network.Consensus.DefaultAssumeValid, settings.BlockAssumedValid);
+            try
+            {
+                Network network = Network.StratisMain;
+                ConsensusSettings settings = new ConsensusSettings().Load(NodeSettings.Default(network));
+                Assert.Equal(network.Consensus.DefaultAssumeValid, settings.BlockAssumedValid);
 
-            network = Network.StratisTest;
-            settings = new ConsensusSettings().Load(NodeSettings.Default(network));
-            Assert.Equal(network.Consensus.DefaultAssumeValid, settings.BlockAssumedValid);
+                network = Network.StratisTest;
+                settings = new ConsensusSettings().Load(NodeSettings.Default(network));
+                Assert.Equal(network.Consensus.DefaultAssumeValid, settings.BlockAssumedValid);
 
-            network = Network.Main;
-            settings = new ConsensusSettings().Load(NodeSettings.Default(network));
-            Assert.Equal(network.Consensus.DefaultAssumeValid, settings.BlockAssumedValid);
+                network = Network.Main;
+                settings = new ConsensusSettings().Load(NodeSettings.Default(network));
+                Assert.Equal(network.Consensus.DefaultAssumeValid, settings.BlockAssumedValid);
 
-            network = Network.TestNet;
-            settings = new ConsensusSettings().Load(NodeSettings.Default(network));
-            Assert.Equal(network.Consensus.DefaultAssumeValid, settings.BlockAssumedValid);
+                network = Network.TestNet;
+                settings = new ConsensusSettings().Load(NodeSettings.Default(network));
+                Assert.Equal(network.Consensus.DefaultAssumeValid, settings.BlockAssumedValid);
+            }
+            finally
+            {
+                Block.BlockSignature = false;
+                Transaction.TimeStamp = false;
+            }
         }
     }
 }

--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/CommonRules/AssumeValidRuleTest.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/CommonRules/AssumeValidRuleTest.cs
@@ -1,0 +1,139 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using Stratis.Bitcoin.Features.Consensus.Rules.CommonRules;
+using Stratis.Bitcoin.Features.Wallet.Tests;
+using Xunit;
+
+namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
+{
+    public class AssumeValidRuleTest : ConsensusRuleUnitTestBase
+    {
+        public AssumeValidRuleTest() : base()
+        {
+        }
+
+        [Fact]
+        public void Initialize_CheckpointsRuleInConsensusRules_DoesNotThrowException()
+        {
+            this.consensusRules.RegisterRule<CheckpointsRule>();
+
+            this.consensusRules.RegisterRule<AssumeValidRule>();
+        }
+
+        [Fact]
+        public void Initialize_CheckpointsRuleNotInConsensusRules_ThrowExceptions()
+        {
+            Assert.Throws<Exception>(() =>
+            {
+                this.consensusRules.RegisterRule<AssumeValidRule>();
+            });
+        }
+
+        [Fact]
+        public void RunAsync_SkipValidation_ReturnsCompletedTask()
+        {
+            this.consensusRules.RegisterRule<CheckpointsRule>();
+
+            var rule = this.consensusRules.RegisterRule<AssumeValidRule>();
+
+            Assert.True(rule.RunAsync(new RuleContext() { SkipValidation = true }).GetAwaiter().IsCompleted);
+        }
+
+        [Fact]
+        public void RunAsync_DoNotSkipValidation_BlockAssumedValidNotSetOnConsensus_ReturnsCompletedTask()
+        {
+            this.consensusRules.ConsensusSettings.BlockAssumedValid = null;
+            this.consensusRules.RegisterRule<CheckpointsRule>();
+
+            var rule = this.consensusRules.RegisterRule<AssumeValidRule>();
+            var ruleContext = new RuleContext() { SkipValidation = false };
+
+            Assert.True(rule.RunAsync(ruleContext).GetAwaiter().IsCompleted);
+            Assert.False(ruleContext.SkipValidation);
+        }
+
+        [Fact]
+        public void RunAsync_DoNotSkipValidation_BlockAssumedValidSetOnConsensus_BlockNotOnChain_DoesNotSetSkipValidation()
+        {
+            this.consensusRules.ConsensusSettings.BlockAssumedValid = new NBitcoin.uint256(25);
+            this.consensusRules.RegisterRule<CheckpointsRule>();
+
+            var rule = this.consensusRules.RegisterRule<AssumeValidRule>();
+            var ruleContext = new RuleContext() { SkipValidation = false };
+
+            Assert.True(rule.RunAsync(ruleContext).GetAwaiter().IsCompleted);
+            Assert.False(ruleContext.SkipValidation);
+        }
+
+        [Fact]
+        public void RunAsync_DoNotSkipValidation_BlockAssumedValidSetOnConsensus_BlockLowerThanAssumedValidHeight_SetSkipValidation()
+        {
+            this.concurrentChain = WalletTestsHelpers.GenerateChainWithHeight(15, this.network);
+            this.consensusSettings.BlockAssumedValid = this.concurrentChain.GetBlock(10).HashBlock;
+
+            this.consensusRules = this.InitializeConsensusRules();
+            this.consensusRules.RegisterRule<CheckpointsRule>();
+
+            var rule = this.consensusRules.RegisterRule<AssumeValidRule>();
+            var ruleContext = new RuleContext()
+            {
+                SkipValidation = false,
+                BlockValidationContext = new BlockValidationContext()
+                {
+                    ChainedBlock = this.concurrentChain.GetBlock(5)
+                }
+            };
+
+            Assert.True(rule.RunAsync(ruleContext).GetAwaiter().IsCompleted);
+            Assert.True(ruleContext.SkipValidation);
+        }
+
+        [Fact]
+        public void RunAsync_DoNotSkipValidation_BlockAssumedValidSetOnConsensus_BlockEqualToThanAssumedValidHeight_SetSkipValidation()
+        {
+            this.concurrentChain = WalletTestsHelpers.GenerateChainWithHeight(15, this.network);
+            this.consensusSettings.BlockAssumedValid = this.concurrentChain.GetBlock(10).HashBlock;
+
+            this.consensusRules = this.InitializeConsensusRules();
+            this.consensusRules.RegisterRule<CheckpointsRule>();
+
+            var rule = this.consensusRules.RegisterRule<AssumeValidRule>();
+            var ruleContext = new RuleContext()
+            {
+                SkipValidation = false,
+                BlockValidationContext = new BlockValidationContext()
+                {
+                    ChainedBlock = this.concurrentChain.GetBlock(10)
+                }
+            };
+
+            Assert.True(rule.RunAsync(ruleContext).GetAwaiter().IsCompleted);
+            Assert.True(ruleContext.SkipValidation);
+        }
+
+        [Fact]
+        public void RunAsync_DoNotSkipValidation_BlockAssumedValidSetOnConsensus_BlockHigherThanAssumedValidHeight_DoesNotSetSkipValidation()
+        {
+            this.concurrentChain = WalletTestsHelpers.GenerateChainWithHeight(15, this.network);
+            this.consensusSettings.BlockAssumedValid = this.concurrentChain.GetBlock(3).HashBlock;
+
+            this.consensusRules = this.InitializeConsensusRules();
+            this.consensusRules.RegisterRule<CheckpointsRule>();
+
+            var rule = this.consensusRules.RegisterRule<AssumeValidRule>();
+            var ruleContext = new RuleContext()
+            {
+                SkipValidation = false,
+                BlockValidationContext = new BlockValidationContext()
+                {
+                    ChainedBlock = this.concurrentChain.GetBlock(10)
+                }
+            };
+
+            Assert.True(rule.RunAsync(ruleContext).GetAwaiter().IsCompleted);
+            Assert.False(ruleContext.SkipValidation);
+        }
+    }
+}

--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/CommonRules/AssumeValidRuleTest.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/CommonRules/AssumeValidRuleTest.cs
@@ -2,8 +2,8 @@
 using System.Collections.Generic;
 using System.Text;
 using System.Threading.Tasks;
+using NBitcoin;
 using Stratis.Bitcoin.Features.Consensus.Rules.CommonRules;
-using Stratis.Bitcoin.Features.Wallet.Tests;
 using Xunit;
 
 namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
@@ -70,7 +70,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
         [Fact]
         public void RunAsync_DoNotSkipValidation_BlockAssumedValidSetOnConsensus_BlockLowerThanAssumedValidHeight_SetSkipValidation()
         {
-            this.concurrentChain = WalletTestsHelpers.GenerateChainWithHeight(15, this.network);
+            this.concurrentChain = GenerateChainWithHeight(15, this.network);
             this.consensusSettings.BlockAssumedValid = this.concurrentChain.GetBlock(10).HashBlock;
 
             this.consensusRules = this.InitializeConsensusRules();
@@ -93,7 +93,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
         [Fact]
         public void RunAsync_DoNotSkipValidation_BlockAssumedValidSetOnConsensus_BlockEqualToThanAssumedValidHeight_SetSkipValidation()
         {
-            this.concurrentChain = WalletTestsHelpers.GenerateChainWithHeight(15, this.network);
+            this.concurrentChain = GenerateChainWithHeight(15, this.network);
             this.consensusSettings.BlockAssumedValid = this.concurrentChain.GetBlock(10).HashBlock;
 
             this.consensusRules = this.InitializeConsensusRules();
@@ -116,7 +116,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
         [Fact]
         public void RunAsync_DoNotSkipValidation_BlockAssumedValidSetOnConsensus_BlockHigherThanAssumedValidHeight_DoesNotSetSkipValidation()
         {
-            this.concurrentChain = WalletTestsHelpers.GenerateChainWithHeight(15, this.network);
+            this.concurrentChain = GenerateChainWithHeight(15, this.network);
             this.consensusSettings.BlockAssumedValid = this.concurrentChain.GetBlock(3).HashBlock;
 
             this.consensusRules = this.InitializeConsensusRules();
@@ -134,6 +134,26 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
 
             Assert.True(rule.RunAsync(ruleContext).GetAwaiter().IsCompleted);
             Assert.False(ruleContext.SkipValidation);
+        }
+
+        private static ConcurrentChain GenerateChainWithHeight(int blockAmount, Network network)
+        {
+            var chain = new ConcurrentChain(network);
+            var nonce = RandomUtils.GetUInt32();
+            var prevBlockHash = chain.Genesis.HashBlock;
+            for (var i = 0; i < blockAmount; i++)
+            {
+                var block = new Block();
+                block.AddTransaction(new Transaction());
+                block.UpdateMerkleRoot();
+                block.Header.BlockTime = new DateTimeOffset(new DateTime(2017, 1, 1, 0, 0, 0, DateTimeKind.Utc).AddDays(i));
+                block.Header.HashPrevBlock = prevBlockHash;
+                block.Header.Nonce = nonce;
+                chain.SetTip(block.Header);
+                prevBlockHash = block.GetHash();
+            }
+
+            return chain;
         }
     }
 }

--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/CommonRules/BlockHeaderPowContextualRuleTest.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/CommonRules/BlockHeaderPowContextualRuleTest.cs
@@ -4,7 +4,7 @@ using Stratis.Bitcoin.Features.Consensus.Rules.CommonRules;
 using Stratis.Bitcoin.Utilities;
 using Xunit;
 
-namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules
+namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
 {
     public class BlockHeaderPowContextualRuleTest
     {

--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/CommonRules/BlockHeaderRuleTest.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/CommonRules/BlockHeaderRuleTest.cs
@@ -3,7 +3,7 @@ using NBitcoin;
 using Stratis.Bitcoin.Features.Consensus.Rules.CommonRules;
 using Xunit;
 
-namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules
+namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
 {
     public class BlockHeaderRuleTest
     {

--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/ConsensusRuleDescriptorTest.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/ConsensusRuleDescriptorTest.cs
@@ -1,0 +1,118 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using Stratis.Bitcoin.Features.Consensus.Rules;
+using Xunit;
+
+namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules
+{
+    public class ConsensusRuleDescriptorTest
+    {
+        [Fact]
+        public void Constructor_ConsensusRuleWithValidationAttribute_InitializesClass()
+        {
+            var rule = new TestConsensusRuleWithValidationAttribute("myRule");
+
+            var descriptor = new ConsensusRuleDescriptor(rule);
+
+            Assert.True(descriptor.Rule is TestConsensusRuleWithValidationAttribute);
+            Assert.Equal("myRule", (descriptor.Rule as TestConsensusRuleWithValidationAttribute).RuleName);
+
+            Assert.Equal(3, descriptor.Attributes.Count);
+            Assert.True(descriptor.Attributes[0] is MempoolRuleAttribute);
+            Assert.True(descriptor.Attributes[1] is ExecutionRuleAttribute);
+            Assert.True(descriptor.Attributes[2] is ValidationRuleAttribute);
+
+            Assert.False(descriptor.CanSkipValidation);
+        }
+
+        [Fact]
+        public void Constructor_ConsensusRuleWithOptionalValidationAttribute_InitializesClass()
+        {
+            var rule = new TestConsensusRuleWithOptionalValidationAttribute("myRule");
+
+            var descriptor = new ConsensusRuleDescriptor(rule);
+
+            Assert.True(descriptor.Rule is TestConsensusRuleWithOptionalValidationAttribute);
+            Assert.Equal("myRule", (descriptor.Rule as TestConsensusRuleWithOptionalValidationAttribute).RuleName);
+
+            Assert.Equal(3, descriptor.Attributes.Count);
+            Assert.True(descriptor.Attributes[0] is MempoolRuleAttribute);
+            Assert.True(descriptor.Attributes[1] is ExecutionRuleAttribute);
+            Assert.True(descriptor.Attributes[2] is ValidationRuleAttribute);
+
+            Assert.True(descriptor.CanSkipValidation);
+        }
+
+        [Fact]
+        public void Constructor_ConsensusRuleWithoutValidationAttribute_InitializesClass()
+        {
+            var rule = new TestConsensusRuleWithoutValidationAttribute("myRule");
+
+            var descriptor = new ConsensusRuleDescriptor(rule);
+
+            Assert.True(descriptor.Rule is TestConsensusRuleWithoutValidationAttribute);
+            Assert.Equal("myRule", (descriptor.Rule as TestConsensusRuleWithoutValidationAttribute).RuleName);
+
+            Assert.Equal(2, descriptor.Attributes.Count);
+            Assert.True(descriptor.Attributes[0] is MempoolRuleAttribute);
+            Assert.True(descriptor.Attributes[1] is ExecutionRuleAttribute);
+
+            Assert.True(descriptor.CanSkipValidation);
+        }
+
+        [MempoolRule]
+        [ExecutionRule]
+        [ValidationRule(CanSkipValidation = false)]
+        private class TestConsensusRuleWithValidationAttribute : ConsensusRule
+        {
+            public string RuleName { get; }
+
+            public TestConsensusRuleWithValidationAttribute(string ruleName) : base()
+            {
+                this.RuleName = ruleName;
+            }
+
+            public override Task RunAsync(RuleContext context)
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        [MempoolRule]
+        [ExecutionRule]
+        [ValidationRule(CanSkipValidation = true)]
+        private class TestConsensusRuleWithOptionalValidationAttribute : ConsensusRule
+        {
+            public string RuleName { get; }
+
+            public TestConsensusRuleWithOptionalValidationAttribute(string ruleName) : base()
+            {
+                this.RuleName = ruleName;
+            }
+
+            public override Task RunAsync(RuleContext context)
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        [MempoolRule]
+        [ExecutionRule]
+        private class TestConsensusRuleWithoutValidationAttribute : ConsensusRule
+        {
+            public string RuleName { get; }
+
+            public TestConsensusRuleWithoutValidationAttribute(string ruleName) : base()
+            {
+                this.RuleName = ruleName;
+            }
+
+            public override Task RunAsync(RuleContext context)
+            {
+                throw new NotImplementedException();
+            }
+        }
+    }
+}

--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/ConsensusRuleUnitTestBase.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/ConsensusRuleUnitTestBase.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Moq;
+using NBitcoin;
+using Stratis.Bitcoin.Base.Deployments;
+using Stratis.Bitcoin.Features.Consensus.Rules;
+using Stratis.Bitcoin.Features.Consensus.Rules.CommonRules;
+using Stratis.Bitcoin.Utilities;
+using Xunit;
+
+namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules
+{
+    public class ConsensusRuleUnitTestBase
+    {
+        protected Network network;
+        protected Mock<ILoggerFactory> loggerFactory;
+        protected Mock<IDateTimeProvider> dateTimeProvider;
+        protected ConcurrentChain concurrentChain;
+        protected NodeDeployments nodeDeployments;
+        protected ConsensusSettings consensusSettings;
+        protected Mock<ICheckpoints> checkpoints;
+        protected List<ConsensusRule> ruleRegistrations;
+        protected Mock<IRuleRegistration> ruleRegistration;
+        protected TestConsensusRules consensusRules;
+
+        public ConsensusRuleUnitTestBase()
+        {
+            Block.BlockSignature = false;
+            Transaction.TimeStamp = false;
+            this.network = Network.TestNet;
+            this.loggerFactory = new Mock<ILoggerFactory>();
+            this.loggerFactory.Setup(l => l.CreateLogger(It.IsAny<string>()))
+                .Returns(new Mock<ILogger>().Object);
+            this.dateTimeProvider = new Mock<IDateTimeProvider>();
+
+            this.concurrentChain = new ConcurrentChain(this.network);
+            this.nodeDeployments = new NodeDeployments(this.network, this.concurrentChain);
+            this.consensusSettings = new ConsensusSettings
+            {
+                BlockAssumedValid = null,
+                UseCheckpoints = true
+            };
+            this.checkpoints = new Mock<ICheckpoints>();
+
+            this.ruleRegistrations = new List<ConsensusRule>();
+            this.ruleRegistration = new Mock<IRuleRegistration>();
+            this.ruleRegistration.Setup(r => r.GetRules())
+                .Returns(() => { return this.ruleRegistrations; });
+
+            this.consensusRules = InitializeConsensusRules();
+        }
+
+        public TestConsensusRules InitializeConsensusRules()
+        {
+            return new TestConsensusRules(this.network, this.loggerFactory.Object, this.dateTimeProvider.Object, this.concurrentChain, this.nodeDeployments, this.consensusSettings, this.checkpoints.Object);
+        }
+
+    }
+}

--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/ConsensusRuleUnitTestBase.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/ConsensusRuleUnitTestBase.cs
@@ -39,11 +39,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules
 
             this.concurrentChain = new ConcurrentChain(this.network);
             this.nodeDeployments = new NodeDeployments(this.network, this.concurrentChain);
-            this.consensusSettings = new ConsensusSettings
-            {
-                BlockAssumedValid = null,
-                UseCheckpoints = true
-            };
+            this.consensusSettings = new ConsensusSettings();
             this.checkpoints = new Mock<ICheckpoints>();
 
             this.ruleRegistrations = new List<ConsensusRule>();

--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/ConsensusRulesTest.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/ConsensusRulesTest.cs
@@ -23,6 +23,12 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules
         [Fact]
         public void Constructor_InitializesClass()
         {
+            this.consensusSettings = new ConsensusSettings
+            {
+                BlockAssumedValid = null,
+                UseCheckpoints = true
+            };
+
             this.checkpoints.Setup(c => c.GetLastCheckpointHeight())
                 .Returns(15);
             this.dateTimeProvider.Setup(d => d.GetTime())

--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/ConsensusRulesTest.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/ConsensusRulesTest.cs
@@ -258,6 +258,70 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules
             Assert.Equal(consensusError.Code, blockValidationContext.Error.Code);
         }
 
+        // test extension methods
+        [Fact]
+        public void TryFindRule_RuleFound_ReturnsConsensusRule()
+        {
+            this.ruleRegistrations = new List<ConsensusRule> {
+                new BlockSizeRule()
+            };
+
+            var consensusRules = this.InitializeConsensusRules();
+            consensusRules = consensusRules.Register(this.ruleRegistration.Object) as TestConsensusRules;
+
+            var rule = consensusRules.Rules.TryFindRule<BlockSizeRule>();
+
+            Assert.NotNull(rule);
+            Assert.True(rule is BlockSizeRule);
+        }
+
+        [Fact]
+        public void TryFindRule_RuleNotFound_ReturnsNull()
+        {
+            this.ruleRegistrations = new List<ConsensusRule> {
+                new BlockHeaderRule()
+            };
+
+            var consensusRules = this.InitializeConsensusRules();
+            consensusRules = consensusRules.Register(this.ruleRegistration.Object) as TestConsensusRules;
+
+            var rule = consensusRules.Rules.TryFindRule<BlockSizeRule>();
+
+            Assert.Null(rule);
+        }
+
+        [Fact]
+        public void FindRule_RuleFound_ReturnsConsensusRule()
+        {
+            this.ruleRegistrations = new List<ConsensusRule> {
+                new BlockSizeRule()
+            };
+
+            var consensusRules = this.InitializeConsensusRules();
+            consensusRules = consensusRules.Register(this.ruleRegistration.Object) as TestConsensusRules;
+
+            var rule = consensusRules.Rules.FindRule<BlockSizeRule>();
+
+            Assert.NotNull(rule);
+            Assert.True(rule is BlockSizeRule);
+        }
+
+        [Fact]
+        public void FindRule_RuleNotFound_ThrowsException()
+        {
+            Assert.Throws<Exception>(() =>
+            {
+                this.ruleRegistrations = new List<ConsensusRule> {
+                    new BlockHeaderRule()
+                };
+
+                var consensusRules = this.InitializeConsensusRules();
+                consensusRules = consensusRules.Register(this.ruleRegistration.Object) as TestConsensusRules;
+
+                consensusRules.Rules.FindRule<BlockSizeRule>();
+            });
+        }
+
         private TestConsensusRules InitializeConsensusRules()
         {
             return new TestConsensusRules(this.network, this.loggerFactory.Object, this.dateTimeProvider.Object, this.concurrentChain, this.nodeDeployments, this.consensusSettings, this.checkpoints.Object);
@@ -312,7 +376,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules
 
                 return Task.FromResult(15);
             }
-        }
+        }       
 
         private class TestConsensusRules : ConsensusRules
         {

--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/ConsensusRulesTest.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/ConsensusRulesTest.cs
@@ -14,39 +14,10 @@ using Xunit;
 
 namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules
 {
-    public class ConsensusRulesTest
+    public class ConsensusRulesTest : ConsensusRuleUnitTestBase
     {
-        private Network network;
-        private Mock<ILoggerFactory> loggerFactory;
-        private Mock<IDateTimeProvider> dateTimeProvider;
-        private ConcurrentChain concurrentChain;
-        private NodeDeployments nodeDeployments;
-        private ConsensusSettings consensusSettings;
-        private Mock<ICheckpoints> checkpoints;
-        private List<ConsensusRule> ruleRegistrations;
-        private Mock<IRuleRegistration> ruleRegistration;
-
-        public ConsensusRulesTest()
+        public ConsensusRulesTest() : base()
         {
-            this.network = Network.TestNet;
-            this.loggerFactory = new Mock<ILoggerFactory>();
-            this.loggerFactory.Setup(l => l.CreateLogger(typeof(TestConsensusRules).FullName))
-                .Returns(new Mock<ILogger>().Object);
-            this.dateTimeProvider = new Mock<IDateTimeProvider>();
-
-            this.concurrentChain = new ConcurrentChain(this.network);
-            this.nodeDeployments = new NodeDeployments(this.network, this.concurrentChain);
-            this.consensusSettings = new ConsensusSettings
-            {
-                BlockAssumedValid = null,
-                UseCheckpoints = true
-            };
-            this.checkpoints = new Mock<ICheckpoints>();
-
-            this.ruleRegistrations = new List<ConsensusRule>();
-            this.ruleRegistration = new Mock<IRuleRegistration>();
-            this.ruleRegistration.Setup(r => r.GetRules())
-                .Returns(() => { return this.ruleRegistrations; });
         }
 
         [Fact]
@@ -83,7 +54,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules
             };
 
             var consensusRules = InitializeConsensusRules();
-
+            
             consensusRules = consensusRules.Register(this.ruleRegistration.Object) as TestConsensusRules;
 
             var rules = consensusRules.Rules.ToList();
@@ -322,11 +293,6 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules
             });
         }
 
-        private TestConsensusRules InitializeConsensusRules()
-        {
-            return new TestConsensusRules(this.network, this.loggerFactory.Object, this.dateTimeProvider.Object, this.concurrentChain, this.nodeDeployments, this.consensusSettings, this.checkpoints.Object);
-        }
-
         [ValidationRule]
         private class ConsensusRuleWithValidationAttribute : ConsensusRule
         {
@@ -376,14 +342,6 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules
 
                 return Task.FromResult(15);
             }
-        }       
-
-        private class TestConsensusRules : ConsensusRules
-        {
-            public TestConsensusRules(Network network, ILoggerFactory loggerFactory, IDateTimeProvider dateTimeProvider, ConcurrentChain chain, NodeDeployments nodeDeployments, ConsensusSettings consensusSettings, ICheckpoints checkpoints)
-                : base(network, loggerFactory, dateTimeProvider, chain, nodeDeployments, consensusSettings, checkpoints)
-            {
-            }
-        }
+        }              
     }
 }

--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/ConsensusRulesTest.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/ConsensusRulesTest.cs
@@ -1,0 +1,325 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Moq;
+using NBitcoin;
+using Stratis.Bitcoin.Base.Deployments;
+using Stratis.Bitcoin.Features.Consensus.Rules;
+using Stratis.Bitcoin.Features.Consensus.Rules.CommonRules;
+using Stratis.Bitcoin.Utilities;
+using Xunit;
+
+namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules
+{
+    public class ConsensusRulesTest
+    {
+        private Network network;
+        private Mock<ILoggerFactory> loggerFactory;
+        private Mock<IDateTimeProvider> dateTimeProvider;
+        private ConcurrentChain concurrentChain;
+        private NodeDeployments nodeDeployments;
+        private ConsensusSettings consensusSettings;
+        private Mock<ICheckpoints> checkpoints;
+        private List<ConsensusRule> ruleRegistrations;
+        private Mock<IRuleRegistration> ruleRegistration;
+
+        public ConsensusRulesTest()
+        {
+            this.network = Network.TestNet;
+            this.loggerFactory = new Mock<ILoggerFactory>();
+            this.loggerFactory.Setup(l => l.CreateLogger(typeof(TestConsensusRules).FullName))
+                .Returns(new Mock<ILogger>().Object);
+            this.dateTimeProvider = new Mock<IDateTimeProvider>();
+
+            this.concurrentChain = new ConcurrentChain(this.network);
+            this.nodeDeployments = new NodeDeployments(this.network, this.concurrentChain);
+            this.consensusSettings = new ConsensusSettings
+            {
+                BlockAssumedValid = null,
+                UseCheckpoints = true
+            };
+            this.checkpoints = new Mock<ICheckpoints>();
+
+            this.ruleRegistrations = new List<ConsensusRule>();
+            this.ruleRegistration = new Mock<IRuleRegistration>();
+            this.ruleRegistration.Setup(r => r.GetRules())
+                .Returns(() => { return this.ruleRegistrations; });
+        }
+
+        [Fact]
+        public void Constructor_InitializesClass()
+        {
+            this.checkpoints.Setup(c => c.GetLastCheckpointHeight())
+                .Returns(15);
+            this.dateTimeProvider.Setup(d => d.GetTime())
+                .Returns(2);
+
+            var consensusRules = InitializeConsensusRules();
+
+            Assert.Equal(this.network.Name, consensusRules.Network.Name);
+            Assert.Equal(this.dateTimeProvider.Object.GetTime(), consensusRules.DateTimeProvider.GetTime());
+            Assert.Equal(this.concurrentChain.Tip.HashBlock, consensusRules.Chain.Tip.HashBlock);
+            Assert.Equal(this.nodeDeployments.GetFlags(this.concurrentChain.Tip).EnforceBIP30, consensusRules.NodeDeployments.GetFlags(this.concurrentChain.Tip).EnforceBIP30);
+            Assert.True(consensusRules.ConsensusSettings.UseCheckpoints);
+            Assert.Equal(15, consensusRules.Checkpoints.GetLastCheckpointHeight());
+            this.loggerFactory.Verify(l => l.CreateLogger(typeof(TestConsensusRules).FullName));
+        }
+
+        [Fact]
+        public void Register_WithRulesInRuleRegistration_UpdatesConsensusRule_AddsConensusRuleToRules()
+        {
+            this.loggerFactory.Setup(l => l.CreateLogger(typeof(BlockSizeRule).FullName))
+                .Returns(new Mock<ILogger>().Object)
+                .Verifiable();
+            this.loggerFactory.Setup(l => l.CreateLogger(typeof(BlockHeaderRule).FullName))
+                .Returns(new Mock<ILogger>().Object)
+                .Verifiable();
+            this.ruleRegistrations = new List<ConsensusRule> {
+                new BlockSizeRule(),
+                new BlockHeaderRule()
+            };
+
+            var consensusRules = InitializeConsensusRules();
+
+            consensusRules = consensusRules.Register(this.ruleRegistration.Object) as TestConsensusRules;
+
+            var rules = consensusRules.Rules.ToList();
+            Assert.Equal(2, rules.Count);
+            var rule = rules[0].Rule;
+            Assert.Equal(typeof(TestConsensusRules), rule.Parent.GetType());
+            Assert.NotNull(rule.Logger);
+
+            rule = rules[1].Rule;
+            Assert.Equal(typeof(TestConsensusRules), rule.Parent.GetType());
+            Assert.NotNull(rule.Logger);
+
+            this.loggerFactory.Verify();
+        }
+
+        [Fact]
+        public async Task ValidateAsync_RuleWithoutAttributes_GetsRunAsync()
+        {
+            var rule = new Mock<ConsensusRule>();
+            rule.Setup(r => r.RunAsync(It.Is<RuleContext>(c => c.SkipValidation == true)))
+                .Returns(Task.FromResult(1))
+                .Verifiable();
+
+            this.ruleRegistrations = new List<ConsensusRule> { rule.Object };
+
+            var consensusRules = InitializeConsensusRules();
+            consensusRules.Register(this.ruleRegistration.Object);
+
+            await consensusRules.ValidateAsync(new RuleContext() { SkipValidation = true });
+
+            rule.Verify();
+        }
+
+        [Fact]
+        public async Task ValidateAsync_RuleWithValidationRuleAttribute_GetsRunAsync()
+        {
+            var rule = new ConsensusRuleWithValidationAttribute();
+            this.ruleRegistrations = new List<ConsensusRule> { rule };
+            var consensusRules = InitializeConsensusRules();
+            consensusRules.Register(this.ruleRegistration.Object);
+
+            await consensusRules.ValidateAsync(new RuleContext() { SkipValidation = true });
+
+            Assert.True(rule.RunCalled);
+        }
+
+        [Fact]
+        public async Task ValidateAsync_RuleWithNonValidationRuleAttribute_GetsRunAsync()
+        {
+            var rule = new ConsensusRuleWithoutNonValidationRuleAttribute();
+            this.ruleRegistrations = new List<ConsensusRule> { rule };
+            var consensusRules = InitializeConsensusRules();
+            consensusRules.Register(this.ruleRegistration.Object);
+
+            await consensusRules.ValidateAsync(new RuleContext() { SkipValidation = true });
+
+            Assert.False(rule.RunCalled);
+        }
+
+        [Fact]
+        public async Task ExecuteAsync_RuleCannotSkipValidation_ContextCannotSkipValidation_RunsRuleAsync()
+        {
+            var rule = new ConsensusRuleWithValidationAttribute();
+            this.ruleRegistrations = new List<ConsensusRule> { rule };
+            var blockValidationContext = new BlockValidationContext()
+            {
+                RuleContext = new RuleContext()
+                {
+                    SkipValidation = false
+                }
+            };
+            var consensusRules = InitializeConsensusRules();
+            consensusRules.Register(this.ruleRegistration.Object);
+
+            await consensusRules.ExecuteAsync(blockValidationContext);
+
+            Assert.True(rule.RunCalled);
+            Assert.Null(blockValidationContext.Error);
+        }
+
+        [Fact]
+        public async Task ExecuteAsync_RuleCanSkipValidation_ContextRequiresValidation_RunsRuleAsync()
+        {
+            var rule = new ConsensusRuleWithSkipValidationAttribute();
+            this.ruleRegistrations = new List<ConsensusRule> { rule };
+
+            var blockValidationContext = new BlockValidationContext()
+            {
+                RuleContext = new RuleContext()
+                {
+                    SkipValidation = false
+                }
+            };
+            var consensusRules = InitializeConsensusRules();
+            consensusRules.Register(this.ruleRegistration.Object);
+
+            await consensusRules.ExecuteAsync(blockValidationContext);
+
+            Assert.True(rule.RunCalled);
+            Assert.Null(blockValidationContext.Error);
+        }
+
+        [Fact]
+        public async Task ExecuteAsync_RuleCannotSkipValidation_ContextCanSkipValidation_RunsRuleAsync()
+        {
+            var rule = new ConsensusRuleWithValidationAttribute();
+            this.ruleRegistrations = new List<ConsensusRule> { rule };
+
+            var blockValidationContext = new BlockValidationContext()
+            {
+                RuleContext = new RuleContext()
+                {
+                    SkipValidation = true
+                }
+            };
+            var consensusRules = InitializeConsensusRules();
+            consensusRules.Register(this.ruleRegistration.Object);
+
+            await consensusRules.ExecuteAsync(blockValidationContext);
+
+            Assert.True(rule.RunCalled);
+            Assert.Null(blockValidationContext.Error);
+        }
+
+        [Fact]
+        public async Task ExecuteAsync_RuleCanSkipValidation_ContextCanSkipValidation_DoesNotRunRuleAsync()
+        {
+            var rule = new ConsensusRuleWithSkipValidationAttribute();
+            this.ruleRegistrations = new List<ConsensusRule> { rule };
+
+            var blockValidationContext = new BlockValidationContext()
+            {
+                ChainedBlock = this.concurrentChain.Tip,
+                RuleContext = new RuleContext()
+                {
+                    SkipValidation = true
+                }
+            };
+            var consensusRules = InitializeConsensusRules();
+            consensusRules.Register(this.ruleRegistration.Object);
+
+            await consensusRules.ExecuteAsync(blockValidationContext);
+
+            Assert.False(rule.RunCalled);
+            Assert.Null(blockValidationContext.Error);
+        }
+
+        [Fact]
+        public async Task ExecuteAsync_ConsensusErrorException_SetsConsensusErrorOnBlockValidationContextAsync()
+        {
+            var consensusError = ConsensusErrors.BadBlockLength;
+            var rule = new Mock<ConsensusRule>();
+            rule.Setup(r => r.RunAsync(It.Is<RuleContext>(c => c.SkipValidation == false)))
+                .Throws(new ConsensusErrorException(consensusError))
+                .Verifiable();
+
+            this.ruleRegistrations = new List<ConsensusRule> { rule.Object };
+            var blockValidationContext = new BlockValidationContext()
+            {
+                RuleContext = new RuleContext()
+                {
+                    SkipValidation = false
+                }
+            };
+            var consensusRules = InitializeConsensusRules();
+            consensusRules.Register(this.ruleRegistration.Object);
+
+            await consensusRules.ExecuteAsync(blockValidationContext);
+
+            Assert.NotNull(blockValidationContext.Error);
+            Assert.Equal(consensusError.Message, blockValidationContext.Error.Message);
+            Assert.Equal(consensusError.Code, blockValidationContext.Error.Code);
+        }
+
+        private TestConsensusRules InitializeConsensusRules()
+        {
+            return new TestConsensusRules(this.network, this.loggerFactory.Object, this.dateTimeProvider.Object, this.concurrentChain, this.nodeDeployments, this.consensusSettings, this.checkpoints.Object);
+        }
+
+        [ValidationRule]
+        private class ConsensusRuleWithValidationAttribute : ConsensusRule
+        {
+            public bool RunCalled { get; private set; }
+
+            public ConsensusRuleWithValidationAttribute() : base()
+            {
+            }
+
+            public override Task RunAsync(RuleContext context)
+            {
+                this.RunCalled = true;
+
+                return Task.FromResult(15);
+            }
+        }
+
+        [ValidationRule(CanSkipValidation = true)]
+        private class ConsensusRuleWithSkipValidationAttribute : ConsensusRule
+        {
+            public bool RunCalled { get; private set; }
+
+            public ConsensusRuleWithSkipValidationAttribute() : base()
+            {
+            }
+
+            public override Task RunAsync(RuleContext context)
+            {
+                this.RunCalled = true;
+
+                return Task.FromResult(15);
+            }
+        }
+
+        [ExecutionRule]
+        private class ConsensusRuleWithoutNonValidationRuleAttribute : ConsensusRule
+        {
+            public bool RunCalled { get; private set; }
+
+            public ConsensusRuleWithoutNonValidationRuleAttribute() : base()
+            {
+            }
+
+            public override Task RunAsync(RuleContext context)
+            {
+                this.RunCalled = true;
+
+                return Task.FromResult(15);
+            }
+        }
+
+        private class TestConsensusRules : ConsensusRules
+        {
+            public TestConsensusRules(Network network, ILoggerFactory loggerFactory, IDateTimeProvider dateTimeProvider, ConcurrentChain chain, NodeDeployments nodeDeployments, ConsensusSettings consensusSettings, ICheckpoints checkpoints)
+                : base(network, loggerFactory, dateTimeProvider, chain, nodeDeployments, consensusSettings, checkpoints)
+            {
+            }
+        }
+    }
+}

--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/Stratis.Bitcoin.Features.Consensus.Tests.csproj
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/Stratis.Bitcoin.Features.Consensus.Tests.csproj
@@ -35,7 +35,6 @@
     <ProjectReference Include="..\NBitcoin\NBitcoin.csproj" />
     <ProjectReference Include="..\Stratis.Bitcoin.Features.Consensus\Stratis.Bitcoin.Features.Consensus.csproj" />
     <ProjectReference Include="..\Stratis.Bitcoin.Features.Miner\Stratis.Bitcoin.Features.Miner.csproj" />
-    <ProjectReference Include="..\Stratis.Bitcoin.Features.Wallet.Tests\Stratis.Bitcoin.Features.Wallet.Tests.csproj" />
     <ProjectReference Include="..\Stratis.Bitcoin.Tests\Stratis.Bitcoin.Tests.csproj" />
     <ProjectReference Include="..\Stratis.Bitcoin\Stratis.Bitcoin.csproj" />
   </ItemGroup>

--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/Stratis.Bitcoin.Features.Consensus.Tests.csproj
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/Stratis.Bitcoin.Features.Consensus.Tests.csproj
@@ -35,6 +35,7 @@
     <ProjectReference Include="..\NBitcoin\NBitcoin.csproj" />
     <ProjectReference Include="..\Stratis.Bitcoin.Features.Consensus\Stratis.Bitcoin.Features.Consensus.csproj" />
     <ProjectReference Include="..\Stratis.Bitcoin.Features.Miner\Stratis.Bitcoin.Features.Miner.csproj" />
+    <ProjectReference Include="..\Stratis.Bitcoin.Features.Wallet.Tests\Stratis.Bitcoin.Features.Wallet.Tests.csproj" />
     <ProjectReference Include="..\Stratis.Bitcoin.Tests\Stratis.Bitcoin.Tests.csproj" />
     <ProjectReference Include="..\Stratis.Bitcoin\Stratis.Bitcoin.csproj" />
   </ItemGroup>

--- a/src/Stratis.Bitcoin.Features.Consensus/CoinViews/BackendPerformanceCounter.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/CoinViews/BackendPerformanceCounter.cs
@@ -81,6 +81,8 @@ namespace Stratis.Bitcoin.Features.Consensus.CoinViews
         /// <param name="dateTimeProvider"></param>
         public BackendPerformanceCounter(IDateTimeProvider dateTimeProvider)
         {
+            Guard.NotNull(dateTimeProvider, nameof(dateTimeProvider));
+
             this.dateTimeProvider = dateTimeProvider;
             this.start = this.dateTimeProvider.GetUtcNow();
         }

--- a/src/Stratis.Bitcoin.Features.Consensus/CoinViews/CachePerformanceCounter.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/CoinViews/CachePerformanceCounter.cs
@@ -56,6 +56,8 @@ namespace Stratis.Bitcoin.Features.Consensus.CoinViews
         /// <param name="dateTimeProvider">Provider of date time functionality.</param>
         public CachePerformanceCounter(IDateTimeProvider dateTimeProvider)
         {
+            Guard.NotNull(dateTimeProvider, nameof(dateTimeProvider));
+
             this.dateTimeProvider = dateTimeProvider;
             this.start = this.dateTimeProvider.GetUtcNow();
         }

--- a/src/Stratis.Bitcoin.Features.Consensus/CoinViews/CoinViewStack.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/CoinViews/CoinViewStack.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using Stratis.Bitcoin.Utilities;
 
 namespace Stratis.Bitcoin.Features.Consensus.CoinViews
 {
@@ -21,6 +22,8 @@ namespace Stratis.Bitcoin.Features.Consensus.CoinViews
         /// <param name="top">Coinview at the top of the stack.</param>
         public CoinViewStack(CoinView top)
         {
+            Guard.NotNull(top, nameof(top));
+
             this.Top = top;
             CoinView current = top;
             while (current is IBackedCoinView)
@@ -39,10 +42,14 @@ namespace Stratis.Bitcoin.Features.Consensus.CoinViews
             CoinView current = this.Top;
             while (current is IBackedCoinView)
             {
-                yield return current;
+                if (current != null)
+                    yield return current;
+
                 current = ((IBackedCoinView)current).Inner;
             }
-            yield return current;
+
+            if (current != null)
+                yield return current;
         }
 
         /// <summary>

--- a/src/Stratis.Bitcoin.Features.Consensus/CoinViews/CoinViewStack.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/CoinViews/CoinViewStack.cs
@@ -42,8 +42,7 @@ namespace Stratis.Bitcoin.Features.Consensus.CoinViews
             CoinView current = this.Top;
             while (current is IBackedCoinView)
             {
-                if (current != null)
-                    yield return current;
+                yield return current;
 
                 current = ((IBackedCoinView)current).Inner;
             }

--- a/src/Stratis.Bitcoin.Features.Consensus/CoinViews/FetchCoinsResponse.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/CoinViews/FetchCoinsResponse.cs
@@ -10,10 +10,10 @@ namespace Stratis.Bitcoin.Features.Consensus.CoinViews
     public class FetchCoinsResponse
     {
         /// <summary>Hash of the block header for which <see cref="UnspentOutputs"/> is related.</summary>
-        public uint256 BlockHash { get; set; }
+        public uint256 BlockHash { get; private set; }
 
         /// <summary>Unspent outputs of the requested transactions.</summary>
-        public UnspentOutputs[] UnspentOutputs { get; set; }
+        public UnspentOutputs[] UnspentOutputs { get; private set; }
 
         /// <summary>
         /// Initializes an instance of the object.
@@ -22,6 +22,9 @@ namespace Stratis.Bitcoin.Features.Consensus.CoinViews
         /// <param name="blockHash">Block hash of the coinview's current tip.</param>
         public FetchCoinsResponse(UnspentOutputs[] unspent, uint256 blockHash)
         {
+            Guard.NotNull(unspent, nameof(unspent));
+            Guard.NotNull(blockHash, nameof(blockHash));
+
             this.BlockHash = blockHash;
             this.UnspentOutputs = unspent;
         }

--- a/src/Stratis.Bitcoin.Features.Consensus/ConsensusSettings.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/ConsensusSettings.cs
@@ -3,6 +3,7 @@ using System.Text;
 using Microsoft.Extensions.Logging;
 using NBitcoin;
 using Stratis.Bitcoin.Configuration;
+using Stratis.Bitcoin.Utilities;
 
 namespace Stratis.Bitcoin.Features.Consensus
 {
@@ -34,8 +35,8 @@ namespace Stratis.Bitcoin.Features.Consensus
         /// <returns>These consensus config settings.</returns>
         public ConsensusSettings Load(NodeSettings nodeSettings)
         {
-            ILogger logger = nodeSettings.LoggerFactory.CreateLogger(typeof(ConsensusSettings).FullName);
-
+            Guard.NotNull(nodeSettings, nameof(nodeSettings));
+            
             TextFileConfiguration config = nodeSettings.ConfigReader;
             this.UseCheckpoints = config.GetOrDefault<bool>("checkpoints", true);
 
@@ -48,6 +49,7 @@ namespace Stratis.Bitcoin.Features.Consensus
                 this.BlockAssumedValid = config.GetOrDefault<uint256>("assumevalid", nodeSettings.Network.Consensus.DefaultAssumeValid);
             }
 
+            ILogger logger = nodeSettings.LoggerFactory.CreateLogger(typeof(ConsensusSettings).FullName);
             logger.LogDebug("Checkpoints are {0}.", this.UseCheckpoints ? "enabled" : "disabled");
             logger.LogDebug("Assume valid block is '{0}'.", this.BlockAssumedValid == null ? "disabled" : this.BlockAssumedValid.ToString());
 
@@ -58,6 +60,8 @@ namespace Stratis.Bitcoin.Features.Consensus
         /// <param name="network">The network to use.</param>
         public static void PrintHelp(Network network)
         {
+            Guard.NotNull(network, nameof(network));
+
             var builder = new StringBuilder();
 
             builder.AppendLine($"-checkpoints=<0 or 1>     Use checkpoints. Default 1.");

--- a/src/Stratis.Bitcoin.Features.Consensus/Rules/ConsensusRule.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/Rules/ConsensusRule.cs
@@ -52,6 +52,8 @@ namespace Stratis.Bitcoin.Features.Consensus.Rules
         /// </summary>
         public ConsensusRuleDescriptor(ConsensusRule rule)
         {
+            Guard.NotNull(rule, nameof(rule));
+
             this.Rule = rule;
             this.Attributes = Attribute.GetCustomAttributes(rule.GetType()).OfType<RuleAttribute>().ToList();
 

--- a/src/Stratis.Bitcoin.Features.Consensus/Rules/ConsensusRules.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/Rules/ConsensusRules.cs
@@ -47,6 +47,14 @@ namespace Stratis.Bitcoin.Features.Consensus.Rules
         /// </summary>
         protected ConsensusRules(Network network, ILoggerFactory loggerFactory, IDateTimeProvider dateTimeProvider, ConcurrentChain chain, NodeDeployments nodeDeployments, ConsensusSettings consensusSettings, ICheckpoints checkpoints)
         {
+            Guard.NotNull(network, nameof(network));
+            Guard.NotNull(loggerFactory, nameof(loggerFactory));
+            Guard.NotNull(dateTimeProvider, nameof(dateTimeProvider));
+            Guard.NotNull(chain, nameof(chain));
+            Guard.NotNull(nodeDeployments, nameof(nodeDeployments));
+            Guard.NotNull(consensusSettings, nameof(consensusSettings));
+            Guard.NotNull(checkpoints, nameof(checkpoints));
+
             this.Network = network;
             this.DateTimeProvider = dateTimeProvider;
             this.Chain = chain;
@@ -65,6 +73,8 @@ namespace Stratis.Bitcoin.Features.Consensus.Rules
         /// <inheritdoc />
         public ConsensusRules Register(IRuleRegistration ruleRegistration)
         {
+            Guard.NotNull(ruleRegistration, nameof(ruleRegistration));
+
             foreach (var consensusRule in ruleRegistration.GetRules())
             {
                 consensusRule.Parent = this;

--- a/src/Stratis.Bitcoin.Features.MemoryPool/MemPoolCoinView.cs
+++ b/src/Stratis.Bitcoin.Features.MemoryPool/MemPoolCoinView.cs
@@ -86,7 +86,7 @@ namespace Stratis.Bitcoin.Features.MemoryPool
                 return this.memPool.MapTx.Values.Where(t => ids.Contains(t.TransactionHash)).Select(s => s.Transaction).ToList();
             });
             IEnumerable<UnspentOutputs> memOutputs = mempoolcoins.Select(s => new UnspentOutputs(TxMempool.MempoolHeight, s));
-            coins.UnspentOutputs = coins.UnspentOutputs.Concat(memOutputs).ToArray();
+            coins = new FetchCoinsResponse(coins.UnspentOutputs.Concat(memOutputs).ToArray(), coins.BlockHash);
 
             // the UTXO set might have been updated with a recently received block
             // but the block has not yet arrived to the mempool and remove the pending trx

--- a/src/Stratis.Bitcoin/Base/Deployments/NodeDeployments.cs
+++ b/src/Stratis.Bitcoin/Base/Deployments/NodeDeployments.cs
@@ -1,4 +1,5 @@
 ﻿using NBitcoin;
+using Stratis.Bitcoin.Utilities;
 
 namespace Stratis.Bitcoin.Base.Deployments
 {
@@ -14,6 +15,9 @@ namespace Stratis.Bitcoin.Base.Deployments
 
         public NodeDeployments(Network network, ConcurrentChain chain)
         {
+            Guard.NotNull(network, nameof(network));
+            Guard.NotNull(chain, nameof(chain));
+
             this.network = network;
             this.chain = chain;
             this.BIP9 = new ThresholdConditionCache(network.Consensus);
@@ -21,6 +25,8 @@ namespace Stratis.Bitcoin.Base.Deployments
 
         public virtual DeploymentFlags GetFlags(ChainedBlock block)
         {
+            Guard.NotNull(block, nameof(block));
+
             lock (this.BIP9)
             {
                 ThresholdState[] states = this.BIP9.GetStates(block.Previous);

--- a/src/Stratis.Bitcoin/Base/Deployments/ThresholdConditionCache.cs
+++ b/src/Stratis.Bitcoin/Base/Deployments/ThresholdConditionCache.cs
@@ -29,8 +29,7 @@ namespace Stratis.Bitcoin.Base.Deployments
 
         private Consensus consensus;
 
-        private
-        Dictionary<uint256, ThresholdState?[]> cache = new Dictionary<uint256, ThresholdState?[]>();
+        private Dictionary<uint256, ThresholdState?[]> cache = new Dictionary<uint256, ThresholdState?[]>();
 
         public ThresholdConditionCache(Consensus consensus)
         {


### PR DESCRIPTION
I've started to create tests for the consensus project. 
This commit contains tests for some general classes of the coinviews folder, consensus rule executers and a start to unit tests for the consensus rules. The plan is to add tests like dan added for consensusrules later after the unit tests are in place.