### PR TITLE
Protect file from corruption while saving

### DIFF
--- a/src/Stratis.Bitcoin.Features.Wallet/WalletManager.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/WalletManager.cs
@@ -1216,8 +1216,8 @@ namespace Stratis.Bitcoin.Features.Wallet
             };
 
             // Create a folder if none exists and persist the file.
-            this.fileStorage.SaveToFile(walletFile, $"{name}.{WalletFileExtension}");
-
+            this.SaveWallet(walletFile);
+            
             this.logger.LogTrace("(-)");
             return walletFile;
         }

--- a/src/Stratis.Bitcoin.Tests/Utilities/FileStorageTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Utilities/FileStorageTest.cs
@@ -227,6 +227,103 @@ namespace Stratis.Bitcoin.Tests.Utilities
             Assert.False(loadedObjects.Any());
         }
 
+        [Fact]
+        public void GivenSaveWithBackupIsCalled_WhenTheFileExistsandWasChanged_ThenABackupIsSaved()
+        {
+            // Arrange
+            TestObject testObject = new TestObject { Property1 = "prop1", Property2 = "prop2" };
+            string dir = this.GetFolderPathForTestExecution();
+            FileStorage<TestObject> fileStorage = new FileStorage<TestObject>(dir);
+            fileStorage.SaveToFile(testObject, "savedTestObject.json", true);
+            testObject.Property1 = testObject.Property1 + "-changed";
+            fileStorage.SaveToFile(testObject, "savedTestObject.json", true);
+
+            // Act
+            bool isFileExists = fileStorage.Exists("savedTestObject.json");
+            bool isBackupFileExists = fileStorage.Exists("savedTestObject.json.bak");
+            
+            // Assert
+            Assert.True(isFileExists);
+            Assert.True(isBackupFileExists);
+
+            TestObject loadedByFileName = fileStorage.LoadByFileName("savedTestObject.json");
+            TestObject loadedBackupByFileName = fileStorage.LoadByFileName("savedTestObject.json.bak");
+
+            Assert.Equal("prop1", loadedBackupByFileName.Property1);
+            Assert.Equal("prop2", loadedBackupByFileName.Property2);
+            Assert.Equal("prop1-changed", loadedByFileName.Property1);
+            Assert.Equal("prop2", loadedByFileName.Property2);
+        }
+
+        [Fact]
+        public void GivenSaveWithBackupIsCalled_WhenTheFileDidntExist_ThenTwoIdenticalFilesAreSaved()
+        {
+            // Arrange
+            TestObject testObject = new TestObject { Property1 = "prop1", Property2 = "prop2" };
+            string dir = this.GetFolderPathForTestExecution();
+            FileStorage<TestObject> fileStorage = new FileStorage<TestObject>(dir);
+            fileStorage.SaveToFile(testObject, "savedTestObject.json", true);
+            
+            // Act
+            bool isFileExists = fileStorage.Exists("savedTestObject.json");
+            bool isBackupFileExists = fileStorage.Exists("savedTestObject.json.bak");
+
+            // Assert
+            Assert.True(isFileExists);
+            Assert.True(isBackupFileExists);
+
+            TestObject loadedByFileName = fileStorage.LoadByFileName("savedTestObject.json");
+            TestObject loadedBackupByFileName = fileStorage.LoadByFileName("savedTestObject.json.bak");
+
+            Assert.Equal("prop1", loadedBackupByFileName.Property1);
+            Assert.Equal("prop2", loadedBackupByFileName.Property2);
+            Assert.Equal("prop1", loadedByFileName.Property1);
+            Assert.Equal("prop2", loadedByFileName.Property2);
+        }
+
+        [Fact]
+        public void GivenSaveFileIsCalled_WhenTheFileDidntExist_ThenNoBackupIsSaved()
+        {
+            // Arrange
+            TestObject testObject = new TestObject { Property1 = "prop1", Property2 = "prop2" };
+            string dir = this.GetFolderPathForTestExecution();
+            FileStorage<TestObject> fileStorage = new FileStorage<TestObject>(dir);
+            fileStorage.SaveToFile(testObject, "savedTestObject.json");
+
+            // Act
+            bool isFileExists = fileStorage.Exists("savedTestObject.json");
+            bool isBackupFileExists = fileStorage.Exists("savedTestObject.json.bak");
+
+            // Assert
+            Assert.True(isFileExists);
+            Assert.False(isBackupFileExists);
+        }
+
+        [Fact]
+        public void GivenSaveFileIsCalled_WhenTheFileExists_ThenNoBackupIsSaved()
+        {
+            // Arrange
+            TestObject testObject = new TestObject { Property1 = "prop1", Property2 = "prop2" };
+            string dir = this.GetFolderPathForTestExecution();
+            FileStorage<TestObject> fileStorage = new FileStorage<TestObject>(dir);
+            fileStorage.SaveToFile(testObject, "savedTestObject.json");
+            testObject.Property1 = testObject.Property1 + "-changed";
+            fileStorage.SaveToFile(testObject, "savedTestObject.json");
+
+            // Act
+            bool isFileExists = fileStorage.Exists("savedTestObject.json");
+            bool isBackupFileExists = fileStorage.Exists("savedTestObject.json.bak");
+
+            // Assert
+            Assert.True(isFileExists);
+            Assert.False(isBackupFileExists);
+            TestObject loadedByFileName = fileStorage.LoadByFileName("savedTestObject.json");
+            Assert.Equal("prop1-changed", loadedByFileName.Property1);
+            Assert.Equal("prop2", loadedByFileName.Property2);
+
+        }
+
+
         public void Dispose()
         {
             DirectoryInfo directoryInfo = new DirectoryInfo(TestFolder);

--- a/src/Stratis.Bitcoin.Tests/Utilities/FileStorageTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Utilities/FileStorageTest.cs
@@ -282,6 +282,47 @@ namespace Stratis.Bitcoin.Tests.Utilities
         }
 
         [Fact]
