### PR TITLE
Switch from the chain if it's no longer represented by any peer that we're connected to

### DIFF
--- a/src/NBitcoin/ConcurrentChain.cs
+++ b/src/NBitcoin/ConcurrentChain.cs
@@ -149,7 +149,7 @@ namespace NBitcoin
         {
             using (this.lockObject.LockWrite())
             {
-                if (this.tip == null || block.ChainWork > this.tip.ChainWork)
+                if ((this.tip == null) || (block.ChainWork > this.tip.ChainWork))
                 {
                     this.SetTipLocked(block);
                     return true;

--- a/src/NBitcoin/ConcurrentChain.cs
+++ b/src/NBitcoin/ConcurrentChain.cs
@@ -154,9 +154,9 @@ namespace NBitcoin
                     this.SetTipLocked(block);
                     return true;
                 }
-                else
-                    return false;
             }
+
+            return false;
         }
 
         private ChainedBlock SetTipLocked(ChainedBlock block)

--- a/src/NBitcoin/ConcurrentChain.cs
+++ b/src/NBitcoin/ConcurrentChain.cs
@@ -144,12 +144,18 @@ namespace NBitcoin
         /// Sets the tip of this chain to the tip of another chain if it's chainwork is greater.
         /// </summary>
         /// <param name="block">Tip to set.</param>
-        public void SetTipIfChainworkIsGreater(ChainedBlock block)
+        /// <returns><c>true</c> if the tip was set; <c>false</c> otherwise.</returns>
+        public bool SetTipIfChainworkIsGreater(ChainedBlock block)
         {
             using (this.lockObject.LockWrite())
             {
                 if (this.tip == null || block.ChainWork > this.tip.ChainWork)
+                {
                     this.SetTipLocked(block);
+                    return true;
+                }
+                else
+                    return false;
             }
         }
 

--- a/src/NBitcoin/ConcurrentChain.cs
+++ b/src/NBitcoin/ConcurrentChain.cs
@@ -140,6 +140,19 @@ namespace NBitcoin
             }
         }
 
+        /// <summary>
+        /// Sets the tip of this chain to the tip of another chain if it's chainwork is greater.
+        /// </summary>
+        /// <param name="block">Tip to set.</param>
+        public void SetTipIfChainworkIsGreater(ChainedBlock block)
+        {
+            using (this.lockObject.LockWrite())
+            {
+                if (this.tip == null || block.ChainWork > this.tip.ChainWork)
+                    this.SetTipLocked(block);
+            }
+        }
+
         private ChainedBlock SetTipLocked(ChainedBlock block)
         {
             int height = this.Tip == null ? -1 : this.Tip.Height;

--- a/src/Stratis.Bitcoin.Features.Consensus/ConsensusLoop.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/ConsensusLoop.cs
@@ -231,6 +231,9 @@ namespace Stratis.Bitcoin.Features.Consensus
                 // chain will never know if a reorg happened.
                 utxoHash = await this.UTXOSet.Rewind().ConfigureAwait(false);
             }
