### PR TITLE
Move checkpoints to network (#1341)

### DIFF
--- a/src/NBitcoin.Tests/NetworkBuilderTest.cs
+++ b/src/NBitcoin.Tests/NetworkBuilderTest.cs
@@ -64,9 +64,9 @@ namespace NBitcoin.Tests
 
         [Fact]
         public void SetTxFees_MinRelayTxFee_SetsTxFeesOnBuilder()
-        {            
+        {
             this.builder.SetTxFees(0, 0, 1231);
-            
+
             Assert.Equal(0, this.builder.MinTxFee);
             Assert.Equal(0, this.builder.FallbackFee);
             Assert.Equal(1231, this.builder.MinRelayTxFee);
@@ -202,9 +202,52 @@ namespace NBitcoin.Tests
         }
 
         [Fact]
+        public void BuildAndRegister_SetNoName_ThrowsInvalidOperationException()
+        {
+            this.builder.SetName(null);
+
+            Assert.Throws<InvalidOperationException>(() => this.builder.BuildAndRegister());
+        }
+
+        [Fact]
+        public void BuildAndRegister_RegisterTwice_ThrowsInvalidOperationException()
+        {
+            this.builder.SetName("MyDuplicateNetwork");
+            this.builder.SetGenesis(new Block(new BlockHeader() { Version = 10 }));
+            this.builder.SetConsensus(new Consensus() { CoinType = 15 });
+
+            this.builder.BuildAndRegister();
+
+            Assert.Throws<InvalidOperationException>(() => this.builder.BuildAndRegister());
+        }
+
+        [Fact]
+        public void BuildAndRegister_ConsensusNotProvided_ThrowsInvalidOperationException()
+        {
+            var genesis = new Block(new BlockHeader() { Version = 10 });
+
+            this.builder.SetName("ConsensusNotSetNetwork");
+            this.builder.SetGenesis(genesis);
+            this.builder.SetConsensus(null);
+
+            Assert.Throws<InvalidOperationException>(() => this.builder.BuildAndRegister());
+        }
+
+        [Fact]
+        public void BuildAndRegister_GenesisNotProvided_ThrowsInvalidOperationException()
+        {
+            var consensus = new Consensus() { CoinType = 15 };
+            this.builder.SetName("GenesisNotSetNetwork");
+            this.builder.SetGenesis(null);
+            this.builder.SetConsensus(consensus);
+
+            Assert.Throws<InvalidOperationException>(() => this.builder.BuildAndRegister());
+        }
+
+        [Fact]
         public void BuildAndRegister_SetName_SetsNetworkNameOnNetwork()
         {
-            this.builder.SetName("MyNetwork");
+            this.PrepareValidNetwork("MyNetwork");
 
             Network result = this.builder.BuildAndRegister();
 
@@ -214,7 +257,7 @@ namespace NBitcoin.Tests
         [Fact]
         public void BuildAndRegister_SetRootFolderName_SetsRootFolderNameOnNetwork()
         {
-            this.builder.SetName("RootFolderNetwork");
+            this.PrepareValidNetwork("RootFolderNetwork");
             this.builder.SetRootFolderName("MyRootFolder");
 
             Network result = this.builder.BuildAndRegister();
@@ -225,7 +268,7 @@ namespace NBitcoin.Tests
         [Fact]
         public void BuildAndRegister_SetDefaultConfigFilename_SetsDefaultConfigFilenameOnNetwork()
         {
-            this.builder.SetName("DefaultConfigFileNetwork");
+            this.PrepareValidNetwork("DefaultConfigFileNetwork");
             this.builder.SetDefaultConfigFilename("MyDefaultConfigFileName");
 
             Network result = this.builder.BuildAndRegister();
@@ -236,7 +279,7 @@ namespace NBitcoin.Tests
         [Fact]
         public void BuildAndRegister_SetTxFees_MinTxFee_SetsTxFeesOnNetwork()
         {
-            this.builder.SetName("MinTxFeeNetwork");
+            this.PrepareValidNetwork("MinTxFeeNetwork");
             this.builder.SetTxFees(1500, 0, 0);
 
             Network result = this.builder.BuildAndRegister();
@@ -249,7 +292,7 @@ namespace NBitcoin.Tests
         [Fact]
         public void BuildAndRegister_SetTxFees_FallbackFee_SetsTxFeesOnNetwork()
         {
-            this.builder.SetName("FallbackFeeNetwork");
+            this.PrepareValidNetwork("FallbackFeeNetwork");
             this.builder.SetTxFees(0, 2130, 0);
 
             Network result = this.builder.BuildAndRegister();
@@ -262,7 +305,7 @@ namespace NBitcoin.Tests
         [Fact]
         public void BuildAndRegister_SetTxFees_MinRelayTxFee_SetsTxFeesOnNetwork()
         {
-            this.builder.SetName("MinRelayTxFeeNetwork");
+            this.PrepareValidNetwork("MinRelayTxFeeNetwork");
             this.builder.SetTxFees(0, 0, 1231);
 
             Network result = this.builder.BuildAndRegister();
@@ -275,7 +318,7 @@ namespace NBitcoin.Tests
         [Fact]
         public void BuildAndRegister_SetMaxTimeOffsetSeconds_SetsMaxTimeOffsetSecondsOnNetwork()
         {
-            this.builder.SetName("MaxTimeOffsetSecondsNetwork");
+            this.PrepareValidNetwork("MaxTimeOffsetSecondsNetwork");
             this.builder.SetMaxTimeOffsetSeconds(918);
 
             Network result = this.builder.BuildAndRegister();
@@ -286,7 +329,7 @@ namespace NBitcoin.Tests
         [Fact]
         public void BuildAndRegister_SetSetMaxTipAge_SetsMaxTipAgeOnNetwork()
         {
-            this.builder.SetName("SetMaxTipAgeNetwork");
+            this.PrepareValidNetwork("SetMaxTipAgeNetwork");
             this.builder.SetMaxTipAge(712);
 
             Network result = this.builder.BuildAndRegister();
@@ -297,7 +340,7 @@ namespace NBitcoin.Tests
         [Fact]
         public void BuildAndRegister_AddAlias_RegistersNetworkWithAliasToNetworks()
         {
-            this.builder.SetName("AliasNetwork");
+            this.PrepareValidNetwork("AliasNetwork");
             this.builder.AddAlias("NetworkNameByAlias");
 
             Network result = this.builder.BuildAndRegister();
@@ -310,7 +353,7 @@ namespace NBitcoin.Tests
         [Fact]
         public void BuildAndRegister_SetRPCPort_SetsRPCPortOnNetwork()
         {
-            this.builder.SetName("SetRPCPortNetwork");
+            this.PrepareValidNetwork("SetRPCPortNetwork");
             this.builder.SetRPCPort(8339);
 
             Network result = this.builder.BuildAndRegister();
@@ -321,7 +364,7 @@ namespace NBitcoin.Tests
         [Fact]
         public void BuildAndRegister_SetPort_SetsPortOnNetwork()
         {
-            this.builder.SetName("SetPortNetwork");
+            this.PrepareValidNetwork("SetPortNetwork");
             this.builder.SetPort(14000);
 
             Network result = this.builder.BuildAndRegister();
@@ -332,7 +375,7 @@ namespace NBitcoin.Tests
         [Fact]
         public void BuildAndRegister_SetMagic_SetsMagicOnNetwork()
         {
-            this.builder.SetName("SetMagicNetwork");
+            this.PrepareValidNetwork("SetMagicNetwork");
             this.builder.SetMagic(1231241);
 
             Network result = this.builder.BuildAndRegister();
@@ -343,7 +386,7 @@ namespace NBitcoin.Tests
         [Fact]
         public void BuildAndRegister_AddDNSSeeds_SetsDNSSeedsOnNetwork()
         {
-            this.builder.SetName("SetDNSSeedsNetwork");
+            this.PrepareValidNetwork("SetDNSSeedsNetwork");
             this.builder.AddDNSSeeds(new DNSSeedData[] { new DNSSeedData("dnsNode1", "3.4.2.1") });
 
             Network result = this.builder.BuildAndRegister();
@@ -356,7 +399,7 @@ namespace NBitcoin.Tests
         [Fact]
         public void BuildAndRegister_AddSeeds_SetsSeedsOnNetwork()
         {
-            this.builder.SetName("SetSeedsNetwork");
+            this.PrepareValidNetwork("SetSeedsNetwork");
             this.builder.AddSeeds(new NetworkAddress[] { new NetworkAddress(IPAddress.Parse("::ffff:0:0"), 1234) });
 
             Network result = this.builder.BuildAndRegister();
@@ -385,7 +428,7 @@ namespace NBitcoin.Tests
         [Fact]
         public void BuildAndRegister_SetBase58Bytes_SetsBase58PrefixesOnNetwork()
         {
-            this.builder.SetName("SetBase58BytesNetwork");
+            this.PrepareValidNetwork("SetBase58BytesNetwork");
             this.builder.SetBase58Bytes(Base58Type.SCRIPT_ADDRESS, new byte[] { (196) });
 
             Network result = this.builder.BuildAndRegister();
@@ -396,7 +439,7 @@ namespace NBitcoin.Tests
         [Fact]
         public void BuildAndRegister_SetSetBech32_HumanReadable_SetsBech32EncodersOnNetwork()
         {
-            this.builder.SetName("SetBech34ReadableNetwork");
+            this.PrepareValidNetwork("SetBech34ReadableNetwork");
             this.builder.SetBech32(Bech32Type.WITNESS_PUBKEY_ADDRESS, "bc");
 
             Network result = this.builder.BuildAndRegister();
@@ -408,7 +451,7 @@ namespace NBitcoin.Tests
         public void BuildAndRegister_SetSetBech32_ExistingEncoder_SetsBech32EncodersOnNetwork()
         {
             Bech32Encoder encoder = Encoders.Bech32("bc");
-            this.builder.SetName("SetBech32EncoderNetwork");
+            this.PrepareValidNetwork("SetBech32EncoderNetwork");
             this.builder.SetBech32(Bech32Type.WITNESS_PUBKEY_ADDRESS, encoder);
 
             Network result = this.builder.BuildAndRegister();
@@ -423,7 +466,7 @@ namespace NBitcoin.Tests
             {
                 { 33333, new CheckpointInfo(new uint256("0x000000002dd5588a74784eaa7ab0507a18ad16a236e7b1ce69f00d7ddfb5d0a6")) },
             };
-            this.builder.SetName("SetCheckpointsNetwork");
+            this.PrepareValidNetwork("SetCheckpointsNetwork");
             this.builder.SetCheckpoints(checkpoints);
 
             Network result = this.builder.BuildAndRegister();
@@ -433,6 +476,13 @@ namespace NBitcoin.Tests
             Assert.Equal(33333, resultingCheckpoint.Key);
             Assert.Equal(new uint256("0x000000002dd5588a74784eaa7ab0507a18ad16a236e7b1ce69f00d7ddfb5d0a6"), resultingCheckpoint.Value.Hash);
             Assert.Null(resultingCheckpoint.Value.StakeModifierV2);
+        }
+
+        private void PrepareValidNetwork(string networkName)
+        {
+            this.builder.SetName(networkName);
+            this.builder.SetGenesis(new Block(new BlockHeader() { Version = 10 }));
+            this.builder.SetConsensus(new Consensus() { CoinType = 15 });
         }
     }
 }

--- a/src/NBitcoin.Tests/NetworkBuilderTest.cs
+++ b/src/NBitcoin.Tests/NetworkBuilderTest.cs
@@ -1,0 +1,438 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Text;
+using NBitcoin.DataEncoders;
+using NBitcoin.Protocol;
+using Xunit;
+
+namespace NBitcoin.Tests
+{
+    public class NetworkBuilderTest
+    {
+        private NetworkBuilder builder;
+
+        public NetworkBuilderTest()
+        {
+            this.builder = new NetworkBuilder();
+        }
+
+        [Fact]
+        public void SetName_SetsNetworkNameOnBuilder()
+        {
+            this.builder.SetName("MyNetwork");
+
+            Assert.Equal("MyNetwork", this.builder.Name);
+        }
+
+        [Fact]
+        public void SetRootFolderName_SetsRootFolderNameOnBuilder()
+        {
+            this.builder.SetRootFolderName("MyRootFolder");
+
+            Assert.Equal("MyRootFolder", this.builder.RootFolderName);
+        }
+
+        [Fact]
+        public void SetDefaultConfigFilename_SetsDefaultConfigFilenameOnBuilder()
+        {
+            this.builder.SetDefaultConfigFilename("MyDefaultConfigFileName");
+
+            Assert.Equal("MyDefaultConfigFileName", this.builder.DefaultConfigFilename);
+        }
+
+        [Fact]
+        public void SetTxFees_MinTxFee_SetsTxFeesOnBuilder()
+        {
+            this.builder.SetTxFees(1500, 0, 0);
+
+            Assert.Equal(1500, this.builder.MinTxFee);
+            Assert.Equal(0, this.builder.FallbackFee);
+            Assert.Equal(0, this.builder.MinRelayTxFee);
+        }
+
+        [Fact]
+        public void _SetTxFees_FallbackFee_SetsTxFeesOnBuilder()
+        {
+            this.builder.SetTxFees(0, 2130, 0);
+
+            Assert.Equal(0, this.builder.MinTxFee);
+            Assert.Equal(2130, this.builder.FallbackFee);
+            Assert.Equal(0, this.builder.MinRelayTxFee);
+        }
+
+        [Fact]
+        public void SetTxFees_MinRelayTxFee_SetsTxFeesOnBuilder()
+        {            
+            this.builder.SetTxFees(0, 0, 1231);
+            
+            Assert.Equal(0, this.builder.MinTxFee);
+            Assert.Equal(0, this.builder.FallbackFee);
+            Assert.Equal(1231, this.builder.MinRelayTxFee);
+        }
+
+        [Fact]
+        public void SetMaxTimeOffsetSeconds_SetsMaxTimeOffsetSecondsOnBuilder()
+        {
+            this.builder.SetMaxTimeOffsetSeconds(918);
+
+            Assert.Equal(918, this.builder.MaxTimeOffsetSeconds);
+        }
+
+        [Fact]
+        public void SetSetMaxTipAge_SetsMaxTipAgeOnBuilder()
+        {
+            this.builder.SetMaxTipAge(712);
+
+            Assert.Equal(712, this.builder.MaxTipAge);
+        }
+
+        [Fact]
+        public void AddAlias_AddsAliasToBuilder()
+        {
+            this.builder.AddAlias("NetworkNameByAlias");
+
+            Assert.NotEmpty(this.builder.Aliases);
+            Assert.Equal("NetworkNameByAlias", this.builder.Aliases.ElementAt(0));
+        }
+
+        [Fact]
+        public void SetRPCPort_SetsRPCPortOnBuilder()
+        {
+            this.builder.SetRPCPort(8339);
+
+            Assert.Equal(8339, this.builder.RPCPort);
+        }
+
+        [Fact]
+        public void SetPort_SetsPortOnBuilder()
+        {
+            this.builder.SetPort(14000);
+
+            Assert.Equal(14000, this.builder.Port);
+        }
+
+        [Fact]
+        public void SetMagic_SetsMagicOnBuilder()
+        {
+            this.builder.SetMagic(1231241);
+
+            Assert.Equal((uint)1231241, this.builder.Magic);
+        }
+
+        [Fact]
+        public void AddDNSSeeds_SetsDNSSeedsOnBuilder()
+        {
+            this.builder.AddDNSSeeds(new DNSSeedData[] { new DNSSeedData("dnsNode1", "3.4.2.1") });
+
+            Assert.NotEmpty(this.builder.Seeds);
+            Assert.Equal("3.4.2.1", this.builder.Seeds.ToList()[0].Host);
+            Assert.Equal("dnsNode1", this.builder.Seeds.ToList()[0].Name);
+        }
+
+        [Fact]
+        public void AddSeeds_SetsSeedsOnBuilder()
+        {
+            this.builder.AddSeeds(new NetworkAddress[] { new NetworkAddress(IPAddress.Parse("::ffff:0:0"), 1234) });
+
+            Assert.NotEmpty(this.builder.FixedSeeds);
+            Assert.Equal(IPAddress.Parse("::ffff:0:0"), this.builder.FixedSeeds.ToList()[0].Endpoint.Address);
+            Assert.Equal(1234, this.builder.FixedSeeds.ToList()[0].Endpoint.Port);
+        }
+
+        [Fact]
+        public void SetConsensus_SetsConsensusOnNetwork()
+        {
+            var consensus = new Consensus() { CoinType = 15 };
+
+            this.builder.SetConsensus(consensus);
+
+            Assert.Equal(15, this.builder.Consensus.CoinType);
+        }
+
+        [Fact]
+        public void SetGenesis_SetsGenesisOnBuilder()
+        {
+            var genesis = new Block(new BlockHeader() { Version = 10 });
+            this.builder.SetGenesis(genesis);
+
+            Assert.Equal(10, this.builder.Genesis.Header.Version);
+        }
+
+        [Fact]
+        public void SetBase58Bytes_SetsBase58PrefixesOnBuilder()
+        {
+            this.builder.SetBase58Bytes(Base58Type.SCRIPT_ADDRESS, new byte[] { (196) });
+
+            Assert.Equal(new byte[] { (196) }, this.builder.Base58Prefixes[Base58Type.SCRIPT_ADDRESS]);
+        }
+
+        [Fact]
+        public void SetSetBech32_HumanReadable_SetsBech32EncodersOnBuilder()
+        {
+            this.builder.SetBech32(Bech32Type.WITNESS_PUBKEY_ADDRESS, "bc");
+
+            Assert.Equal(Encoders.Bech32("bc").HumanReadablePart, this.builder.Bech32Prefixes[Bech32Type.WITNESS_PUBKEY_ADDRESS].HumanReadablePart);
+        }
+
+        [Fact]
+        public void SetSetBech32_ExistingEncoder_SetsBech32EncodersOnBuilder()
+        {
+            Bech32Encoder encoder = Encoders.Bech32("bc");
+            this.builder.SetBech32(Bech32Type.WITNESS_PUBKEY_ADDRESS, encoder);
+
+            Assert.Equal(encoder.HumanReadablePart, this.builder.Bech32Prefixes[Bech32Type.WITNESS_PUBKEY_ADDRESS].HumanReadablePart);
+        }
+
+        [Fact]
+        public void SetCheckpoints_SetsCheckpointsOnBuilder()
+        {
+            var checkpoints = new Dictionary<int, CheckpointInfo>()
+            {
+                { 33333, new CheckpointInfo(new uint256("0x000000002dd5588a74784eaa7ab0507a18ad16a236e7b1ce69f00d7ddfb5d0a6")) },
+            };
+            this.builder.SetCheckpoints(checkpoints);
+
+            Assert.NotEmpty(this.builder.Checkpoints);
+            KeyValuePair<int, CheckpointInfo> resultingCheckpoint = this.builder.Checkpoints.ElementAt(0);
+            Assert.Equal(33333, resultingCheckpoint.Key);
+            Assert.Equal(new uint256("0x000000002dd5588a74784eaa7ab0507a18ad16a236e7b1ce69f00d7ddfb5d0a6"), resultingCheckpoint.Value.Hash);
+            Assert.Null(resultingCheckpoint.Value.StakeModifierV2);
+        }
+
+        [Fact]
+        public void BuildAndRegister_SetName_SetsNetworkNameOnNetwork()
+        {
+            this.builder.SetName("MyNetwork");
+
+            Network result = this.builder.BuildAndRegister();
+
+            Assert.Equal("MyNetwork", result.Name);
+        }
+
+        [Fact]
+        public void BuildAndRegister_SetRootFolderName_SetsRootFolderNameOnNetwork()
+        {
+            this.builder.SetName("RootFolderNetwork");
+            this.builder.SetRootFolderName("MyRootFolder");
+
+            Network result = this.builder.BuildAndRegister();
+
+            Assert.Equal("MyRootFolder", result.RootFolderName);
+        }
+
+        [Fact]
+        public void BuildAndRegister_SetDefaultConfigFilename_SetsDefaultConfigFilenameOnNetwork()
+        {
+            this.builder.SetName("DefaultConfigFileNetwork");
+            this.builder.SetDefaultConfigFilename("MyDefaultConfigFileName");
+
+            Network result = this.builder.BuildAndRegister();
+
+            Assert.Equal("MyDefaultConfigFileName", result.DefaultConfigFilename);
+        }
+
+        [Fact]
+        public void BuildAndRegister_SetTxFees_MinTxFee_SetsTxFeesOnNetwork()
+        {
+            this.builder.SetName("MinTxFeeNetwork");
+            this.builder.SetTxFees(1500, 0, 0);
+
+            Network result = this.builder.BuildAndRegister();
+
+            Assert.Equal(1500, result.MinTxFee);
+            Assert.Equal(0, result.FallbackFee);
+            Assert.Equal(0, result.MinRelayTxFee);
+        }
+
+        [Fact]
+        public void BuildAndRegister_SetTxFees_FallbackFee_SetsTxFeesOnNetwork()
+        {
+            this.builder.SetName("FallbackFeeNetwork");
+            this.builder.SetTxFees(0, 2130, 0);
+
+            Network result = this.builder.BuildAndRegister();
+
+            Assert.Equal(0, result.MinTxFee);
+            Assert.Equal(2130, result.FallbackFee);
+            Assert.Equal(0, result.MinRelayTxFee);
+        }
+
+        [Fact]
+        public void BuildAndRegister_SetTxFees_MinRelayTxFee_SetsTxFeesOnNetwork()
+        {
+            this.builder.SetName("MinRelayTxFeeNetwork");
+            this.builder.SetTxFees(0, 0, 1231);
+
+            Network result = this.builder.BuildAndRegister();
+
+            Assert.Equal(0, result.MinTxFee);
+            Assert.Equal(0, result.FallbackFee);
+            Assert.Equal(1231, result.MinRelayTxFee);
+        }
+
+        [Fact]
+        public void BuildAndRegister_SetMaxTimeOffsetSeconds_SetsMaxTimeOffsetSecondsOnNetwork()
+        {
+            this.builder.SetName("MaxTimeOffsetSecondsNetwork");
+            this.builder.SetMaxTimeOffsetSeconds(918);
+
+            Network result = this.builder.BuildAndRegister();
+
+            Assert.Equal(918, result.MaxTimeOffsetSeconds);
+        }
+
+        [Fact]
+        public void BuildAndRegister_SetSetMaxTipAge_SetsMaxTipAgeOnNetwork()
+        {
+            this.builder.SetName("SetMaxTipAgeNetwork");
+            this.builder.SetMaxTipAge(712);
+
+            Network result = this.builder.BuildAndRegister();
+
+            Assert.Equal(712, result.MaxTipAge);
+        }
+
+        [Fact]
+        public void BuildAndRegister_AddAlias_RegistersNetworkWithAliasToNetworks()
+        {
+            this.builder.SetName("AliasNetwork");
+            this.builder.AddAlias("NetworkNameByAlias");
+
+            Network result = this.builder.BuildAndRegister();
+
+            Assert.Equal("AliasNetwork", result.Name);
+            var network = Network.GetNetwork("NetworkNameByAlias");
+            Assert.Equal(network.Name, result.Name);
+        }
+
+        [Fact]
+        public void BuildAndRegister_SetRPCPort_SetsRPCPortOnNetwork()
+        {
+            this.builder.SetName("SetRPCPortNetwork");
+            this.builder.SetRPCPort(8339);
+
+            Network result = this.builder.BuildAndRegister();
+
+            Assert.Equal(8339, result.RPCPort);
+        }
+
+        [Fact]
+        public void BuildAndRegister_SetPort_SetsPortOnNetwork()
+        {
+            this.builder.SetName("SetPortNetwork");
+            this.builder.SetPort(14000);
+
+            Network result = this.builder.BuildAndRegister();
+
+            Assert.Equal(14000, result.DefaultPort);
+        }
+
+        [Fact]
+        public void BuildAndRegister_SetMagic_SetsMagicOnNetwork()
+        {
+            this.builder.SetName("SetMagicNetwork");
+            this.builder.SetMagic(1231241);
+
+            Network result = this.builder.BuildAndRegister();
+
+            Assert.Equal((uint)1231241, result.Magic);
+        }
+
+        [Fact]
+        public void BuildAndRegister_AddDNSSeeds_SetsDNSSeedsOnNetwork()
+        {
+            this.builder.SetName("SetDNSSeedsNetwork");
+            this.builder.AddDNSSeeds(new DNSSeedData[] { new DNSSeedData("dnsNode1", "3.4.2.1") });
+
+            Network result = this.builder.BuildAndRegister();
+
+            Assert.NotEmpty(result.DNSSeeds);
+            Assert.Equal("3.4.2.1", result.DNSSeeds.ToList()[0].Host);
+            Assert.Equal("dnsNode1", result.DNSSeeds.ToList()[0].Name);
+        }
+
+        [Fact]
+        public void BuildAndRegister_AddSeeds_SetsSeedsOnNetwork()
+        {
+            this.builder.SetName("SetSeedsNetwork");
+            this.builder.AddSeeds(new NetworkAddress[] { new NetworkAddress(IPAddress.Parse("::ffff:0:0"), 1234) });
+
+            Network result = this.builder.BuildAndRegister();
+
+            Assert.NotEmpty(result.SeedNodes);
+            Assert.Equal(IPAddress.Parse("::ffff:0:0"), result.SeedNodes.ToList()[0].Endpoint.Address);
+            Assert.Equal(1234, result.SeedNodes.ToList()[0].Endpoint.Port);
+        }
+
+        [Fact]
+        public void BuildAndRegister_SetConsensus_SetGenesis_SetsConsensusAndGenesisOnNetwork()
+        {
+            var genesis = new Block(new BlockHeader() { Version = 10 });
+            var consensus = new Consensus() { CoinType = 15 };
+
+            this.builder.SetName("SetConsensusNetwork");
+            this.builder.SetConsensus(consensus);
+            this.builder.SetGenesis(genesis);
+
+            Network result = this.builder.BuildAndRegister();
+
+            Assert.Equal(15, result.Consensus.CoinType);
+            Assert.Equal(10, result.GetGenesis().Header.Version);
+        }
+
+        [Fact]
+        public void BuildAndRegister_SetBase58Bytes_SetsBase58PrefixesOnNetwork()
+        {
+            this.builder.SetName("SetBase58BytesNetwork");
+            this.builder.SetBase58Bytes(Base58Type.SCRIPT_ADDRESS, new byte[] { (196) });
+
+            Network result = this.builder.BuildAndRegister();
+
+            Assert.Equal(new byte[] { (196) }, result.base58Prefixes[(int)Base58Type.SCRIPT_ADDRESS]);
+        }
+
+        [Fact]
+        public void BuildAndRegister_SetSetBech32_HumanReadable_SetsBech32EncodersOnNetwork()
+        {
+            this.builder.SetName("SetBech34ReadableNetwork");
+            this.builder.SetBech32(Bech32Type.WITNESS_PUBKEY_ADDRESS, "bc");
+
+            Network result = this.builder.BuildAndRegister();
+
+            Assert.Equal(Encoders.Bech32("bc").HumanReadablePart, result.bech32Encoders[(int)Bech32Type.WITNESS_PUBKEY_ADDRESS].HumanReadablePart);
+        }
+
+        [Fact]
+        public void BuildAndRegister_SetSetBech32_ExistingEncoder_SetsBech32EncodersOnNetwork()
+        {
+            Bech32Encoder encoder = Encoders.Bech32("bc");
+            this.builder.SetName("SetBech32EncoderNetwork");
+            this.builder.SetBech32(Bech32Type.WITNESS_PUBKEY_ADDRESS, encoder);
+
+            Network result = this.builder.BuildAndRegister();
+
+            Assert.Equal(encoder.HumanReadablePart, result.bech32Encoders[(int)Bech32Type.WITNESS_PUBKEY_ADDRESS].HumanReadablePart);
+        }
+
+        [Fact]
+        public void BuildAndRegister_SetCheckpoints_SetsCheckpointsOnNetwork()
+        {
+            var checkpoints = new Dictionary<int, CheckpointInfo>()
+            {
+                { 33333, new CheckpointInfo(new uint256("0x000000002dd5588a74784eaa7ab0507a18ad16a236e7b1ce69f00d7ddfb5d0a6")) },
+            };
+            this.builder.SetName("SetCheckpointsNetwork");
+            this.builder.SetCheckpoints(checkpoints);
+
+            Network result = this.builder.BuildAndRegister();
+
+            Assert.NotEmpty(result.Checkpoints);
+            KeyValuePair<int, CheckpointInfo> resultingCheckpoint = result.Checkpoints.ElementAt(0);
+            Assert.Equal(33333, resultingCheckpoint.Key);
+            Assert.Equal(new uint256("0x000000002dd5588a74784eaa7ab0507a18ad16a236e7b1ce69f00d7ddfb5d0a6"), resultingCheckpoint.Value.Hash);
+            Assert.Null(resultingCheckpoint.Value.StakeModifierV2);
+        }
+    }
+}

--- a/src/NBitcoin/CheckpointInfo.cs
+++ b/src/NBitcoin/CheckpointInfo.cs
@@ -1,0 +1,26 @@
+﻿namespace NBitcoin
+{
+    /// <summary>
+    /// Description of checkpointed block.
+    /// </summary>
+    public class CheckpointInfo
+    {
+        /// <summary>Hash of the checkpointed block header.</summary>
+        public uint256 Hash { get; private set; }
+
+        /// <summary>Stake modifier V2 value of the checkpointed block.</summary>
+        /// <remarks>Stratis only.</remarks>
+        public uint256 StakeModifierV2 { get; private set; }
+
+        /// <summary>
+        /// Initializes a new instance of the object.
+        /// </summary>
+        /// <param name="hash">Hash of the checkpointed block header.</param>
+        /// <param name="stakeModifierV2">Stake modifier V2 value of the checkpointed block. Stratis network only.</param>
+        public CheckpointInfo(uint256 hash, uint256 stakeModifierV2 = null)
+        {
+            this.Hash = hash;
+            this.StakeModifierV2 = stakeModifierV2;
+        }
+    }
+}

--- a/src/NBitcoin/Network.cs
+++ b/src/NBitcoin/Network.cs
@@ -66,7 +66,7 @@ namespace NBitcoin
         WITNESS_PUBKEY_ADDRESS,
         WITNESS_SCRIPT_ADDRESS
     }
-    
+
     public enum BuriedDeployments : int
     {
         /// <summary>
@@ -83,7 +83,7 @@ namespace NBitcoin
         /// Strict DER signature
         /// </summary>
         BIP66
-    }    
+    }
 
     public class Consensus
     {
@@ -131,7 +131,7 @@ namespace NBitcoin
                 get { return this.parameters[(int) index]; }
                 set { this.parameters[(int) index] = value; }
             }
-        }       
+        }
 
         public Consensus()
         {
@@ -330,6 +330,12 @@ namespace NBitcoin
             if (GetNetwork(builder.Name) != null)
                 throw new InvalidOperationException("The network " + builder.Name + " is already registered.");
 
+            if (builder.Genesis == null)
+                throw new InvalidOperationException("A genesis block needs to be provided.");
+
+            if (builder.Consensus == null)
+                throw new InvalidOperationException("A consensus needs to be provided.");
+
             Network network = new Network();
             network.Name = builder.Name;
             network.RootFolderName = builder.RootFolderName;
@@ -339,8 +345,7 @@ namespace NBitcoin
             network.DefaultPort = builder.Port;
             network.RPCPort = builder.RPCPort;
             network.genesis = builder.Genesis;
-            if(network.consensus != null && network.genesis != null)
-                network.consensus.HashGenesisBlock = network.genesis.GetHash();
+            network.consensus.HashGenesisBlock = network.genesis.GetHash();
 
             foreach (DNSSeedData seed in builder.Seeds)
             {

--- a/src/NBitcoin/Network.cs
+++ b/src/NBitcoin/Network.cs
@@ -83,31 +83,7 @@ namespace NBitcoin
         /// Strict DER signature
         /// </summary>
         BIP66
-    }
-
-    /// <summary>
-    /// Description of checkpointed block.
-    /// </summary>
-    public class CheckpointInfo
-    {
-        /// <summary>Hash of the checkpointed block header.</summary>
-        public uint256 Hash { get; set; }
-
-        /// <summary>Stake modifier V2 value of the checkpointed block.</summary>
-        /// <remarks>Stratis only.</remarks>
-        public uint256 StakeModifierV2 { get; set; }
-
-        /// <summary>
-        /// Initializes a new instance of the object.
-        /// </summary>
-        /// <param name="hash">Hash of the checkpointed block header.</param>
-        /// <param name="stakeModifierV2">Stake modifier V2 value of the checkpointed block. Stratis network only.</param>
-        public CheckpointInfo(uint256 hash, uint256 stakeModifierV2 = null)
-        {
-            this.Hash = hash;
-            this.StakeModifierV2 = stakeModifierV2;
-        }
-    }
+    }    
 
     public class Consensus
     {

--- a/src/NBitcoin/NetworkBuilder.cs
+++ b/src/NBitcoin/NetworkBuilder.cs
@@ -17,7 +17,7 @@ namespace NBitcoin
         internal int Port;
         internal uint Magic;
         internal Consensus Consensus;
-        internal List<DNSSeedData> Seeds ;
+        internal List<DNSSeedData> Seeds;
         internal List<NetworkAddress> FixedSeeds;
         internal Block Genesis;
         internal long MinTxFee;
@@ -25,6 +25,7 @@ namespace NBitcoin
         internal int MaxTipAge;
         internal long FallbackFee;
         internal long MinRelayTxFee;
+        internal Dictionary<int, CheckpointInfo> Checkpoints;
 
         public NetworkBuilder()
         {
@@ -33,6 +34,7 @@ namespace NBitcoin
             this.Aliases = new List<string>();
             this.Seeds = new List<DNSSeedData>();
             this.FixedSeeds = new List<NetworkAddress>();
+            this.Checkpoints = new Dictionary<int, CheckpointInfo>();
         }
 
         public NetworkBuilder SetName(string name)
@@ -95,7 +97,7 @@ namespace NBitcoin
 
         public void CopyFrom(Network network)
         {
-            if(network == null)
+            if (network == null)
                 throw new ArgumentNullException("network");
 
             this.Base58Prefixes.Clear();
@@ -108,6 +110,7 @@ namespace NBitcoin
                 this.SetBech32((Bech32Type)i, network.bech32Encoders[i]);
 
             this.SetConsensus(network.Consensus)
+                .SetCheckpoints(network.Checkpoints)
                 .SetGenesis(network.GetGenesis())
                 .SetMagic(this.Magic)
                 .SetPort(network.DefaultPort)
@@ -121,7 +124,7 @@ namespace NBitcoin
         {
             this.Aliases.Add(alias);
             return this;
-        }        
+        }
 
         public NetworkBuilder SetRPCPort(int port)
         {
@@ -151,18 +154,18 @@ namespace NBitcoin
             this.FixedSeeds.AddRange(seeds);
             return this;
         }
-        
+
         public NetworkBuilder SetConsensus(Consensus consensus)
         {
             this.Consensus = consensus?.Clone();
             return this;
         }
-        
+
         public NetworkBuilder SetGenesis(Block genesis)
         {
             this.Genesis = genesis;
             return this;
-        }        
+        }
 
         public NetworkBuilder SetBase58Bytes(Base58Type type, byte[] bytes)
         {
@@ -178,6 +181,15 @@ namespace NBitcoin
         public NetworkBuilder SetBech32(Bech32Type type, Bech32Encoder encoder)
         {
             this.Bech32Prefixes.AddOrReplace(type, encoder);
+            return this;
+        }
+
+        public NetworkBuilder SetCheckpoints(Dictionary<int, CheckpointInfo> checkpoints)
+        {
+            if (checkpoints == null)
+                throw new ArgumentNullException("checkpoints");
+
+            this.Checkpoints = checkpoints;
             return this;
         }
 

--- a/src/NBitcoin/Networks.cs
+++ b/src/NBitcoin/Networks.cs
@@ -155,6 +155,32 @@ namespace NBitcoin
             network.MinTxFee = 1000;
             network.FallbackFee = 20000;
             network.MinRelayTxFee = 1000;
+            
+            // Partially obtained from https://github.com/bitcoin/bitcoin/blob/b1973d6181eacfaaf45effb67e0c449ea3a436b8/src/chainparams.cpp#L146
+            var checkpoints = new Dictionary<int, CheckpointInfo>
+            {
+                { 11111, new CheckpointInfo(new uint256("0x0000000069e244f73d78e8fd29ba2fd2ed618bd6fa2ee92559f542fdb26e7c1d")) },
+                { 33333, new CheckpointInfo(new uint256("0x000000002dd5588a74784eaa7ab0507a18ad16a236e7b1ce69f00d7ddfb5d0a6")) },
+                { 74000, new CheckpointInfo(new uint256("0x0000000000573993a3c9e41ce34471c079dcf5f52a0e824a81e7f953b8661a20")) },
+                { 105000, new CheckpointInfo(new uint256("0x00000000000291ce28027faea320c8d2b054b2e0fe44a773f3eefb151d6bdc97")) },
+                { 134444, new CheckpointInfo(new uint256("0x00000000000005b12ffd4cd315cd34ffd4a594f430ac814c91184a0d42d2b0fe")) },
+                { 168000, new CheckpointInfo(new uint256("0x000000000000099e61ea72015e79632f216fe6cb33d7899acb35b75c8303b763")) },
+                { 193000, new CheckpointInfo(new uint256("0x000000000000059f452a5f7340de6682a977387c17010ff6e6c3bd83ca8b1317")) },
+                { 210000, new CheckpointInfo(new uint256("0x000000000000048b95347e83192f69cf0366076336c639f9b7228e9ba171342e")) },
+                { 216116, new CheckpointInfo(new uint256("0x00000000000001b4f4b433e81ee46494af945cf96014816a4e2370f11b23df4e")) },
+                { 225430, new CheckpointInfo(new uint256("0x00000000000001c108384350f74090433e7fcf79a606b8e797f065b130575932")) },
+                { 250000, new CheckpointInfo(new uint256("0x000000000000003887df1f29024b06fc2200b55f8af8f35453d7be294df2d214")) },
+                { 279000, new CheckpointInfo(new uint256("0x0000000000000001ae8c72a0b0c301f67e3afca10e819efa9041e458e9bd7e40")) },
+                { 295000, new CheckpointInfo(new uint256("0x00000000000000004d9b4ef50f0f9d686fd69db2e03af35a100370c64632a983")) },
+                // Our own new checkpoints.
+                { 486000, new CheckpointInfo(new uint256("0x000000000000000000a2a8104d61651f76c666b70754d6e9346176385f7afa24")) },
+                { 491800, new CheckpointInfo(new uint256("0x000000000000000000d80de1f855902b50941bc3a3d0f71064d9613fd3943dc4")) },
+            };
+
+            foreach (var checkpoint in checkpoints)
+            {
+                network.checkpoints.Add(checkpoint.Key, checkpoint.Value);
+            }       
 
             NetworksContainer.TryAdd("mainnet", network);
             NetworksContainer.TryAdd(network.Name.ToLowerInvariant(), network);
@@ -233,6 +259,19 @@ namespace NBitcoin
             network.MinTxFee = 1000;
             network.FallbackFee = 20000;
             network.MinRelayTxFee = 1000;
+            
+            // Partially obtained from https://github.com/bitcoin/bitcoin/blob/b1973d6181eacfaaf45effb67e0c449ea3a436b8/src/chainparams.cpp#L246
+            var checkpoints = new Dictionary<int, CheckpointInfo>
+            {
+                { 546, new CheckpointInfo(new uint256("000000002a936ca763904c3c35fce2f3556c559c0214345d31b1bcebf76acb70")) },
+                // Our own new checkpoints.
+                { 1210000, new CheckpointInfo(new uint256("00000000461201277cf8c635fc10d042d6f0a7eaa57f6c9e8c099b9e0dbc46dc")) },
+            };
+
+            foreach (var checkpoint in checkpoints)
+            {
+                network.checkpoints.Add(checkpoint.Key, checkpoint.Value);
+            }
 
             NetworksContainer.TryAdd("test", network);
             NetworksContainer.TryAdd(network.Name.ToLowerInvariant(), network);
@@ -248,7 +287,7 @@ namespace NBitcoin
                 RootFolderName = BitcoinRootFolderName,
                 DefaultConfigFilename = BitcoinDefaultConfigFilename
             };
-            
+
             network.consensus.SubsidyHalvingInterval = 150;
             network.consensus.MajorityEnforceBlockUpgrade = 750;
             network.consensus.MajorityRejectBlockOutdated = 950;
@@ -314,7 +353,7 @@ namespace NBitcoin
             var consensus = new Consensus();
 
             consensus.NetworkOptions = new NetworkOptions() { IsProofOfStake = true };
-            consensus.GetPoWHash = (n, h) => Crypto.HashX13.Instance.Hash(h.ToBytes(options:n)); 
+            consensus.GetPoWHash = (n, h) => Crypto.HashX13.Instance.Hash(h.ToBytes(options: n));
 
             consensus.SubsidyHalvingInterval = 210000;
             consensus.MajorityEnforceBlockUpgrade = 750;
@@ -338,7 +377,7 @@ namespace NBitcoin
 
             consensus.LastPOWBlock = 12500;
 
-            consensus.ProofOfStakeLimit =   new BigInteger(uint256.Parse("00000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff").ToBytes(false));
+            consensus.ProofOfStakeLimit = new BigInteger(uint256.Parse("00000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff").ToBytes(false));
             consensus.ProofOfStakeLimitV2 = new BigInteger(uint256.Parse("000000000000ffffffffffffffffffffffffffffffffffffffffffffffffffff").ToBytes(false));
 
             consensus.CoinType = 105;
@@ -347,6 +386,27 @@ namespace NBitcoin
 
             Block genesis = CreateStratisGenesisBlock(1470467000, 1831645, 0x1e0fffff, 1, Money.Zero);
             consensus.HashGenesisBlock = genesis.GetHash(consensus.NetworkOptions);
+
+            var checkpoints = new Dictionary<int, CheckpointInfo>
+            {
+                { 0, new CheckpointInfo(new uint256("0x0000066e91e46e5a264d42c89e1204963b2ee6be230b443e9159020539d972af"), new uint256("0x0000000000000000000000000000000000000000000000000000000000000000")) },
+                { 2, new CheckpointInfo(new uint256("0xbca5936f638181e74a5f1e9999c95b0ce77da48c2688399e72bcc53a00c61eff"), new uint256("0x7d61c139a471821caa6b7635a4636e90afcfe5e195040aecbc1ad7d24924db1e")) }, // Premine
+                { 50, new CheckpointInfo(new uint256("0x0353b43f4ce80bf24578e7c0141d90d7962fb3a4b4b4e5a17925ca95e943b816"), new uint256("0x7c2af3b10d13f9d2bc6063baaf7f0860d90d870c994378144f9bf85d0d555061")) },
+                { 100, new CheckpointInfo(new uint256("0x688468a8aa48cd1c2197e42e7d8acd42760b7e2ac4bcab9d18ac149a673e16f6"), new uint256("0xcf2b1e9e76aaa3d96f255783eb2d907bf6ccb9c1deeb3617149278f0e4a1ab1b")) },
+                { 150, new CheckpointInfo(new uint256("0xe4ae9663519abec15e28f68bdb2cb89a739aee22f53d1573048d69141db6ee5d"), new uint256("0xa6c17173e958dc716cc0892ce33dad8bc327963d78a16c436264ceae43d584ce")) },
+                { 127500, new CheckpointInfo(new uint256("0x4773ca7512489df22de03aa03938412fab5b46154b05df004b97bcbeaa184078"), new uint256("0x619743c02ebaff06b90fcc5c60c52dba8aa3fdb6ba3800aae697cbb3c5483f17")) },
+                { 128943, new CheckpointInfo(new uint256("0x36bcaa27a53d3adf22b2064150a297adb02ac39c24263a5ceb73856832d49679"), new uint256("0xa3a6fd04e41fcaae411a3990aaabcf5e086d2d06c72c849182b27b4de8c2c42a")) },
+                { 136601, new CheckpointInfo(new uint256("0xf5c5210c55ff1ef9c04715420a82728e1647f3473e31dc478b3745a97b4a6d10"), new uint256("0x42058fabe21f7b118a9e358eaf9ef574dadefd024244899e71f2f6d618161e16")) }, // Hardfork to V2 - Drifting Bug Fix
+                { 170000, new CheckpointInfo(new uint256("0x22b10952e0cf7e85bfc81c38f1490708f195bff34d2951d193cc20e9ca1fc9d5"), new uint256("0xa4942a6c99cba397cf2b18e4b912930fe1e64a7413c3d97c5a926c2af9073091")) },
+                { 200000, new CheckpointInfo(new uint256("0x2391dd493be5d0ff0ef57c3b08c73eefeecc2701b80f983054bb262f7a146989"), new uint256("0x253152d129e82c30c584197deb6833502eff3ec2f30014008f75842d7bb48453")) },
+                { 250000, new CheckpointInfo(new uint256("0x681c70fab7c1527246138f0cf937f0eb013838b929fbe9a831af02a60fc4bf55"), new uint256("0x24eed95e00c90618aa9d137d2ee273267285c444c9cde62a25a3e880c98a3685")) },
+                { 300000, new CheckpointInfo(new uint256("0xd10ca8c2f065a49ae566c7c9d7a2030f4b8b7f71e4c6fc6b2a02509f94cdcd44"), new uint256("0x39c4dd765b49652935524248b4de4ccb604df086d0723bcd81faf5d1c2489304")) },
+                { 350000, new CheckpointInfo(new uint256("0xe2b76d1a068c4342f91db7b89b66e0f2146d3a4706c21f3a262737bb7339253a"), new uint256("0xd1dd94985eaaa028c893687a7ddf89143dcf0176918f958c2d01f33d64910399")) },
+                { 390000, new CheckpointInfo(new uint256("0x4682737abc2a3257fdf4c3c119deb09cbac75981969e2ffa998b4f76b7c657bb"), new uint256("0xd84b204ee94499ff65262328a428851fb4f4d2741e928cdd088fdf1deb5413b8")) },
+                { 394000, new CheckpointInfo(new uint256("0x42857fa2bc15d45cdcaae83411f755b95985da1cb464ee23f6d40936df523e9f"), new uint256("0x2314b336906a2ed2a39cbdf6fc0622530709c62dbb3a3729de17154fc9d1a7c4")) },
+                { 528000, new CheckpointInfo(new uint256("0x7aff2c48b398446595d01e27b5cd898087cec63f94ff73f9ad695c6c9bcee33a"), new uint256("0x3bdc865661390c7681b078e52ed3ad3c53ec7cff97b8c45b74abed3ace289fcc")) },
+                { 576000, new CheckpointInfo(new uint256("0xe705476b940e332098d1d5b475d7977312ff8c08cbc8256ce46a3e2c6d5408b8"), new uint256("0x10e31bb5e245ea19650280cfd3ac1a76259fa0002d02e861d2ab5df290534b56")) },
+            };
 
             // The message start string is designed to be unlikely to occur in normal data.
             // The characters are rarely used upper ASCII, not valid as UTF-8, and produce
@@ -362,40 +422,41 @@ namespace NBitcoin
             Assert(genesis.Header.HashMerkleRoot == uint256.Parse("0x65a26bc20b0351aebf05829daefa8f7db2f800623439f3c114257c91447f1518"));
 
             var builder = new NetworkBuilder()
-                .SetName("StratisMain")
-                .SetRootFolderName(StratisRootFolderName)
-                .SetDefaultConfigFilename(StratisDefaultConfigFilename)
-                .SetConsensus(consensus)
-                .SetMagic(magic)
-                .SetGenesis(genesis)
-                .SetPort(16178)
-                .SetRPCPort(16174)
-                .SetTxFees(10000, 60000, 10000)
-                .SetMaxTimeOffsetSeconds(StratisMaxTimeOffsetSeconds)
-                .SetMaxTipAge(StratisDefaultMaxTipAgeInSeconds)
+                    .SetName("StratisMain")
+                    .SetRootFolderName(StratisRootFolderName)
+                    .SetDefaultConfigFilename(StratisDefaultConfigFilename)
+                    .SetConsensus(consensus)
+                    .SetCheckpoints(checkpoints)
+                    .SetMagic(magic)
+                    .SetGenesis(genesis)
+                    .SetPort(16178)
+                    .SetRPCPort(16174)
+                    .SetTxFees(10000, 60000, 10000)
+                    .SetMaxTimeOffsetSeconds(StratisMaxTimeOffsetSeconds)
+                    .SetMaxTipAge(StratisDefaultMaxTipAgeInSeconds)
 
-                .AddDNSSeeds(new[]
-                {
+                    .AddDNSSeeds(new[]
+                    {
                     new DNSSeedData("seednode1.stratisplatform.com", "seednode1.stratisplatform.com"),
                     new DNSSeedData("seednode2.stratis.cloud", "seednode2.stratis.cloud"),
                     new DNSSeedData("seednode3.stratisplatform.com", "seednode3.stratisplatform.com"),
                     new DNSSeedData("seednode4.stratis.cloud", "seednode4.stratis.cloud")
-                })
+                    })
 
-                .SetBase58Bytes(Base58Type.PUBKEY_ADDRESS, new byte[] {(63)})
-                .SetBase58Bytes(Base58Type.SCRIPT_ADDRESS, new byte[] {(125)})
-                .SetBase58Bytes(Base58Type.SECRET_KEY, new byte[] {(63 + 128)})
-                .SetBase58Bytes(Base58Type.ENCRYPTED_SECRET_KEY_NO_EC, new byte[] {0x01, 0x42})
-                .SetBase58Bytes(Base58Type.ENCRYPTED_SECRET_KEY_EC, new byte[] {0x01, 0x43})
-                .SetBase58Bytes(Base58Type.EXT_PUBLIC_KEY, new byte[] {(0x04), (0x88), (0xB2), (0x1E)})
-                .SetBase58Bytes(Base58Type.EXT_SECRET_KEY, new byte[] {(0x04), (0x88), (0xAD), (0xE4)})
-                .SetBase58Bytes(Base58Type.PASSPHRASE_CODE, new byte[] {0x2C, 0xE9, 0xB3, 0xE1, 0xFF, 0x39, 0xE2})
-                .SetBase58Bytes(Base58Type.CONFIRMATION_CODE, new byte[] {0x64, 0x3B, 0xF6, 0xA8, 0x9A})
-                .SetBase58Bytes(Base58Type.STEALTH_ADDRESS, new byte[] {0x2a})
-                .SetBase58Bytes(Base58Type.ASSET_ID, new byte[] {23})
-                .SetBase58Bytes(Base58Type.COLORED_ADDRESS, new byte[] {0x13})
-                .SetBech32(Bech32Type.WITNESS_PUBKEY_ADDRESS, "bc")
-                .SetBech32(Bech32Type.WITNESS_SCRIPT_ADDRESS, "bc");
+                    .SetBase58Bytes(Base58Type.PUBKEY_ADDRESS, new byte[] { (63) })
+                    .SetBase58Bytes(Base58Type.SCRIPT_ADDRESS, new byte[] { (125) })
+                    .SetBase58Bytes(Base58Type.SECRET_KEY, new byte[] { (63 + 128) })
+                    .SetBase58Bytes(Base58Type.ENCRYPTED_SECRET_KEY_NO_EC, new byte[] { 0x01, 0x42 })
+                    .SetBase58Bytes(Base58Type.ENCRYPTED_SECRET_KEY_EC, new byte[] { 0x01, 0x43 })
+                    .SetBase58Bytes(Base58Type.EXT_PUBLIC_KEY, new byte[] { (0x04), (0x88), (0xB2), (0x1E) })
+                    .SetBase58Bytes(Base58Type.EXT_SECRET_KEY, new byte[] { (0x04), (0x88), (0xAD), (0xE4) })
+                    .SetBase58Bytes(Base58Type.PASSPHRASE_CODE, new byte[] { 0x2C, 0xE9, 0xB3, 0xE1, 0xFF, 0x39, 0xE2 })
+                    .SetBase58Bytes(Base58Type.CONFIRMATION_CODE, new byte[] { 0x64, 0x3B, 0xF6, 0xA8, 0x9A })
+                    .SetBase58Bytes(Base58Type.STEALTH_ADDRESS, new byte[] { 0x2a })
+                    .SetBase58Bytes(Base58Type.ASSET_ID, new byte[] { 23 })
+                    .SetBase58Bytes(Base58Type.COLORED_ADDRESS, new byte[] { 0x13 })
+                    .SetBech32(Bech32Type.WITNESS_PUBKEY_ADDRESS, "bc")
+                    .SetBech32(Bech32Type.WITNESS_SCRIPT_ADDRESS, "bc");
 
             var seed = new[] { "101.200.198.155", "103.24.76.21", "104.172.24.79" };
             var fixedSeeds = new List<NetworkAddress>();
@@ -446,33 +507,44 @@ namespace NBitcoin
 
             consensus.DefaultAssumeValid = new uint256("0x98fa6ef0bca5b431f15fd79dc6f879dc45b83ed4b1bbe933a383ef438321958e"); // 372652
 
-            var builder = new NetworkBuilder()
-                .SetName("StratisTest")
-                .SetRootFolderName(StratisRootFolderName)
-                .SetDefaultConfigFilename(StratisDefaultConfigFilename)
-                .SetConsensus(consensus)
-                .SetMagic(magic)
-                .SetGenesis(genesis)
-                .SetPort(26178)
-                .SetRPCPort(26174)
-                .SetMaxTimeOffsetSeconds(StratisMaxTimeOffsetSeconds)
-                .SetMaxTipAge(StratisDefaultMaxTipAgeInSeconds)
-                .SetTxFees(10000, 60000, 10000)
-                .SetBase58Bytes(Base58Type.PUBKEY_ADDRESS, new byte[] { (65) })
-                .SetBase58Bytes(Base58Type.SCRIPT_ADDRESS, new byte[] { (196) })
-                .SetBase58Bytes(Base58Type.SECRET_KEY, new byte[] { (65 + 128) })
-                .SetBase58Bytes(Base58Type.ENCRYPTED_SECRET_KEY_NO_EC, new byte[] { 0x01, 0x42 })
-                .SetBase58Bytes(Base58Type.ENCRYPTED_SECRET_KEY_EC, new byte[] { 0x01, 0x43 })
-                .SetBase58Bytes(Base58Type.EXT_PUBLIC_KEY, new byte[] { (0x04), (0x88), (0xB2), (0x1E) })
-                .SetBase58Bytes(Base58Type.EXT_SECRET_KEY, new byte[] { (0x04), (0x88), (0xAD), (0xE4) })
+            var checkpoints = new Dictionary<int, CheckpointInfo>
+            {
+                { 0, new CheckpointInfo(new uint256("0x00000e246d7b73b88c9ab55f2e5e94d9e22d471def3df5ea448f5576b1d156b9"), new uint256("0x0000000000000000000000000000000000000000000000000000000000000000")) },
+                { 2, new CheckpointInfo(new uint256("0x56959b1c8498631fb0ca5fe7bd83319dccdc6ac003dccb3171f39f553ecfa2f2"), new uint256("0x13f4c27ca813aefe2d9018077f8efeb3766796b9144fcc4cd51803bf4376ab02")) },
+                { 50000, new CheckpointInfo(new uint256("0xb42c18eacf8fb5ed94eac31943bd364451d88da0fd44cc49616ffea34d530ad4"), new uint256("0x824934ddc5f935e854ac59ae7f5ed25f2d29a7c3914cac851f3eddb4baf96d78")) },
+                { 100000, new CheckpointInfo(new uint256("0xf9e2f7561ee4b92d3bde400d251363a0e8924204c326da7f4ad9ccc8863aad79"), new uint256("0xdef8d92d20becc71f662ee1c32252aca129f1bf4744026b116d45d9bfe67e9fb")) },
+                { 115000, new CheckpointInfo(new uint256("0x8496c77060c8a2b5c9a888ade991f25aa33c232b4413594d556daf9043fad400"), new uint256("0x1886430484a9a36b56a7eb8bd25e9ebe4fc8eec8f9a84f5073f71e08f2feac90")) },
+                { 163000, new CheckpointInfo(new uint256("0x4e44a9e0119a2e7cbf15e570a3c649a5605baa601d953a465b5ebd1c1982212a"), new uint256("0x0646fc7db8f3426eb209e1228c7d82724faa46a060f5bbbd546683ef30be245c")) },
+            };
 
-                .AddDNSSeeds(new[]
-                {
+            var builder = new NetworkBuilder()
+                    .SetName("StratisTest")
+                    .SetRootFolderName(StratisRootFolderName)
+                    .SetDefaultConfigFilename(StratisDefaultConfigFilename)
+                    .SetConsensus(consensus)
+                    .SetCheckpoints(checkpoints)
+                    .SetMagic(magic)
+                    .SetGenesis(genesis)
+                    .SetPort(26178)
+                    .SetRPCPort(26174)
+                    .SetMaxTimeOffsetSeconds(StratisMaxTimeOffsetSeconds)
+                    .SetMaxTipAge(StratisDefaultMaxTipAgeInSeconds)
+                    .SetTxFees(10000, 60000, 10000)
+                    .SetBase58Bytes(Base58Type.PUBKEY_ADDRESS, new byte[] { (65) })
+                    .SetBase58Bytes(Base58Type.SCRIPT_ADDRESS, new byte[] { (196) })
+                    .SetBase58Bytes(Base58Type.SECRET_KEY, new byte[] { (65 + 128) })
+                    .SetBase58Bytes(Base58Type.ENCRYPTED_SECRET_KEY_NO_EC, new byte[] { 0x01, 0x42 })
+                    .SetBase58Bytes(Base58Type.ENCRYPTED_SECRET_KEY_EC, new byte[] { 0x01, 0x43 })
+                    .SetBase58Bytes(Base58Type.EXT_PUBLIC_KEY, new byte[] { (0x04), (0x88), (0xB2), (0x1E) })
+                    .SetBase58Bytes(Base58Type.EXT_SECRET_KEY, new byte[] { (0x04), (0x88), (0xAD), (0xE4) })
+
+                    .AddDNSSeeds(new[]
+                    {
                     new DNSSeedData("testnet1.stratisplatform.com", "testnet1.stratisplatform.com"),
                     new DNSSeedData("testnet2.stratisplatform.com", "testnet2.stratisplatform.com"),
                     new DNSSeedData("testnet3.stratisplatform.com", "testnet3.stratisplatform.com"),
                     new DNSSeedData("testnet4.stratisplatform.com", "testnet4.stratisplatform.com")
-                });
+                    });
 
             builder.AddSeeds(new[]
             {
@@ -480,7 +552,7 @@ namespace NBitcoin
                 new NetworkAddress(IPAddress.Parse("13.70.81.5"), 3389), // beard cloud node  
                 new NetworkAddress(IPAddress.Parse("191.235.85.131"), 3389), // fassa cloud node  
                 new NetworkAddress(IPAddress.Parse("52.232.58.52"), 26178), // neurosploit public node
-            }); 
+            });
 
             return builder.BuildAndRegister();
         }
@@ -506,7 +578,7 @@ namespace NBitcoin
             messageStart[1] = 0xf2;
             messageStart[2] = 0xc0;
             messageStart[3] = 0xef;
-            var magic = BitConverter.ToUInt32(messageStart, 0); 
+            var magic = BitConverter.ToUInt32(messageStart, 0);
 
             var genesis = Network.StratisMain.GetGenesis();
             genesis.Header.Time = 1494909211;

--- a/src/NBitcoin/Networks.cs
+++ b/src/NBitcoin/Networks.cs
@@ -155,32 +155,24 @@ namespace NBitcoin
             network.MinTxFee = 1000;
             network.FallbackFee = 20000;
             network.MinRelayTxFee = 1000;
-            
-            // Partially obtained from https://github.com/bitcoin/bitcoin/blob/b1973d6181eacfaaf45effb67e0c449ea3a436b8/src/chainparams.cpp#L146
-            var checkpoints = new Dictionary<int, CheckpointInfo>
-            {
-                { 11111, new CheckpointInfo(new uint256("0x0000000069e244f73d78e8fd29ba2fd2ed618bd6fa2ee92559f542fdb26e7c1d")) },
-                { 33333, new CheckpointInfo(new uint256("0x000000002dd5588a74784eaa7ab0507a18ad16a236e7b1ce69f00d7ddfb5d0a6")) },
-                { 74000, new CheckpointInfo(new uint256("0x0000000000573993a3c9e41ce34471c079dcf5f52a0e824a81e7f953b8661a20")) },
-                { 105000, new CheckpointInfo(new uint256("0x00000000000291ce28027faea320c8d2b054b2e0fe44a773f3eefb151d6bdc97")) },
-                { 134444, new CheckpointInfo(new uint256("0x00000000000005b12ffd4cd315cd34ffd4a594f430ac814c91184a0d42d2b0fe")) },
-                { 168000, new CheckpointInfo(new uint256("0x000000000000099e61ea72015e79632f216fe6cb33d7899acb35b75c8303b763")) },
-                { 193000, new CheckpointInfo(new uint256("0x000000000000059f452a5f7340de6682a977387c17010ff6e6c3bd83ca8b1317")) },
-                { 210000, new CheckpointInfo(new uint256("0x000000000000048b95347e83192f69cf0366076336c639f9b7228e9ba171342e")) },
-                { 216116, new CheckpointInfo(new uint256("0x00000000000001b4f4b433e81ee46494af945cf96014816a4e2370f11b23df4e")) },
-                { 225430, new CheckpointInfo(new uint256("0x00000000000001c108384350f74090433e7fcf79a606b8e797f065b130575932")) },
-                { 250000, new CheckpointInfo(new uint256("0x000000000000003887df1f29024b06fc2200b55f8af8f35453d7be294df2d214")) },
-                { 279000, new CheckpointInfo(new uint256("0x0000000000000001ae8c72a0b0c301f67e3afca10e819efa9041e458e9bd7e40")) },
-                { 295000, new CheckpointInfo(new uint256("0x00000000000000004d9b4ef50f0f9d686fd69db2e03af35a100370c64632a983")) },
-                // Our own new checkpoints.
-                { 486000, new CheckpointInfo(new uint256("0x000000000000000000a2a8104d61651f76c666b70754d6e9346176385f7afa24")) },
-                { 491800, new CheckpointInfo(new uint256("0x000000000000000000d80de1f855902b50941bc3a3d0f71064d9613fd3943dc4")) },
-            };
 
-            foreach (var checkpoint in checkpoints)
-            {
-                network.checkpoints.Add(checkpoint.Key, checkpoint.Value);
-            }       
+            // Partially obtained from https://github.com/bitcoin/bitcoin/blob/b1973d6181eacfaaf45effb67e0c449ea3a436b8/src/chainparams.cpp#L146
+            network.checkpoints.Add(11111, new CheckpointInfo(new uint256("0x0000000069e244f73d78e8fd29ba2fd2ed618bd6fa2ee92559f542fdb26e7c1d")));
+            network.checkpoints.Add(33333, new CheckpointInfo(new uint256("0x000000002dd5588a74784eaa7ab0507a18ad16a236e7b1ce69f00d7ddfb5d0a6")));
+            network.checkpoints.Add(74000, new CheckpointInfo(new uint256("0x0000000000573993a3c9e41ce34471c079dcf5f52a0e824a81e7f953b8661a20")));
+            network.checkpoints.Add(105000, new CheckpointInfo(new uint256("0x00000000000291ce28027faea320c8d2b054b2e0fe44a773f3eefb151d6bdc97")));
+            network.checkpoints.Add(134444, new CheckpointInfo(new uint256("0x00000000000005b12ffd4cd315cd34ffd4a594f430ac814c91184a0d42d2b0fe")));
+            network.checkpoints.Add(168000, new CheckpointInfo(new uint256("0x000000000000099e61ea72015e79632f216fe6cb33d7899acb35b75c8303b763")));
+            network.checkpoints.Add(193000, new CheckpointInfo(new uint256("0x000000000000059f452a5f7340de6682a977387c17010ff6e6c3bd83ca8b1317")));
+            network.checkpoints.Add(210000, new CheckpointInfo(new uint256("0x000000000000048b95347e83192f69cf0366076336c639f9b7228e9ba171342e")));
+            network.checkpoints.Add(216116, new CheckpointInfo(new uint256("0x00000000000001b4f4b433e81ee46494af945cf96014816a4e2370f11b23df4e")));
+            network.checkpoints.Add(225430, new CheckpointInfo(new uint256("0x00000000000001c108384350f74090433e7fcf79a606b8e797f065b130575932")));
+            network.checkpoints.Add(250000, new CheckpointInfo(new uint256("0x000000000000003887df1f29024b06fc2200b55f8af8f35453d7be294df2d214")));
+            network.checkpoints.Add(279000, new CheckpointInfo(new uint256("0x0000000000000001ae8c72a0b0c301f67e3afca10e819efa9041e458e9bd7e40")));
+            network.checkpoints.Add(295000, new CheckpointInfo(new uint256("0x00000000000000004d9b4ef50f0f9d686fd69db2e03af35a100370c64632a983")));
+            // Our own new checkpoints.
+            network.checkpoints.Add(486000, new CheckpointInfo(new uint256("0x000000000000000000a2a8104d61651f76c666b70754d6e9346176385f7afa24")));
+            network.checkpoints.Add(491800, new CheckpointInfo(new uint256("0x000000000000000000d80de1f855902b50941bc3a3d0f71064d9613fd3943dc4")));
 
             NetworksContainer.TryAdd("mainnet", network);
             NetworksContainer.TryAdd(network.Name.ToLowerInvariant(), network);
@@ -259,19 +251,11 @@ namespace NBitcoin
             network.MinTxFee = 1000;
             network.FallbackFee = 20000;
             network.MinRelayTxFee = 1000;
-            
-            // Partially obtained from https://github.com/bitcoin/bitcoin/blob/b1973d6181eacfaaf45effb67e0c449ea3a436b8/src/chainparams.cpp#L246
-            var checkpoints = new Dictionary<int, CheckpointInfo>
-            {
-                { 546, new CheckpointInfo(new uint256("000000002a936ca763904c3c35fce2f3556c559c0214345d31b1bcebf76acb70")) },
-                // Our own new checkpoints.
-                { 1210000, new CheckpointInfo(new uint256("00000000461201277cf8c635fc10d042d6f0a7eaa57f6c9e8c099b9e0dbc46dc")) },
-            };
 
-            foreach (var checkpoint in checkpoints)
-            {
-                network.checkpoints.Add(checkpoint.Key, checkpoint.Value);
-            }
+            // Partially obtained from https://github.com/bitcoin/bitcoin/blob/b1973d6181eacfaaf45effb67e0c449ea3a436b8/src/chainparams.cpp#L246
+            network.checkpoints.Add(546, new CheckpointInfo(new uint256("000000002a936ca763904c3c35fce2f3556c559c0214345d31b1bcebf76acb70")));
+            // Our own new checkpoints.
+            network.checkpoints.Add(1210000, new CheckpointInfo(new uint256("00000000461201277cf8c635fc10d042d6f0a7eaa57f6c9e8c099b9e0dbc46dc")));
 
             NetworksContainer.TryAdd("test", network);
             NetworksContainer.TryAdd(network.Name.ToLowerInvariant(), network);
@@ -421,7 +405,7 @@ namespace NBitcoin
             Assert(consensus.HashGenesisBlock == uint256.Parse("0x0000066e91e46e5a264d42c89e1204963b2ee6be230b443e9159020539d972af"));
             Assert(genesis.Header.HashMerkleRoot == uint256.Parse("0x65a26bc20b0351aebf05829daefa8f7db2f800623439f3c114257c91447f1518"));
 
-            var builder = new NetworkBuilder()
+            NetworkBuilder builder = new NetworkBuilder()
                     .SetName("StratisMain")
                     .SetRootFolderName(StratisRootFolderName)
                     .SetDefaultConfigFilename(StratisDefaultConfigFilename)
@@ -484,7 +468,7 @@ namespace NBitcoin
             Block.BlockSignature = true;
             Transaction.TimeStamp = true;
 
-            var consensus = Network.StratisMain.Consensus.Clone();
+            Consensus consensus = Network.StratisMain.Consensus.Clone();
             consensus.PowLimit = new Target(uint256.Parse("0000ffff00000000000000000000000000000000000000000000000000000000"));
 
             // The message start string is designed to be unlikely to occur in normal data.
@@ -497,7 +481,7 @@ namespace NBitcoin
             messageStart[3] = 0x11;
             var magic = BitConverter.ToUInt32(messageStart, 0); //0x5223570; 
 
-            var genesis = Network.StratisMain.GetGenesis();
+            Block genesis = Network.StratisMain.GetGenesis();
             genesis.Header.Time = 1493909211;
             genesis.Header.Nonce = 2433759;
             genesis.Header.Bits = consensus.PowLimit;
@@ -517,7 +501,7 @@ namespace NBitcoin
                 { 163000, new CheckpointInfo(new uint256("0x4e44a9e0119a2e7cbf15e570a3c649a5605baa601d953a465b5ebd1c1982212a"), new uint256("0x0646fc7db8f3426eb209e1228c7d82724faa46a060f5bbbd546683ef30be245c")) },
             };
 
-            var builder = new NetworkBuilder()
+            NetworkBuilder builder = new NetworkBuilder()
                     .SetName("StratisTest")
                     .SetRootFolderName(StratisRootFolderName)
                     .SetDefaultConfigFilename(StratisDefaultConfigFilename)
@@ -567,7 +551,7 @@ namespace NBitcoin
             Block.BlockSignature = true;
             Transaction.TimeStamp = true;
 
-            var consensus = Network.StratisTest.Consensus.Clone();
+            Consensus consensus = Network.StratisTest.Consensus.Clone();
             consensus.PowLimit = new Target(uint256.Parse("7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"));
 
             consensus.PowAllowMinDifficultyBlocks = true;
@@ -580,7 +564,7 @@ namespace NBitcoin
             messageStart[3] = 0xef;
             var magic = BitConverter.ToUInt32(messageStart, 0);
 
-            var genesis = Network.StratisMain.GetGenesis();
+            Block genesis = Network.StratisMain.GetGenesis();
             genesis.Header.Time = 1494909211;
             genesis.Header.Nonce = 2433759;
             genesis.Header.Bits = consensus.PowLimit;
@@ -590,7 +574,7 @@ namespace NBitcoin
 
             consensus.DefaultAssumeValid = null; // turn off assumevalid for regtest.
 
-            var builder = new NetworkBuilder()
+            NetworkBuilder builder = new NetworkBuilder()
                 .SetName("StratisRegTest")
                 .SetRootFolderName(StratisRootFolderName)
                 .SetDefaultConfigFilename(StratisDefaultConfigFilename)

--- a/src/Stratis.Bitcoin.Features.Consensus/Checkpoints.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/Checkpoints.cs
@@ -34,30 +34,6 @@ namespace Stratis.Bitcoin.Features.Consensus
     }
 
     /// <summary>
-    /// Description of checkpointed block.
-    /// </summary>
-    public class CheckpointInfo
-    {
-        /// <summary>Hash of the checkpointed block header.</summary>
-        public uint256 Hash { get; set; }
-
-        /// <summary>Stake modifier V2 value of the checkpointed block.</summary>
-        /// <remarks>Stratis only.</remarks>
-        public uint256 StakeModifierV2 { get; set; }
-
-        /// <summary>
-        /// Initializes a new instance of the object.
-        /// </summary>
-        /// <param name="hash">Hash of the checkpointed block header.</param>
-        /// <param name="stakeModifierV2">Stake modifier V2 value of the checkpointed block. Stratis network only.</param>
-        public CheckpointInfo(uint256 hash, uint256 stakeModifierV2 = null)
-        {
-            this.Hash = hash;
-            this.StakeModifierV2 = stakeModifierV2;
-        }
-    }
-
-    /// <summary>
     /// Checkpoints is a mechanism on how to avoid validation of historic blocks for which there
     /// already is a consensus on the network. This allows speeding up IBD, especially on POS networks.
     /// </summary>
@@ -69,82 +45,17 @@ namespace Stratis.Bitcoin.Features.Consensus
     /// </remarks>
     public class Checkpoints : ICheckpoints
     {
-        /// <summary>List of selected checkpoints for STRAT mainnet.</summary>
-        private static Dictionary<int, CheckpointInfo> stratisMainnetCheckpoints = new Dictionary<int, CheckpointInfo>
-        {
-            { 0, new CheckpointInfo(new uint256("0x0000066e91e46e5a264d42c89e1204963b2ee6be230b443e9159020539d972af"), new uint256("0x0000000000000000000000000000000000000000000000000000000000000000")) },
-            { 2, new CheckpointInfo(new uint256("0xbca5936f638181e74a5f1e9999c95b0ce77da48c2688399e72bcc53a00c61eff"), new uint256("0x7d61c139a471821caa6b7635a4636e90afcfe5e195040aecbc1ad7d24924db1e")) }, // Premine
-            { 50, new CheckpointInfo(new uint256("0x0353b43f4ce80bf24578e7c0141d90d7962fb3a4b4b4e5a17925ca95e943b816"), new uint256("0x7c2af3b10d13f9d2bc6063baaf7f0860d90d870c994378144f9bf85d0d555061")) },
-            { 100, new CheckpointInfo(new uint256("0x688468a8aa48cd1c2197e42e7d8acd42760b7e2ac4bcab9d18ac149a673e16f6"), new uint256("0xcf2b1e9e76aaa3d96f255783eb2d907bf6ccb9c1deeb3617149278f0e4a1ab1b")) },
-            { 150, new CheckpointInfo(new uint256("0xe4ae9663519abec15e28f68bdb2cb89a739aee22f53d1573048d69141db6ee5d"), new uint256("0xa6c17173e958dc716cc0892ce33dad8bc327963d78a16c436264ceae43d584ce")) },
-            { 127500, new CheckpointInfo(new uint256("0x4773ca7512489df22de03aa03938412fab5b46154b05df004b97bcbeaa184078"), new uint256("0x619743c02ebaff06b90fcc5c60c52dba8aa3fdb6ba3800aae697cbb3c5483f17")) },
-            { 128943, new CheckpointInfo(new uint256("0x36bcaa27a53d3adf22b2064150a297adb02ac39c24263a5ceb73856832d49679"), new uint256("0xa3a6fd04e41fcaae411a3990aaabcf5e086d2d06c72c849182b27b4de8c2c42a")) },
-            { 136601, new CheckpointInfo(new uint256("0xf5c5210c55ff1ef9c04715420a82728e1647f3473e31dc478b3745a97b4a6d10"), new uint256("0x42058fabe21f7b118a9e358eaf9ef574dadefd024244899e71f2f6d618161e16")) }, // Hardfork to V2 - Drifting Bug Fix
-            { 170000, new CheckpointInfo(new uint256("0x22b10952e0cf7e85bfc81c38f1490708f195bff34d2951d193cc20e9ca1fc9d5"), new uint256("0xa4942a6c99cba397cf2b18e4b912930fe1e64a7413c3d97c5a926c2af9073091")) },
-            { 200000, new CheckpointInfo(new uint256("0x2391dd493be5d0ff0ef57c3b08c73eefeecc2701b80f983054bb262f7a146989"), new uint256("0x253152d129e82c30c584197deb6833502eff3ec2f30014008f75842d7bb48453")) },
-            { 250000, new CheckpointInfo(new uint256("0x681c70fab7c1527246138f0cf937f0eb013838b929fbe9a831af02a60fc4bf55"), new uint256("0x24eed95e00c90618aa9d137d2ee273267285c444c9cde62a25a3e880c98a3685")) },
-            { 300000, new CheckpointInfo(new uint256("0xd10ca8c2f065a49ae566c7c9d7a2030f4b8b7f71e4c6fc6b2a02509f94cdcd44"), new uint256("0x39c4dd765b49652935524248b4de4ccb604df086d0723bcd81faf5d1c2489304")) },
-            { 350000, new CheckpointInfo(new uint256("0xe2b76d1a068c4342f91db7b89b66e0f2146d3a4706c21f3a262737bb7339253a"), new uint256("0xd1dd94985eaaa028c893687a7ddf89143dcf0176918f958c2d01f33d64910399")) },
-            { 390000, new CheckpointInfo(new uint256("0x4682737abc2a3257fdf4c3c119deb09cbac75981969e2ffa998b4f76b7c657bb"), new uint256("0xd84b204ee94499ff65262328a428851fb4f4d2741e928cdd088fdf1deb5413b8")) },
-            { 394000, new CheckpointInfo(new uint256("0x42857fa2bc15d45cdcaae83411f755b95985da1cb464ee23f6d40936df523e9f"), new uint256("0x2314b336906a2ed2a39cbdf6fc0622530709c62dbb3a3729de17154fc9d1a7c4")) },
-            { 528000, new CheckpointInfo(new uint256("0x7aff2c48b398446595d01e27b5cd898087cec63f94ff73f9ad695c6c9bcee33a"), new uint256("0x3bdc865661390c7681b078e52ed3ad3c53ec7cff97b8c45b74abed3ace289fcc")) },
-            { 576000, new CheckpointInfo(new uint256("0xe705476b940e332098d1d5b475d7977312ff8c08cbc8256ce46a3e2c6d5408b8"), new uint256("0x10e31bb5e245ea19650280cfd3ac1a76259fa0002d02e861d2ab5df290534b56")) },
-        };
-
-        /// <summary>List of selected checkpoints for STRAT testnet.</summary>
-        private static Dictionary<int, CheckpointInfo> stratisTestnetCheckpoints = new Dictionary<int, CheckpointInfo>
-        {
-            { 0, new CheckpointInfo(new uint256("0x00000e246d7b73b88c9ab55f2e5e94d9e22d471def3df5ea448f5576b1d156b9"), new uint256("0x0000000000000000000000000000000000000000000000000000000000000000")) },
-            { 2, new CheckpointInfo(new uint256("0x56959b1c8498631fb0ca5fe7bd83319dccdc6ac003dccb3171f39f553ecfa2f2"), new uint256("0x13f4c27ca813aefe2d9018077f8efeb3766796b9144fcc4cd51803bf4376ab02")) },
-            { 50000, new CheckpointInfo(new uint256("0xb42c18eacf8fb5ed94eac31943bd364451d88da0fd44cc49616ffea34d530ad4"), new uint256("0x824934ddc5f935e854ac59ae7f5ed25f2d29a7c3914cac851f3eddb4baf96d78")) },
-            { 100000, new CheckpointInfo(new uint256("0xf9e2f7561ee4b92d3bde400d251363a0e8924204c326da7f4ad9ccc8863aad79"), new uint256("0xdef8d92d20becc71f662ee1c32252aca129f1bf4744026b116d45d9bfe67e9fb")) },
-            { 115000, new CheckpointInfo(new uint256("0x8496c77060c8a2b5c9a888ade991f25aa33c232b4413594d556daf9043fad400"), new uint256("0x1886430484a9a36b56a7eb8bd25e9ebe4fc8eec8f9a84f5073f71e08f2feac90")) },
-            { 163000, new CheckpointInfo(new uint256("0x4e44a9e0119a2e7cbf15e570a3c649a5605baa601d953a465b5ebd1c1982212a"), new uint256("0x0646fc7db8f3426eb209e1228c7d82724faa46a060f5bbbd546683ef30be245c")) },
-        };
-
-        /// <summary>List of selected checkpoints for Bitcoin mainnet.</summary>
-        /// <remarks>Partially obtained from https://github.com/bitcoin/bitcoin/blob/b1973d6181eacfaaf45effb67e0c449ea3a436b8/src/chainparams.cpp#L146 .</remarks>
-        private static Dictionary<int, CheckpointInfo> bitcoinMainnetCheckpoints = new Dictionary<int, CheckpointInfo>
-        {
-            { 11111, new CheckpointInfo(new uint256("0x0000000069e244f73d78e8fd29ba2fd2ed618bd6fa2ee92559f542fdb26e7c1d")) },
-            { 33333, new CheckpointInfo(new uint256("0x000000002dd5588a74784eaa7ab0507a18ad16a236e7b1ce69f00d7ddfb5d0a6")) },
-            { 74000, new CheckpointInfo(new uint256("0x0000000000573993a3c9e41ce34471c079dcf5f52a0e824a81e7f953b8661a20")) },
-            { 105000, new CheckpointInfo(new uint256("0x00000000000291ce28027faea320c8d2b054b2e0fe44a773f3eefb151d6bdc97")) },
-            { 134444, new CheckpointInfo(new uint256("0x00000000000005b12ffd4cd315cd34ffd4a594f430ac814c91184a0d42d2b0fe")) },
-            { 168000, new CheckpointInfo(new uint256("0x000000000000099e61ea72015e79632f216fe6cb33d7899acb35b75c8303b763")) },
-            { 193000, new CheckpointInfo(new uint256("0x000000000000059f452a5f7340de6682a977387c17010ff6e6c3bd83ca8b1317")) },
-            { 210000, new CheckpointInfo(new uint256("0x000000000000048b95347e83192f69cf0366076336c639f9b7228e9ba171342e")) },
-            { 216116, new CheckpointInfo(new uint256("0x00000000000001b4f4b433e81ee46494af945cf96014816a4e2370f11b23df4e")) },
-            { 225430, new CheckpointInfo(new uint256("0x00000000000001c108384350f74090433e7fcf79a606b8e797f065b130575932")) },
-            { 250000, new CheckpointInfo(new uint256("0x000000000000003887df1f29024b06fc2200b55f8af8f35453d7be294df2d214")) },
-            { 279000, new CheckpointInfo(new uint256("0x0000000000000001ae8c72a0b0c301f67e3afca10e819efa9041e458e9bd7e40")) },
-            { 295000, new CheckpointInfo(new uint256("0x00000000000000004d9b4ef50f0f9d686fd69db2e03af35a100370c64632a983")) },
-            // Our own new checkpoints.
-            { 486000, new CheckpointInfo(new uint256("0x000000000000000000a2a8104d61651f76c666b70754d6e9346176385f7afa24")) },
-            { 491800, new CheckpointInfo(new uint256("0x000000000000000000d80de1f855902b50941bc3a3d0f71064d9613fd3943dc4")) },
-        };
-
-        /// <summary>List of selected checkpoints for Bitcoin testnet.</summary>
-        /// <remarks>Obtained from https://github.com/bitcoin/bitcoin/blob/b1973d6181eacfaaf45effb67e0c449ea3a436b8/src/chainparams.cpp#L246 .</remarks>
-        private static Dictionary<int, CheckpointInfo> bitcoinTestnetCheckpoints = new Dictionary<int, CheckpointInfo>
-        {
-            { 546, new CheckpointInfo(new uint256("000000002a936ca763904c3c35fce2f3556c559c0214345d31b1bcebf76acb70")) },
-            // Our own new checkpoints.
-            { 1210000, new CheckpointInfo(new uint256("00000000461201277cf8c635fc10d042d6f0a7eaa57f6c9e8c099b9e0dbc46dc")) },
-        };
-
-        /// <summary>Checkpoints for the specific instance of the class and its network.</summary>
-        private readonly Dictionary<int, CheckpointInfo> networkSpecificCheckpoints;
+        /// <summary>The current network. </summary>
+        private Network network;
 
         /// <summary>Consensus settings for the full node.</summary>
-        private ConsensusSettings ConsensusSettings { get; }
+        private ConsensusSettings consensusSettings { get; }
 
         /// <summary>
         /// Initializes a new instance of the object.
         /// </summary>
         public Checkpoints()
         {
-            this.networkSpecificCheckpoints = new Dictionary<int, CheckpointInfo>();
         }
 
         /// <summary>
@@ -157,14 +68,8 @@ namespace Stratis.Bitcoin.Features.Consensus
             Guard.NotNull(network, nameof(network));
             Guard.NotNull(consensusSettings, nameof(consensusSettings));
 
-            this.ConsensusSettings = consensusSettings;
-
-            if (network.Equals(Network.Main)) this.networkSpecificCheckpoints = bitcoinMainnetCheckpoints;
-            else if (network.Equals(Network.TestNet)) this.networkSpecificCheckpoints = bitcoinTestnetCheckpoints;
-            else if (network.Equals(Network.RegTest)) this.networkSpecificCheckpoints = new Dictionary<int, CheckpointInfo>();
-            else if (network.Equals(Network.StratisMain)) this.networkSpecificCheckpoints = stratisMainnetCheckpoints;
-            else if (network.Equals(Network.StratisTest)) this.networkSpecificCheckpoints = stratisTestnetCheckpoints;
-            else this.networkSpecificCheckpoints = new Dictionary<int, CheckpointInfo>();
+            this.consensusSettings = consensusSettings;
+            this.network = network;
         }
 
         /// <inheritdoc />
@@ -193,10 +98,10 @@ namespace Stratis.Bitcoin.Features.Consensus
 
         private Dictionary<int, CheckpointInfo> GetCheckpoints()
         {
-            if (this.ConsensusSettings == null || !this.ConsensusSettings.UseCheckpoints)
+            if (this.consensusSettings == null || !this.consensusSettings.UseCheckpoints)
                 return new Dictionary<int, CheckpointInfo>();
 
-            return this.networkSpecificCheckpoints;
+            return this.network.Checkpoints;
         }
     }
 }


### PR DESCRIPTION
This PR moves the checkpoints to the network file and adds methods to include them in the nodebuilder.
See https://github.com/stratisproject/StratisBitcoinFullNode/issues/1341

@dangershony please have a look. I'm still unsure where to move CheckpointInfo to.