### PR TITLE
Update miner unit tests broken by #1290 and fix integration tests

### DIFF
--- a/src/Stratis.Bitcoin.Features.BlockStore/BlockStoreLoop.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/BlockStoreLoop.cs
@@ -219,7 +219,7 @@ namespace Stratis.Bitcoin.Features.BlockStore
         /// </summary>
         internal void ShutDown()
         {
-            this.asyncLoop?.Dispose(); // null check in case loop was not started.
+            this.asyncLoop?.Dispose();
             this.DownloadAndStoreBlocksAsync(CancellationToken.None, true).Wait();
         }
 

--- a/src/Stratis.Bitcoin.Features.BlockStore/BlockStoreLoop.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/BlockStoreLoop.cs
@@ -219,7 +219,7 @@ namespace Stratis.Bitcoin.Features.BlockStore
         /// </summary>
         internal void ShutDown()
         {
-            this.asyncLoop.Dispose();
+            this.asyncLoop?.Dispose(); // null check in case loop was not started.
             this.DownloadAndStoreBlocksAsync(CancellationToken.None, true).Wait();
         }
 

--- a/src/Stratis.Bitcoin.Features.Consensus/ConsensusLoop.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/ConsensusLoop.cs
@@ -250,7 +250,7 @@ namespace Stratis.Bitcoin.Features.Consensus
         public void Stop()
         {
             this.Puller.Dispose();
-            this.asyncLoop.Dispose();
+            this.asyncLoop?.Dispose(); // null check in case loop was not started.
             this.consensusLock.Dispose();
         }
 

--- a/src/Stratis.Bitcoin.Features.Consensus/ConsensusLoop.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/ConsensusLoop.cs
@@ -250,7 +250,7 @@ namespace Stratis.Bitcoin.Features.Consensus
         public void Stop()
         {
             this.Puller.Dispose();
-            this.asyncLoop?.Dispose(); // null check in case loop was not started.
+            this.asyncLoop?.Dispose();
             this.consensusLock.Dispose();
         }
 

--- a/src/Stratis.Bitcoin.Features.Miner.Tests/PosBlockAssemblerTest.cs
+++ b/src/Stratis.Bitcoin.Features.Miner.Tests/PosBlockAssemblerTest.cs
@@ -11,6 +11,7 @@ using Stratis.Bitcoin.Features.MemoryPool;
 using Stratis.Bitcoin.Features.MemoryPool.Interfaces;
 using Stratis.Bitcoin.Tests.Common.Logging;
 using Stratis.Bitcoin.Utilities;
+using Stratis.Bitcoin.Utilities.Extensions;
 using Xunit;
 
 namespace Stratis.Bitcoin.Features.Miner.Tests
