### PR TITLE
Payload command length check

### DIFF
--- a/src/Stratis.Bitcoin/P2P/Protocol/Payloads/PayloadAttribute.cs
+++ b/src/Stratis.Bitcoin/P2P/Protocol/Payloads/PayloadAttribute.cs
@@ -22,6 +22,9 @@ namespace Stratis.Bitcoin.P2P.Protocol.Payloads
         /// <param name="commandName"></param>
         public PayloadAttribute(string commandName)
         {
+            if (commandName.Length > 12)
+                throw new ArgumentException("Protocol violation: command name is limited to 12 characters.");
+            
             this.Name = commandName;
         }
     }


### PR DESCRIPTION
This pr adds a check for the `commandName` of the payload. 

I believe this is needed because if a new payload is created (let's say by someone who builds on top of the node and implements a new protocol message) and it's command name doesn't meet the limitations set by the protocol the communication with this payload won't be possible, however no error will be spawned while trying to use a payload with long command name and the node will run normally.