### PR TITLE
Merge to master - Wallet Thread and error message fixes (#1264)

### DIFF
--- a/src/Stratis.Bitcoin.Features.Wallet.Tests/WalletManagerTest.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet.Tests/WalletManagerTest.cs
@@ -812,8 +812,8 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
             });
             walletManager.Wallets.Add(wallet);
 
-            var result = walletManager.GetOrCreateChangeAddress(walletManager.GetAccounts("myWallet").First());
-
+            var result = walletManager.GetUnusedChangeAddress(new WalletAccountReference(wallet.Name, wallet.AccountsRoot.First().Accounts.First().Name));
+            
             Assert.Equal(alice.GetAddress().ToString(), result.Address);
         }
 
@@ -839,8 +839,8 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
                 ExternalAddresses = new List<HdAddress>()
             });
             walletManager.Wallets.Add(wallet);
-
-            var result = walletManager.GetOrCreateChangeAddress(walletManager.GetAccounts("myWallet").First());
+            
+            var result = walletManager.GetUnusedChangeAddress(new WalletAccountReference(wallet.Name, wallet.AccountsRoot.First().Accounts.First().Name));
 
             Assert.NotNull(result.Address);
         }

--- a/src/Stratis.Bitcoin.Features.Wallet/Interfaces/IWalletManager.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Interfaces/IWalletManager.cs
@@ -102,7 +102,21 @@ namespace Stratis.Bitcoin.Features.Wallet.Interfaces
         /// <returns>An unused address or a newly created address, in Base58 format.</returns>
         HdAddress GetUnusedAddress(WalletAccountReference accountReference);
 
-        IEnumerable<HdAddress> GetUnusedAddresses(WalletAccountReference accountReference, int count);
+        /// <summary>
+        /// Gets the first change address that contains no transaction.
+        /// </summary>
+        /// <param name="accountReference">The name of the wallet and account.</param>
+        /// <returns>An unused change address or a newly created change address, in Base58 format.</returns>
+        HdAddress GetUnusedChangeAddress(WalletAccountReference accountReference);
+
+        /// <summary>
+        /// Gets a collection of unused receiving or change addresses.
+        /// </summary>
+        /// <param name="accountReference">The name of the wallet and account.</param>
+        /// <param name="count">The number of addresses to create.</param>
+        /// <param name="isChange">A value indicating whether or not the addresses to get should be receiving or change addresses.</param>
+        /// <returns>A list of unused addresses. New addresses will be created as necessary.</returns>
+        IEnumerable<HdAddress> GetUnusedAddresses(WalletAccountReference accountReference, int count, bool isChange = false);
 
         /// <summary>
         /// Gets a collection of addresses containing transactions for this coin.
@@ -215,14 +229,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Interfaces
         /// </summary>
         /// <returns></returns>
         ICollection<uint256> GetFirstWalletBlockLocator();
-
-        /// <summary>
-        /// Gets a change address or create one if all change addresses are used.
-        /// </summary>
-        /// <param name="account">The account to create the change address.</param>
-        /// <returns>The new HD address.</returns>
-        HdAddress GetOrCreateChangeAddress(HdAccount account);
-
+        
         /// <summary>
         /// Gets the list of the wallet filenames, along with the folder in which they're contained.
         /// </summary>

--- a/src/Stratis.Bitcoin.Features.Wallet/Models/RequestModels.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Models/RequestModels.cs
@@ -125,6 +125,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Models
         public string DestinationAddress { get; set; }
 
         [Required(ErrorMessage = "An amount is required.")]
+        [MoneyFormat(ErrorMessage = "The amount is not in the correct format.")]
         public string Amount { get; set; }
 
         public string FeeType { get; set; }

--- a/src/Stratis.Bitcoin.Features.Wallet/Wallet.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Wallet.cs
@@ -599,7 +599,7 @@ namespace Stratis.Bitcoin.Features.Wallet
         {
             var addresses = isChange ? this.InternalAddresses : this.ExternalAddresses;
 
-            // Get the index of the last address that contains transactions.
+            // Get the index of the last address.
             int firstNewAddressIndex = 0;
             if (addresses.Any())
             {

--- a/src/Stratis.Bitcoin.Features.Wallet/WalletTransactionHandler.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/WalletTransactionHandler.cs
@@ -233,12 +233,8 @@ namespace Stratis.Bitcoin.Features.Wallet
         /// <param name="context">The context associated with the current transaction being built.</param>
         private void FindChangeAddress(TransactionBuildContext context)
         {
-            Wallet wallet = this.walletManager.GetWalletByName(context.AccountReference.WalletName);
-            HdAccount account = wallet.AccountsRoot.Single(a => a.CoinType == this.coinType)
-                .GetAccountByName(context.AccountReference.AccountName);
-
-            // get address to send the change to
-            context.ChangeAddress = this.walletManager.GetOrCreateChangeAddress(account);
+            // Get an address to send the change to.
+            context.ChangeAddress = this.walletManager.GetUnusedChangeAddress(new WalletAccountReference(context.AccountReference.WalletName, context.AccountReference.AccountName));
             context.TransactionBuilder.SetChange(context.ChangeAddress.ScriptPubKey);
         }
 


### PR DESCRIPTION
* MAde the GetUnusedAddresses support change addresses

* now using the new GetUnusedAddresses to protect the wallet from threading issues

* Fixed grammar

* Add error message for invalid Money amount

* Added optimization improvement based on Dan's comment