### PR TITLE
Fix PowMiningTest

### DIFF
--- a/src/Stratis.Bitcoin.Features.Miner.Tests/PowMiningTest.cs
+++ b/src/Stratis.Bitcoin.Features.Miner.Tests/PowMiningTest.cs
@@ -31,7 +31,7 @@ namespace Stratis.Bitcoin.Features.Miner.Tests
 
         public PowMiningTest(PowMiningTestFixture fixture)
         {
-            // Ensure that these flags match the values derived from the Network and NetworkOptions.
+            // Static flags should match the values derived from the Network and NetworkOptions.
             Transaction.TimeStamp = true;
             Block.BlockSignature = true;
 

--- a/src/Stratis.Bitcoin.Features.Miner.Tests/PowMiningTest.cs
+++ b/src/Stratis.Bitcoin.Features.Miner.Tests/PowMiningTest.cs
@@ -31,6 +31,7 @@ namespace Stratis.Bitcoin.Features.Miner.Tests
 
         public PowMiningTest(PowMiningTestFixture fixture)
         {
+            // Ensure that these flags match the values derived from the Network and NetworkOptions.
             Transaction.TimeStamp = true;
             Block.BlockSignature = true;
 

--- a/src/Stratis.Bitcoin.Features.Miner.Tests/PowMiningTest.cs
+++ b/src/Stratis.Bitcoin.Features.Miner.Tests/PowMiningTest.cs
@@ -28,14 +28,9 @@ namespace Stratis.Bitcoin.Features.Miner.Tests
         private Network network;
         private Mock<INodeLifetime> nodeLifetime;
         private PowMining powMining;
-        private readonly bool initialBlockSignature;
-        private readonly bool initialTimestamp;
 
         public PowMiningTest(PowMiningTestFixture fixture)
         {
-            this.initialBlockSignature = Block.BlockSignature;
-            this.initialTimestamp = Transaction.TimeStamp;
-
             Transaction.TimeStamp = true;
             Block.BlockSignature = true;
 
@@ -67,9 +62,6 @@ namespace Stratis.Bitcoin.Features.Miner.Tests
 
         public void Dispose()
         {
-            Block.BlockSignature = this.initialBlockSignature;
-            Transaction.TimeStamp = this.initialTimestamp;
-
             this.network.Consensus.Options = this.initialNetworkOptions;
         }
 


### PR DESCRIPTION
This PR investigates the removal of the code that changes the static flags in the  `Dispose` method. This has been done due to the unpredictability of when the method is called.

NOT READY FOR PROMOTION YET

Due to the intermittent nature of the issue the PR will include some dummy commits to ensure that the problem is not re-occurring.