### PR TITLE
Add GetBlocksAsync method to IBlockRepository

### DIFF
--- a/src/Stratis.Bitcoin.Features.BlockStore.Tests/BlockRepositoryInMemory.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore.Tests/BlockRepositoryInMemory.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using NBitcoin;
 using Stratis.Bitcoin.Utilities;
@@ -52,6 +53,11 @@ namespace Stratis.Bitcoin.Features.BlockStore.Tests
         public Task<Block> GetAsync(uint256 hash)
         {
             return Task.FromResult(this.store[hash]);
+        }
+
+        public Task<List<Block>> GetBlocksAsync(List<uint256> hashes)
+        {
+            return Task.FromResult(hashes.Select(hash => this.store[hash]).ToList());
         }
 
         public Task PutAsync(uint256 nextBlockHash, List<Block> blocks)

--- a/src/Stratis.Bitcoin.Features.BlockStore.Tests/BlockRepositoryInMemory.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore.Tests/BlockRepositoryInMemory.cs
@@ -54,10 +54,11 @@ namespace Stratis.Bitcoin.Features.BlockStore.Tests
         {
             return Task.FromResult(this.store[hash]);
         }
-
+        
+        /// <inheritdoc />
         public Task<List<Block>> GetBlocksAsync(List<uint256> hashes)
         {
-            return Task.FromResult(hashes.Select(hash => this.store[hash]).ToList());
+            return Task.FromResult(hashes.Select(hash => this.store.TryGetValue(hash, out Block block) ? block : null).ToList());
         }
 
         public Task PutAsync(uint256 nextBlockHash, List<Block> blocks)

--- a/src/Stratis.Bitcoin.Features.BlockStore/BlockRepository.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/BlockRepository.cs
@@ -546,14 +546,14 @@ namespace Stratis.Bitcoin.Features.BlockStore
                             results[key.Item1] = blockRow.Value;
                             this.PerformanceCounter.AddRepositoryHitCount(1);
 
-                            this.logger.LogTrace("(-):{0}={1}", key.Item1, blockRow.Value);
+                            this.logger.LogTrace("Block hash '{0}' loaded from the store.", key.Item1);
                         }
                         else
                         {
                             results[key.Item1] = null;
                             this.PerformanceCounter.AddRepositoryMissCount(1);
 
-                            this.logger.LogTrace("(-):{0}=[NO_BLOCK]", key.Item1);
+                            this.logger.LogTrace("Block hash '{0}' not found in the store.", key.Item1);
                         }
                     }
                 }

--- a/src/Stratis.Bitcoin.Features.BlockStore/BlockRepository.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/BlockRepository.cs
@@ -39,7 +39,8 @@ namespace Stratis.Bitcoin.Features.BlockStore
         /// <summary>
         /// Get the blocks from the database by using block hashes.
         /// </summary>
-        /// <param name="hash">The block hash.</param>
+        /// <param name="hashes">The block hashes.</param>
+        /// <returns>The blocks (or null if not found) in the same order as the hashes on input.</returns>
         Task<List<Block>> GetBlocksAsync(List<uint256> hashes);
 
         /// <summary>
@@ -515,10 +516,7 @@ namespace Stratis.Bitcoin.Features.BlockStore
             return task;
         }
 
-        /// <summary>
-        /// Get multiple blocks from the database by their block hashes.
-        /// </summary>
-        /// <param name="hashes">The block hashes.</param>
+        /// <inheritdoc />
         public Task<List<Block>> GetBlocksAsync(List<uint256> hashes)
         {
             Guard.NotNull(hashes, nameof(hashes));
@@ -552,6 +550,7 @@ namespace Stratis.Bitcoin.Features.BlockStore
                         }
                         else
                         {
+                            results[key.Item1] = null;
                             this.PerformanceCounter.AddRepositoryMissCount(1);
 
                             this.logger.LogTrace("(-):{0}=[NO_BLOCK]", key.Item1);

--- a/src/Stratis.Bitcoin.Features.BlockStore/BlockRepository.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/BlockRepository.cs
@@ -39,7 +39,7 @@ namespace Stratis.Bitcoin.Features.BlockStore
         /// <summary>
         /// Get the blocks from the database by using block hashes.
         /// </summary>
-        /// <param name="hashes">The block hashes.</param>
+        /// <param name="hashes">A list of unique block hashes.</param>
         /// <returns>The blocks (or null if not found) in the same order as the hashes on input.</returns>
         Task<List<Block>> GetBlocksAsync(List<uint256> hashes);
 

--- a/src/Stratis.Bitcoin.Features.BlockStore/BlockRepository.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/BlockRepository.cs
@@ -678,7 +678,7 @@ namespace Stratis.Bitcoin.Features.BlockStore
                     transaction.ValuesLazyLoadingIsOn = false;
 
                     List<Block> blocks = this.GetBlocksFromHashes(transaction, hashes);
-                    this.OnDeleteBlocks(transaction, blocks);
+                    this.OnDeleteBlocks(transaction, blocks.Where(b => b != null).ToList());
                     this.SaveBlockHash(transaction, newBlockHash);
                     transaction.Commit();
                 }


### PR DESCRIPTION
This PR adds the GetBlocksAsync method to the BlockRepository and BlockRepositoryInMemory classes.

The method opens the possibility of further optimization by allowing multiple blocks to be returned in a single call and by leveraging sorted access within the underlying DBreeze database.

The new method has relevance to https://github.com/stratisproject/StratisBitcoinFullNode/issues/1103.
