### PR TITLE
Added account name parameter to get balances and get history

### DIFF
--- a/src/Stratis.Bitcoin.Features.Wallet.Tests/WalletControllerTest.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet.Tests/WalletControllerTest.cs
@@ -697,7 +697,14 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
         {
             var walletName = "myWallet";
             var mockWalletWrapper = new Mock<IWalletManager>();
-            mockWalletWrapper.Setup(w => w.GetHistory(walletName)).Returns(new List<FlatHistory>());
+            mockWalletWrapper.Setup(w => w.GetHistory(walletName, null)).Returns(new List<AccountHistory>
+            {
+                new AccountHistory
+                {
+                    History = new List<FlatHistory>(),
+                    Account = new HdAccount()
+                }
+            });
             mockWalletWrapper.Setup(w => w.GetWalletByName(walletName)).Returns(new Wallet());
 
             var controller = new WalletController(this.LoggerFactory.Object, mockWalletWrapper.Object, new Mock<IWalletTransactionHandler>().Object, new Mock<IWalletSyncManager>().Object, It.IsAny<ConnectionManager>(), Network.Main, new Mock<ConcurrentChain>().Object, new Mock<IBroadcasterManager>().Object, DateTimeProvider.Default);
@@ -710,8 +717,10 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
             var model = viewResult.Value as WalletHistoryModel;
 
             Assert.NotNull(model);
-
-            Assert.Empty(model.TransactionsHistory);
+            Assert.NotNull(model.AccountsHistoryModel);
+            Assert.NotEmpty(model.AccountsHistoryModel);
+            Assert.Single(model.AccountsHistoryModel);
+            Assert.Empty(model.AccountsHistoryModel.First().TransactionsHistory);
         }
 
         [Fact]
@@ -724,18 +733,17 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
 
             var addresses = new List<HdAddress> { address };
             Wallet wallet = WalletTestsHelpers.CreateWallet(walletName);
+            HdAccount account = new HdAccount { ExternalAddresses = addresses };
             wallet.AccountsRoot.Add(new AccountRoot()
             {
-                Accounts = new List<HdAccount> { new HdAccount
-                {
-                    ExternalAddresses = addresses
-                } }
+                Accounts = new List<HdAccount> { account }
             });
 
             List<FlatHistory> flat = addresses.SelectMany(s => s.Transactions.Select(t => new FlatHistory { Address = s, Transaction = t })).ToList();
 
+            var accountsHistory = new List<AccountHistory> { new AccountHistory { History = flat, Account = account } };
             var mockWalletWrapper = new Mock<IWalletManager>();
-            mockWalletWrapper.Setup(w => w.GetHistory(walletName)).Returns(flat);
+            mockWalletWrapper.Setup(w => w.GetHistory(walletName, null)).Returns(accountsHistory);
             mockWalletWrapper.Setup(w => w.GetWalletByName(walletName)).Returns(wallet);
 
             var controller = new WalletController(this.LoggerFactory.Object, mockWalletWrapper.Object, new Mock<IWalletTransactionHandler>().Object, new Mock<IWalletSyncManager>().Object, It.IsAny<ConnectionManager>(), Network.Main, new Mock<ConcurrentChain>().Object, new Mock<IBroadcasterManager>().Object, DateTimeProvider.Default);
@@ -748,9 +756,11 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
             var model = viewResult.Value as WalletHistoryModel;
 
             Assert.NotNull(model);
+            Assert.Single(model.AccountsHistoryModel);
 
-            Assert.Single(model.TransactionsHistory);
-            TransactionItemModel resultingTransactionModel = model.TransactionsHistory[0];
+            var historyModel = model.AccountsHistoryModel.ElementAt(0);
+            Assert.Single(historyModel.TransactionsHistory);
+            TransactionItemModel resultingTransactionModel = historyModel.TransactionsHistory[0];
 
             Assert.Equal(TransactionItemType.Received, resultingTransactionModel.Type);
             Assert.Equal(address.Address, resultingTransactionModel.ToAddress);
@@ -779,18 +789,17 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
 
             var addresses = new List<HdAddress> { address, changeAddress };
             Wallet wallet = WalletTestsHelpers.CreateWallet(walletName);
+            HdAccount account = new HdAccount { ExternalAddresses = addresses };
             wallet.AccountsRoot.Add(new AccountRoot()
             {
-                Accounts = new List<HdAccount> { new HdAccount
-                {
-                    ExternalAddresses = addresses
-                } }
+                Accounts = new List<HdAccount> { account }
             });
 
             List<FlatHistory> flat = addresses.SelectMany(s => s.Transactions.Select(t => new FlatHistory { Address = s, Transaction = t })).ToList();
+            var accountsHistory = new List<AccountHistory> { new AccountHistory { History = flat, Account = account } };
 
             var mockWalletWrapper = new Mock<IWalletManager>();
-            mockWalletWrapper.Setup(w => w.GetHistory(walletName)).Returns(flat);
+            mockWalletWrapper.Setup(w => w.GetHistory(walletName, null)).Returns(accountsHistory);
             mockWalletWrapper.Setup(w => w.GetWalletByName(walletName)).Returns(wallet);
 
             var controller = new WalletController(this.LoggerFactory.Object, mockWalletWrapper.Object, new Mock<IWalletTransactionHandler>().Object, new Mock<IWalletSyncManager>().Object, It.IsAny<ConnectionManager>(), Network.Main, new Mock<ConcurrentChain>().Object, new Mock<IBroadcasterManager>().Object, DateTimeProvider.Default);
@@ -803,9 +812,11 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
             var model = viewResult.Value as WalletHistoryModel;
 
             Assert.NotNull(model);
+            Assert.Single(model.AccountsHistoryModel);
 
-            Assert.Equal(2, model.TransactionsHistory.Count);
-            TransactionItemModel resultingTransactionModel = model.TransactionsHistory[0];
+            var historyModel = model.AccountsHistoryModel.ElementAt(0);
+            Assert.Equal(2, historyModel.TransactionsHistory.Count);
+            TransactionItemModel resultingTransactionModel = historyModel.TransactionsHistory[0];
 
             Assert.Equal(TransactionItemType.Received, resultingTransactionModel.Type);
             Assert.Equal(address.Address, resultingTransactionModel.ToAddress);
