### PR TITLE
Update StratisD to respect the configuration file network selection

### DIFF
--- a/src/Stratis.Bitcoin/Configuration/NodeSettings.cs
+++ b/src/Stratis.Bitcoin/Configuration/NodeSettings.cs
@@ -101,7 +101,10 @@ namespace Stratis.Bitcoin.Configuration
                 if (testNet && regTest)
                     throw new ConfigurationException("Invalid combination of -regtest and -testnet.");
 
-                this.Network = testNet ? Network.TestNet : regTest ? Network.RegTest : Network.Main;
+                if (protocolVersion == ProtocolVersion.ALT_PROTOCOL_VERSION)
+                    this.Network = testNet ? Network.StratisTest : regTest ? Network.StratisRegTest : Network.StratisMain;
+                else
+                    this.Network = testNet ? Network.TestNet : regTest ? Network.RegTest : Network.Main;
             }
 
             // Setting the data directory.

--- a/src/Stratis.StratisD/Program.cs
+++ b/src/Stratis.StratisD/Program.cs
@@ -28,9 +28,7 @@ namespace Stratis.StratisD
         {
             try
             {
-                Network network = args.Contains("-testnet") ? Network.StratisTest : Network.StratisMain;
-                NodeSettings nodeSettings = new NodeSettings(network, ProtocolVersion.ALT_PROTOCOL_VERSION, args:args, loadConfiguration:false);
-
+                NodeSettings nodeSettings = new NodeSettings(protocolVersion:ProtocolVersion.ALT_PROTOCOL_VERSION, args:args, loadConfiguration:false);
 
                 // NOTES: running BTC and STRAT side by side is not possible yet as the flags for serialization are static
                 var node = new FullNodeBuilder()


### PR DESCRIPTION
This PR updates StratisD to respect the configuration files' network selection ('regtest' or 'testnet').