### PR TITLE
Remove loggerfactory from testbase

### DIFF
--- a/src/Stratis.Bitcoin.Features.BlockStore.Tests/BlockRepositoryTest.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore.Tests/BlockRepositoryTest.cs
@@ -2,13 +2,13 @@
 using System.Linq;
 using DBreeze;
 using NBitcoin;
-using Stratis.Bitcoin.Tests.Common;
+using Stratis.Bitcoin.Tests.Common.Logging;
 using Stratis.Bitcoin.Utilities;
 using Xunit;
 
 namespace Stratis.Bitcoin.Features.BlockStore.Tests
 {
-    public class BlockRepositoryTest : TestBase
+    public class BlockRepositoryTest : LogsTestBase
     {
         [Fact]
         public void InitializesGenBlockAndTxIndexOnFirstLoad()
@@ -430,7 +430,7 @@ namespace Stratis.Bitcoin.Features.BlockStore.Tests
 
         private IBlockRepository SetupRepository(Network main, string dir)
         {
-            var repository = new BlockRepository(main, dir, DateTimeProvider.Default, this.loggerFactory);
+            var repository = new BlockRepository(main, dir, DateTimeProvider.Default, this.LoggerFactory.Object);
             repository.InitializeAsync().GetAwaiter().GetResult();
 
             return repository;

--- a/src/Stratis.Bitcoin.Features.BlockStore.Tests/LoopTests/BlockStoreLoopIntegration.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore.Tests/LoopTests/BlockStoreLoopIntegration.cs
@@ -40,7 +40,7 @@ namespace Stratis.Bitcoin.Features.BlockStore.Tests.LoopTests
                 Assert.Null(fluent.Loop.StoreTip);
 
                 var nextChainedBlock = block04;
-                var checkExistsStep = new CheckNextChainedBlockExistStep(fluent.Loop, this.loggerFactory);
+                var checkExistsStep = new CheckNextChainedBlockExistStep(fluent.Loop, this.LoggerFactory.Object);
                 checkExistsStep.ExecuteAsync(nextChainedBlock, new CancellationToken(), false).GetAwaiter().GetResult();
 
                 Assert.Equal(fluent.Loop.StoreTip.Header.GetHash(), block04.Header.GetHash());
@@ -79,7 +79,7 @@ namespace Stratis.Bitcoin.Features.BlockStore.Tests.LoopTests
                 Assert.Equal(fluent.Loop.BlockRepository.BlockHash, block14.Header.GetHash());
 
                 var nextChainedBlock = block10;
-                var reorganiseStep = new ReorganiseBlockRepositoryStep(fluent.Loop, this.loggerFactory);
+                var reorganiseStep = new ReorganiseBlockRepositoryStep(fluent.Loop, this.LoggerFactory.Object);
                 reorganiseStep.ExecuteAsync(nextChainedBlock, new CancellationToken(), false).GetAwaiter().GetResult();
 
                 Assert.Equal(fluent.Loop.StoreTip.Header.GetHash(), block10.Previous.Header.GetHash());
@@ -118,7 +118,7 @@ namespace Stratis.Bitcoin.Features.BlockStore.Tests.LoopTests
                 //Start processing pending blocks from block 5
                 var nextChainedBlock = fluent.Loop.Chain.GetBlock(blocks[5].GetHash());
 
-                var processPendingStorageStep = new ProcessPendingStorageStep(fluent.Loop, this.loggerFactory);
+                var processPendingStorageStep = new ProcessPendingStorageStep(fluent.Loop, this.LoggerFactory.Object);
                 processPendingStorageStep.ExecuteAsync(nextChainedBlock, new CancellationToken(), false).GetAwaiter().GetResult();
 
                 Assert.Equal(blocks[14].GetHash(), fluent.Loop.BlockRepository.BlockHash);
@@ -154,7 +154,7 @@ namespace Stratis.Bitcoin.Features.BlockStore.Tests.LoopTests
                 // Start processing blocks to download from block 5
                 var nextChainedBlock = fluent.Loop.Chain.GetBlock(blocks[5].GetHash());
 
-                var step = new DownloadBlockStep(fluent.Loop, this.loggerFactory, DateTimeProvider.Default);
+                var step = new DownloadBlockStep(fluent.Loop, this.LoggerFactory.Object, DateTimeProvider.Default);
                 step.ExecuteAsync(nextChainedBlock, new CancellationToken(), false).GetAwaiter().GetResult();
 
                 Assert.Equal(blocks[9].GetHash(), fluent.Loop.BlockRepository.BlockHash);

--- a/src/Stratis.Bitcoin.Features.BlockStore.Tests/LoopTests/BlockStoreLoopStepBaseTest.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore.Tests/LoopTests/BlockStoreLoopStepBaseTest.cs
@@ -10,6 +10,7 @@ using Stratis.Bitcoin.Connection;
 using Stratis.Bitcoin.Interfaces;
 using Stratis.Bitcoin.P2P.Peer;
 using Stratis.Bitcoin.Tests.Common;
+using Stratis.Bitcoin.Tests.Common.Logging;
 using Stratis.Bitcoin.Utilities;
 
 namespace Stratis.Bitcoin.Features.BlockStore.Tests.LoopTests
@@ -17,7 +18,7 @@ namespace Stratis.Bitcoin.Features.BlockStore.Tests.LoopTests
     /// <summary>
     /// Base test class for all the BlockStoreLoop tests.
     /// </summary>
-    public class BlockStoreLoopStepBaseTest : TestBase
+    public class BlockStoreLoopStepBaseTest : LogsTestBase
     {
         internal void AddBlockToPendingStorage(BlockStoreLoop blockStoreLoop, Block block)
         {

--- a/src/Stratis.Bitcoin.Features.BlockStore.Tests/LoopTests/BlockStoreLoopStepCheckNextChainedBlockExistStepTest.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore.Tests/LoopTests/BlockStoreLoopStepCheckNextChainedBlockExistStepTest.cs
@@ -30,7 +30,7 @@ namespace Stratis.Bitcoin.Features.BlockStore.Tests.LoopTests
                 Assert.Null(fluent.Loop.StoreTip);
 
                 var nextChainedBlock = block04;
-                var checkExistsStep = new CheckNextChainedBlockExistStep(fluent.Loop, this.loggerFactory);
+                var checkExistsStep = new CheckNextChainedBlockExistStep(fluent.Loop, this.LoggerFactory.Object);
                 checkExistsStep.ExecuteAsync(nextChainedBlock, new CancellationToken(), false).GetAwaiter().GetResult();
 
                 var options = NetworkOptions.TemporaryOptions;

--- a/src/Stratis.Bitcoin.Features.BlockStore.Tests/LoopTests/BlockStoreLoopStepFindBlocksTaskTest.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore.Tests/LoopTests/BlockStoreLoopStepFindBlocksTaskTest.cs
@@ -37,9 +37,9 @@ namespace Stratis.Bitcoin.Features.BlockStore.Tests.LoopTests
                 var nextChainedBlock = fluent.Loop.Chain.GetBlock(blocks[5].GetHash());
 
                 // Create Task Context
-                var context = new BlockStoreInnerStepContext(new CancellationToken(), fluent.Loop, nextChainedBlock, this.loggerFactory, DateTimeProvider.Default);
+                var context = new BlockStoreInnerStepContext(new CancellationToken(), fluent.Loop, nextChainedBlock, this.LoggerFactory.Object, DateTimeProvider.Default);
 
-                var task = new BlockStoreInnerStepFindBlocks(this.loggerFactory);
+                var task = new BlockStoreInnerStepFindBlocks(this.LoggerFactory.Object);
                 task.ExecuteAsync(context).GetAwaiter().GetResult();
 
                 // Block[5] through Block[9] should be in the DownloadStack
@@ -73,9 +73,9 @@ namespace Stratis.Bitcoin.Features.BlockStore.Tests.LoopTests
                 var nextChainedBlock = fluent.Loop.Chain.GetBlock(blocks[45].GetHash());
 
                 // Create Task Context
-                var context = new BlockStoreInnerStepContext(new CancellationToken(), fluent.Loop, nextChainedBlock, this.loggerFactory, DateTimeProvider.Default);
+                var context = new BlockStoreInnerStepContext(new CancellationToken(), fluent.Loop, nextChainedBlock, this.LoggerFactory.Object, DateTimeProvider.Default);
 
-                var task = new BlockStoreInnerStepFindBlocks(this.loggerFactory);
+                var task = new BlockStoreInnerStepFindBlocks(this.LoggerFactory.Object);
                 task.ExecuteAsync(context).GetAwaiter().GetResult();
 
                 // Block[45] through Block[50] should be in the DownloadStack
@@ -122,9 +122,9 @@ namespace Stratis.Bitcoin.Features.BlockStore.Tests.LoopTests
                 var nextChainedBlock = fluent.Loop.Chain.GetBlock(blocks[1].GetHash());
 
                 // Create Task Context
-                var context = new BlockStoreInnerStepContext(new CancellationToken(), fluent.Loop, nextChainedBlock, this.loggerFactory, DateTimeProvider.Default);
+                var context = new BlockStoreInnerStepContext(new CancellationToken(), fluent.Loop, nextChainedBlock, this.LoggerFactory.Object, DateTimeProvider.Default);
 
-                var task = new BlockStoreInnerStepFindBlocks(this.loggerFactory);
+                var task = new BlockStoreInnerStepFindBlocks(this.LoggerFactory.Object);
                 task.ExecuteAsync(context).GetAwaiter().GetResult();
 
                 // DownloadStack should only contain Block[1]
@@ -159,9 +159,9 @@ namespace Stratis.Bitcoin.Features.BlockStore.Tests.LoopTests
                 var nextChainedBlock = fluent.Loop.Chain.GetBlock(blocks[1].GetHash());
 
                 // Create Task Context
-                var context = new BlockStoreInnerStepContext(new CancellationToken(), fluent.Loop, nextChainedBlock, this.loggerFactory, DateTimeProvider.Default);
+                var context = new BlockStoreInnerStepContext(new CancellationToken(), fluent.Loop, nextChainedBlock, this.LoggerFactory.Object, DateTimeProvider.Default);
 
-                var task = new BlockStoreInnerStepFindBlocks(this.loggerFactory);
+                var task = new BlockStoreInnerStepFindBlocks(this.LoggerFactory.Object);
                 task.ExecuteAsync(context).GetAwaiter().GetResult();
 
                 // DownloadStack should only contain Block[1]
@@ -196,9 +196,9 @@ namespace Stratis.Bitcoin.Features.BlockStore.Tests.LoopTests
                 var nextChainedBlock = fluent.Loop.Chain.GetBlock(blocks[2].GetHash());
 
                 // Create Task Context
-                var context = new BlockStoreInnerStepContext(new CancellationToken(), fluent.Loop, nextChainedBlock, this.loggerFactory, DateTimeProvider.Default);
+                var context = new BlockStoreInnerStepContext(new CancellationToken(), fluent.Loop, nextChainedBlock, this.LoggerFactory.Object, DateTimeProvider.Default);
 
-                var task = new BlockStoreInnerStepFindBlocks(this.loggerFactory);
+                var task = new BlockStoreInnerStepFindBlocks(this.LoggerFactory.Object);
                 task.ExecuteAsync(context).GetAwaiter().GetResult();
 
                 // DownloadStack should only contain nextChainedBlock

--- a/src/Stratis.Bitcoin.Features.BlockStore.Tests/LoopTests/BlockStoreLoopStepReadBlocksTest.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore.Tests/LoopTests/BlockStoreLoopStepReadBlocksTest.cs
@@ -40,7 +40,7 @@ namespace Stratis.Bitcoin.Features.BlockStore.Tests.LoopTests
                 // Start processing blocks to download from block 5
                 var nextChainedBlock = fluent.Loop.Chain.GetBlock(blocks[5].GetHash());
 
-                var step = new DownloadBlockStep(fluent.Loop, this.loggerFactory, DateTimeProvider.Default);
+                var step = new DownloadBlockStep(fluent.Loop, this.LoggerFactory.Object, DateTimeProvider.Default);
                 step.ExecuteAsync(nextChainedBlock, new CancellationToken(), false).GetAwaiter().GetResult();
 
                 Assert.Equal(blocks[9].GetHash(), fluent.Loop.BlockRepository.BlockHash);
@@ -72,11 +72,11 @@ namespace Stratis.Bitcoin.Features.BlockStore.Tests.LoopTests
                 var nextChainedBlock = fluent.Loop.Chain.GetBlock(blocks[1].GetHash());
 
                 // Create Task Context
-                var context = new BlockStoreInnerStepContext(new CancellationToken(), fluent.Loop, nextChainedBlock, this.loggerFactory, DateTimeProvider.Default);
+                var context = new BlockStoreInnerStepContext(new CancellationToken(), fluent.Loop, nextChainedBlock, this.LoggerFactory.Object, DateTimeProvider.Default);
                 context.DownloadStack.Enqueue(nextChainedBlock);
                 context.StallCount = 10001;
 
-                var task = new BlockStoreInnerStepReadBlocks(this.loggerFactory);
+                var task = new BlockStoreInnerStepReadBlocks(this.LoggerFactory.Object);
                 var result = task.ExecuteAsync(context).GetAwaiter().GetResult();
 
                 Assert.Equal(InnerStepResult.Stop, result);
@@ -104,10 +104,10 @@ namespace Stratis.Bitcoin.Features.BlockStore.Tests.LoopTests
                 var nextChainedBlock = fluent.Loop.Chain.GetBlock(blocks[1].GetHash());
 
                 // Create Task Context
-                var context = new BlockStoreInnerStepContext(new CancellationToken(), fluent.Loop, nextChainedBlock, this.loggerFactory, DateTimeProvider.Default);
+                var context = new BlockStoreInnerStepContext(new CancellationToken(), fluent.Loop, nextChainedBlock, this.LoggerFactory.Object, DateTimeProvider.Default);
                 context.StallCount = 10001;
 
-                var task = new BlockStoreInnerStepReadBlocks(this.loggerFactory);
+                var task = new BlockStoreInnerStepReadBlocks(this.LoggerFactory.Object);
                 var result = task.ExecuteAsync(context).GetAwaiter().GetResult();
                 Assert.Equal(InnerStepResult.Stop, result);
             }

--- a/src/Stratis.Bitcoin.Features.BlockStore.Tests/LoopTests/BlockStoreLoopStepReorganiseTest.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore.Tests/LoopTests/BlockStoreLoopStepReorganiseTest.cs
@@ -38,7 +38,7 @@ namespace Stratis.Bitcoin.Features.BlockStore.Tests.LoopTests
 
                 //Reorganise (delete) blocks from the block repository that is not found
                 var nextChainedBlock = block10;
-                var reorganiseStep = new ReorganiseBlockRepositoryStep(fluent.Loop, this.loggerFactory);
+                var reorganiseStep = new ReorganiseBlockRepositoryStep(fluent.Loop, this.LoggerFactory.Object);
                 reorganiseStep.ExecuteAsync(nextChainedBlock, new CancellationToken(), false).GetAwaiter().GetResult();
 
                 Assert.Equal(fluent.Loop.StoreTip.Header.GetHash(), block10.Previous.Header.GetHash());

--- a/src/Stratis.Bitcoin.Features.BlockStore.Tests/LoopTests/BlockStoreLoopStepTryPendingTest.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore.Tests/LoopTests/BlockStoreLoopStepTryPendingTest.cs
@@ -41,7 +41,7 @@ namespace Stratis.Bitcoin.Features.BlockStore.Tests.LoopTests
                 //Start processing pending blocks from block 5
                 var nextChainedBlock = fluent.Loop.Chain.GetBlock(blocks[5].GetHash());
 
-                var processPendingStorageStep = new ProcessPendingStorageStep(fluent.Loop, this.loggerFactory);
+                var processPendingStorageStep = new ProcessPendingStorageStep(fluent.Loop, this.LoggerFactory.Object);
                 processPendingStorageStep.ExecuteAsync(nextChainedBlock, new CancellationToken(), false).GetAwaiter().GetResult();
 
                 Assert.Equal(blocks[9].GetHash(), fluent.Loop.BlockRepository.BlockHash);
@@ -86,7 +86,7 @@ namespace Stratis.Bitcoin.Features.BlockStore.Tests.LoopTests
                 //Start processing pending blocks from block 5
                 var nextChainedBlock = fluent.Loop.Chain.GetBlock(blocks[5].GetHash());
 
-                var processPendingStorageStep = new ProcessPendingStorageStep(fluent.Loop, this.loggerFactory);
+                var processPendingStorageStep = new ProcessPendingStorageStep(fluent.Loop, this.LoggerFactory.Object);
                 processPendingStorageStep.ExecuteAsync(nextChainedBlock, new CancellationToken(), false).GetAwaiter().GetResult();
 
                 Assert.Equal(blocks[14].GetHash(), fluent.Loop.BlockRepository.BlockHash);
@@ -131,7 +131,7 @@ namespace Stratis.Bitcoin.Features.BlockStore.Tests.LoopTests
                 //Start processing pending blocks from block 5
                 var nextChainedBlock = fluent.Loop.Chain.GetBlock(blocks[5].GetHash());
 
-                var processPendingStorageStep = new ProcessPendingStorageStep(fluent.Loop, this.loggerFactory);
+                var processPendingStorageStep = new ProcessPendingStorageStep(fluent.Loop, this.LoggerFactory.Object);
                 processPendingStorageStep.ExecuteAsync(nextChainedBlock, new CancellationToken(), false).GetAwaiter().GetResult();
 
                 Assert.Equal(blocks[2499].GetHash(), fluent.Loop.BlockRepository.BlockHash);
@@ -171,7 +171,7 @@ namespace Stratis.Bitcoin.Features.BlockStore.Tests.LoopTests
                 //Start processing pending blocks from block 5
                 var nextChainedBlock = fluent.Loop.Chain.GetBlock(blocks[5].GetHash());
 
-                var processPendingStorageStep = new ProcessPendingStorageStep(fluent.Loop, this.loggerFactory);
+                var processPendingStorageStep = new ProcessPendingStorageStep(fluent.Loop, this.LoggerFactory.Object);
                 processPendingStorageStep.ExecuteAsync(nextChainedBlock, new CancellationToken(), true).GetAwaiter().GetResult();
 
                 Assert.Equal(blocks[14].GetHash(), fluent.Loop.BlockRepository.BlockHash);

--- a/src/Stratis.Bitcoin.Tests.Common/Logging/LogsTestBase.cs
+++ b/src/Stratis.Bitcoin.Tests.Common/Logging/LogsTestBase.cs
@@ -11,7 +11,7 @@ namespace Stratis.Bitcoin.Tests.Common.Logging
         /// This class is not able to work concurrently because logs is a static class.
         /// The logs class needs to be refactored first before tests can run in parallel.
         /// </remarks>
-        public LogsTestBase()
+        public LogsTestBase() : base()
         {
             this.FullNodeLogger = new Mock<ILogger>();
             this.RPCLogger = new Mock<ILogger>();

--- a/src/Stratis.Bitcoin.Tests.Common/TestBase.cs
+++ b/src/Stratis.Bitcoin.Tests.Common/TestBase.cs
@@ -11,15 +11,11 @@ namespace Stratis.Bitcoin.Tests.Common
 {
     public class TestBase
     {
-        /// <summary>Factory for creating loggers.</summary>
-        public readonly ILoggerFactory loggerFactory;
-
         /// <summary>
         /// Initializes logger factory for inherited tests.
         /// </summary>
         public TestBase()
-        {
-            this.loggerFactory = new LoggerFactory();
+        {         
             DBreezeSerializer serializer = new DBreezeSerializer();
             serializer.Initialize();
         }

--- a/src/Stratis.Bitcoin.Tests/P2P/PeerAddressManagerBehaviourTests.cs
+++ b/src/Stratis.Bitcoin.Tests/P2P/PeerAddressManagerBehaviourTests.cs
@@ -8,13 +8,13 @@ using Stratis.Bitcoin.P2P;
 using Stratis.Bitcoin.P2P.Peer;
 using Stratis.Bitcoin.P2P.Protocol;
 using Stratis.Bitcoin.P2P.Protocol.Payloads;
-using Stratis.Bitcoin.Tests.Common;
+using Stratis.Bitcoin.Tests.Common.Logging;
 using Stratis.Bitcoin.Utilities;
 using Xunit;
 
 namespace Stratis.Bitcoin.Tests.P2P
 {
-    public sealed class PeerAddressManagerBehaviourTests : TestBase
+    public sealed class PeerAddressManagerBehaviourTests : LogsTestBase
     {
         private readonly ExtendedLoggerFactory extendedLoggerFactory;
         private readonly Network network;
@@ -36,7 +36,7 @@ namespace Stratis.Bitcoin.Tests.P2P
             var endpoint = new IPEndPoint(ipAddress, 80);
 
             var peerFolder = AssureEmptyDirAsDataFolder(Path.Combine(AppContext.BaseDirectory, "PeerAddressManagerBehaviourTests"));
-            var addressManager = new PeerAddressManager(DateTimeProvider.Default, peerFolder, this.loggerFactory, new SelfEndpointTracker());
+            var addressManager = new PeerAddressManager(DateTimeProvider.Default, peerFolder, this.LoggerFactory.Object, new SelfEndpointTracker());
             addressManager.AddPeer(endpoint, IPAddress.Loopback);
 
             var networkPeer = new Mock<INetworkPeer>();
@@ -73,7 +73,7 @@ namespace Stratis.Bitcoin.Tests.P2P
             var endpoint = new IPEndPoint(ipAddress, 80);
 
             var peerFolder = AssureEmptyDirAsDataFolder(Path.Combine(AppContext.BaseDirectory, "PeerAddressManagerBehaviourTests"));
-            var addressManager = new PeerAddressManager(DateTimeProvider.Default, peerFolder, this.loggerFactory, new SelfEndpointTracker());
+            var addressManager = new PeerAddressManager(DateTimeProvider.Default, peerFolder, this.LoggerFactory.Object, new SelfEndpointTracker());
             addressManager.AddPeer(endpoint, IPAddress.Loopback);
 
             var networkPeer = new Mock<INetworkPeer>();

--- a/src/Stratis.Bitcoin.Tests/P2P/PeerAddressManagerTests.cs
+++ b/src/Stratis.Bitcoin.Tests/P2P/PeerAddressManagerTests.cs
@@ -2,13 +2,13 @@
 using System.IO;
 using System.Net;
 using Stratis.Bitcoin.P2P;
-using Stratis.Bitcoin.Tests.Common;
+using Stratis.Bitcoin.Tests.Common.Logging;
 using Stratis.Bitcoin.Utilities;
 using Xunit;
 
 namespace Stratis.Bitcoin.Tests.P2P
 {
-    public sealed class PeerAddressManagerTests : TestBase
+    public sealed class PeerAddressManagerTests : LogsTestBase
     {
         [Fact]
         public void PeerFile_CanSaveAndLoadPeers_PeerConnected()
@@ -17,7 +17,7 @@ namespace Stratis.Bitcoin.Tests.P2P
             var endpoint = new IPEndPoint(ipAddress, 80);
 
             var peerFolder = AssureEmptyDirAsDataFolder(Path.Combine(AppContext.BaseDirectory, "PeerAddressManager"));
-            var addressManager = new PeerAddressManager(DateTimeProvider.Default, peerFolder, this.loggerFactory, new SelfEndpointTracker());
+            var addressManager = new PeerAddressManager(DateTimeProvider.Default, peerFolder, this.LoggerFactory.Object, new SelfEndpointTracker());
             addressManager.AddPeer(endpoint, IPAddress.Loopback);
 
             var applicableDate = DateTime.UtcNow.Date;
@@ -46,7 +46,7 @@ namespace Stratis.Bitcoin.Tests.P2P
 
             var peerFolder = AssureEmptyDirAsDataFolder(Path.Combine(AppContext.BaseDirectory, "PeerAddressManager"));
 
-            var addressManager = new PeerAddressManager(DateTimeProvider.Default, peerFolder, this.loggerFactory, new SelfEndpointTracker());
+            var addressManager = new PeerAddressManager(DateTimeProvider.Default, peerFolder, this.LoggerFactory.Object, new SelfEndpointTracker());
             addressManager.AddPeer(endpoint, IPAddress.Loopback);
 
             var applicableDate = DateTime.UtcNow.Date;
@@ -76,7 +76,7 @@ namespace Stratis.Bitcoin.Tests.P2P
 
             var peerFolder = AssureEmptyDirAsDataFolder(Path.Combine(AppContext.BaseDirectory, "PeerAddressManager"));
 
-            var addressManager = new PeerAddressManager(DateTimeProvider.Default, peerFolder, this.loggerFactory, new SelfEndpointTracker());
+            var addressManager = new PeerAddressManager(DateTimeProvider.Default, peerFolder, this.LoggerFactory.Object, new SelfEndpointTracker());
             addressManager.AddPeer(endpoint, IPAddress.Loopback);
 
             var applicableDate = DateTime.UtcNow.Date;
@@ -108,7 +108,7 @@ namespace Stratis.Bitcoin.Tests.P2P
 
             var peerFolder = AssureEmptyDirAsDataFolder(Path.Combine(AppContext.BaseDirectory, "PeerAddressManager"));
 
-            var addressManager = new PeerAddressManager(DateTimeProvider.Default, peerFolder, this.loggerFactory, new SelfEndpointTracker());
+            var addressManager = new PeerAddressManager(DateTimeProvider.Default, peerFolder, this.LoggerFactory.Object, new SelfEndpointTracker());
             addressManager.AddPeer(endpoint, IPAddress.Loopback);
 
             var applicableDate = DateTimeProvider.Default.GetUtcNow();
@@ -144,7 +144,7 @@ namespace Stratis.Bitcoin.Tests.P2P
 
             var peerFolder = AssureEmptyDirAsDataFolder(Path.Combine(AppContext.BaseDirectory, "PeerAddressManager"));
 
-            var addressManager = new PeerAddressManager(DateTimeProvider.Default, peerFolder, this.loggerFactory, new SelfEndpointTracker());
+            var addressManager = new PeerAddressManager(DateTimeProvider.Default, peerFolder, this.LoggerFactory.Object, new SelfEndpointTracker());
             addressManager.AddPeer(endpoint, IPAddress.Loopback);
 
             var applicableDate = DateTimeProvider.Default.GetUtcNow();

--- a/src/Stratis.Bitcoin.Tests/P2P/PeerConnectorTests.cs
+++ b/src/Stratis.Bitcoin.Tests/P2P/PeerConnectorTests.cs
@@ -1,8 +1,9 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.IO;
+using System.Linq;
 using System.Net;
+using System.Threading.Tasks;
+using Moq;
 using NBitcoin;
 using Stratis.Bitcoin.Configuration;
 using Stratis.Bitcoin.Configuration.Logging;
@@ -10,15 +11,13 @@ using Stratis.Bitcoin.Configuration.Settings;
 using Stratis.Bitcoin.Connection;
 using Stratis.Bitcoin.P2P;
 using Stratis.Bitcoin.P2P.Peer;
+using Stratis.Bitcoin.Tests.Common.Logging;
 using Stratis.Bitcoin.Utilities;
 using Xunit;
-using Moq;
-using System.Threading.Tasks;
-using Stratis.Bitcoin.Tests.Common;
 
 namespace Stratis.Bitcoin.Tests.P2P
 {
-    public sealed class PeerConnectorTests : TestBase
+    public sealed class PeerConnectorTests : LogsTestBase
     {
         private readonly IAsyncLoopFactory asyncLoopFactory;
         private readonly ExtendedLoggerFactory extendedLoggerFactory;
@@ -274,7 +273,7 @@ namespace Stratis.Bitcoin.Tests.P2P
         {
             var connectionManager = new ConnectionManager(
                 DateTimeProvider.Default,
-                this.loggerFactory,
+                this.LoggerFactory.Object,
                 this.network,
                 this.networkPeerFactory,
                 nodeSettings,

--- a/src/Stratis.Bitcoin.Tests/P2P/PeerSelectorTests.cs
+++ b/src/Stratis.Bitcoin.Tests/P2P/PeerSelectorTests.cs
@@ -4,18 +4,17 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net;
-using NBitcoin.Protocol;
 using Stratis.Bitcoin.Configuration;
 using Stratis.Bitcoin.Configuration.Logging;
 using Stratis.Bitcoin.P2P;
-using Stratis.Bitcoin.Tests.Common;
+using Stratis.Bitcoin.Tests.Common.Logging;
 using Stratis.Bitcoin.Utilities;
 using Stratis.Bitcoin.Utilities.Extensions;
 using Xunit;
 
 namespace Stratis.Bitcoin.Tests.P2P
 {
-    public sealed class PeerSelectorTests : TestBase
+    public sealed class PeerSelectorTests : LogsTestBase
     {
         private readonly ExtendedLoggerFactory extendedLoggerFactory;
 
@@ -726,7 +725,7 @@ namespace Stratis.Bitcoin.Tests.P2P
             var selfEndpointTracker = new SelfEndpointTracker();
             selfEndpointTracker.Add(selfIpEndPoint);
 
-            var peerSelector = new PeerSelector(new DateTimeProvider(), this.loggerFactory, peerAddresses, selfEndpointTracker);
+            var peerSelector = new PeerSelector(new DateTimeProvider(), this.LoggerFactory.Object, peerAddresses, selfEndpointTracker);
              
             IEnumerable<PeerAddress> peers = peerSelector.SelectPeersForDiscovery(2);
 


### PR DESCRIPTION
Removed the obsolete loggerfactory from testbase and update all unit tests using it to use the mock instead.