### PR TITLE
Refactor / Make read-only the DataDir and ConfigurationFile

### DIFF
--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/TestRulesContext.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/TestRulesContext.cs
@@ -57,12 +57,6 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules
             Directory.CreateDirectory(dataDir);
 
             testRulesContext.NodeSettings = new NodeSettings(network, args:new[] { $"-datadir={dataDir}" });
-
-            if (dataDir != null)
-            {
-                testRulesContext.NodeSettings.DataDir = dataDir;
-            }
-
             testRulesContext.LoggerFactory = testRulesContext.NodeSettings.LoggerFactory;
             testRulesContext.LoggerFactory.AddConsoleWithFilters();
             testRulesContext.DateTimeProvider = DateTimeProvider.Default;

--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/TestChainFactory.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/TestChainFactory.cs
@@ -71,17 +71,11 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests
             var testChainContext = new TestChainContext() { Network = network };
 
             testChainContext.NodeSettings = new NodeSettings(network, args:new string[] { $"-datadir={dataDir}" });
-
-            if (dataDir != null)
-            {
-                testChainContext.NodeSettings.DataDir = dataDir;
-            }
-
             testChainContext.ConnectionSettings = new ConnectionManagerSettings();
             testChainContext.ConnectionSettings.Load(testChainContext.NodeSettings);
-
             testChainContext.LoggerFactory = testChainContext.NodeSettings.LoggerFactory;
             testChainContext.DateTimeProvider = DateTimeProvider.Default;
+
             network.Consensus.Options = new PowConsensusOptions();
 
             ConsensusSettings consensusSettings = new ConsensusSettings().Load(testChainContext.NodeSettings);

--- a/src/Stratis.Bitcoin.Features.Dns.Tests/GivenADnsFeature.cs
+++ b/src/Stratis.Bitcoin.Features.Dns.Tests/GivenADnsFeature.cs
@@ -161,8 +161,7 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
             Mock<IWhitelistManager> whitelistManager = new Mock<IWhitelistManager>();
 
             Mock<INodeLifetime> nodeLifetime = new Mock<INodeLifetime>();
-            NodeSettings nodeSettings = NodeSettings.Default();
-            nodeSettings.DataDir = Directory.GetCurrentDirectory();
+            NodeSettings nodeSettings = new NodeSettings(args:new string[] { $"-datadir={Directory.GetCurrentDirectory()}" });
             DataFolder dataFolder = CreateDataFolder(this);
 
             Mock<ILogger> logger = new Mock<ILogger>(MockBehavior.Loose);
@@ -207,8 +206,7 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
             nodeLifetime.Setup(n => n.ApplicationStopping).Returns(source.Token);
             INodeLifetime nodeLifetimeObject = nodeLifetime.Object;
 
-            NodeSettings nodeSettings = NodeSettings.Default();
-            nodeSettings.DataDir = Directory.GetCurrentDirectory();
+            NodeSettings nodeSettings = new NodeSettings(args:new string[] { $"-datadir={ Directory.GetCurrentDirectory() }" });
             DataFolder dataFolder = CreateDataFolder(this);
 
             Mock<ILogger> logger = new Mock<ILogger>(MockBehavior.Loose);
@@ -250,8 +248,7 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
             nodeLifetime.Setup(n => n.ApplicationStopping).Returns(source.Token);
             INodeLifetime nodeLifetimeObject = nodeLifetime.Object;
 
-            NodeSettings nodeSettings = NodeSettings.Default();
-            nodeSettings.DataDir = Directory.GetCurrentDirectory();
+            NodeSettings nodeSettings = new NodeSettings(args: new string[] { $"-datadir={ Directory.GetCurrentDirectory() }" });
             DataFolder dataFolder = CreateDataFolder(this);
 
             Mock<ILogger> logger = new Mock<ILogger>();
@@ -300,8 +297,7 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
             nodeLifetime.Setup(n => n.ApplicationStopping).Returns(source.Token);
             INodeLifetime nodeLifetimeObject = nodeLifetime.Object;
 
