### PR TITLE
Fix test classes: PosBlockAssemblerTest, PowBlockAssemblerTest and Po…

### DIFF
--- a/src/Stratis.Bitcoin.Features.Miner.Tests/PosBlockAssemblerTest.cs
+++ b/src/Stratis.Bitcoin.Features.Miner.Tests/PosBlockAssemblerTest.cs
@@ -42,6 +42,9 @@ namespace Stratis.Bitcoin.Features.Miner.Tests
 
             SetupValidator();
             SetupConsensusLoop();
+
+            Transaction.TimeStamp = true;
+            Block.BlockSignature = true;
         }
 
         [Fact]

--- a/src/Stratis.Bitcoin.Features.Miner.Tests/PowBlockAssemblerTest.cs
+++ b/src/Stratis.Bitcoin.Features.Miner.Tests/PowBlockAssemblerTest.cs
@@ -38,6 +38,9 @@ namespace Stratis.Bitcoin.Features.Miner.Tests
 
             SetupValidator();
             SetupConsensusLoop();
+
+            Transaction.TimeStamp = true;
+            Block.BlockSignature = true;
         }
 
         [Fact]

--- a/src/Stratis.Bitcoin.Features.Miner.Tests/PowMiningTest.cs
+++ b/src/Stratis.Bitcoin.Features.Miner.Tests/PowMiningTest.cs
@@ -35,8 +35,6 @@ namespace Stratis.Bitcoin.Features.Miner.Tests
         {
             this.initialBlockSignature = Block.BlockSignature;
             this.initialTimestamp = Transaction.TimeStamp;
-            Transaction.TimeStamp = true;
-            Block.BlockSignature = true;
 
             this.asyncLoopFactory = new Mock<IAsyncLoopFactory>();
 
@@ -49,6 +47,9 @@ namespace Stratis.Bitcoin.Features.Miner.Tests
             SetupBlockAssembler();
 
             this.powMining = new PowMining(this.consensusLoop.Object, this.chain, this.network, this.assemblerFactory.Object, this.nodeLifetime.Object, this.asyncLoopFactory.Object, this.LoggerFactory.Object);
+
+            Transaction.TimeStamp = true;
+            Block.BlockSignature = true;
         }
 
         public void Dispose()

--- a/src/Stratis.Bitcoin.Features.Miner.Tests/PowMiningTest.cs
+++ b/src/Stratis.Bitcoin.Features.Miner.Tests/PowMiningTest.cs
@@ -49,9 +49,6 @@ namespace Stratis.Bitcoin.Features.Miner.Tests
             SetupBlockAssembler();
 
             this.powMining = new PowMining(this.consensusLoop.Object, this.chain, this.network, this.assemblerFactory.Object, this.nodeLifetime.Object, this.asyncLoopFactory.Object, this.LoggerFactory.Object);
-
-            Transaction.TimeStamp = true;
-            Block.BlockSignature = true;
         }
 
         public void Dispose()

--- a/src/Stratis.Bitcoin.Features.Miner.Tests/PowMiningTest.cs
+++ b/src/Stratis.Bitcoin.Features.Miner.Tests/PowMiningTest.cs
@@ -42,6 +42,9 @@ namespace Stratis.Bitcoin.Features.Miner.Tests
             SetupBlockAssembler();
 
             this.powMining = new PowMining(this.consensusLoop.Object, this.chain, this.network, this.assemblerFactory.Object, this.nodeLifetime.Object, this.asyncLoopFactory.Object, this.LoggerFactory.Object);
+
+            Transaction.TimeStamp = true;
+            Block.BlockSignature = true;
         }
 
         [Fact]


### PR DESCRIPTION
This PR fixes the test classes: PosBlockAssemblerTest, PowBlockAssemblerTest and PowMiningTest.

Failing test cases:
```
PosBlockAssemblerTest
=====================
AddTransactions_WithoutTransactionsInMempool_DoesNotAddEntriesToBlock
AddTransactions_TransactionNotInblock_AddsTransactionToBlock
AddTransactions_TransactionAlreadyInInblock_DoesNotAddTransactionToBlock
ComputeBlockVersion_UsingChainTipAndConsensus_Bip9DeploymentActive_UpdatesHeightAndVersion
ComputeBlockVersion_UsingChainTipAndConsensus_NoBip9DeploymentActive_UpdatesHeightAndVersion
CreateCoinbase_CreatesCoinbaseTemplateTransaction_AddsToBlockTemplate
CreateNewBlock_WithScript_ReturnsBlockTemplate
CreateNewBlock_WithScript_DoesNotValidateTemplateUsingRuleContext
TestBlockValidity_DoesNotValidateBlockUsingRuleContext
UpdateHeaders_UsingChainAndNetwork_PreparesStakeBlockHeaders

PowBlockAssemblerTest
=====================
CreateCoinbase_CreatesCoinbaseTemplateTransaction_AddsToBlockTemplate
CreateNewBlock_WithScript_ReturnsBlockTemplate
CreateNewBlock_WithScript_ValidatesTemplateUsingRuleContext
AddTransactions_TransactionAlreadyInInblock_DoesNotAddTransactionToBlock
AddTransactions_TransactionNotInblock_AddsTransactionToBlock
AddTransactions_WithoutTransactionsInMempool_DoesNotAddEntriesToBlock
ComputeBlockVersion_UsingChainTipAndConsensus_Bip9DeploymentActive_UpdatesHeightAndVersion
ComputeBlockVersion_UsingChainTipAndConsensus_NoBip9DeploymentActive_UpdatesHeightAndVersion
TestBlockValidity_UsesRuleContextToValidateBlock
UpdateHeaders_UsingChainAndNetwork_PreparesBlockHeaders

PowMiningTest
=============
GenerateBlocks_MultipleBlocks_BlockValidationContextError_ReturnsValidGeneratedBlocks
GenerateBlocks_MultipleBlocks_ChainedBlockNotPresentInBlockValidationContext_ReturnsValidGeneratedBlocks
GenerateBlocks_MultipleBlocks_ReturnsGeneratedBlocks
GenerateBlocks_SingleBlock_BlockValidationContextErrorInvalidPrevTip_ContinuesExecution_ReturnsGeneratedBlock
GenerateBlocks_SingleBlock_ChainedBlockNotPresentInBlockValidationContext_ReturnsEmptyList
GenerateBlocks_SingleBlock_MaxTriesReached_StopsGeneratingBlocks_ReturnsEmptyList
GenerateBlocks_SingleBlock_ReturnsGeneratedBlock
GenerateBlocks_SingleBlock_ValidationContextError_ReturnsEmptyList
GenerateBlocks_ZeroBlocks_ReturnsEmptyList
IncrementExtraNonce_HashPrevBlockNotSameAsBlockHeaderHashPrevBlock_IncrementsExtraNonce_UpdatesCoinBaseTransactionAndMerkleRoot
IncrementExtraNonce_HashPrevBlockNotSameAsBlockHeaderHashPrevBlock_ResetsExtraNonceAndHashPrevBlock_UpdatesCoinBaseTransactionAndMerkleRoot
Mine_CreatedAsyncLoop_GeneratesBlocksUntilCancelled
Mine_FirstCall_CreatesNewMiningLoop_ReturnsMiningLoop
Mine_SecondCall_ReturnsSameMiningLoop
```