+
+            this.Chain.SetTip(this.Tip);
+
             this.Puller.SetLocation(this.Tip);
 
             this.asyncLoop = this.asyncLoopFactory.Run($"Consensus Loop", async (token) =>

--- a/src/Stratis.Bitcoin.Tests/Base/BestChainSelectorTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Base/BestChainSelectorTest.cs
@@ -1,0 +1,132 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using DBreeze;
+using Microsoft.Extensions.Logging;
+using Moq;
+using NBitcoin;
+using Stratis.Bitcoin.Base;
+using Xunit;
+
+namespace Stratis.Bitcoin.Tests.Base
+{
+    public class BestChainSelectorTest
+    {
+        private readonly Mock<IChainState> chainState;
+        private readonly List<ChainedBlock> chainedBlocks;
+
+        public BestChainSelectorTest()
+        {
+            this.chainedBlocks = new List<ChainedBlock>();
+            var chain = new ConcurrentChain(Network.StratisMain);
+
+            for (int i = 0; i < 20; ++i)
+            {
+                var header = new BlockHeader()
+                {
+                    Nonce = RandomUtils.GetUInt32(),
+                    HashPrevBlock = chain.Tip.HashBlock,
+                    Bits = Target.Difficulty1
+                };
+
+                var chainedBlock = new ChainedBlock(header, header.GetHash(Network.StratisMain.NetworkOptions), chain.Tip);
+
+                chain.SetTip(chainedBlock);
+                
+                this.chainedBlocks.Add(chainedBlock);
+            }
+
+            // Let block #5 be the consensus tip.
+            this.chainState = new Mock<IChainState>().SetupProperty(x => x.ConsensusTip, this.chainedBlocks[5]);
+        }
+
+        /// <summary>
+        /// Tests that a new tip will be selected if the only provider of the best tip disconnects.
+        /// </summary>
+        [Fact]
+        public async Task NewTipIsSelectedWhenBestTipProviderDisconnectsAsync()
+        {
+            var chain = new ConcurrentChain(Network.StratisMain);
+            var chainSelector = new BestChainSelector(chain, this.chainState.Object, new LoggerFactory());
+
+            chain.SetTip(this.chainedBlocks[10]);
+
+            ChainedBlock tipFromFirstPeer = this.chainedBlocks[15];
+            chainSelector.TrySetAvailableTip(0, tipFromFirstPeer);
+            Assert.Equal(chain.Tip, tipFromFirstPeer);
+
+            ChainedBlock tipFromSecondPeer = this.chainedBlocks[18];
+            chainSelector.TrySetAvailableTip(1, tipFromSecondPeer);
+            Assert.Equal(chain.Tip, tipFromSecondPeer);
+
+            //Disconnect second peer
+            chainSelector.RemoveAvailableTip(1);
+
+            await Task.Delay(100).ConfigureAwait(false);
+            
+            Assert.Equal(chain.Tip, tipFromFirstPeer);
+
+            //Disconnect first peer
+            chainSelector.RemoveAvailableTip(0);
+
+            await Task.Delay(100).ConfigureAwait(false);
+
+            Assert.Equal(chain.Tip, this.chainState.Object.ConsensusTip);
+        }
+
+        /// <summary>
+        /// Tests that a new tip will be selected if the only provider of the best tip disconnects.
+        /// </summary>
+        [Fact]
+        public async Task CantSwitchToTipBelowConsensusAsync()
+        {
+            var chain = new ConcurrentChain(Network.StratisMain);
+            var chainSelector = new BestChainSelector(chain, this.chainState.Object, new LoggerFactory());
+
+            chain.SetTip(this.chainedBlocks[10]);
+            
+            chainSelector.TrySetAvailableTip(0, this.chainedBlocks[15]);
+            chainSelector.TrySetAvailableTip(1, this.chainedBlocks[2]);
+            chainSelector.TrySetAvailableTip(2, this.chainedBlocks[3]);
+            chainSelector.TrySetAvailableTip(3, this.chainedBlocks[4]);
+            
+            await Task.Delay(100).ConfigureAwait(false);
+
+            Assert.Equal(chain.Tip, this.chainedBlocks[15]);
+
+            chainSelector.RemoveAvailableTip(0);
+
+            await Task.Delay(100).ConfigureAwait(false);
+
+            Assert.Equal(chain.Tip, this.chainState.Object.ConsensusTip);
+        }
+
+        /// <summary>
+        /// Tests that nothing happens if one of the best tip providers disconnects.
+        /// </summary>
+        [Fact]
+        public async Task OneOfManyBestChainProvidersDisconnectsAsync()
+        {
+            var chain = new ConcurrentChain(Network.StratisMain);
+            var chainSelector = new BestChainSelector(chain, this.chainState.Object, new LoggerFactory());
+
+            chain.SetTip(this.chainedBlocks[10]);
+
+            ChainedBlock tip = this.chainedBlocks[15];
+
+            chainSelector.TrySetAvailableTip(0, tip);
+            chainSelector.TrySetAvailableTip(1, tip);
+            chainSelector.TrySetAvailableTip(2, tip);
+
+            Assert.Equal(chain.Tip, tip);
+
+            chainSelector.RemoveAvailableTip(0);
+
+            await Task.Delay(100).ConfigureAwait(false);
+
+            Assert.Equal(chain.Tip, tip);
+        }
+    }
+}

--- a/src/Stratis.Bitcoin/Base/BaseFeature.cs
+++ b/src/Stratis.Bitcoin/Base/BaseFeature.cs
@@ -100,6 +100,9 @@ namespace Stratis.Bitcoin.Base
         /// <summary>Provider of IBD state.</summary>
         private readonly IInitialBlockDownloadState initialBlockDownloadState;
 
+        /// <summary>Selects the best available chain based on Tips provided by the peers and switches to it.</summary>
+        private readonly BestChainSelector bestChainSelector;
+
         /// <summary>
         /// Initializes a new instance of the object.
         /// </summary>
@@ -116,6 +119,7 @@ namespace Stratis.Bitcoin.Base
         /// <param name="dbreezeSerializer">Provider of binary (de)serialization for data stored in the database.</param>
         /// <param name="loggerFactory">Factory to be used to create logger for the node.</param>
         /// <param name="initialBlockDownloadState">Provider of IBD state.</param>
+        /// <param name="bestChainSelector">Selects the best available chain based on Tips provided by the peers and switches to it.</param>
         public BaseFeature(
             NodeSettings nodeSettings,
             DataFolder dataFolder,
@@ -131,7 +135,8 @@ namespace Stratis.Bitcoin.Base
             ILoggerFactory loggerFactory,
             IInitialBlockDownloadState initialBlockDownloadState,
             IPeerBanning peerBanning,
-            IPeerAddressManager peerAddressManager)
+            IPeerAddressManager peerAddressManager,
+            BestChainSelector bestChainSelector)
         {
             this.chainState = Guard.NotNull(chainState, nameof(chainState));
             this.chainRepository = Guard.NotNull(chainRepository, nameof(chainRepository));
@@ -140,6 +145,7 @@ namespace Stratis.Bitcoin.Base
             this.nodeLifetime = Guard.NotNull(nodeLifetime, nameof(nodeLifetime));
             this.chain = Guard.NotNull(chain, nameof(chain));
             this.connectionManager = Guard.NotNull(connectionManager, nameof(connectionManager));
+            this.bestChainSelector = bestChainSelector;
             this.peerBanning = Guard.NotNull(peerBanning, nameof(peerBanning));
 
             this.peerAddressManager = Guard.NotNull(peerAddressManager, nameof(peerAddressManager));
@@ -174,7 +180,7 @@ namespace Stratis.Bitcoin.Base
 
             var connectionParameters = this.connectionManager.Parameters;
             connectionParameters.IsRelay = !this.nodeSettings.ConfigReader.GetOrDefault("blocksonly", false);
-            connectionParameters.TemplateBehaviors.Add(new ChainHeadersBehavior(this.chain, this.chainState, this.initialBlockDownloadState, this.loggerFactory));
+            connectionParameters.TemplateBehaviors.Add(new ChainHeadersBehavior(this.chain, this.chainState, this.initialBlockDownloadState, this.bestChainSelector, this.loggerFactory));
             connectionParameters.TemplateBehaviors.Add(new PeerBanningBehavior(this.loggerFactory, this.peerBanning, this.nodeSettings));
 
             this.StartAddressManager(connectionParameters);

--- a/src/Stratis.Bitcoin/Base/BaseFeature.cs
+++ b/src/Stratis.Bitcoin/Base/BaseFeature.cs
@@ -100,7 +100,7 @@ namespace Stratis.Bitcoin.Base
         /// <summary>Provider of IBD state.</summary>
         private readonly IInitialBlockDownloadState initialBlockDownloadState;
 
-        /// <summary>Selects the best available chain based on Tips provided by the peers and switches to it.</summary>
+        /// <summary>Selects the best available chain based on tips provided by the peers and switches to it.</summary>
         private readonly BestChainSelector bestChainSelector;
 
         /// <summary>
@@ -119,7 +119,7 @@ namespace Stratis.Bitcoin.Base
         /// <param name="dbreezeSerializer">Provider of binary (de)serialization for data stored in the database.</param>
         /// <param name="loggerFactory">Factory to be used to create logger for the node.</param>
         /// <param name="initialBlockDownloadState">Provider of IBD state.</param>
-        /// <param name="bestChainSelector">Selects the best available chain based on Tips provided by the peers and switches to it.</param>
+        /// <param name="bestChainSelector">Selects the best available chain based on tips provided by the peers and switches to it.</param>
         public BaseFeature(
             NodeSettings nodeSettings,
             DataFolder dataFolder,

--- a/src/Stratis.Bitcoin/Base/BaseFeature.cs
+++ b/src/Stratis.Bitcoin/Base/BaseFeature.cs
@@ -316,6 +316,7 @@ namespace Stratis.Bitcoin.Base
                     services.AddSingleton<IConnectionManager, ConnectionManager>();
                     services.AddSingleton<ConnectionManagerSettings>();
                     services.AddSingleton<PayloadProvider>(new PayloadProvider().DiscoverPayloads());
+                    services.AddSingleton<BestChainSelector>();
 
                     // Peer address manager
                     services.AddSingleton<IPeerAddressManager, PeerAddressManager>();

--- a/src/Stratis.Bitcoin/Base/BestChainSelector.cs
+++ b/src/Stratis.Bitcoin/Base/BestChainSelector.cs
@@ -141,7 +141,10 @@ namespace Stratis.Bitcoin.Base
                     if (this.chain.SetTipIfChainworkIsGreater(tip))
                     {
                         // This allows garbage collection to collect the duplicated pendingTip and ancestors.
-                        tip = this.chain.GetBlock(tip.HashBlock);
+                        ChainedBlock chainedTip = this.chain.GetBlock(tip.HashBlock);
+
+                        if (chainedTip != null)
+                            tip = chainedTip;
                     }
                 }
 

--- a/src/Stratis.Bitcoin/Base/BestChainSelector.cs
+++ b/src/Stratis.Bitcoin/Base/BestChainSelector.cs
@@ -196,6 +196,9 @@ namespace Stratis.Bitcoin.Base
 
             this.unavailableTipsProcessingQueue.Dispose();
 
+            // Switch to the consensus tip. 
+            this.chain.SetTip(this.chainState.ConsensusTip);
+
             this.logger.LogTrace("(-)");
         }
     }

