### PR TITLE
Added AddPayload method to PayloadProvider

### DIFF
--- a/src/Stratis.Bitcoin/P2P/Protocol/Payloads/PayloadAttribute.cs
+++ b/src/Stratis.Bitcoin/P2P/Protocol/Payloads/PayloadAttribute.cs
@@ -91,6 +91,23 @@ namespace Stratis.Bitcoin.P2P.Protocol.Payloads
         }
 
         /// <summary>
+        /// Add a payload to the Provider by specifying its type.
+        /// </summary>
+        /// <param name="type">The type to payload to add.  Must derive from <see cref="Payload"/>.</param>
+        public void AddPayload(Type payloadType)
+        {
+            Guard.NotNull(payloadType, nameof(payloadType));
+            Guard.Assert(payloadType.IsSubclassOf(typeof(Payload)));
+
+            var payloadAttribute = payloadType.GetCustomAttributes(typeof(PayloadAttribute), true)
+                .OfType<PayloadAttribute>().First();
+            Guard.Assert(payloadAttribute != null);
+
+            this.nameToType.Add(payloadAttribute.Name, payloadType);
+            this.typeToName.Add(payloadType, payloadAttribute.Name);
+        }
+        
+        /// <summary>
         /// Get the <see cref="Payload"/> type associated with the command name.
         /// </summary>
         /// <param name="commandName">The command name.</param>

--- a/src/Stratis.Bitcoin/P2P/Protocol/Payloads/PayloadAttribute.cs
+++ b/src/Stratis.Bitcoin/P2P/Protocol/Payloads/PayloadAttribute.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using Stratis.Bitcoin.Utilities;
 
 namespace Stratis.Bitcoin.P2P.Protocol.Payloads
 {


### PR DESCRIPTION
Example usage from the FederatedGateway:

```
// add our payload
var payloadProvider = this.fullNode.Services.ServiceProvider.GetService(typeof(PayloadProvider)) as PayloadProvider;
payloadProvider.AddPayload(typeof(RequestPartialTransactionPayload));
```