-            NodeSettings nodeSettings = NodeSettings.Default();
-            nodeSettings.DataDir = Directory.GetCurrentDirectory();
+            NodeSettings nodeSettings = new NodeSettings(args: new string[] { $"-datadir={ Directory.GetCurrentDirectory() }" });
             DataFolder dataFolder = CreateDataFolder(this);
 
             using (DnsFeature feature = new DnsFeature(dnsServer, whitelistManager, loggerFactory, nodeLifetimeObject, new DnsSettings().Load(nodeSettings), nodeSettings, dataFolder, asyncLoopFactory))

--- a/src/Stratis.Bitcoin.Features.Dns.Tests/GivenADnsSeedServer.cs
+++ b/src/Stratis.Bitcoin.Features.Dns.Tests/GivenADnsSeedServer.cs
@@ -160,8 +160,7 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
             INodeLifetime nodeLifetime = new Mock<INodeLifetime>().Object;
             ILoggerFactory loggerFactory = new Mock<ILoggerFactory>().Object;
             IDateTimeProvider dateTimeProvider = new Mock<IDateTimeProvider>().Object;
-            NodeSettings nodeSettings = NodeSettings.Default();
-            nodeSettings.DataDir = @"C:\";
+            NodeSettings nodeSettings = new NodeSettings(args: new string[] { $"-datadir=C:\\" });
             Action a = () => { new DnsSeedServer(udpClient, masterFile, asyncLoopFactory, nodeLifetime, loggerFactory, dateTimeProvider, new DnsSettings().Load(nodeSettings), null); };
 
             // Act and Assert.

--- a/src/Stratis.Bitcoin.Features.MemoryPool.Tests/FullNodeBuilderTest.cs
+++ b/src/Stratis.Bitcoin.Features.MemoryPool.Tests/FullNodeBuilderTest.cs
@@ -21,8 +21,8 @@ namespace Stratis.Bitcoin.Features.MemoryPool.Tests
             // mempool requires all the features to be a fullnode
 
 
-            var nodeSettings = NodeSettings.Default();
-            nodeSettings.DataDir = "Stratis.Bitcoin.Features.MemoryPool.Tests/TestData/FullNodeBuilderTest/CanHaveAllServicesTest";
+            NodeSettings nodeSettings = new NodeSettings(args: new string[] {
+                $"-datadir=Stratis.Bitcoin.Features.MemoryPool.Tests/TestData/FullNodeBuilderTest/CanHaveAllServicesTest" });
             var fullNodeBuilder = new FullNodeBuilder(nodeSettings);
             IFullNode fullNode = fullNodeBuilder
                 .UsePowConsensus()

--- a/src/Stratis.Bitcoin.Features.MemoryPool.Tests/MempoolPersistenceTest.cs
+++ b/src/Stratis.Bitcoin.Features.MemoryPool.Tests/MempoolPersistenceTest.cs
@@ -189,8 +189,7 @@ namespace Stratis.Bitcoin.Features.MemoryPool.Tests
             int expectedLinesPerTransaction = 3;
             int expectedHeaderLines = 2;
             int expectedLines = numTx * expectedLinesPerTransaction + expectedHeaderLines;
-            var settings = NodeSettings.Default();
-            settings.DataDir = Path.Combine(this.dir, "SaveStreamTest");
+            var settings = new NodeSettings(args: new string[] { $"-datadir={ Path.Combine(this.dir, "SaveStreamTest") }" });
             MempoolPersistence persistence = new MempoolPersistence(settings, new LoggerFactory());
             IEnumerable<MempoolPersistenceEntry> toSave = this.CreateTestEntries(numTx);
             List<MempoolPersistenceEntry> loaded;
@@ -225,9 +224,7 @@ namespace Stratis.Bitcoin.Features.MemoryPool.Tests
 
         private NodeSettings CreateSettings(string subDirName)
         {
-            var settings = NodeSettings.Default();
-            settings.DataDir = Directory.CreateDirectory(Path.Combine(this.dir, subDirName)).FullName;
-            return settings;
+            return new NodeSettings(args:new string[] { $"-datadir={ Directory.CreateDirectory(Path.Combine(this.dir, subDirName)).FullName }" });
         }
 
         private IEnumerable<MempoolPersistenceEntry> CreateTestEntries(int numTx)

--- a/src/Stratis.Bitcoin.Features.RPC/RPCFeature.cs
+++ b/src/Stratis.Bitcoin.Features.RPC/RPCFeature.cs
@@ -54,7 +54,7 @@ namespace Stratis.Bitcoin.Features.RPC
         /// Get the default configuration.
         /// </summary>
         /// <param name="builder">The string builder to add the settings to.</param>
