### PR TITLE
[Integration] Fix the POS test

### DIFF
--- a/src/Stratis.Bitcoin.IntegrationTests/BlockStore/RetrieveFromBlockStoreSpecification.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/BlockStore/RetrieveFromBlockStoreSpecification.cs
@@ -43,6 +43,5 @@ namespace Stratis.Bitcoin.IntegrationTests.BlockStore
             And(the_wrong_transaction_id_should_return_null);
             And(the_block_with_the_wrong_id_should_return_null);
         }
-
     }
 }

--- a/src/Stratis.Bitcoin.IntegrationTests/EnvironmentMockUpHelpers/NodeRunners.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/EnvironmentMockUpHelpers/NodeRunners.cs
@@ -100,7 +100,7 @@ namespace Stratis.Bitcoin.IntegrationTests.EnvironmentMockUpHelpers
                         .AddPowPosMining()
                         .AddRPC()
                         .MockIBD()
-                        .SubstituteDateTimeProviderFor<MiningFeature>(new GenerateCoinsFastDateTimeProvider())
+                        .SubstituteDateTimeProviderFor<MiningFeature>()
                         .Build();
             }
 
@@ -299,7 +299,7 @@ namespace Stratis.Bitcoin.IntegrationTests.EnvironmentMockUpHelpers
                     .UseWallet()
                     .AddRPC()
                     .MockIBD()
-                    .SubstituteDateTimeProviderFor<MiningFeature>(new GenerateCoinsFastDateTimeProvider())
+                    .SubstituteDateTimeProviderFor<MiningFeature>()
                     .Build();
             }
 

--- a/src/Stratis.Bitcoin.IntegrationTests/Extensions/CoreNodeExtensions.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/Extensions/CoreNodeExtensions.cs
@@ -14,7 +14,7 @@ namespace Stratis.Bitcoin.IntegrationTests
         /// Substitute the <see cref="IDateTimeProvider"/> for a given feature.
         /// </summary>
         /// <typeparam name="T">The feature to substitute the provider for.</typeparam>
-        public static IFullNodeBuilder SubstituteDateTimeProviderFor<T>(this IFullNodeBuilder fullNodeBuilder, IDateTimeProvider provider)
+        public static IFullNodeBuilder SubstituteDateTimeProviderFor<T>(this IFullNodeBuilder fullNodeBuilder)
         {
             fullNodeBuilder.ConfigureFeature(features =>
             {
@@ -25,7 +25,9 @@ namespace Stratis.Bitcoin.IntegrationTests
                     {
                         ServiceDescriptor service = services.FirstOrDefault(s => s.ServiceType == typeof(IDateTimeProvider));
                         if (service != null)
-                            services.Remove(service); services.AddSingleton(provider);
+                            services.Remove(service);
+
+                        services.AddSingleton<IDateTimeProvider, GenerateCoinsFastDateTimeProvider>();
                     });
                 }
             });

--- a/src/Stratis.Bitcoin.IntegrationTests/Miners/ProofOfStakeMintCoinsSteps.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/Miners/ProofOfStakeMintCoinsSteps.cs
@@ -37,9 +37,6 @@ namespace Stratis.Bitcoin.IntegrationTests.Miners
 
         private const string WalletAccount = "account 0";
 
-        private bool initialBlockSignature;
-        private bool initialTimeStamp;
-
         public ProofOfStakeMintCoinsSpecification(ITestOutputHelper outputHelper)
             : base(outputHelper)
         {
@@ -50,9 +47,6 @@ namespace Stratis.Bitcoin.IntegrationTests.Miners
             this.sharedSteps = new SharedSteps();
             this.nodeGroupBuilder = new NodeGroupBuilder();
 
-            this.initialBlockSignature = Transaction.TimeStamp;
-            this.initialTimeStamp = Block.BlockSignature;
-
             Transaction.TimeStamp = true;
             Block.BlockSignature = true;
         }
@@ -60,9 +54,6 @@ namespace Stratis.Bitcoin.IntegrationTests.Miners
         protected override void AfterTest()
         {
             this.nodeGroupBuilder.Dispose();
-
-            Transaction.TimeStamp = this.initialBlockSignature;
-            Block.BlockSignature = this.initialBlockSignature;
         }
 
         private void a_proof_of_work_node_with_wallet()

--- a/src/Stratis.Bitcoin.IntegrationTests/TestFramework/BddSpecification.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/TestFramework/BddSpecification.cs
@@ -3,7 +3,6 @@ using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
-using NBitcoin;
 using Stratis.Bitcoin.Tests.Common;
 using Xunit.Abstractions;
 
@@ -22,7 +21,7 @@ namespace Stratis.Bitcoin.IntegrationTests.TestFramework
             this.output = output;
             this.startOfTestTime = DateTime.UtcNow;
 
-            this.staticFlagIsolator = new StaticFlagIsolator(Network.RegTest);
+            this.staticFlagIsolator = new StaticFlagIsolator();
             this.BeforeTest();
         }
 

--- a/src/Stratis.Bitcoin.Tests.Common/StaticFlagIsolator.cs
+++ b/src/Stratis.Bitcoin.Tests.Common/StaticFlagIsolator.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 using NBitcoin;
 
 namespace Stratis.Bitcoin.Tests.Common
@@ -13,17 +11,11 @@ namespace Stratis.Bitcoin.Tests.Common
     {
         private readonly bool previousTimeStamp;
         private readonly bool previousBlockSignature;
-        public StaticFlagIsolator(Network network)
+
+        public StaticFlagIsolator()
         {
             this.previousBlockSignature = Block.BlockSignature;
             this.previousTimeStamp = Transaction.TimeStamp;
-
-            var isStratisNetwork = network == Network.StratisTest 
-                                    || network == Network.StratisMain
-                                    || network == Network.StratisRegTest;
-            Transaction.TimeStamp = isStratisNetwork;
-            Block.BlockSignature = isStratisNetwork;
-            
         }
 
         public void Dispose()


### PR DESCRIPTION
Fix test by implementing a better date time provider that is more in line with the actual node works. I.e. we don't do any time manipulation on the block header and transaction level.

Also, needed to fix the StaticFlagIsolator as we should only use it to store the initial flag values and reset them after the test has completed.