### PR TITLE
Fixed unconfirmed trx bug

### DIFF
--- a/src/Stratis.Bitcoin.Features.Wallet.Tests/WalletTestsHelpers.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet.Tests/WalletTestsHelpers.cs
@@ -402,7 +402,8 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
                         {
                             BlockHeight = height,
                             Amount = new Money(new Random().Next(500000, 1000000)),
-                            SpendingDetails = new SpendingDetails()
+                            SpendingDetails = new SpendingDetails(),
+                            Id = new uint256()
                         }
                     }
                 };

--- a/src/Stratis.Bitcoin.Features.Wallet/WalletManager.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/WalletManager.cs
@@ -433,10 +433,10 @@ namespace Stratis.Bitcoin.Features.Wallet
                 // Get the account.
                 HdAccount account = wallet.GetAccountByCoinType(accountReference.AccountName, this.coinType);
 
-                List<HdAddress> unusedAddresses = isChange ? 
-                    account.InternalAddresses.Where(acc => !acc.Transactions.Any()).ToList() : 
+                List<HdAddress> unusedAddresses = isChange ?
+                    account.InternalAddresses.Where(acc => !acc.Transactions.Any()).ToList() :
                     account.ExternalAddresses.Where(acc => !acc.Transactions.Any()).ToList();
-                
+
                 int diff = unusedAddresses.Count - count;
                 List<HdAddress> newAddresses = new List<HdAddress>();
                 if (diff < 0)
@@ -458,7 +458,7 @@ namespace Stratis.Bitcoin.Features.Wallet
             this.logger.LogTrace("(-)");
             return addresses;
         }
-        
+
         /// <inheritdoc />
         public (string folderPath, IEnumerable<string>) GetWalletsFiles()
         {
@@ -533,7 +533,7 @@ namespace Stratis.Bitcoin.Features.Wallet
                 {
                     accounts.AddRange(wallet.GetAccountsByCoinType(this.coinType));
                 }
-                
+
                 foreach (var account in accounts)
                 {
                     (Money AmountConfirmed, Money AmountUnconfirmed) result = account.GetSpendableAmount();
@@ -783,7 +783,7 @@ namespace Stratis.Bitcoin.Features.Wallet
             Guard.NotNull(transaction, nameof(transaction));
             uint256 hash = transaction.GetHash();
             this.logger.LogTrace("({0}:'{1}',{2}:{3})", nameof(transaction), hash, nameof(blockHeight), blockHeight);
-            
+
             bool foundReceivingTrx = false, foundSendingTrx = false;
 
             lock (this.lockObject)
@@ -1010,7 +1010,6 @@ namespace Stratis.Bitcoin.Features.Wallet
 
                 spentTransaction.SpendingDetails = spendingDetails;
                 spentTransaction.MerkleProof = null;
-                this.RemoveInputKeysLookupLock(spentTransaction);
             }
             else // If this spending transaction is being confirmed in a block.
             {
@@ -1227,9 +1226,9 @@ namespace Stratis.Bitcoin.Features.Wallet
                         if (address.Pubkey != null)
                             this.keysLookup[address.Pubkey] = address;
 
-                        foreach (var unspentTransaction in address.UnspentTransactions())
+                        foreach (var transaction in address.Transactions)
                         {
-                            this.outpointLookup[new OutPoint(unspentTransaction.Id, unspentTransaction.Index)] = unspentTransaction;
+                            this.outpointLookup[new OutPoint(transaction.Id, transaction.Index)] = transaction;
                         }
                     }
                 }
@@ -1267,20 +1266,6 @@ namespace Stratis.Bitcoin.Features.Wallet
             lock (this.lockObject)
             {
                 this.outpointLookup[new OutPoint(transactionData.Id, transactionData.Index)] = transactionData;
-            }
-        }
-
-        /// <summary>
-        /// Remove from the list of unspent outputs kept in memory.
-        /// </summary>
-        private void RemoveInputKeysLookupLock(TransactionData transactionData)
-        {
-            Guard.NotNull(transactionData, nameof(transactionData));
-            Guard.NotNull(transactionData.SpendingDetails, nameof(transactionData.SpendingDetails));
-            
-            lock (this.lockObject)
-            {
-                this.outpointLookup.Remove(new OutPoint(transactionData.Id, transactionData.Index));
             }
         }
 


### PR DESCRIPTION
There was a bug whereby transactions sent to an address would not get confirmed.
The outgoing transaction would get registered in the wallet file, but not updated once it was confirmed in a block.

The explanation is as follows: 
The wallet manager maintains in memory a dictionary of unspent transactions, which makes checking whether incoming transactions affects the wallet or not, much easier and much faster.
The problem was that this list was marking an spent transactions as spent, even before it was confirmed. So when the transaction would show up in a block as confirmed, the manager would not even process it, and the "unconfirmed" status of the transaction would never move to "confirmed".

The resolution is that this dictionary is now keeping a list of all the transactions, unspent or not. Lookup is still very fast, and since transaction processing is idempotent, the transactions are processed properly.