@@ -816,7 +827,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
             Assert.Null(resultingTransactionModel.Fee);
             Assert.Equal(0, resultingTransactionModel.Payments.Count);
 
-            resultingTransactionModel = model.TransactionsHistory[1];
+            resultingTransactionModel = historyModel.TransactionsHistory[1];
 
             Assert.Equal(TransactionItemType.Send, resultingTransactionModel.Type);
             Assert.Null(resultingTransactionModel.ToAddress);
@@ -853,18 +864,17 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
             var addresses = new List<HdAddress> { address, changeAddress };
 
             Wallet wallet = WalletTestsHelpers.CreateWallet(walletName);
+            HdAccount account = new HdAccount { ExternalAddresses = addresses };
             wallet.AccountsRoot.Add(new AccountRoot()
             {
-                Accounts = new List<HdAccount> { new HdAccount
-                {
-                    ExternalAddresses = addresses
-                } }
+                Accounts = new List<HdAccount> { account }
             });
 
             List<FlatHistory> flat = addresses.SelectMany(s => s.Transactions.Select(t => new FlatHistory { Address = s, Transaction = t })).ToList();
+            var accountsHistory = new List<AccountHistory> { new AccountHistory { History = flat, Account = account } };
 
             var mockWalletWrapper = new Mock<IWalletManager>();
-            mockWalletWrapper.Setup(w => w.GetHistory(walletName)).Returns(flat);
+            mockWalletWrapper.Setup(w => w.GetHistory(walletName, null)).Returns(accountsHistory);
             mockWalletWrapper.Setup(w => w.GetWalletByName(walletName)).Returns(wallet);
 
             var controller = new WalletController(this.LoggerFactory.Object, mockWalletWrapper.Object, new Mock<IWalletTransactionHandler>().Object, new Mock<IWalletSyncManager>().Object, It.IsAny<ConnectionManager>(), Network.Main, new Mock<ConcurrentChain>().Object, new Mock<IBroadcasterManager>().Object, DateTimeProvider.Default);
@@ -877,9 +887,12 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
             var model = viewResult.Value as WalletHistoryModel;
 
             Assert.NotNull(model);
+            Assert.Single(model.AccountsHistoryModel);
 
-            Assert.Equal(2, model.TransactionsHistory.Count);
-            TransactionItemModel resultingTransactionModel = model.TransactionsHistory[1];
+            var historyModel = model.AccountsHistoryModel.ElementAt(0);
+            Assert.Equal(2, historyModel.TransactionsHistory.Count);
+
+            TransactionItemModel resultingTransactionModel = historyModel.TransactionsHistory[1];
             Assert.Equal(0, resultingTransactionModel.Fee);
         }
 
@@ -947,19 +960,18 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
             };
 
             Wallet wallet = WalletTestsHelpers.CreateWallet(walletName);
+            HdAccount account = new HdAccount { ExternalAddresses = addresses };
             wallet.AccountsRoot.Add(new AccountRoot()
             {
-                Accounts = new List<HdAccount> { new HdAccount
-                {
-                    ExternalAddresses = addresses
-                } }
+                Accounts = new List<HdAccount> { account }
             });
-
+            
             List<FlatHistory> flat = addresses.SelectMany(s => s.Transactions.Select(t => new FlatHistory { Address = s, Transaction = t })).ToList();
+            var accountsHistory = new List<AccountHistory> { new AccountHistory { History = flat, Account = account } };
 
             var mockWalletManager = new Mock<IWalletManager>();
             mockWalletManager.Setup(w => w.GetWalletByName(walletName)).Returns(wallet);