+        public void GivenSaveFileWithNoBackupIsCalled_WhenTheFileExists_ThenNoBackupIsSaved()
+        {
+            // Arrange
+            TestObject testObject = new TestObject { Property1 = "prop1", Property2 = "prop2" };
+            string dir = this.GetFolderPathForTestExecution();
+            FileStorage<TestObject> fileStorage = new FileStorage<TestObject>(dir);
+            fileStorage.SaveToFile(testObject, "savedTestObject.json", false);
+            testObject.Property1 = testObject.Property1 + "-changed";
+            fileStorage.SaveToFile(testObject, "savedTestObject.json");
+
+            // Act
+            bool isFileExists = fileStorage.Exists("savedTestObject.json");
+            bool isBackupFileExists = fileStorage.Exists("savedTestObject.json.bak");
+
+            // Assert
+            Assert.True(isFileExists);
+            Assert.False(isBackupFileExists);
+            TestObject loadedByFileName = fileStorage.LoadByFileName("savedTestObject.json");
+            Assert.Equal("prop1-changed", loadedByFileName.Property1);
+            Assert.Equal("prop2", loadedByFileName.Property2);
+        }
+
+        [Fact]
+        public void GivenSaveFileWithNoBackupIsCalled_WhenTheFileDidntExist_ThenNoBackupIsSaved()
+        {
+            // Arrange
+            TestObject testObject = new TestObject { Property1 = "prop1", Property2 = "prop2" };
+            string dir = this.GetFolderPathForTestExecution();
+            FileStorage<TestObject> fileStorage = new FileStorage<TestObject>(dir);
+            fileStorage.SaveToFile(testObject, "savedTestObject.json", false);
+
+            // Act
+            bool isFileExists = fileStorage.Exists("savedTestObject.json");
+            bool isBackupFileExists = fileStorage.Exists("savedTestObject.json.bak");
+
+            // Assert
+            Assert.True(isFileExists);
+            Assert.False(isBackupFileExists);
+        }
+
+        [Fact]
         public void GivenSaveFileIsCalled_WhenTheFileDidntExist_ThenNoBackupIsSaved()
         {
             // Arrange
@@ -320,9 +361,7 @@ namespace Stratis.Bitcoin.Tests.Utilities
             TestObject loadedByFileName = fileStorage.LoadByFileName("savedTestObject.json");
             Assert.Equal("prop1-changed", loadedByFileName.Property1);
             Assert.Equal("prop2", loadedByFileName.Property2);
-
         }
-
 
         public void Dispose()
         {

--- a/src/Stratis.Bitcoin/Utilities/FileStorage.cs
+++ b/src/Stratis.Bitcoin/Utilities/FileStorage.cs
@@ -40,11 +40,14 @@ namespace Stratis.Bitcoin.Utilities
             Guard.NotNull(toSave, nameof(toSave));
 
             string filePath = Path.Combine(this.FolderPath, fileName);
+            string tempFilePath = $"{filePath}.temp";
+
+            File.WriteAllText(tempFilePath, JsonConvert.SerializeObject(toSave, Formatting.Indented));
 
             // If the file does not exist yet, create it.
             if (!File.Exists(filePath))
             {
-                File.WriteAllText(filePath, JsonConvert.SerializeObject(toSave, Formatting.Indented));
+                File.Move(tempFilePath, filePath);
 
                 if (saveBackupFile)
                 {
@@ -55,9 +58,7 @@ namespace Stratis.Bitcoin.Utilities
             }
 
             // Replace the file if it already exists. 
-            // This ensures the file does not get corrupted in the event of a crash.
-            string tempFilePath = $"{filePath}.temp";
-            File.WriteAllText(tempFilePath, JsonConvert.SerializeObject(toSave, Formatting.Indented));
+            // This ensures the file does not get corrupted in the event of a crash. 
             File.Replace(tempFilePath, filePath, saveBackupFile ? $"{filePath}.bak" : null);
         }
 

--- a/src/Stratis.Bitcoin/Utilities/FileStorage.cs
+++ b/src/Stratis.Bitcoin/Utilities/FileStorage.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Newtonsoft.Json;
@@ -40,7 +41,7 @@ namespace Stratis.Bitcoin.Utilities
             Guard.NotNull(toSave, nameof(toSave));
 
             string filePath = Path.Combine(this.FolderPath, fileName);
-            string tempFilePath = $"{filePath}.temp";
+            string tempFilePath = $"{filePath}.{DateTime.UtcNow.Ticks}.temp";
 
             File.WriteAllText(tempFilePath, JsonConvert.SerializeObject(toSave, Formatting.Indented));
 


### PR DESCRIPTION
This should fix https://github.com/stratisproject/StratisBitcoinFullNode/issues/1230 and hopefully https://github.com/stratisproject/StratisBitcoinFullNode/issues/1231.

I added a call to `File.Replace` when saving the file so that the file never gets in a corrupted state.
This call is atomic in the sense that the file is either replaced successfully or not replaced at all.

Additionally, I added a parameter to the `FileStorage.SaveFile` method where a backup file (.bak) will be saved every time the file is saved. So the backup will have the previous version, and the file will have the new version.

More here: https://msdn.microsoft.com/en-us/library/windows/desktop/hh802690%28v=vs.85%29.aspx
    