@@ -101,6 +102,8 @@ namespace Stratis.Bitcoin.Features.Miner.Tests
             this.ExecuteWithConsensusOptions(new PosConsensusOptions(), () =>
             {
                 var chain = GenerateChainWithHeight(5, this.network, this.key);
+                this.dateTimeProvider.Setup(d => d.GetAdjustedTime())
+                    .Returns(new DateTime(2017, 1, 7, 0, 0, 1, DateTimeKind.Utc));
                 var transaction = CreateTransaction(this.network, this.key, 5, new Money(400 * 1000 * 1000), new Key(), new uint256(124124));
                 var txFee = new Money(1000);
                 SetupTxMempool(chain, this.network.Consensus.Options as PosConsensusOptions, txFee, transaction);
@@ -133,6 +136,7 @@ namespace Stratis.Bitcoin.Features.Miner.Tests
                 Assert.Equal(2, blockTemplate.Block.Transactions.Count);
 
                 var resultingTransaction = blockTemplate.Block.Transactions[0];
+                Assert.Equal((uint)new DateTime(2017, 1, 7, 0, 0, 1, DateTimeKind.Utc).ToUnixTimestamp(), resultingTransaction.Time);
                 Assert.NotEmpty(resultingTransaction.Inputs);
                 Assert.NotEmpty(resultingTransaction.Outputs);
                 Assert.True(resultingTransaction.IsCoinBase);
@@ -164,6 +168,8 @@ namespace Stratis.Bitcoin.Features.Miner.Tests
             this.ExecuteWithConsensusOptions(newOptions, () =>
             {
                 var chain = GenerateChainWithHeight(5, this.network, this.key);
+                this.dateTimeProvider.Setup(d => d.GetAdjustedTime())
+                    .Returns(new DateTime(2017, 1, 7, 0, 0, 1, DateTimeKind.Utc));
                 this.consensusLoop.Setup(c => c.Tip)
                     .Returns(chain.GetBlock(5));
 
@@ -190,7 +196,6 @@ namespace Stratis.Bitcoin.Features.Miner.Tests
                 this.stakeValidator.Verify();
             });
         }
-
 
         [Fact]
         public void ComputeBlockVersion_UsingChainTipAndConsensus_NoBip9DeploymentActive_UpdatesHeightAndVersion()
@@ -257,6 +262,8 @@ namespace Stratis.Bitcoin.Features.Miner.Tests
             this.ExecuteWithConsensusOptions(new PosConsensusOptions(), () =>
             {
                 var chain = GenerateChainWithHeight(5, this.network, this.key);
+                this.dateTimeProvider.Setup(d => d.GetAdjustedTime())
+                    .Returns(new DateTime(2017, 1, 7, 0, 0, 1, DateTimeKind.Utc));
 
                 var posBlockAssembler = new PosTestBlockAssembler(this.consensusLoop.Object, this.network, new MempoolSchedulerLock(), this.txMempool.Object,
                                                  this.dateTimeProvider.Object, this.stakeChain.Object, this.stakeValidator.Object, chain.Tip, this.LoggerFactory.Object);
@@ -268,6 +275,7 @@ namespace Stratis.Bitcoin.Features.Miner.Tests
                 Assert.Equal(new Money(-1), result.VTxFees[0]);
 
                 var resultingTransaction = result.Block.Transactions[0];
+                Assert.Equal((uint)new DateTime(2017, 1, 7, 0, 0, 1, DateTimeKind.Utc).ToUnixTimestamp(), resultingTransaction.Time);
                 Assert.True(resultingTransaction.IsCoinBase);
                 Assert.False(resultingTransaction.IsCoinStake);
                 Assert.Equal(Money.Zero, resultingTransaction.TotalOut);

--- a/src/Stratis.Bitcoin.Features.Miner.Tests/PowBlockAssemblerTest.cs
+++ b/src/Stratis.Bitcoin.Features.Miner.Tests/PowBlockAssemblerTest.cs
@@ -11,6 +11,7 @@ using Stratis.Bitcoin.Features.MemoryPool;
 using Stratis.Bitcoin.Features.MemoryPool.Interfaces;
 using Stratis.Bitcoin.Tests.Common.Logging;
 using Stratis.Bitcoin.Utilities;
+using Stratis.Bitcoin.Utilities.Extensions;
 using Xunit;
 
 namespace Stratis.Bitcoin.Features.Miner.Tests
@@ -46,6 +47,8 @@ namespace Stratis.Bitcoin.Features.Miner.Tests
             this.ExecuteWithConsensusOptions(new PowConsensusOptions(), () =>
             {
                 var chain = GenerateChainWithHeight(5, this.network, this.key);
+                this.dateTimeProvider.Setup(d => d.GetAdjustedTime())
+                    .Returns(new DateTime(2017, 1, 7, 0, 0, 1, DateTimeKind.Utc));
                 var transaction = CreateTransaction(this.network, this.key, 5, new Money(400 * 1000 * 1000), new Key(), new uint256(124124));
                 var txFee = new Money(1000);
                 SetupTxMempool(chain, this.network.Consensus.Options as PowConsensusOptions, txFee, transaction);
@@ -69,6 +72,7 @@ namespace Stratis.Bitcoin.Features.Miner.Tests
                 Assert.Equal(2, blockTemplate.Block.Transactions.Count);
 
                 var resultingTransaction = blockTemplate.Block.Transactions[0];
+                Assert.Equal((uint)new DateTime(2017, 1, 7, 0, 0, 1, DateTimeKind.Utc).ToUnixTimestamp(), resultingTransaction.Time);
                 Assert.NotEmpty(resultingTransaction.Inputs);
                 Assert.NotEmpty(resultingTransaction.Outputs);
                 Assert.True(resultingTransaction.IsCoinBase);
@@ -100,6 +104,8 @@ namespace Stratis.Bitcoin.Features.Miner.Tests
             this.ExecuteWithConsensusOptions(newOptions, () =>
             {
                 var chain = GenerateChainWithHeight(5, this.network, this.key);
+                this.dateTimeProvider.Setup(d => d.GetAdjustedTime())
+                    .Returns(new DateTime(2017, 1, 7, 0, 0, 1, DateTimeKind.Utc));
                 this.consensusLoop.Setup(c => c.Tip)
                     .Returns(chain.GetBlock(5));
 
@@ -187,17 +193,20 @@ namespace Stratis.Bitcoin.Features.Miner.Tests
             this.ExecuteWithConsensusOptions(new PowConsensusOptions(), () =>
             {
                 var chain = GenerateChainWithHeight(5, this.network, this.key);
+                this.dateTimeProvider.Setup(d => d.GetAdjustedTime())
+                    .Returns(new DateTime(2017, 1, 7, 0, 0, 1, DateTimeKind.Utc));
 
                 var powBlockAssembler = new PowTestBlockAssembler(this.consensusLoop.Object, this.network, new MempoolSchedulerLock(), this.txMempool.Object,
                                                          this.dateTimeProvider.Object, chain.Tip, this.LoggerFactory.Object);
 
                 var result = powBlockAssembler.CreateCoinBase(chain.Tip, this.key.ScriptPubKey);
-
+                
                 Assert.NotEmpty(result.Block.Transactions);
                 Assert.Equal(-1, result.TxSigOpsCost[0]);
                 Assert.Equal(new Money(-1), result.VTxFees[0]);
 
                 var resultingTransaction = result.Block.Transactions[0];
+                Assert.Equal((uint)new DateTime(2017, 1, 7, 0, 0, 1, DateTimeKind.Utc).ToUnixTimestamp(), resultingTransaction.Time);
                 Assert.True(resultingTransaction.IsCoinBase);
                 Assert.False(resultingTransaction.IsCoinStake);
                 Assert.Equal(Money.Zero, resultingTransaction.TotalOut);

--- a/src/Stratis.Bitcoin.IntegrationTests/MemoryPoolTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/MemoryPoolTests.cs
@@ -13,6 +13,12 @@ namespace Stratis.Bitcoin.IntegrationTests
 {
     public class MemoryPoolTests
     {
+        public MemoryPoolTests()
+        {
+            Block.BlockSignature = false;
+            Transaction.TimeStamp = false;
+        }
+
         public class DateTimeProviderSet : DateTimeProvider
         {
             public long time;

--- a/src/Stratis.Bitcoin.IntegrationTests/RPC/RPCTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/RPC/RPCTests.cs
@@ -38,6 +38,9 @@ namespace Stratis.Bitcoin.IntegrationTests.RPC
 
         public RpcTests(RpcTestFixtureStratis RpcTestFixture)
         {
+            Block.BlockSignature = false;
+            Transaction.TimeStamp = false;
+
             this.rpcTestFixture = RpcTestFixture;
         }
 


### PR DESCRIPTION
After #1290 several unit tests failed related to the block assemblers. This PR fixes them.