### PR TITLE
Change WalletPassword type from string to SecureString

### DIFF
--- a/src/Stratis.Bitcoin.Features.Wallet/Stratis.Bitcoin.Features.Wallet.csproj
+++ b/src/Stratis.Bitcoin.Features.Wallet/Stratis.Bitcoin.Features.Wallet.csproj
@@ -29,6 +29,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Filter" Version="1.1.2" />
+    <PackageReference Include="System.Security.SecureString" Version="4.3.0" />
     <PackageReference Include="System.Xml.XmlSerializer" Version="4.3.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.0.0" />
   </ItemGroup>

--- a/src/Stratis.Bitcoin.Features.Wallet/WalletTransactionHandler.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/WalletTransactionHandler.cs
@@ -8,6 +8,7 @@ using NBitcoin;
 using NBitcoin.Policy;
 using Stratis.Bitcoin.Features.Wallet.Interfaces;
 using Stratis.Bitcoin.Utilities;
+using Stratis.Bitcoin.Utilities.Extensions;
 
 namespace Stratis.Bitcoin.Features.Wallet
 {
@@ -200,19 +201,6 @@ namespace Stratis.Bitcoin.Features.Wallet
         }
 
         /// <summary>
-        /// Retrieves the underlying string from a SecureString object.
-        /// </summary>
-        /// <param name="secstrPassword">The SecureString object.</param>
-        /// <returns>The underlying string contained in this object.</returns>
-        public string convertToUNSecureString(SecureString secstrPassword)
-        {
-            if (secstrPassword == null)
-                return null;
-
-            return new System.Net.NetworkCredential(string.Empty, secstrPassword).Password;
-        }
-
-        /// <summary>
         /// Load's all the private keys for each of the <see cref="HdAddress"/> in <see cref="TransactionBuildContext.UnspentOutputs"/>
         /// </summary>
         /// <param name="context">The context associated with the current transaction being built.</param>
@@ -224,7 +212,7 @@ namespace Stratis.Bitcoin.Features.Wallet
             Wallet wallet = this.walletManager.GetWalletByName(context.AccountReference.WalletName);
 
             // get extended private key
-            var privateKey = Key.Parse(wallet.EncryptedSeed, convertToUNSecureString(context.WalletPassword), wallet.Network);
+            var privateKey = Key.Parse(wallet.EncryptedSeed, context.WalletPassword?.FromSecureString(), wallet.Network);
             var seedExtKey = new ExtKey(privateKey, wallet.ChainCode);
 
             var signingKeys = new HashSet<ISecret>();
@@ -394,13 +382,7 @@ namespace Stratis.Bitcoin.Features.Wallet
 
             this.AccountReference = accountReference;
             this.Recipients = recipients;
-            this.WalletPassword = null;
-            if (walletPassword != null)
-            {
-                this.WalletPassword = new SecureString();
-                foreach (var ch in walletPassword.ToCharArray())
-                    this.WalletPassword.AppendChar(ch);
-            }
+            this.WalletPassword = walletPassword?.ToSecureString();
             this.FeeType = FeeType.Medium;
             this.MinConfirmations = 1;
             this.SelectedInputs = new List<OutPoint>();

--- a/src/Stratis.Bitcoin/Utilities/Extensions/StringExtensions.cs
+++ b/src/Stratis.Bitcoin/Utilities/Extensions/StringExtensions.cs
@@ -12,10 +12,9 @@ namespace Stratis.Bitcoin.Utilities.Extensions
         public static SecureString ToSecureString(this string input)
         {
             var output = new SecureString();
+
             foreach (char c in input.ToCharArray())
-            {
                 output.AppendChar(c);
-            }
 
             return output;
         }
@@ -27,9 +26,6 @@ namespace Stratis.Bitcoin.Utilities.Extensions
         /// <returns>The underlying string contained in this object.</returns>
         public static string FromSecureString(this SecureString secstrPassword)
         {
-            if (secstrPassword == null)
-                return null;
-
             return new System.Net.NetworkCredential(string.Empty, secstrPassword).Password;
         }
     }

--- a/src/Stratis.Bitcoin/Utilities/Extensions/StringExtensions.cs
+++ b/src/Stratis.Bitcoin/Utilities/Extensions/StringExtensions.cs
@@ -1,0 +1,36 @@
+﻿using System.Security;
+
+namespace Stratis.Bitcoin.Utilities.Extensions
+{
+    public static class StringExtensions
+    {
+        /// <summary>
+        /// Converts a string to a SecureString object.
+        /// </summary>
+        /// <param name="input">The string to convert.</param>
+        /// <returns>The SecureString result.</returns>
+        public static SecureString ToSecureString(this string input)
+        {
+            var output = new SecureString();
+            foreach (char c in input.ToCharArray())
+            {
+                output.AppendChar(c);
+            }
+
+            return output;
+        }
+
+        /// <summary>
+        /// Retrieves the underlying string from a SecureString object.
+        /// </summary>
+        /// <param name="secstrPassword">The SecureString object.</param>
+        /// <returns>The underlying string contained in this object.</returns>
+        public static string FromSecureString(this SecureString secstrPassword)
+        {
+            if (secstrPassword == null)
+                return null;
+
+            return new System.Net.NetworkCredential(string.Empty, secstrPassword).Password;
+        }
+    }
+}


### PR DESCRIPTION
This PR changes the type of the WalletPassword member variable found on the TransactionBuildContext class from string to SecureString.