-        public static void GetDefaultConfiguration(StringBuilder builder)
+        public static void BuildDefaultConfigurationFile(StringBuilder builder)
         {
             builder.AppendLine("####RPC Settings####");
             builder.AppendLine("#Activate RPC Server (default: 0)");

--- a/src/Stratis.Bitcoin.Features.RPC/RPCFeature.cs
+++ b/src/Stratis.Bitcoin.Features.RPC/RPCFeature.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Text;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -47,6 +48,21 @@ namespace Stratis.Bitcoin.Features.RPC
         public static void PrintHelp(Network network)
         {
             RpcSettings.PrintHelp(network);
+        }
+
+        /// <summary>
+        /// Get the default configuration.
+        /// </summary>
+        /// <param name="builder">The string builder to add the settings to.</param>
+        public static void GetDefaultConfiguration(StringBuilder builder)
+        {
+            builder.AppendLine("####RPC Settings####");
+            builder.AppendLine("#Activate RPC Server (default: 0)");
+            builder.AppendLine("#server=0");
+            builder.AppendLine("#Where the RPC Server binds (default: 127.0.0.1 and ::1)");
+            builder.AppendLine("#rpcbind=127.0.0.1");
+            builder.AppendLine("#Ip address allowed to connect to RPC (default all: 0.0.0.0 and ::)");
+            builder.AppendLine("#rpcallowip=127.0.0.1");
         }
 
         public override void Initialize()

--- a/src/Stratis.Bitcoin.Tests/Builder/FullNodeBuilderExtensionsTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Builder/FullNodeBuilderExtensionsTest.cs
@@ -43,9 +43,9 @@ namespace Stratis.Bitcoin.Tests.Builder
         [Fact]
         public void UseDefaultNodeSettingsConfiguresNodeBuilderWithDefaultSettings()
         {
-            var nodeSettings = NodeSettings.Default();
-            nodeSettings.ConfigurationFile = "TestData/FullNodeBuilder/UseNodeSettingsConfFile";
-            nodeSettings.DataDir = "TestData/FullNodeBuilder/UseNodeSettings";
+            var nodeSettings = new NodeSettings(args: new string[] {
+                "-datadir=TestData/FullNodeBuilder/UseNodeSettings",
+                "-conf=TestData/FullNodeBuilder/UseNodeSettingsConfFile"});
 
             FullNodeBuilderNodeSettingsExtension.UseNodeSettings(this.fullNodeBuilder, nodeSettings);
 
@@ -60,9 +60,9 @@ namespace Stratis.Bitcoin.Tests.Builder
         [Fact]
         public void UseNodeSettingsUsingTestNetConfiguresNodeBuilderWithTestnetSettings()
         {
-            NodeSettings nodeSettings = NodeSettings.Default(Network.TestNet);
-            nodeSettings.ConfigurationFile = "TestData/FullNodeBuilder/UseNodeSettingsConfFile";
-            nodeSettings.DataDir = "TestData/FullNodeBuilder/UseNodeSettings";
+            NodeSettings nodeSettings = new NodeSettings(Network.TestNet, args:new string[] {
+                "-datadir=TestData/FullNodeBuilder/UseNodeSettings",
+                "-conf=TestData/FullNodeBuilder/UseNodeSettingsConfFile" });
 
             FullNodeBuilderNodeSettingsExtension.UseNodeSettings(this.fullNodeBuilder, nodeSettings);
 
@@ -77,9 +77,9 @@ namespace Stratis.Bitcoin.Tests.Builder
         [Fact]
         public void UseNodeSettingsUsingRegTestNetConfiguresNodeBuilderWithRegTestNet()
         {
-            NodeSettings nodeSettings = NodeSettings.Default(Network.RegTest);
-            nodeSettings.ConfigurationFile = "TestData/FullNodeBuilder/UseNodeSettingsConfFile";
-            nodeSettings.DataDir = "TestData/FullNodeBuilder/UseNodeSettings";
+            NodeSettings nodeSettings = new NodeSettings(Network.RegTest, args:new string[] {
+                "-datadir=TestData/FullNodeBuilder/UseNodeSettings",
+                "-conf=TestData/FullNodeBuilder/UseNodeSettingsConfFile" });
 
             FullNodeBuilderNodeSettingsExtension.UseNodeSettings(this.fullNodeBuilder, nodeSettings);
 

--- a/src/Stratis.Bitcoin.Tests/Builder/FullNodeBuilderExtensionsTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Builder/FullNodeBuilderExtensionsTest.cs
@@ -44,8 +44,7 @@ namespace Stratis.Bitcoin.Tests.Builder
         public void UseDefaultNodeSettingsConfiguresNodeBuilderWithDefaultSettings()
         {
             var nodeSettings = new NodeSettings(args: new string[] {
-                "-datadir=TestData/FullNodeBuilder/UseNodeSettings",
-                "-conf=TestData/FullNodeBuilder/UseNodeSettingsConfFile"});
+                "-datadir=TestData/FullNodeBuilder/UseNodeSettings" });
 
             FullNodeBuilderNodeSettingsExtension.UseNodeSettings(this.fullNodeBuilder, nodeSettings);
 
@@ -61,8 +60,7 @@ namespace Stratis.Bitcoin.Tests.Builder
         public void UseNodeSettingsUsingTestNetConfiguresNodeBuilderWithTestnetSettings()
         {
             NodeSettings nodeSettings = new NodeSettings(Network.TestNet, args:new string[] {
-                "-datadir=TestData/FullNodeBuilder/UseNodeSettings",
-                "-conf=TestData/FullNodeBuilder/UseNodeSettingsConfFile" });
+                "-datadir=TestData/FullNodeBuilder/UseNodeSettings" });
 
             FullNodeBuilderNodeSettingsExtension.UseNodeSettings(this.fullNodeBuilder, nodeSettings);
 
@@ -78,8 +76,7 @@ namespace Stratis.Bitcoin.Tests.Builder
         public void UseNodeSettingsUsingRegTestNetConfiguresNodeBuilderWithRegTestNet()
         {
             NodeSettings nodeSettings = new NodeSettings(Network.RegTest, args:new string[] {
-                "-datadir=TestData/FullNodeBuilder/UseNodeSettings",
-                "-conf=TestData/FullNodeBuilder/UseNodeSettingsConfFile" });
+                "-datadir=TestData/FullNodeBuilder/UseNodeSettings" });
 
             FullNodeBuilderNodeSettingsExtension.UseNodeSettings(this.fullNodeBuilder, nodeSettings);
 

--- a/src/Stratis.Bitcoin/Builder/FullNodeBuilder.cs
+++ b/src/Stratis.Bitcoin/Builder/FullNodeBuilder.cs
@@ -158,10 +158,9 @@ namespace Stratis.Bitcoin.Builder
                 throw new InvalidOperationException("full node already built");
             this.fullNodeBuilt = true;
 
-            this.NodeSettings?.LoadConfiguration();
-
             this.Services = this.BuildServices();
 
+            // Print command-line help
             if (this.NodeSettings?.PrintHelpAndExit ?? false)
             {
                 foreach (var featureRegistration in this.Features.FeatureRegistrations)
@@ -175,10 +174,13 @@ namespace Stratis.Bitcoin.Builder
                 return null;
             }
 
+            // Load configuration file
+            this.NodeSettings?.LoadConfiguration(this.Features.FeatureRegistrations);
+
             var fullNodeServiceProvider = this.Services.BuildServiceProvider();
             this.ConfigureServices(fullNodeServiceProvider);
 
-            //obtain the nodeSettings from the service (it's set used FullNodeBuilder.UseNodeSettings)
+            // Obtain the nodeSettings from the service (it's set used FullNodeBuilder.UseNodeSettings)
             var nodeSettings = fullNodeServiceProvider.GetService<NodeSettings>();
             if (nodeSettings == null)
                 throw new NodeBuilderException("NodeSettings not specified");

--- a/src/Stratis.Bitcoin/Configuration/NodeSettings.cs
+++ b/src/Stratis.Bitcoin/Configuration/NodeSettings.cs
@@ -138,10 +138,10 @@ namespace Stratis.Bitcoin.Configuration
         /// <summary>List of paths to important files and folders.</summary>
         public DataFolder DataFolder { get; set; }
 
-        /// <summary>Path to the data directory.</summary>
+        /// <summary>Path to the data directory. This value is read-only and is set in the constructor's args.</summary>
         public string DataDir { get; private set; }
 
-        /// <summary>Path to the configuration file.</summary>
+        /// <summary>Path to the configuration file. This value is read-only and is set in the constructor's args.</summary>
         public string ConfigurationFile { get; private set; }
 
         /// <summary>Option to skip (most) non-standard transaction checks, for testnet/regtest only.</summary>

--- a/src/Stratis.Bitcoin/Configuration/NodeSettings.cs
+++ b/src/Stratis.Bitcoin/Configuration/NodeSettings.cs
@@ -120,10 +120,10 @@ namespace Stratis.Bitcoin.Configuration
         public DataFolder DataFolder { get; set; }
 
         /// <summary>Path to the data directory.</summary>
-        public string DataDir { get; set; }
+        public string DataDir { get; private set; }
 
         /// <summary>Path to the configuration file.</summary>
-        public string ConfigurationFile { get; set; }
+        public string ConfigurationFile { get; private set; }
 
         /// <summary>Option to skip (most) non-standard transaction checks, for testnet/regtest only.</summary>
         public bool RequireStandard { get; set; }

--- a/src/Stratis.Bitcoin/Configuration/NodeSettings.cs
+++ b/src/Stratis.Bitcoin/Configuration/NodeSettings.cs
@@ -1,13 +1,16 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net;
+using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Text;
 using Microsoft.Extensions.Logging;
 using NBitcoin;
 using NBitcoin.Protocol;
 using NLog.Extensions.Logging;
+using Stratis.Bitcoin.Builder.Feature;
 using Stratis.Bitcoin.Configuration.Logging;
 using Stratis.Bitcoin.Configuration.Settings;
 using Stratis.Bitcoin.Utilities;
@@ -99,6 +102,22 @@ namespace Stratis.Bitcoin.Configuration
                 this.Network = testNet ? Network.TestNet : regTest ? Network.RegTest : Network.Main;
             }
 
