### PR TITLE
PoS Minting null exception

### DIFF
--- a/src/Stratis.Bitcoin.Features.Miner/PosMinting.cs
+++ b/src/Stratis.Bitcoin.Features.Miner/PosMinting.cs
@@ -520,7 +520,7 @@ namespace Stratis.Bitcoin.Features.Miner
                 {
                     UnspentOutputs set = coinset.UnspentOutputs.FirstOrDefault(f => f?.TransactionId == infoTransaction.Transaction.Id);
                     TxOut utxo = (set != null) && (infoTransaction.Transaction.Index < set.Outputs.Length) ? set.Outputs[infoTransaction.Transaction.Index] : null;
-                    uint256 hashBock = this.chain.GetBlock((int) set.Height)?.HashBlock;
+                    uint256 hashBock = set != null ? this.chain.GetBlock((int) set.Height)?.HashBlock : null;
 
                     if ((utxo != null) && (utxo.Value > Money.Zero) && (hashBock != null))
                     {

--- a/src/Stratis.Bitcoin.Features.Miner/PosMinting.cs
+++ b/src/Stratis.Bitcoin.Features.Miner/PosMinting.cs
@@ -520,16 +520,16 @@ namespace Stratis.Bitcoin.Features.Miner
                 {
                     UnspentOutputs set = coinset.UnspentOutputs.FirstOrDefault(f => f?.TransactionId == infoTransaction.Transaction.Id);
                     TxOut utxo = (set != null) && (infoTransaction.Transaction.Index < set.Outputs.Length) ? set.Outputs[infoTransaction.Transaction.Index] : null;
-                    uint256 hashBock = set != null ? this.chain.GetBlock((int) set.Height)?.HashBlock : null;
+                    uint256 hashBlock = set != null ? this.chain.GetBlock((int) set.Height)?.HashBlock : null;
 
-                    if ((utxo != null) && (utxo.Value > Money.Zero) && (hashBock != null))
+                    if ((utxo != null) && (utxo.Value > Money.Zero) && (hashBlock != null))
                     {
                         var utxoStakeDescription = new UtxoStakeDescription();
 
                         utxoStakeDescription.TxOut = utxo;
                         utxoStakeDescription.OutPoint = new OutPoint(set.TransactionId, infoTransaction.Transaction.Index);
                         utxoStakeDescription.Address = infoTransaction.Address;
-                        utxoStakeDescription.HashBlock = hashBock;
+                        utxoStakeDescription.HashBlock = hashBlock;
                         utxoStakeDescription.UtxoSet = set;
                         utxoStakeDescription.Secret = walletSecret; // Temporary.
                         utxoStakeDescriptions.Add(utxoStakeDescription);


### PR DESCRIPTION
A null exception was possible during the mining. It would stop the mining loop. 


Bug log:

```
[2018-04-11 19:56:48.0332 9] ERROR: Stratis.Bitcoin.Utilities.AsyncLoop+<>c__DisplayClass16_0+<<StartAsync>b__0>d.MoveNext PosMining.Stake threw an unhandled exception: System.NullReferenceException: Object reference not set to an instance of an object.
   at Stratis.Bitcoin.Features.Miner.PosMinting.<GenerateBlocksAsync>d__44.MoveNext() in C:\Users\user\Desktop\FNExploits\src\Stratis.Bitcoin.Features.Miner\PosMinting.cs:line 523
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at Stratis.Bitcoin.Features.Miner.PosMinting.<>c__DisplayClass42_0.<<Stake>b__0>d.MoveNext() in C:\Users\user\Desktop\FNExploits\src\Stratis.Bitcoin.Features.Miner\PosMinting.cs:line 426
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at Stratis.Bitcoin.Utilities.AsyncLoop.<>c__DisplayClass16_0.<<StartAsync>b__0>d.MoveNext() in C:\Users\user\Desktop\FNExploits\src\Stratis.Bitcoin\Utilities\AsyncLoop.cs:line 136
```