-            mockWalletManager.Setup(w => w.GetHistory(walletName)).Returns(flat);
+            mockWalletManager.Setup(w => w.GetHistory(walletName, null)).Returns(accountsHistory);
 
             var controller = new WalletController(this.LoggerFactory.Object, mockWalletManager.Object, new Mock<IWalletTransactionHandler>().Object, new Mock<IWalletSyncManager>().Object, It.IsAny<ConnectionManager>(), Network.Main, new Mock<ConcurrentChain>().Object, new Mock<IBroadcasterManager>().Object, DateTimeProvider.Default);
             IActionResult result = controller.GetHistory(new WalletHistoryRequest
@@ -971,11 +983,13 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
             var model = viewResult.Value as WalletHistoryModel;
 
             Assert.NotNull(model);
+            Assert.Single(model.AccountsHistoryModel);
 
-            Assert.Single(model.TransactionsHistory);
+            var historyModel = model.AccountsHistoryModel.ElementAt(0);
+            Assert.Single(historyModel.TransactionsHistory);
 
-            TransactionItemModel resultingTransactionModel = model.TransactionsHistory[0];
-
+            TransactionItemModel resultingTransactionModel = historyModel.TransactionsHistory[0];
+            
             Assert.Equal(TransactionItemType.Send, resultingTransactionModel.Type);
             Assert.Equal(new uint256(15), resultingTransactionModel.Id);
             Assert.Equal(10, resultingTransactionModel.ConfirmedInBlock);
@@ -992,7 +1006,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
         {
             var walletName = "myWallet";
             var mockWalletWrapper = new Mock<IWalletManager>();
-            mockWalletWrapper.Setup(w => w.GetHistory("myWallet")).Throws(new InvalidOperationException("Issue retrieving wallets."));
+            mockWalletWrapper.Setup(w => w.GetHistory("myWallet", null)).Throws(new InvalidOperationException("Issue retrieving wallets."));
             mockWalletWrapper.Setup(w => w.GetWalletByName(walletName)).Returns(new Wallet());
 
             var controller = new WalletController(this.LoggerFactory.Object, mockWalletWrapper.Object, new Mock<IWalletTransactionHandler>().Object, new Mock<IWalletSyncManager>().Object, It.IsAny<ConnectionManager>(), Network.Main, new Mock<ConcurrentChain>().Object, new Mock<IBroadcasterManager>().Object, DateTimeProvider.Default);
@@ -1045,18 +1059,17 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
 
             var addresses = new List<HdAddress> { address, changeAddress, changeAddress2 };
             Wallet wallet = WalletTestsHelpers.CreateWallet(walletName);
+            HdAccount account = new HdAccount { ExternalAddresses = addresses };
             wallet.AccountsRoot.Add(new AccountRoot()
             {
-                Accounts = new List<HdAccount> { new HdAccount
-                {
-                    ExternalAddresses = addresses
-                } }
+                Accounts = new List<HdAccount> { account }
             });
 
             List<FlatHistory> flat = addresses.SelectMany(s => s.Transactions.Select(t => new FlatHistory { Address = s, Transaction = t })).ToList();
 
             var mockWalletWrapper = new Mock<IWalletManager>();
-            mockWalletWrapper.Setup(w => w.GetHistory(walletName)).Returns(flat);
+            var accountsHistory = new List<AccountHistory> { new AccountHistory { History = flat, Account = account } };
+            mockWalletWrapper.Setup(w => w.GetHistory(walletName, null)).Returns(accountsHistory);
             mockWalletWrapper.Setup(w => w.GetWalletByName(walletName)).Returns(wallet);
 
             var controller = new WalletController(this.LoggerFactory.Object, mockWalletWrapper.Object, new Mock<IWalletTransactionHandler>().Object, new Mock<IWalletSyncManager>().Object, It.IsAny<ConnectionManager>(), Network.Main, new Mock<ConcurrentChain>().Object, new Mock<IBroadcasterManager>().Object, DateTimeProvider.Default);
@@ -1069,10 +1082,13 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
             var model = viewResult.Value as WalletHistoryModel;
 
             Assert.NotNull(model);
+            Assert.Single(model.AccountsHistoryModel);
 
-            Assert.Equal(3, model.TransactionsHistory.Count);
-            TransactionItemModel resultingTransactionModel = model.TransactionsHistory[0];
+            var historyModel = model.AccountsHistoryModel.ElementAt(0);
+            Assert.Equal(3, historyModel.TransactionsHistory.Count);
 
+            TransactionItemModel resultingTransactionModel = historyModel.TransactionsHistory[0];
+            
             Assert.Equal(TransactionItemType.Received, resultingTransactionModel.Type);
             Assert.Equal(address.Address, resultingTransactionModel.ToAddress);
             Assert.Equal(transaction.Id, resultingTransactionModel.Id);
@@ -1082,7 +1098,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
             Assert.Null(resultingTransactionModel.Fee);
             Assert.Equal(0, resultingTransactionModel.Payments.Count);
 
-            resultingTransactionModel = model.TransactionsHistory[1];
+            resultingTransactionModel = historyModel.TransactionsHistory[1];
 
             Assert.Equal(TransactionItemType.Send, resultingTransactionModel.Type);
             Assert.Null(resultingTransactionModel.ToAddress);
@@ -1097,7 +1113,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
             Assert.Equal(paymentDetails.DestinationAddress, resultingPayment.DestinationAddress);
             Assert.Equal(paymentDetails.Amount, resultingPayment.Amount);
 
-            resultingTransactionModel = model.TransactionsHistory[2];
+            resultingTransactionModel = historyModel.TransactionsHistory[2];
 
             Assert.Equal(TransactionItemType.Send, resultingTransactionModel.Type);
             Assert.Null(resultingTransactionModel.ToAddress);
@@ -1147,7 +1163,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
             };
 
             var mockWalletWrapper = new Mock<IWalletManager>();
-            mockWalletWrapper.Setup(w => w.GetBalances("myWallet")).Returns(accountsBalances);
+            mockWalletWrapper.Setup(w => w.GetBalances("myWallet", null)).Returns(accountsBalances);
             
             var controller = new WalletController(this.LoggerFactory.Object, mockWalletWrapper.Object, new Mock<IWalletTransactionHandler>().Object, new Mock<IWalletSyncManager>().Object, It.IsAny<ConnectionManager>(), Network.Main, new Mock<ConcurrentChain>().Object, new Mock<IBroadcasterManager>().Object, DateTimeProvider.Default);
             IActionResult result = controller.GetBalance(new WalletBalanceRequest
@@ -1222,7 +1238,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
         public void GetBalanceWithExceptionReturnsBadRequest()
         {
             var mockWalletWrapper = new Mock<IWalletManager>();
-            mockWalletWrapper.Setup(m => m.GetBalances("myWallet"))
+            mockWalletWrapper.Setup(m => m.GetBalances("myWallet", null))
                   .Throws(new InvalidOperationException("Issue retrieving accounts."));
 
             var controller = new WalletController(this.LoggerFactory.Object, mockWalletWrapper.Object, new Mock<IWalletTransactionHandler>().Object, new Mock<IWalletSyncManager>().Object, It.IsAny<ConnectionManager>(), Network.Main, new Mock<ConcurrentChain>().Object, new Mock<IBroadcasterManager>().Object, DateTimeProvider.Default);

--- a/src/Stratis.Bitcoin.Features.Wallet.Tests/WalletManagerTest.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet.Tests/WalletManagerTest.cs
@@ -916,22 +916,30 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
             });
             walletManager.Wallets.Add(wallet);
 
-            var result = walletManager.GetHistory("myWallet");
+            var result = walletManager.GetHistory("myWallet").ToList();
 
-            Assert.Equal(2, result.Count());
-            var address = result.ElementAt(0);
-            Assert.Equal("myUsedExternalAddress", address.Address.Address);
-            address = result.ElementAt(1);
-            Assert.Equal("myUsedInternalAddress", address.Address.Address);
+            Assert.NotEmpty(result);
+            Assert.Single(result);
+            var accountHistory = result.ElementAt(0);
+            Assert.NotNull(accountHistory.Account);
+            Assert.Equal("myAccount", accountHistory.Account.Name);
+            Assert.NotEmpty(accountHistory.History);
+            Assert.Equal(2, accountHistory.History.Count());
+
+            var historyAddress = accountHistory.History.ElementAt(0);
+            Assert.Equal("myUsedExternalAddress", historyAddress.Address.Address);
+            historyAddress = accountHistory.History.ElementAt(1);
+            Assert.Equal("myUsedInternalAddress", historyAddress.Address.Address);
         }
 
         [Fact]
