### PR TITLE
Fix BlockStore test cases

### DIFF
--- a/src/Stratis.Bitcoin.Features.BlockStore.Tests/BlockRepositoryTest.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore.Tests/BlockRepositoryTest.cs
@@ -10,6 +10,13 @@ namespace Stratis.Bitcoin.Features.BlockStore.Tests
 {
     public class BlockRepositoryTest : LogsTestBase
     {
+        public BlockRepositoryTest()
+        {
+            // Ensure that these flags match the Network and NetworkOptions being used
+            Transaction.TimeStamp = false;
+            Block.BlockSignature = false;
+        }
+
         [Fact]
         public void InitializesGenBlockAndTxIndexOnFirstLoad()
         {

--- a/src/Stratis.Bitcoin.Features.BlockStore.Tests/LoopTests/BlockStoreLoopStepBaseTest.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore.Tests/LoopTests/BlockStoreLoopStepBaseTest.cs
@@ -20,6 +20,13 @@ namespace Stratis.Bitcoin.Features.BlockStore.Tests.LoopTests
     /// </summary>
     public class BlockStoreLoopStepBaseTest : LogsTestBase
     {
+        public BlockStoreLoopStepBaseTest()
+        {
+            // Ensure that these flags match the Network and NetworkOptions being used
+            Transaction.TimeStamp = false;
+            Block.BlockSignature = false;
+        }
+
         internal void AddBlockToPendingStorage(BlockStoreLoop blockStoreLoop, Block block)
         {
             var chainedBlock = blockStoreLoop.Chain.GetBlock(block.GetHash());

--- a/src/Stratis.Bitcoin.Features.BlockStore.Tests/StoreSettingsTest.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore.Tests/StoreSettingsTest.cs
@@ -1,4 +1,5 @@
-﻿using Stratis.Bitcoin.Builder;
+﻿using NBitcoin;
+using Stratis.Bitcoin.Builder;
 using Stratis.Bitcoin.Configuration;
 using Stratis.Bitcoin.Tests.Common;
 using Xunit;
@@ -7,6 +8,13 @@ namespace Stratis.Bitcoin.Features.BlockStore.Tests
 {
     public class StoreSettingsTest : TestBase
     {
+        public StoreSettingsTest()
+        {
+            // Ensure that these flags match the Network and NetworkOptions being used
+            Transaction.TimeStamp = false;
+            Block.BlockSignature = false;
+        }
+
         [Fact]
         public void CanSpecifyStoreSettings()
         {


### PR DESCRIPTION
This PR fixes the following test cases which are currently failing intermittently:

BlockStoreLoopIntegration
=========================
CheckNextChainedBlockExists_WithNextChainedBlock_Exists_SetStoreTipAndBlockHash
DownloadBlockStep_WithNewBlocksToDownload_DownloadBlocksAndPushToRepo
ProcessPendingStorage_PushToRepo_BeforeDownloadingNewBlocks
ReorganiseBlockRepository_WithBlockRepositoryAndChainOutofSync_ReorganiseBlocks

BlockStoreLoopStepReorganiseTest
================================
ReorganiseBlockRepository_WithBlockRepositoryAndChainOutofSync_ReorganiseBlocks_InMemory

BlockStoreLoopStepCheckNextChainedBlockExistStepTest
====================================================
CheckNextChainedBlockExists_WithNextChainedBlock_Exists_SetStoreTipAndBlockHash_InMemory

BlockStoreLoopStepDownloadBlocksTest
====================================
BlockStoreInnerStepReadBlocks_CanBreakExecution_DownloadStackIsEmpty
BlockStoreInnerStepReadBlocks_WithBlocksToAskAndRead_CanBreakExecutionOnStallCountReached
BlockStoreInnerStepReadBlocks_WithBlocksToAskAndRead_PushToRepository

BlockStoreLoopStepTryPendingTest
================================
ProcessPendingStorage_PushToRepo_IBD_MaxPendingInsertBlockSize_InMemory
ProcessPendingStorage_PushToRepo_NotIBD_InMemory
ProcessPendingStorage_PushToRepo_IBD_InMemory
ProcessPendingStorage_PushToRepo_Disposing_InMemory

BlockRepositoryTest
===================
DeleteAsyncRemovesBlocksAndTransactions
DoesNotOverwriteExistingBlockAndTxIndexOnFirstLoad
ExistAsyncWithExistingBlockReturnsTrue
ExistAsyncWithoutExistingBlockReturnsFalse
GetAsyncWithExistingBlockReturnsBlock
GetAsyncWithoutExistingBlockReturnsNull
GetTrxAsyncWithoutTransactionIndexReturnsNewTransaction
GetTrxAsyncWithoutTransactionInIndexReturnsNull
GetTrxAsyncWithTransactionReturnsExistingTransaction
GetTrxBlockIdAsyncWithoutExistingTransactionReturnsNull
GetTrxBlockIdAsyncWithoutTxIndexReturnsDefaultId
GetTrxBlockIdAsyncWithTransactionReturnsBlockId
InitializesGenBlockAndTxIndexOnFirstLoad
PutAsyncWritesBlocksAndTransactionsToDbAndSavesNextBlockHash
SetBlockHashUpdatesBlockHash
SetTxIndexUpdatesTxIndex

StoreSettingsTest
===========
CanSpecifyStoreSettings