### PR TITLE
Fix failing CreateCoinBase and CreateNewBlock test cases

### DIFF
--- a/src/Stratis.Bitcoin.Features.Miner/PowBlockAssembler.cs
+++ b/src/Stratis.Bitcoin.Features.Miner/PowBlockAssembler.cs
@@ -322,7 +322,7 @@ namespace Stratis.Bitcoin.Features.Miner
             // Set the coin base with zero money.
             // Once we have the fee we can update the amount.
             this.coinbase = new Transaction();
-            this.coinbase.Time = (uint)this.dateTimeProvider.GetAdjustedTime().ToUnixTimestamp();
+            this.coinbase.Time = (uint)this.dateTimeProvider.GetAdjustedTimeAsUnixTimestamp();
             this.coinbase.AddInput(TxIn.CreateCoinbase(this.ChainTip.Height + 1));
             this.coinbase.AddOutput(new TxOut(Money.Zero, this.scriptPubKeyIn));
             this.pblock.AddTransaction(this.coinbase);


### PR DESCRIPTION
This PR fixes the following error:

`Message: System.ArgumentOutOfRangeException : The UTC time represented when the offset is applied must be between year 0 and 10,000.
Parameter name: offset`

The error occurs in the following test cases:

- CreateCoinbase_CreatesCoinbaseTemplateTransaction_AddsToBlockTemplate
- CreateNewBlock_WithScript_DoesNotValidateTemplateUsingRuleContext
- CreateNewBlock_WithScript_ReturnsBlockTemplate
- CreateNewBlock_WithScript_ValidatesTemplateUsingRuleContext