-        public void GetHistoryByWalletWithExistingWalletReturnsAllAddressesWithTransactions()
+        public void GetHistoryByAccountWithExistingAccountReturnsAllAddressesWithTransactions()
         {
             var walletManager = new WalletManager(this.LoggerFactory.Object, Network.Main, new Mock<ConcurrentChain>().Object, NodeSettings.Default(), new Mock<WalletSettings>().Object,
                 CreateDataFolder(this), new Mock<IWalletFeePolicy>().Object, new Mock<IAsyncLoopFactory>().Object, new NodeLifetime(), DateTimeProvider.Default);
             var wallet = this.walletFixture.GenerateBlankWallet("myWallet", "password");
-            wallet.AccountsRoot.ElementAt(0).Accounts.Add(new HdAccount
+
+            HdAccount account = new HdAccount
             {
                 Index = 0,
                 Name = "myAccount",
@@ -941,30 +949,39 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
                     WalletTestsHelpers.CreateAddressWithEmptyTransaction(0, "myUsedExternalAddress"),
                     WalletTestsHelpers.CreateAddressWithoutTransaction(1, "myUnusedExternalAddress"),
                 },
-                InternalAddresses = new List<HdAddress> {
+                InternalAddresses = new List<HdAddress>
+                {
                     WalletTestsHelpers.CreateAddressWithEmptyTransaction(0, "myUsedInternalAddress"),
                     WalletTestsHelpers.CreateAddressWithoutTransaction(1, "myUnusedInternalAddress"),
                 },
                 ExtendedPubKey = "blabla"
-            });
+            };
+
+            wallet.AccountsRoot.ElementAt(0).Accounts.Add(account);
             walletManager.Wallets.Add(wallet);
 
-            var result = walletManager.GetHistory(wallet);
+            var accountHistory = walletManager.GetHistory(account);
 
-            Assert.Equal(2, result.Count());
-            var address = result.ElementAt(0);
-            Assert.Equal("myUsedExternalAddress", address.Address.Address);
-            address = result.ElementAt(1);
-            Assert.Equal("myUsedInternalAddress", address.Address.Address);
+            Assert.NotNull(accountHistory);
+            Assert.NotNull(accountHistory.Account);
+            Assert.Equal("myAccount", accountHistory.Account.Name);
+            Assert.NotEmpty(accountHistory.History);
+            Assert.Equal(2, accountHistory.History.Count());
+
+            var historyAddress = accountHistory.History.ElementAt(0);
+            Assert.Equal("myUsedExternalAddress", historyAddress.Address.Address);
+            historyAddress = accountHistory.History.ElementAt(1);
+            Assert.Equal("myUsedInternalAddress", historyAddress.Address.Address);
         }
 
         [Fact]
-        public void GetHistoryByWalletWithoutHavingAddressesWithTransactionsReturnsEmptyList()
+        public void GetHistoryByAccountWithoutHavingAddressesWithTransactionsReturnsEmptyList()
         {
             var walletManager = new WalletManager(this.LoggerFactory.Object, Network.Main, new Mock<ConcurrentChain>().Object, NodeSettings.Default(), new Mock<WalletSettings>().Object,
                 CreateDataFolder(this), new Mock<IWalletFeePolicy>().Object, new Mock<IAsyncLoopFactory>().Object, new NodeLifetime(), DateTimeProvider.Default);
             var wallet = this.walletFixture.GenerateBlankWallet("myWallet", "password");
-            wallet.AccountsRoot.ElementAt(0).Accounts.Add(new HdAccount
+
+            HdAccount account = new HdAccount
             {
                 Index = 0,
                 Name = "myAccount",
@@ -972,12 +989,15 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
                 ExternalAddresses = new List<HdAddress>(),
                 InternalAddresses = new List<HdAddress>(),
                 ExtendedPubKey = "blabla"
-            });
+            };
+            wallet.AccountsRoot.ElementAt(0).Accounts.Add(account);
             walletManager.Wallets.Add(wallet);
 
-            var result = walletManager.GetHistory(wallet);
+            var result = walletManager.GetHistory(account);
 
-            Assert.Empty(result);
+            Assert.NotNull(result.Account);
+            Assert.Equal("myAccount", result.Account.Name);
+            Assert.Empty(result.History);
         }
 
         [Fact]

--- a/src/Stratis.Bitcoin.Features.Wallet.Tests/WalletManagerTest.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet.Tests/WalletManagerTest.cs
@@ -812,8 +812,8 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
             });
             walletManager.Wallets.Add(wallet);
 
-            var result = walletManager.GetOrCreateChangeAddress(walletManager.GetAccounts("myWallet").First());
-
+            var result = walletManager.GetUnusedChangeAddress(new WalletAccountReference(wallet.Name, wallet.AccountsRoot.First().Accounts.First().Name));
+            
             Assert.Equal(alice.GetAddress().ToString(), result.Address);
         }
 
@@ -839,8 +839,8 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
                 ExternalAddresses = new List<HdAddress>()
             });
             walletManager.Wallets.Add(wallet);
-
-            var result = walletManager.GetOrCreateChangeAddress(walletManager.GetAccounts("myWallet").First());
+            
+            var result = walletManager.GetUnusedChangeAddress(new WalletAccountReference(wallet.Name, wallet.AccountsRoot.First().Accounts.First().Name));
 
             Assert.NotNull(result.Address);
         }

--- a/src/Stratis.Bitcoin.Features.Wallet/Controllers/WalletController.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Controllers/WalletController.cs
@@ -322,130 +322,143 @@ namespace Stratis.Bitcoin.Features.Wallet.Controllers
                 WalletHistoryModel model = new WalletHistoryModel();
 
                 // Get a list of all the transactions, with the addresses associated with them.
-                List<FlatHistory> items = this.walletManager.GetHistory(request.WalletName).ToList().OrderByDescending(o => o.Transaction.CreationTime).Take(200).ToList();
+                IEnumerable<AccountHistory> accountsHistory = this.walletManager.GetHistory(request.WalletName, request.AccountName);
 