+            // Setting the data directory.
+            if (this.DataDir == null)
+            {
+                this.DataDir = this.CreateDefaultDataDirectories(Path.Combine("StratisNode", this.Network.RootFolderName), this.Network);
+            }
+            else
+            {
+                // Create the data directories if they don't exist.
+                string directoryPath = Path.Combine(this.DataDir, this.Network.RootFolderName, this.Network.Name);
+                Directory.CreateDirectory(directoryPath);
+                this.DataDir = directoryPath;
+                this.Logger.LogDebug("Data directory initialized with path {0}.", directoryPath);
+            }
+
+            this.DataFolder = new DataFolder(this.DataDir);
+
             // Load configuration from .ctor?
             if (loadConfiguration)
                 this.LoadConfiguration();
@@ -181,7 +200,7 @@ namespace Stratis.Bitcoin.Configuration
         /// </summary>
         /// <returns>Initialized node configuration.</returns>
         /// <exception cref="ConfigurationException">Thrown in case of any problems with the configuration file or command line arguments.</exception>
-        public NodeSettings LoadConfiguration()
+        public NodeSettings LoadConfiguration(List<IFeatureRegistration> features = null)
         {
             // Configuration already loaded?
             if (this.ConfigReader != null)
@@ -190,24 +209,10 @@ namespace Stratis.Bitcoin.Configuration
             // Get the arguments set previously
             var args = this.LoadArgs;
 
-            // Setting the data directory.
-            if (this.DataDir == null)
-            {
-                this.DataDir = this.CreateDefaultDataDirectories(Path.Combine("StratisNode", this.Network.RootFolderName), this.Network);
-            }
-            else
-            {
-                // Create the data directories if they don't exist.
-                string directoryPath = Path.Combine(this.DataDir, this.Network.RootFolderName, this.Network.Name);
-                Directory.CreateDirectory(directoryPath);
-                this.DataDir = directoryPath;
-                this.Logger.LogDebug("Data directory initialized with path {0}.", directoryPath);
-            }
-
             // If no configuration file path is passed in the args, load the default file.
             if (this.ConfigurationFile == null)
             {
-                this.ConfigurationFile = this.CreateDefaultConfigurationFile();
+                this.ConfigurationFile = this.CreateDefaultConfigurationFile(features);
             }
 
             var consoleConfig = new TextFileConfiguration(args);
@@ -215,7 +220,6 @@ namespace Stratis.Bitcoin.Configuration
             this.ConfigReader = config;
             consoleConfig.MergeInto(config);
 
-            this.DataFolder = new DataFolder(this.DataDir);
             if (!Directory.Exists(this.DataFolder.CoinViewPath))
                 Directory.CreateDirectory(this.DataFolder.CoinViewPath);
 
@@ -301,7 +305,7 @@ namespace Stratis.Bitcoin.Configuration
         /// Creates a default configuration file if no configuration file is found.
         /// </summary>
         /// <returns>Path to the configuration file.</returns>
-        private string CreateDefaultConfigurationFile()
+        private string CreateDefaultConfigurationFile(List<IFeatureRegistration> features = null)
         {
             string configFilePath = Path.Combine(this.DataDir, this.Network.DefaultConfigFilename);
             this.Logger.LogDebug("Configuration file set to '{0}'.", configFilePath);
@@ -312,13 +316,14 @@ namespace Stratis.Bitcoin.Configuration
                 this.Logger.LogDebug("Creating configuration file...");
 
                 StringBuilder builder = new StringBuilder();
-                builder.AppendLine("####RPC Settings####");
-                builder.AppendLine("#Activate RPC Server (default: 0)");
-                builder.AppendLine("#server=0");
-                builder.AppendLine("#Where the RPC Server binds (default: 127.0.0.1 and ::1)");
-                builder.AppendLine("#rpcbind=127.0.0.1");
-                builder.AppendLine("#Ip address allowed to connect to RPC (default all: 0.0.0.0 and ::)");
-                builder.AppendLine("#rpcallowip=127.0.0.1");
+
+                foreach (var featureRegistration in features)
+                {
+                    MethodInfo getDefaultConfiguration = featureRegistration.FeatureType.GetMethod("GetDefaultConfiguration", BindingFlags.Public | BindingFlags.Static);
+
+                    getDefaultConfiguration?.Invoke(null, new object[] { builder });
+                }
+
                 File.WriteAllText(configFilePath, builder.ToString());
             }
             return configFilePath;

--- a/src/Stratis.Bitcoin/Configuration/NodeSettings.cs
+++ b/src/Stratis.Bitcoin/Configuration/NodeSettings.cs
@@ -321,7 +321,7 @@ namespace Stratis.Bitcoin.Configuration
                 {
                     foreach (var featureRegistration in features)
                     {
-                        MethodInfo getDefaultConfiguration = featureRegistration.FeatureType.GetMethod("GetDefaultConfiguration", BindingFlags.Public | BindingFlags.Static);
+                        MethodInfo getDefaultConfiguration = featureRegistration.FeatureType.GetMethod("BuildDefaultConfigurationFile", BindingFlags.Public | BindingFlags.Static);
 
                         getDefaultConfiguration?.Invoke(null, new object[] { builder });
                     }

--- a/src/Stratis.Bitcoin/Configuration/NodeSettings.cs
+++ b/src/Stratis.Bitcoin/Configuration/NodeSettings.cs
@@ -317,11 +317,14 @@ namespace Stratis.Bitcoin.Configuration
 
                 StringBuilder builder = new StringBuilder();
 
-                foreach (var featureRegistration in features)
+                if (features != null)
                 {
-                    MethodInfo getDefaultConfiguration = featureRegistration.FeatureType.GetMethod("GetDefaultConfiguration", BindingFlags.Public | BindingFlags.Static);
+                    foreach (var featureRegistration in features)
+                    {
+                        MethodInfo getDefaultConfiguration = featureRegistration.FeatureType.GetMethod("GetDefaultConfiguration", BindingFlags.Public | BindingFlags.Static);
 
-                    getDefaultConfiguration?.Invoke(null, new object[] { builder });
+                        getDefaultConfiguration?.Invoke(null, new object[] { builder });
+                    }
                 }
 
                 File.WriteAllText(configFilePath, builder.ToString());


### PR DESCRIPTION
This PR:
- makes the member variables "DataDir" and "ConfigurationFile" on the "NodeSettings" class read-only.
- updates the tests to pass these values via the constructor.
- refactors NodeSettings and moves the RPC-specific code to the RPC feature.