### PR TITLE
add pid, blockStore height to NodeStatus

### DIFF
--- a/src/Stratis.Bitcoin.Features.BlockStore/BlockStoreFeature.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/BlockStoreFeature.cs
@@ -186,6 +186,7 @@ namespace Stratis.Bitcoin.Features.BlockStore
                         services.AddSingleton<IBlockStoreCache, BlockStoreCache>();
                         services.AddSingleton<StoreBlockPuller>();
                         services.AddSingleton<BlockStoreLoop>();
+                        services.AddSingleton<IStoreStateProvider>(x => x.GetService<BlockStoreLoop>());
                         services.AddSingleton<BlockStoreManager>();
                         services.AddSingleton<BlockStoreSignaled>();
                         services.AddSingleton<StoreSettings>(new StoreSettings(setup));

--- a/src/Stratis.Bitcoin.Features.BlockStore/BlockStoreLoop.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/BlockStoreLoop.cs
@@ -16,7 +16,7 @@ namespace Stratis.Bitcoin.Features.BlockStore
     /// <summary>
     /// The BlockStoreLoop simultaneously finds and downloads blocks and stores them in the BlockRepository.
     /// </summary>
-    public class BlockStoreLoop
+    public class BlockStoreLoop : IStoreStateProvider
     {
         /// <summary>Factory for creating background async loop tasks.</summary>
         private readonly IAsyncLoopFactory asyncLoopFactory;
@@ -85,7 +85,7 @@ namespace Stratis.Bitcoin.Features.BlockStore
         private readonly StoreSettings storeSettings;
 
         /// <summary>The highest stored block in the repository.</summary>
-        internal ChainedHeader StoreTip { get; private set; }
+        public ChainedHeader StoreTip { get; private set; }
 
         /// <summary>Public constructor for unit testing.</summary>
         public BlockStoreLoop(IAsyncLoopFactory asyncLoopFactory,

--- a/src/Stratis.Bitcoin/Controllers/Models/StatusModel.cs
+++ b/src/Stratis.Bitcoin/Controllers/Models/StatusModel.cs
@@ -27,6 +27,9 @@ namespace Stratis.Bitcoin.Controllers.Models
         /// <summary>The network the current node is running on.</summary>
         public string Network { get; set; }
 
+        /// <summary> The processId of the node.</summary>
+        public int PID { get; set; }
+
         /// <summary>The height of the consensus.</summary>
         public int ConsensusHeight { get; set; }
 

--- a/src/Stratis.Bitcoin/Controllers/Models/StatusModel.cs
+++ b/src/Stratis.Bitcoin/Controllers/Models/StatusModel.cs
@@ -33,6 +33,9 @@ namespace Stratis.Bitcoin.Controllers.Models
         /// <summary>The height of the consensus.</summary>
         public int ConsensusHeight { get; set; }
 
+        /// <summary> The height of the full blocks downloaded to BlockStore </summary>
+        public int BlockStoreHeight { get; set; }
+
         /// <summary>A collection of inbound peers.</summary>
         public List<ConnectedPeerModel> InboundPeers { get; set; }
 

--- a/src/Stratis.Bitcoin/Controllers/NodeController.cs
+++ b/src/Stratis.Bitcoin/Controllers/NodeController.cs
@@ -5,6 +5,7 @@ using Stratis.Bitcoin.Builder.Feature;
 using Stratis.Bitcoin.Configuration;
 using Stratis.Bitcoin.Connection;
 using Stratis.Bitcoin.Controllers.Models;
+using Stratis.Bitcoin.Interfaces;
 using Stratis.Bitcoin.P2P.Peer;
 using Stratis.Bitcoin.Utilities;
 using System.Diagnostics;
@@ -32,7 +33,9 @@ namespace Stratis.Bitcoin.Controllers
         /// <summary>The connection manager.</summary>
         private readonly IConnectionManager connectionManager;
 
-        public NodeController(IFullNode fullNode, ILoggerFactory loggerFactory, IDateTimeProvider dateTimeProvider, IChainState chainState, NodeSettings nodeSettings, IConnectionManager connectionManager)
+        private readonly IStoreStateProvider storeStateProvider;
+
+        public NodeController(IFullNode fullNode, ILoggerFactory loggerFactory, IDateTimeProvider dateTimeProvider, IChainState chainState, IStoreStateProvider storeStateProvider, NodeSettings nodeSettings, IConnectionManager connectionManager)
         {
             this.fullNode = fullNode;
             this.logger = loggerFactory.CreateLogger(this.GetType().FullName);
@@ -40,6 +43,7 @@ namespace Stratis.Bitcoin.Controllers
             this.chainState = chainState;
             this.nodeSettings = nodeSettings;
             this.connectionManager = connectionManager;
+            this.storeStateProvider = storeStateProvider;
         }
 
         /// <summary>
@@ -57,6 +61,7 @@ namespace Stratis.Bitcoin.Controllers
                 PID = Process.GetCurrentProcess().Id,
                 Network = this.fullNode.Network.Name,
                 ConsensusHeight = this.chainState.ConsensusTip.Height,
+                BlockStoreHeight = storeStateProvider.StoreTip.Height,
                 DataDirectoryPath = this.nodeSettings.DataDir,
                 RunningTime = this.dateTimeProvider.GetUtcNow() - this.fullNode.StartTime
             };

--- a/src/Stratis.Bitcoin/Controllers/NodeController.cs
+++ b/src/Stratis.Bitcoin/Controllers/NodeController.cs
@@ -7,6 +7,7 @@ using Stratis.Bitcoin.Connection;
 using Stratis.Bitcoin.Controllers.Models;
 using Stratis.Bitcoin.P2P.Peer;
 using Stratis.Bitcoin.Utilities;
+using System.Diagnostics;
 
 namespace Stratis.Bitcoin.Controllers
 {
@@ -53,6 +54,7 @@ namespace Stratis.Bitcoin.Controllers
             {
                 Version = this.fullNode.Version?.ToString() ?? "0",
                 Agent = this.nodeSettings.Agent,
+                PID = Process.GetCurrentProcess().Id,
                 Network = this.fullNode.Network.Name,
                 ConsensusHeight = this.chainState.ConsensusTip.Height,
                 DataDirectoryPath = this.nodeSettings.DataDir,

--- a/src/Stratis.Bitcoin/Interfaces/IStoreStateProvider.cs
+++ b/src/Stratis.Bitcoin/Interfaces/IStoreStateProvider.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using NBitcoin;
+
+namespace Stratis.Bitcoin.Interfaces
+{
+    public interface IStoreStateProvider
+    {
+        ChainedHeader StoreTip { get; }
+    }
+}


### PR DESCRIPTION
`GET:http://localhost:37221/api/Node/status` now responds:
```
{
  "agent": "StratisBitcoin",
  "version": "1.1.2.0",
  "network": "StratisMain",
  "pid": 8284,
  "consensusHeight": 195519,
  "blockStoreHeight": 195519,
  "inboundPeers": [],
  "outboundPeers": [
    {
      "version": "/Stratis:2.0.0.3/",
      "remoteSocketEndpoint": "[::ffff:113.167.183.194]:16178",
      "tipHeight": 538405
    }
  ],
  "enabledFeatures": [
    "Stratis.Bitcoin.Base.BaseFeature",
    "Stratis.Bitcoin.Features.Consensus.ConsensusFeature",
    "Stratis.Bitcoin.Features.BlockStore.BlockStoreFeature",
    "Stratis.Bitcoin.Features.MemoryPool.MempoolFeature",
    "Stratis.Bitcoin.Features.Wallet.WalletFeature",
    "Stratis.Bitcoin.Features.Miner.MiningFeature",
    "Stratis.Bitcoin.Features.Api.ApiFeature",
    "Stratis.Bitcoin.Features.RPC.RPCFeature"
  ],
  "dataDirectoryPath": "C:\\Users\\dcsle\\AppData\\Roaming\\StratisNode\\stratis\\StratisMain",
  "runningTime": "00:00:52.5545221"
}
```

Design decision to use provider courtesy of noescape0