-                // Represents a sublist containing only the transactions that have already been spent.
-                List<FlatHistory> spendingDetails = items.Where(t => t.Transaction.SpendingDetails != null).ToList();
-
-                // Represents a sublist of transactions associated with receive addresses + a sublist of already spent transactions associated with change addresses.
-                // In effect, we filter out 'change' transactions that are not spent, as we don't want to show these in the history.
-                List<FlatHistory> history = items.Where(t => !t.Address.IsChangeAddress() || (t.Address.IsChangeAddress() && !t.Transaction.IsSpendable())).ToList();
-
-                // Represents a sublist of 'change' transactions.
-                List<FlatHistory> allchange = items.Where(t => t.Address.IsChangeAddress()).ToList();
-
-                foreach (var item in history)
+                foreach (var accountHistory in accountsHistory)
                 {
-                    var transaction = item.Transaction;
-                    var address = item.Address;
+                    List<TransactionItemModel> transactionItems = new List<TransactionItemModel>();
 
-                    // We don't show in history transactions that are outputs of staking transactions.
-                    if (transaction.IsCoinStake != null && transaction.IsCoinStake.Value && transaction.SpendingDetails == null)
+                    List<FlatHistory> items = accountHistory.History.OrderByDescending(o => o.Transaction.CreationTime).Take(200).ToList();
+
+                    // Represents a sublist containing only the transactions that have already been spent.
+                    List<FlatHistory> spendingDetails = items.Where(t => t.Transaction.SpendingDetails != null).ToList();
+
+                    // Represents a sublist of transactions associated with receive addresses + a sublist of already spent transactions associated with change addresses.
+                    // In effect, we filter out 'change' transactions that are not spent, as we don't want to show these in the history.
+                    List<FlatHistory> history = items.Where(t => !t.Address.IsChangeAddress() || (t.Address.IsChangeAddress() && !t.Transaction.IsSpendable())).ToList();
+
+                    // Represents a sublist of 'change' transactions.
+                    List<FlatHistory> allchange = items.Where(t => t.Address.IsChangeAddress()).ToList();
+
+                    foreach (var item in history)
                     {
-                        continue;
-                    }
+                        var transaction = item.Transaction;
+                        var address = item.Address;
 
-                    // First we look for staking transaction as they require special attention.
-                    // A staking transaction spends one of our inputs into 2 outputs, paid to the same address.
-                    if (transaction.SpendingDetails?.IsCoinStake != null && transaction.SpendingDetails.IsCoinStake.Value)
-                    {
-                        // We look for the 2 outputs related to our spending input.
-                        List<FlatHistory> relatedOutputs = items.Where(h => h.Transaction.Id == transaction.SpendingDetails.TransactionId && h.Transaction.IsCoinStake != null && h.Transaction.IsCoinStake.Value).ToList();
-                        if (relatedOutputs.Any())
-                        {
-                            // Add staking transaction details.
-                            // The staked amount is calculated as the difference between the sum of the outputs and the input and should normally be equal to 1.
-                            TransactionItemModel stakingItem = new TransactionItemModel
-                            {
-                                Type = TransactionItemType.Staked,
-                                ToAddress = address.Address,
-                                Amount = relatedOutputs.Sum(o => o.Transaction.Amount) - transaction.Amount,
-                                Id = transaction.SpendingDetails.TransactionId,
-                                Timestamp = transaction.SpendingDetails.CreationTime,
-                                ConfirmedInBlock = transaction.SpendingDetails.BlockHeight
-                            };
-
-                            model.TransactionsHistory.Add(stakingItem);
-                        }
-
-                        // No need for further processing if the transaction itself is the output of a staking transaction.
-                        if (transaction.IsCoinStake != null)
+                        // We don't show in history transactions that are outputs of staking transactions.
+                        if (transaction.IsCoinStake != null && transaction.IsCoinStake.Value && transaction.SpendingDetails == null)
                         {
                             continue;
                         }
-                    }
 
-                    // Create a record for a 'receive' transaction.
-                    if (!address.IsChangeAddress())
-                    {
-                        // Add incoming fund transaction details.
-                        TransactionItemModel receivedItem = new TransactionItemModel
+                        // First we look for staking transaction as they require special attention.
+                        // A staking transaction spends one of our inputs into 2 outputs, paid to the same address.
+                        if (transaction.SpendingDetails?.IsCoinStake != null && transaction.SpendingDetails.IsCoinStake.Value)
                         {
-                            Type = TransactionItemType.Received,
-                            ToAddress = address.Address,
-                            Amount = transaction.Amount,
-                            Id = transaction.Id,
-                            Timestamp = transaction.CreationTime,
-                            ConfirmedInBlock = transaction.BlockHeight
-                        };
-
-                        model.TransactionsHistory.Add(receivedItem);
-                    }
-
-                    // If this is a normal transaction (not staking) that has been spent, add outgoing fund transaction details.
-                    if (transaction.SpendingDetails != null && transaction.SpendingDetails.IsCoinStake == null)
-                    {
-                        // Create a record for a 'send' transaction.
-                        var spendingTransactionId = transaction.SpendingDetails.TransactionId;
-                        TransactionItemModel sentItem = new TransactionItemModel
-                        {
-                            Type = TransactionItemType.Send,
-                            Id = spendingTransactionId,
-                            Timestamp = transaction.SpendingDetails.CreationTime,
-                            ConfirmedInBlock = transaction.SpendingDetails.BlockHeight,
-                            Amount = Money.Zero
-                        };
-
-                        // If this 'send' transaction has made some external payments, i.e the funds were not sent to another address in the wallet.
-                        if (transaction.SpendingDetails.Payments != null)
-                        {
-                            sentItem.Payments = new List<PaymentDetailModel>();
-                            foreach (var payment in transaction.SpendingDetails.Payments)
+                            // We look for the 2 outputs related to our spending input.
+                            List<FlatHistory> relatedOutputs = items.Where(h => h.Transaction.Id == transaction.SpendingDetails.TransactionId && h.Transaction.IsCoinStake != null && h.Transaction.IsCoinStake.Value).ToList();
+                            if (relatedOutputs.Any())
                             {
-                                sentItem.Payments.Add(new PaymentDetailModel
+                                // Add staking transaction details.
+                                // The staked amount is calculated as the difference between the sum of the outputs and the input and should normally be equal to 1.
+                                TransactionItemModel stakingItem = new TransactionItemModel
                                 {
-                                    DestinationAddress = payment.DestinationAddress,
-                                    Amount = payment.Amount
-                                });
+                                    Type = TransactionItemType.Staked,
+                                    ToAddress = address.Address,
+                                    Amount = relatedOutputs.Sum(o => o.Transaction.Amount) - transaction.Amount,
+                                    Id = transaction.SpendingDetails.TransactionId,
+                                    Timestamp = transaction.SpendingDetails.CreationTime,
+                                    ConfirmedInBlock = transaction.SpendingDetails.BlockHeight
+                                };
 
-                                sentItem.Amount += payment.Amount;
+                                transactionItems.Add(stakingItem);
+                            }
+
+                            // No need for further processing if the transaction itself is the output of a staking transaction.
+                            if (transaction.IsCoinStake != null)
+                            {
+                                continue;
                             }
                         }
 
-                        // Get the change address for this spending transaction.
-                        var changeAddress = allchange.FirstOrDefault(a => a.Transaction.Id == spendingTransactionId);
-
-                        // Find all the spending details containing the spending transaction id and aggregate the sums.
-                        // This is our best shot at finding the total value of inputs for this transaction.
-                        var inputsAmount = new Money(spendingDetails.Where(t => t.Transaction.SpendingDetails.TransactionId == spendingTransactionId).Sum(t => t.Transaction.Amount));
-
-                        // The fee is calculated as follows: funds in utxo - amount spent - amount sent as change.
-                        sentItem.Fee = inputsAmount - sentItem.Amount - (changeAddress == null ? 0 : changeAddress.Transaction.Amount);
-
-                        // Mined/staked coins add more coins to the total out.
-                        // That makes the fee negative. If that's the case ignore the fee.
-                        if (sentItem.Fee < 0)
-                            sentItem.Fee = 0;
-
-                        if (!model.TransactionsHistory.Contains(sentItem, new SentTransactionItemModelComparer()))
+                        // Create a record for a 'receive' transaction.
+                        if (!address.IsChangeAddress())
                         {
-                            model.TransactionsHistory.Add(sentItem);
+                            // Add incoming fund transaction details.
+                            TransactionItemModel receivedItem = new TransactionItemModel
+                            {
+                                Type = TransactionItemType.Received,
+                                ToAddress = address.Address,
+                                Amount = transaction.Amount,
+                                Id = transaction.Id,
+                                Timestamp = transaction.CreationTime,
+                                ConfirmedInBlock = transaction.BlockHeight
+                            };
+
+                            transactionItems.Add(receivedItem);
+                        }
+
+                        // If this is a normal transaction (not staking) that has been spent, add outgoing fund transaction details.
+                        if (transaction.SpendingDetails != null && transaction.SpendingDetails.IsCoinStake == null)
+                        {
+                            // Create a record for a 'send' transaction.
+                            var spendingTransactionId = transaction.SpendingDetails.TransactionId;
+                            TransactionItemModel sentItem = new TransactionItemModel
+                            {
+                                Type = TransactionItemType.Send,
+                                Id = spendingTransactionId,
+                                Timestamp = transaction.SpendingDetails.CreationTime,
+                                ConfirmedInBlock = transaction.SpendingDetails.BlockHeight,
+                                Amount = Money.Zero
+                            };
+
+                            // If this 'send' transaction has made some external payments, i.e the funds were not sent to another address in the wallet.
+                            if (transaction.SpendingDetails.Payments != null)
+                            {
+                                sentItem.Payments = new List<PaymentDetailModel>();
+                                foreach (var payment in transaction.SpendingDetails.Payments)
+                                {
+                                    sentItem.Payments.Add(new PaymentDetailModel
+                                    {
+                                        DestinationAddress = payment.DestinationAddress,
+                                        Amount = payment.Amount
+                                    });
+
+                                    sentItem.Amount += payment.Amount;
+                                }
+                            }
+
+                            // Get the change address for this spending transaction.
+                            var changeAddress = allchange.FirstOrDefault(a => a.Transaction.Id == spendingTransactionId);
+
+                            // Find all the spending details containing the spending transaction id and aggregate the sums.
+                            // This is our best shot at finding the total value of inputs for this transaction.
+                            var inputsAmount = new Money(spendingDetails.Where(t => t.Transaction.SpendingDetails.TransactionId == spendingTransactionId).Sum(t => t.Transaction.Amount));
+
+                            // The fee is calculated as follows: funds in utxo - amount spent - amount sent as change.
+                            sentItem.Fee = inputsAmount - sentItem.Amount - (changeAddress == null ? 0 : changeAddress.Transaction.Amount);
+
+                            // Mined/staked coins add more coins to the total out.
+                            // That makes the fee negative. If that's the case ignore the fee.
+                            if (sentItem.Fee < 0)
+                                sentItem.Fee = 0;
+
+                            if (!transactionItems.Contains(sentItem, new SentTransactionItemModelComparer()))
+                            {
+                                transactionItems.Add(sentItem);
+                            }
                         }
                     }