--- a/src/Stratis.Bitcoin/Base/BestChainSelector.cs
+++ b/src/Stratis.Bitcoin/Base/BestChainSelector.cs
@@ -1,0 +1,104 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using NBitcoin;
+using Stratis.Bitcoin.Utilities;
+
+namespace Stratis.Bitcoin.Base
+{
+    /// <summary>
+    /// Selects the best available chain based on Tips provided by the peers and switches to it.
+    /// </summary>
+    /// <remarks>
+    /// When a peer that provided the best chain is disconnected we select the best chain that is backed by one of the connected
+    /// peers and switch to it since we are not interested in a chain that is not represented by any peer.
+    /// </remarks>
+    public class BestChainSelector : IDisposable
+    {
+        private readonly ConcurrentChain chain;
+
+        private readonly AsyncQueue<ChainedBlock> unavailableTipsProcessingQueue;
+
+        private Task dequeueTask;
+
+        private readonly Dictionary<int, ChainedBlock> availableTips;
+
+        private readonly CancellationTokenSource cancellation;
+
+        /// <summary>Protects access to <see cref="availableTips"/>.</summary>
+        private readonly object lockObject;
+
+        /// <summary>
+        /// Creates new instance of <see cref="BestChainSelector"/>
+        /// </summary>
+        public BestChainSelector(ConcurrentChain chain)
+        {
+            this.chain = chain;
+
+            this.lockObject = new object();
+            this.availableTips = new Dictionary<int, ChainedBlock>();
+            this.unavailableTipsProcessingQueue = new AsyncQueue<ChainedBlock>();
+            this.cancellation = new CancellationTokenSource();
+
+            //move max reorg and chain switching here
+            //chb provides a tip and we answer if its ok or peer should be banned
+        }
+
+        public void Initialize()
+        {
+            this.dequeueTask = Task.Run(async () =>
+            {
+                while (!this.cancellation.IsCancellationRequested)
+                {
+                    // tip or a peer that was disconnected
+                    ChainedBlock tip = await this.unavailableTipsProcessingQueue.DequeueAsync().ConfigureAwait(false);
+
+                    if (tip != this.chain.Tip)
+                        continue;
+
+                    lock (this.lockObject)
+                    {
+                        ChainedBlock bestTip = this.availableTips.Aggregate((item1, item2) => item1.Value.ChainWork > item2.Value.ChainWork ? item1 : item2).Value;
+
+                        if (bestTip != this.chain.Tip)
+                            this.chain.SetTip(bestTip);
+                    }
+                }
+            });
+        }
+        
+        public void SetAvailableTip(int peerConnectionId, ChainedBlock tip)
+        {
+            lock (this.lockObject)
+            {
+                this.availableTips.AddOrReplace(peerConnectionId, tip);
+            }
+        }
+
+        public void RemoveAvailableTip(int peerConnectionId)
+        {
+            lock (this.lockObject)
+            {
+                if (this.availableTips.TryGetValue(peerConnectionId, out ChainedBlock tip))
+                {
+                    this.availableTips.Remove(peerConnectionId);
+                    this.unavailableTipsProcessingQueue.Enqueue(tip);
+                }
+            }
+        }
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            this.cancellation.Cancel();
+
+            this.dequeueTask?.Wait();
+
+            this.unavailableTipsProcessingQueue.Dispose();
+        }
+    }
+}