+
+                    model.AccountsHistoryModel.Add(new AccountHistoryModel
+                    {
+                        TransactionsHistory = transactionItems.OrderByDescending(t => t.Timestamp).ToList(),
+                        Name = accountHistory.Account.Name,
+                        CoinType = this.coinType,
+                        HdPath = accountHistory.Account.HdPath
+                    });
                 }
-
-                model.TransactionsHistory = model.TransactionsHistory.OrderByDescending(t => t.Timestamp).ToList();
-
+                
                 return this.Json(model);
             }
             catch (Exception e)
@@ -476,7 +489,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Controllers
             {
                 WalletBalanceModel model = new WalletBalanceModel();
 
-                IEnumerable<AccountBalance> balances = this.walletManager.GetBalances(request.WalletName);
+                IEnumerable<AccountBalance> balances = this.walletManager.GetBalances(request.WalletName, request.AccountName);
 
                 foreach (AccountBalance balance in balances)
                 {

--- a/src/Stratis.Bitcoin.Features.Wallet/FlatHistory.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/FlatHistory.cs
@@ -1,5 +1,20 @@
-﻿namespace Stratis.Bitcoin.Features.Wallet
+﻿using System.Collections.Generic;
+
+namespace Stratis.Bitcoin.Features.Wallet
 {
+    public class AccountHistory
+    {
+        /// <summary>
+        /// The account for which the history is retrieved.
+        /// </summary>
+        public HdAccount Account { get; set; }
+
+        /// <summary>
+        /// The collection of history items.
+        /// </summary>
+        public IEnumerable<FlatHistory> History { get; set; }
+    }
+
     /// <summary>
     /// A class that represents a flat view of the wallets history.
     /// </summary>

--- a/src/Stratis.Bitcoin.Features.Wallet/Interfaces/IWalletManager.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Interfaces/IWalletManager.cs
@@ -115,7 +115,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Interfaces
         /// <param name="accountReference">The name of the wallet and account.</param>
         /// <param name="count">The number of addresses to create.</param>
         /// <param name="isChange">A value indicating whether or not the addresses to get should be receiving or change addresses.</param>
-        /// <returns>A list of addresses.</returns>
+        /// <returns>A list of unused addresses. New addresses will be created as necessary.</returns>
         IEnumerable<HdAddress> GetUnusedAddresses(WalletAccountReference accountReference, int count, bool isChange = false);
 
         /// <summary>

--- a/src/Stratis.Bitcoin.Features.Wallet/Interfaces/IWalletManager.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Interfaces/IWalletManager.cs
@@ -102,7 +102,21 @@ namespace Stratis.Bitcoin.Features.Wallet.Interfaces
         /// <returns>An unused address or a newly created address, in Base58 format.</returns>
         HdAddress GetUnusedAddress(WalletAccountReference accountReference);
 
-        IEnumerable<HdAddress> GetUnusedAddresses(WalletAccountReference accountReference, int count);
+        /// <summary>
+        /// Gets the first change address that contains no transaction.
+        /// </summary>
+        /// <param name="accountReference">The name of the wallet and account.</param>
+        /// <returns>An unused change address or a newly created change address, in Base58 format.</returns>
+        HdAddress GetUnusedChangeAddress(WalletAccountReference accountReference);
+
+        /// <summary>
+        /// Gets a collection of unused receiving or change addresses.
+        /// </summary>
+        /// <param name="accountReference">The name of the wallet and account.</param>
+        /// <param name="count">The number of addresses to create.</param>
+        /// <param name="isChange">A value indicating whether or not the addresses to get should be receiving or change addresses.</param>
+        /// <returns>A list of addresses.</returns>
+        IEnumerable<HdAddress> GetUnusedAddresses(WalletAccountReference accountReference, int count, bool isChange = false);
 
         /// <summary>
         /// Gets a collection of addresses containing transactions for this coin.

--- a/src/Stratis.Bitcoin.Features.Wallet/Interfaces/IWalletManager.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Interfaces/IWalletManager.cs
@@ -229,14 +229,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Interfaces
         /// </summary>
         /// <returns></returns>
         ICollection<uint256> GetFirstWalletBlockLocator();
-
-        /// <summary>
-        /// Gets a change address or create one if all change addresses are used.
-        /// </summary>
-        /// <param name="account">The account to create the change address.</param>
-        /// <returns>The new HD address.</returns>
-        HdAddress GetOrCreateChangeAddress(HdAccount account);
-
+        
         /// <summary>
         /// Gets the list of the wallet filenames, along with the folder in which they're contained.
         /// </summary>

--- a/src/Stratis.Bitcoin.Features.Wallet/Interfaces/IWalletManager.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Interfaces/IWalletManager.cs
@@ -122,22 +122,24 @@ namespace Stratis.Bitcoin.Features.Wallet.Interfaces
         /// Gets a collection of addresses containing transactions for this coin.
         /// </summary>
         /// <param name="walletName">The wallet name.</param>
+        /// <param name="accountName">The account name.</param>
         /// <returns>Collection of address history and transaction pairs.</returns>
-        IEnumerable<FlatHistory> GetHistory(string walletName);
+        IEnumerable<AccountHistory> GetHistory(string walletName, string accountName = null);
 
         /// <summary>
-        /// Gets a collection of addresses containing transactions for this coin.
+        /// Gets the history of the transactions in addresses contained in this account.
         /// </summary>
-        /// <param name="wallet">The wallet to get history from.</param>
-        /// <returns></returns>
-        IEnumerable<FlatHistory> GetHistory(Wallet wallet);
+        /// <param name="account">The account for which to get history.</param>
+        /// <returns>The history for this account.</returns>
+        AccountHistory GetHistory(HdAccount account);
 
         /// <summary>
         /// Gets the balances of this wallet's accounts.
         /// </summary>
         /// <param name="walletName">The wallet name.</param>
+        /// <param name="accountName">The account name.</param>
         /// <returns>Collection of account balances.</returns>
-        IEnumerable<AccountBalance> GetBalances(string walletName);
+        IEnumerable<AccountBalance> GetBalances(string walletName, string accountName = null);
 
         /// <summary>
         /// Gets some general information about a wallet.

--- a/src/Stratis.Bitcoin.Features.Wallet/Models/RequestModels.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Models/RequestModels.cs
@@ -76,12 +76,16 @@ namespace Stratis.Bitcoin.Features.Wallet.Models
     {
         [Required(ErrorMessage = "The name of the wallet is missing.")]
         public string WalletName { get; set; }
+
+        public string AccountName { get; set; }
     }
 
     public class WalletBalanceRequest : RequestModel
     {
         [Required(ErrorMessage = "The name of the wallet is missing.")]
         public string WalletName { get; set; }
+
+        public string AccountName { get; set; }
     }
 
     /// <summary>

--- a/src/Stratis.Bitcoin.Features.Wallet/Models/RequestModels.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Models/RequestModels.cs
@@ -125,6 +125,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Models
         public string DestinationAddress { get; set; }
 
         [Required(ErrorMessage = "An amount is required.")]
+        [MoneyFormat(ErrorMessage = "The amount is not in the correct format.")]
         public string Amount { get; set; }
 
         public string FeeType { get; set; }

--- a/src/Stratis.Bitcoin.Features.Wallet/Models/WalletHistoryModel.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Models/WalletHistoryModel.cs
@@ -12,8 +12,28 @@ namespace Stratis.Bitcoin.Features.Wallet.Models
     {
         public WalletHistoryModel()
         {
+            this.AccountsHistoryModel = new List<AccountHistoryModel>();
+        }
+
+        [JsonProperty(PropertyName = "history")]
+        public List<AccountHistoryModel> AccountsHistoryModel { get; set; }
+    }
+
+    public class AccountHistoryModel
+    {
+        public AccountHistoryModel()
+        {
             this.TransactionsHistory = new List<TransactionItemModel>();
         }
+
+        [JsonProperty(PropertyName = "accountName")]
+        public string Name { get; set; }
+
+        [JsonProperty(PropertyName = "accountHdPath")]
+        public string HdPath { get; set; }
+
+        [JsonProperty(PropertyName = "coinType")]
+        public CoinType CoinType { get; set; }
 
         [JsonProperty(PropertyName = "transactionsHistory")]
         public List<TransactionItemModel> TransactionsHistory { get; set; }

--- a/src/Stratis.Bitcoin.Features.Wallet/Wallet.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Wallet.cs
@@ -599,7 +599,7 @@ namespace Stratis.Bitcoin.Features.Wallet
         {
             var addresses = isChange ? this.InternalAddresses : this.ExternalAddresses;
 
-            // Get the index of the last address that contains transactions.
+            // Get the index of the last address.
             int firstNewAddressIndex = 0;
             if (addresses.Any())
             {

--- a/src/Stratis.Bitcoin.Features.Wallet/WalletManager.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/WalletManager.cs
@@ -472,35 +472,7 @@ namespace Stratis.Bitcoin.Features.Wallet
             this.logger.LogTrace("(-)");
             return addresses;
         }
-
-        /// <inheritdoc />
-        public HdAddress GetOrCreateChangeAddress(HdAccount account)
-        {
-            this.logger.LogTrace("()");
-            HdAddress changeAddress = null;
-
-            lock (this.lockObject)
-            {
-                // Get an address to send the change to.
-                changeAddress = account.GetFirstUnusedChangeAddress();
-
-                // No more change addresses left so create a new one.
-                if (changeAddress == null)
-                {
-                    changeAddress = account.CreateAddresses(this.network, 1, isChange: true).Single();
-
-                    // Adds the address to the list of tracked addresses.
-                    this.UpdateKeysLookupLock(new[] { changeAddress });
-                }
-            }
-
-            // Persist the address to the wallet files.
-            this.SaveWallets();
-
-            this.logger.LogTrace("(-)");
-            return changeAddress;
-        }
-
+        
         /// <inheritdoc />
         public (string folderPath, IEnumerable<string>) GetWalletsFiles()
         {

--- a/src/Stratis.Bitcoin.Features.Wallet/WalletManager.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/WalletManager.cs
@@ -438,29 +438,15 @@ namespace Stratis.Bitcoin.Features.Wallet
                     account.ExternalAddresses.Where(acc => !acc.Transactions.Any()).ToList();
                 
                 int diff = unusedAddresses.Count - count;
+                List<HdAddress> newAddresses = new List<HdAddress>();
                 if (diff < 0)
                 {
-                    IEnumerable<HdAddress> newAddresses = account.CreateAddresses(this.network, Math.Abs(diff), isChange: isChange);
+                    newAddresses = account.CreateAddresses(this.network, Math.Abs(diff), isChange: isChange).ToList();
                     this.UpdateKeysLookupLock(newAddresses);
                     generated = true;
                 }
 
-                if (isChange)
-                {
-                    addresses = account
-                        .InternalAddresses
-                        .Where(acc => !acc.Transactions.Any())
-                        .OrderBy(x => x.Index)
-                        .Take(count);
-                }
-                else
-                {
-                    addresses = account
-                        .ExternalAddresses
-                        .Where(acc => !acc.Transactions.Any())
-                        .OrderBy(x => x.Index)
-                        .Take(count);
-                }
+                addresses = unusedAddresses.Concat(newAddresses).OrderBy(x => x.Index).Take(count);
             }
 
             if (generated)

--- a/src/Stratis.Bitcoin.Features.Wallet/WalletTransactionHandler.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/WalletTransactionHandler.cs
@@ -233,12 +233,8 @@ namespace Stratis.Bitcoin.Features.Wallet
         /// <param name="context">The context associated with the current transaction being built.</param>
         private void FindChangeAddress(TransactionBuildContext context)
         {
-            Wallet wallet = this.walletManager.GetWalletByName(context.AccountReference.WalletName);
-            HdAccount account = wallet.AccountsRoot.Single(a => a.CoinType == this.coinType)
-                .GetAccountByName(context.AccountReference.AccountName);
-
-            // get address to send the change to
-            context.ChangeAddress = this.walletManager.GetOrCreateChangeAddress(account);
+            // Get address to send the change to.
+            context.ChangeAddress = this.walletManager.GetUnusedChangeAddress(new WalletAccountReference(context.AccountReference.WalletName, context.AccountReference.AccountName));
             context.TransactionBuilder.SetChange(context.ChangeAddress.ScriptPubKey);
         }
 

--- a/src/Stratis.Bitcoin.Features.Wallet/WalletTransactionHandler.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/WalletTransactionHandler.cs
@@ -233,7 +233,7 @@ namespace Stratis.Bitcoin.Features.Wallet
         /// <param name="context">The context associated with the current transaction being built.</param>
         private void FindChangeAddress(TransactionBuildContext context)
         {
-            // Get address to send the change to.
+            // Get an address to send the change to.
             context.ChangeAddress = this.walletManager.GetUnusedChangeAddress(new WalletAccountReference(context.AccountReference.WalletName, context.AccountReference.AccountName));
             context.TransactionBuilder.SetChange(context.ChangeAddress.ScriptPubKey);
         }


### PR DESCRIPTION
Fixes https://github.com/stratisproject/FullNodeUI/issues/54
Added account name parameter to get balances and get history.
If the account name is set, data is returned only for this account.
If no account name is set, data is returned for all the accounts in the wallet.