--- a/src/Stratis.Bitcoin/Base/BestChainSelector.cs
+++ b/src/Stratis.Bitcoin/Base/BestChainSelector.cs
@@ -1,8 +1,6 @@
 ﻿using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using NBitcoin;
@@ -54,11 +52,18 @@ namespace Stratis.Bitcoin.Base
             {
                 while (!this.cancellation.IsCancellationRequested)
                 {
-                    // tip or a peer that was disconnected
-                    ChainedBlock tip = await this.unavailableTipsProcessingQueue.DequeueAsync().ConfigureAwait(false);
+                    try
+                    {
+                        // tip or a peer that was disconnected
+                        ChainedBlock tip = await this.unavailableTipsProcessingQueue.DequeueAsync(this.cancellation.Token).ConfigureAwait(false);
 
-                    if (tip != this.chain.Tip)
+                        if (tip != this.chain.Tip)
+                            continue;
+                    }
+                    catch (OperationCanceledException)
+                    {
                         continue;
+                    }
 
                     lock (this.lockObject)
                     {

--- a/src/Stratis.Bitcoin/Base/BestChainSelector.cs
+++ b/src/Stratis.Bitcoin/Base/BestChainSelector.cs
@@ -61,15 +61,15 @@ namespace Stratis.Bitcoin.Base
         {
             this.logger.LogTrace("({0}:'{1}')", nameof(tip), tip);
 
-            // Ignore it if it wasn't the best chain's tip.
-            if (tip != this.chain.Tip)
-            {
-                this.logger.LogTrace("(-)[NOT_BEST_CHAIN_TIP]");
-                return Task.CompletedTask;
-            }
-
             lock (this.lockObject)
             {
+                // Ignore it if it wasn't the best chain's tip.
+                if (tip != this.chain.Tip)
+                {
+                    this.logger.LogTrace("(-)[NOT_BEST_CHAIN_TIP]");
+                    return Task.CompletedTask;
+                }
+
                 // If better tip is not found consensus tip should be used.
                 ChainedBlock bestTip = this.chainState.ConsensusTip;
 

--- a/src/Stratis.Bitcoin/Base/BestChainSelector.cs
+++ b/src/Stratis.Bitcoin/Base/BestChainSelector.cs
@@ -10,7 +10,7 @@ using Stratis.Bitcoin.Utilities;
 namespace Stratis.Bitcoin.Base
 {
     /// <summary>
-    /// Selects the best available chain based on Tips provided by the peers and switches to it.
+    /// Selects the best available chain based on tips provided by the peers and switches to it.
     /// </summary>
     /// <remarks>
     /// When a peer that provided the best chain is disconnected we select the best chain that is backed by one of the connected

--- a/src/Stratis.Bitcoin/Base/ChainHeadersBehavior.cs
+++ b/src/Stratis.Bitcoin/Base/ChainHeadersBehavior.cs
@@ -85,7 +85,7 @@ namespace Stratis.Bitcoin.Base
 
         public bool InvalidHeaderReceived { get; private set; }
 
-        /// <summary>Selects the best available chain based on Tips provided by the peers and switches to it.</summary>
+        /// <summary>Selects the best available chain based on tips provided by the peers and switches to it.</summary>
         private readonly BestChainSelector bestChainSelector;
 
         /// <summary>
@@ -95,7 +95,7 @@ namespace Stratis.Bitcoin.Base
         /// <param name="chainState">Information about node's chain.</param>
         /// <param name="loggerFactory">Factory for creating loggers.</param>
         /// <param name="initialBlockDownloadState">Provider of IBD state.</param>
-        /// <param name="bestChainSelector">Selects the best available chain based on Tips provided by the peers and switches to it.</param>
+        /// <param name="bestChainSelector">Selects the best available chain based on tips provided by the peers and switches to it.</param>
         public ChainHeadersBehavior(ConcurrentChain chain, IChainState chainState, IInitialBlockDownloadState initialBlockDownloadState, BestChainSelector bestChainSelector, ILoggerFactory loggerFactory)
         {
             Guard.NotNull(chain, nameof(chain));
@@ -368,12 +368,9 @@ namespace Stratis.Bitcoin.Base
             if (pendingTipBefore != this.pendingTip)
                 this.logger.LogTrace("Pending tip changed to '{0}'.", this.pendingTip);
 
-            if (this.pendingTip != null)
-            {
-                if (!this.bestChainSelector.TrySetAvailableTip(this.AttachedPeer.Connection.Id, this.pendingTip))
-                    this.InvalidHeaderReceived = true;
-            }
-
+            if ((this.pendingTip != null) && !this.bestChainSelector.TrySetAvailableTip(this.AttachedPeer.Connection.Id, this.pendingTip))
+                this.InvalidHeaderReceived = true;
+            
             ChainedBlock chainedPendingTip = this.pendingTip == null ? null : this.Chain.GetBlock(this.pendingTip.HashBlock);
             if (chainedPendingTip != null)
             {

--- a/src/Stratis.Bitcoin/Base/ChainHeadersBehavior.cs
+++ b/src/Stratis.Bitcoin/Base/ChainHeadersBehavior.cs
@@ -149,10 +149,10 @@ namespace Stratis.Bitcoin.Base
         {
             this.logger.LogTrace("()");
 
-            this.bestChainSelector.RemoveAvailableTip(this.AttachedPeer.Connection.Id);
-
             this.AttachedPeer.MessageReceived.Unregister(this.OnMessageReceivedAsync);
             this.AttachedPeer.StateChanged.Unregister(this.OnStateChangedAsync);
+            
+            this.bestChainSelector.RemoveAvailableTip(this.AttachedPeer.Connection.Id);
 
             this.logger.LogTrace("(-)");
         }

--- a/src/Stratis.Bitcoin/FullNode.cs
+++ b/src/Stratis.Bitcoin/FullNode.cs
@@ -214,8 +214,6 @@ namespace Stratis.Bitcoin
             // Initialize peer connection.
             this.ConnectionManager.Initialize();
 
-            this.bestChainSelector.Initialize();
-
             // Fire INodeLifetime.Started.
             this.nodeLifetime.NotifyStarted();
 

--- a/src/Stratis.Bitcoin/FullNode.cs
+++ b/src/Stratis.Bitcoin/FullNode.cs
@@ -59,6 +59,9 @@ namespace Stratis.Bitcoin
         /// <summary>Component responsible for connections to peers in P2P network.</summary>
         public IConnectionManager ConnectionManager { get; set; }
 
+        /// <summary>Selects the best available chain based on Tips provided by the peers and switches to it.</summary>
+        private BestChainSelector bestChainSelector;
+
         /// <summary>Best chain of block headers from genesis.</summary>
         public ConcurrentChain Chain { get; set; }
 
@@ -170,6 +173,7 @@ namespace Stratis.Bitcoin
             this.InitialBlockDownloadState = this.Services.ServiceProvider.GetService<IInitialBlockDownloadState>();
 
             this.ConnectionManager = this.Services.ServiceProvider.GetService<IConnectionManager>();
+            this.bestChainSelector = this.Services.ServiceProvider.GetService<BestChainSelector>();
             this.loggerFactory = this.Services.ServiceProvider.GetService<NodeSettings>().LoggerFactory;
 
             this.AsyncLoopFactory = this.Services.ServiceProvider.GetService<IAsyncLoopFactory>();
@@ -209,6 +213,8 @@ namespace Stratis.Bitcoin
 
             // Initialize peer connection.
             this.ConnectionManager.Initialize();
+
+            this.bestChainSelector.Initialize();
 
             // Fire INodeLifetime.Started.
             this.nodeLifetime.NotifyStarted();
@@ -268,6 +274,7 @@ namespace Stratis.Bitcoin
             this.nodeLifetime.StopApplication();
 
             this.ConnectionManager.Dispose();
+            this.bestChainSelector.Dispose();
             this.loggerFactory.Dispose();
 
             foreach (IDisposable disposable in this.Resources)

--- a/src/Stratis.Bitcoin/FullNode.cs
+++ b/src/Stratis.Bitcoin/FullNode.cs
@@ -59,7 +59,7 @@ namespace Stratis.Bitcoin
         /// <summary>Component responsible for connections to peers in P2P network.</summary>
         public IConnectionManager ConnectionManager { get; set; }
 
-        /// <summary>Selects the best available chain based on Tips provided by the peers and switches to it.</summary>
+        /// <summary>Selects the best available chain based on tips provided by the peers and switches to it.</summary>
         private BestChainSelector bestChainSelector;
 
         /// <summary>Best chain of block headers from genesis.</summary>


### PR DESCRIPTION
This PR is the first one for #229

It introduces a new component `BestChainSelector` that handles situations when a peer disconnects and selects the best chain tip from the available ones in case disconnected peer was the only one who backed our current best chain. 

ps
Reviewed already by @Aprogiena 