### PR TITLE
Move "ConvertIpAddressToEndpoint" to IPExtensions.cs

### DIFF
--- a/src/Stratis.Bitcoin.Features.RPC/RpcSettings.cs
+++ b/src/Stratis.Bitcoin.Features.RPC/RpcSettings.cs
@@ -6,6 +6,7 @@ using System.Text;
 using Microsoft.Extensions.Logging;
 using NBitcoin;
 using Stratis.Bitcoin.Configuration;
+using Stratis.Bitcoin.Utilities.Extensions;
 
 namespace Stratis.Bitcoin.Features.RPC
 {
@@ -87,7 +88,7 @@ namespace Stratis.Bitcoin.Features.RPC
                 {
                     this.DefaultBindings = config
                         .GetAll("rpcbind")
-                        .Select(p => NodeSettings.ConvertIpAddressToEndpoint(p, this.RPCPort))
+                        .Select(p => p.ToIPEndPoint(this.RPCPort))
                         .ToList();
                 }
                 catch (FormatException)

--- a/src/Stratis.Bitcoin.Tests/NodeConfiguration/NodeSettingsTest.cs
+++ b/src/Stratis.Bitcoin.Tests/NodeConfiguration/NodeSettingsTest.cs
@@ -1,5 +1,6 @@
 ﻿using System.Net;
 using Stratis.Bitcoin.Configuration;
+using Stratis.Bitcoin.Utilities.Extensions;
 using Xunit;
 
 namespace Stratis.Bitcoin.Tests.NodeConfiguration
@@ -10,7 +11,7 @@ namespace Stratis.Bitcoin.Tests.NodeConfiguration
         public void CheckConvertingIPv4AddressToEndpoint()
         {
             // Act
-            IPEndPoint endpoint = NodeSettings.ConvertIpAddressToEndpoint("15.61.23.23", 1234);
+            IPEndPoint endpoint = "15.61.23.23".ToIPEndPoint(1234);
 
             // Assert
             Assert.Equal(1234, endpoint.Port);
@@ -21,7 +22,7 @@ namespace Stratis.Bitcoin.Tests.NodeConfiguration
         public void CheckConvertingIPv4AddressWithPortToEndpoint()
         {
             // Act
-            IPEndPoint endpoint = NodeSettings.ConvertIpAddressToEndpoint("15.61.23.23:1500", 1234);
+            IPEndPoint endpoint = "15.61.23.23:1500".ToIPEndPoint(1234);
 
             // Assert
             Assert.Equal(1500, endpoint.Port);
@@ -32,7 +33,7 @@ namespace Stratis.Bitcoin.Tests.NodeConfiguration
         public void CheckConvertingIPv6AddressToEndpoint()
         {
             // Act
-            IPEndPoint endpoint = NodeSettings.ConvertIpAddressToEndpoint("[1233:3432:2434:2343:3234:2345:6546:4534]", 1234);
+            IPEndPoint endpoint = "[1233:3432:2434:2343:3234:2345:6546:4534]".ToIPEndPoint(1234);
 
             // Assert
             Assert.Equal(1234, endpoint.Port);
@@ -43,7 +44,7 @@ namespace Stratis.Bitcoin.Tests.NodeConfiguration
         public void CheckConvertingIPv6AddressWithPortToEndpoint()
         {
             // Act
-            IPEndPoint endpoint = NodeSettings.ConvertIpAddressToEndpoint("[1233:3432:2434:2343:3234:2345:6546:4534]:5443", 1234);
+            IPEndPoint endpoint = "[1233:3432:2434:2343:3234:2345:6546:4534]:5443".ToIPEndPoint(1234);
 
             // Assert
             Assert.Equal(5443, endpoint.Port);

--- a/src/Stratis.Bitcoin.Tests/NodeConfiguration/NodeSettingsTest.cs
+++ b/src/Stratis.Bitcoin.Tests/NodeConfiguration/NodeSettingsTest.cs
@@ -30,6 +30,17 @@ namespace Stratis.Bitcoin.Tests.NodeConfiguration
         }
 
         [Fact]
+        public void CheckConvertingIPAddressWithInvalidParsedPortNumberToEndpoint()
+        {
+            // Assert
+            Assert.Throws<FormatException>(() =>
+            {
+                // Act
+                IPEndPoint endpoint = "0.0.0.0:454z".ToIPEndPoint(1234);
+            });
+        }
+
+        [Fact]
         public void CheckConvertingIPv4AddressToEndpoint()
         {
             // Act

--- a/src/Stratis.Bitcoin.Tests/NodeConfiguration/NodeSettingsTest.cs
+++ b/src/Stratis.Bitcoin.Tests/NodeConfiguration/NodeSettingsTest.cs
@@ -1,5 +1,5 @@
-﻿using System.Net;
-using Stratis.Bitcoin.Configuration;
+﻿using System;
+using System.Net;
 using Stratis.Bitcoin.Utilities.Extensions;
 using Xunit;
 
@@ -7,6 +7,28 @@ namespace Stratis.Bitcoin.Tests.NodeConfiguration
 {
     public class NodeSettingsTest
     {
+        [Fact]
+        public void CheckConvertingEmptyIPAddressToEndpoint()
+        {
+            // Assert
+            Assert.Throws<FormatException>(() =>
+            {
+                // Act
+                IPEndPoint endpoint = "".ToIPEndPoint(1234);
+            });
+        }
+
+        [Fact]
+        public void CheckConvertingIPAddressWithInvalidPortNumberToEndpoint()
+        {
+            // Assert
+            Assert.Throws<ArgumentException>(() =>
+            {
+                // Act
+                IPEndPoint endpoint = "0.0.0.0".ToIPEndPoint(IPEndPoint.MaxPort + 1);
+            });
+        }
+
         [Fact]
         public void CheckConvertingIPv4AddressToEndpoint()
         {

--- a/src/Stratis.Bitcoin.Tests/NodeConfiguration/NodeSettingsTest.cs
+++ b/src/Stratis.Bitcoin.Tests/NodeConfiguration/NodeSettingsTest.cs
@@ -83,5 +83,27 @@ namespace Stratis.Bitcoin.Tests.NodeConfiguration
             Assert.Equal(5443, endpoint.Port);
             Assert.Equal("1233:3432:2434:2343:3234:2345:6546:4534", endpoint.Address.ToString());
         }
+
+        [Fact]
+        public void CheckConvertingIPEndPointStringToEndpoint()
+        {
+            // Act
+            IPEndPoint endpoint = "::ffff:192.168.4.1".ToIPEndPoint(1234);
+
+            // Assert
+            Assert.Equal(1234, endpoint.Port);
+            Assert.Equal("::ffff:192.168.4.1", endpoint.Address.ToString());
+        }
+
+        [Fact]
+        public void CheckConvertingIPEndPointStringWithPortToEndpoint()
+        {
+            // Act
+            IPEndPoint endpoint = "::ffff:192.168.4.1:80".ToIPEndPoint(1234);
+
+            // Assert
+            Assert.Equal(80, endpoint.Port);
+            Assert.Equal("::ffff:192.168.4.1", endpoint.Address.ToString());
+        }
     }
 }

--- a/src/Stratis.Bitcoin.Tests/NodeConfiguration/NodeSettingsTest.cs
+++ b/src/Stratis.Bitcoin.Tests/NodeConfiguration/NodeSettingsTest.cs
@@ -22,7 +22,7 @@ namespace Stratis.Bitcoin.Tests.NodeConfiguration
         public void CheckConvertingIPAddressWithInvalidPortNumberToEndpoint()
         {
             // Assert
-            Assert.Throws<ArgumentException>(() =>
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
             {
                 // Act
                 IPEndPoint endpoint = "0.0.0.0".ToIPEndPoint(IPEndPoint.MaxPort + 1);

--- a/src/Stratis.Bitcoin/Configuration/NodeSettings.cs
+++ b/src/Stratis.Bitcoin/Configuration/NodeSettings.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Net;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Text;
@@ -267,45 +266,7 @@ namespace Stratis.Bitcoin.Configuration
         }
 
         /// <summary>
-        /// Converts a string to an IP endpoint.
-        /// </summary>
-        /// <param name="ipAddress">String to convert.</param>
-        /// <param name="port">Port to use if <paramref name="ipAddress"/> does not specify it.</param>
-        /// <returns>IP end point representation of the string.</returns>
-        /// <remarks>
-        /// IP addresses can have a port specified such that the format of <paramref name="ipAddress"/> is as such: address:port.
-        /// IPv4 and IPv6 addresses are supported.
-        /// In the case where the default port is passed and the IP address has a port specified in it, the IP address's port will take precedence.
-        /// Examples of addresses that are supported are: 15.61.23.23, 15.61.23.23:1500, [1233:3432:2434:2343:3234:2345:6546:4534], [1233:3432:2434:2343:3234:2345:6546:4534]:8333.</remarks>
-        public static IPEndPoint ConvertIpAddressToEndpoint(string ipAddress, int port)
-        {
-            // Checks the validity of the parameters passed.
-            Guard.NotEmpty(ipAddress, nameof(ipAddress));
-            if (port < IPEndPoint.MinPort || port > IPEndPoint.MaxPort)
-            {
-                throw new ConfigurationException($"Port {port} was outside of the values that can assigned for a port [{IPEndPoint.MinPort}-{IPEndPoint.MaxPort}].");
-            }
-
-            int colon = ipAddress.LastIndexOf(':');
-
-            // if a : is found, and it either follows a [...], or no other : is in the string, treat it as port separator
-            bool fHaveColon = colon != -1;
-            bool fBracketed = fHaveColon && (ipAddress[0] == '[' && ipAddress[colon - 1] == ']'); // if there is a colon, and in[0]=='[', colon is not 0, so in[colon-1] is safe
-            bool fMultiColon = fHaveColon && (ipAddress.LastIndexOf(':', colon - 1) != -1);
-            if (fHaveColon && (colon == 0 || fBracketed || !fMultiColon))
-            {
-                if (int.TryParse(ipAddress.Substring(colon + 1), out var n) && n > IPEndPoint.MinPort && n < IPEndPoint.MaxPort)
-                {
-                    ipAddress = ipAddress.Substring(0, colon);
-                    port = n;
-                }
-            }
-
-            return new IPEndPoint(IPAddress.Parse(ipAddress), port);
-        }
-
-        /// <summary>
-        /// Creates a default configuration file if no configuration file is found.
+        /// Gets the default configuration.
         /// </summary>
         /// <param name="features">The features to include in the configuration file if a default file has to be created.</param>
         /// <returns>Path to the configuration file.</returns>

--- a/src/Stratis.Bitcoin/Configuration/Settings/ConnectionManagerSettings.cs
+++ b/src/Stratis.Bitcoin/Configuration/Settings/ConnectionManagerSettings.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
+using Stratis.Bitcoin.Utilities.Extensions;
 
 namespace Stratis.Bitcoin.Configuration.Settings
 {
@@ -35,7 +36,7 @@ namespace Stratis.Bitcoin.Configuration.Settings
             try
             {
                 this.Connect.AddRange(config.GetAll("connect")
-                    .Select(c => NodeSettings.ConvertIpAddressToEndpoint(c, nodeSettings.Network.DefaultPort)));
+                    .Select(c => c.ToIPEndPoint(nodeSettings.Network.DefaultPort)));
             }
             catch (FormatException)
             {
@@ -45,7 +46,7 @@ namespace Stratis.Bitcoin.Configuration.Settings
             try
             {
                 this.AddNode.AddRange(config.GetAll("addnode")
-                        .Select(c => NodeSettings.ConvertIpAddressToEndpoint(c, nodeSettings.Network.DefaultPort)));
+                        .Select(c => c.ToIPEndPoint(nodeSettings.Network.DefaultPort)));
             }
             catch (FormatException)
             {
@@ -56,7 +57,7 @@ namespace Stratis.Bitcoin.Configuration.Settings
             try
             {
                 this.Listen.AddRange(config.GetAll("bind")
-                        .Select(c => new NodeServerEndpoint(NodeSettings.ConvertIpAddressToEndpoint(c, port), false)));
+                        .Select(c => new NodeServerEndpoint(c.ToIPEndPoint(port), false)));
             }
             catch (FormatException)
             {
@@ -66,7 +67,7 @@ namespace Stratis.Bitcoin.Configuration.Settings
             try
             {
                 this.Listen.AddRange(config.GetAll("whitebind")
-                        .Select(c => new NodeServerEndpoint(NodeSettings.ConvertIpAddressToEndpoint(c, port), true)));
+                        .Select(c => new NodeServerEndpoint(c.ToIPEndPoint(port), true)));
             }
             catch (FormatException)
             {
@@ -83,7 +84,7 @@ namespace Stratis.Bitcoin.Configuration.Settings
             {
                 try
                 {
-                    this.ExternalEndpoint = NodeSettings.ConvertIpAddressToEndpoint(externalIp, port);
+                    this.ExternalEndpoint = externalIp.ToIPEndPoint(port);
                 }
                 catch (FormatException)
                 {

--- a/src/Stratis.Bitcoin/Connection/ConnectionManagerController.cs
+++ b/src/Stratis.Bitcoin/Connection/ConnectionManagerController.cs
@@ -7,6 +7,7 @@ using Stratis.Bitcoin.Configuration;
 using Stratis.Bitcoin.Controllers;
 using Stratis.Bitcoin.P2P.Peer;
 using Stratis.Bitcoin.Utilities;
+using Stratis.Bitcoin.Utilities.Extensions;
 
 namespace Stratis.Bitcoin.Connection
 {
@@ -22,7 +23,7 @@ namespace Stratis.Bitcoin.Connection
         public bool AddNode(string endpointStr, string command)
         {
             Guard.NotNull(this.ConnectionManager, nameof(this.ConnectionManager));
-            IPEndPoint endpoint = NodeSettings.ConvertIpAddressToEndpoint(endpointStr, this.ConnectionManager.Network.DefaultPort);
+            IPEndPoint endpoint = endpointStr.ToIPEndPoint(this.ConnectionManager.Network.DefaultPort);
             switch (command)
             {
                 case "add":

--- a/src/Stratis.Bitcoin/Utilities/Extensions/IPExtensions.cs
+++ b/src/Stratis.Bitcoin/Utilities/Extensions/IPExtensions.cs
@@ -1,4 +1,5 @@
-﻿using System.Net;
+﻿using System;
+using System.Net;
 
 namespace Stratis.Bitcoin.Utilities.Extensions
 {
@@ -19,6 +20,45 @@ namespace Stratis.Bitcoin.Utilities.Extensions
         public static bool Match(this IPEndPoint endPoint, IPEndPoint matchWith)
         {
             return endPoint.Address.ToString() == matchWith.MapToIpv6().Address.ToString() && endPoint.Port == matchWith.MapToIpv6().Port;
+        }
+
+        /// <summary>
+        /// Converts a string to an IP endpoint.
+        /// </summary>
+        /// <param name="ipAddress">String to convert.</param>
+        /// <param name="port">Port to use if <paramref name="ipAddress"/> does not specify it.</param>
+        /// <returns>IP end point representation of the string.</returns>
+        /// <remarks>
+        /// IP addresses can have a port specified such that the format of <paramref name="ipAddress"/> is as such: address:port.
+        /// IPv4 and IPv6 addresses are supported.
+        /// In the case where the default port is passed and the IP address has a port specified in it, the IP address's port will take precedence.
+        /// Examples of addresses that are supported are: 15.61.23.23, 15.61.23.23:1500, [1233:3432:2434:2343:3234:2345:6546:4534], [1233:3432:2434:2343:3234:2345:6546:4534]:8333.</remarks>
+        /// <exception cref="ArgumentException">Thrown in case of the port number is out of range.</exception>    
+        public static IPEndPoint ToIPEndPoint(this string ipAddress, int port)
+        {
+            // Checks the validity of the parameters passed.
+            Guard.NotEmpty(ipAddress, nameof(ipAddress));
+            if (port < IPEndPoint.MinPort || port > IPEndPoint.MaxPort)
+            {
+                throw new ArgumentException($"Port {port} was outside of the values that can assigned for a port [{IPEndPoint.MinPort}-{IPEndPoint.MaxPort}].");
+            }
+
+            int colon = ipAddress.LastIndexOf(':');
+
+            // if a : is found, and it either follows a [...], or no other : is in the string, treat it as port separator
+            bool fHaveColon = colon != -1;
+            bool fBracketed = fHaveColon && (ipAddress[0] == '[' && ipAddress[colon - 1] == ']'); // if there is a colon, and in[0]=='[', colon is not 0, so in[colon-1] is safe
+            bool fMultiColon = fHaveColon && (ipAddress.LastIndexOf(':', colon - 1) != -1);
+            if (fHaveColon && (colon == 0 || fBracketed || !fMultiColon))
+            {
+                if (int.TryParse(ipAddress.Substring(colon + 1), out var n) && n > IPEndPoint.MinPort && n < IPEndPoint.MaxPort)
+                {
+                    ipAddress = ipAddress.Substring(0, colon);
+                    port = n;
+                }
+            }
+
+            return new IPEndPoint(IPAddress.Parse(ipAddress), port);
         }
     }
 }

--- a/src/Stratis.Bitcoin/Utilities/Extensions/IPExtensions.cs
+++ b/src/Stratis.Bitcoin/Utilities/Extensions/IPExtensions.cs
@@ -34,6 +34,7 @@ namespace Stratis.Bitcoin.Utilities.Extensions
         /// In the case where the default port is passed and the IP address has a port specified in it, the IP address's port will take precedence.
         /// Examples of addresses that are supported are: 15.61.23.23, 15.61.23.23:1500, [1233:3432:2434:2343:3234:2345:6546:4534], [1233:3432:2434:2343:3234:2345:6546:4534]:8333.</remarks>
         /// <exception cref="ArgumentException">Thrown in case of the port number is out of range.</exception>    
+        /// <exception cref="FormatException">Thrown in case of the ip address is invalid.</exception>    
         public static IPEndPoint ToIPEndPoint(this string ipAddress, int port)
         {
             // Checks the validity of the parameters passed.

--- a/src/Stratis.Bitcoin/Utilities/Extensions/IPExtensions.cs
+++ b/src/Stratis.Bitcoin/Utilities/Extensions/IPExtensions.cs
@@ -40,7 +40,7 @@ namespace Stratis.Bitcoin.Utilities.Extensions
             int colon = ipAddress.LastIndexOf(':');
             if (colon >= 0)
             {
-                if (colon > ipAddress.IndexOf(']'))
+                if (colon > ipAddress.IndexOf(']') && !(colon < ipAddress.IndexOf('.')))
                 {
                     port = int.Parse(ipAddress.Substring(colon + 1));
                     ipAddress = ipAddress.Substring(0, colon);

--- a/src/Stratis.Bitcoin/Utilities/Extensions/IPExtensions.cs
+++ b/src/Stratis.Bitcoin/Utilities/Extensions/IPExtensions.cs
@@ -44,14 +44,14 @@ namespace Stratis.Bitcoin.Utilities.Extensions
         /// <exception cref="FormatException">Thrown in case of ipAddress is invalid.</exception>    
         public static IPEndPoint ToIPEndPoint(this string ipAddress, int port)
         {
+            // Get the position of the last ':'.
             int colon = ipAddress.LastIndexOf(':');
-            if (colon >= 0)
+
+            // If the last ':' is not followed by ']' or '.' then is must be an ip address / port number separator.
+            if (colon >= 0 && ipAddress.IndexOf(']', colon) < 0 && ipAddress.IndexOf('.', colon) < 0)
             {
-                if (colon > ipAddress.IndexOf(']') && colon > ipAddress.LastIndexOf('.'))
-                {
-                    port = int.Parse(ipAddress.Substring(colon + 1));
-                    ipAddress = ipAddress.Substring(0, colon);
-                }
+                port = int.Parse(ipAddress.Substring(colon + 1));
+                ipAddress = ipAddress.Substring(0, colon);
             }
 
             return new IPEndPoint(IPAddress.Parse(ipAddress), port);

--- a/src/Stratis.Bitcoin/Utilities/Extensions/IPExtensions.cs
+++ b/src/Stratis.Bitcoin/Utilities/Extensions/IPExtensions.cs
@@ -37,21 +37,15 @@ namespace Stratis.Bitcoin.Utilities.Extensions
         public static IPEndPoint ToIPEndPoint(this string ipAddress, int port)
         {
             // Checks the validity of the parameters passed.
-            Guard.NotEmpty(ipAddress, nameof(ipAddress));
             if (port < IPEndPoint.MinPort || port > IPEndPoint.MaxPort)
-            {
                 throw new ArgumentException($"Port {port} was outside of the values that can assigned for a port [{IPEndPoint.MinPort}-{IPEndPoint.MaxPort}].");
-            }
 
             int colon = ipAddress.LastIndexOf(':');
-
-            // if a : is found, and it either follows a [...], or no other : is in the string, treat it as port separator
-            bool fHaveColon = colon != -1;
-            bool fBracketed = fHaveColon && (ipAddress[0] == '[' && ipAddress[colon - 1] == ']'); // if there is a colon, and in[0]=='[', colon is not 0, so in[colon-1] is safe
-            bool fMultiColon = fHaveColon && (ipAddress.LastIndexOf(':', colon - 1) != -1);
-            if (fHaveColon && (colon == 0 || fBracketed || !fMultiColon))
+            if (colon >= 0)
             {
-                if (int.TryParse(ipAddress.Substring(colon + 1), out var n) && n > IPEndPoint.MinPort && n < IPEndPoint.MaxPort)
+                int bracket = ipAddress.IndexOf(']');
+
+                if (colon > bracket && int.TryParse(ipAddress.Substring(colon + 1), out var n))
                 {
                     ipAddress = ipAddress.Substring(0, colon);
                     port = n;

--- a/src/Stratis.Bitcoin/Utilities/Extensions/IPExtensions.cs
+++ b/src/Stratis.Bitcoin/Utilities/Extensions/IPExtensions.cs
@@ -33,7 +33,7 @@ namespace Stratis.Bitcoin.Utilities.Extensions
         /// IPv4 and IPv6 addresses are supported.
         /// In the case where the default port is passed and the IP address has a port specified in it, the IP address's port will take precedence.
         /// Examples of addresses that are supported are: 15.61.23.23, 15.61.23.23:1500, [1233:3432:2434:2343:3234:2345:6546:4534], [1233:3432:2434:2343:3234:2345:6546:4534]:8333.</remarks>
-        /// <exception cref="ArgumentException">Thrown in case of the port number is out of range.</exception>    
+        /// <exception cref="ArgumentOutOfRangeException">Thrown in case of the port number is out of range.</exception>    
         /// <exception cref="FormatException">Thrown in case of ipAddress is invalid.</exception>    
         public static IPEndPoint ToIPEndPoint(this string ipAddress, int port)
         {
@@ -46,10 +46,6 @@ namespace Stratis.Bitcoin.Utilities.Extensions
                     ipAddress = ipAddress.Substring(0, colon);
                 }
             }
-
-            // Checks the validity of the parameters passed or parsed.
-            if (port < IPEndPoint.MinPort || port > IPEndPoint.MaxPort)
-                throw new ArgumentException($"Port {port} was outside of the values that can assigned for a port [{IPEndPoint.MinPort}-{IPEndPoint.MaxPort}].");
 
             return new IPEndPoint(IPAddress.Parse(ipAddress), port);
         }

--- a/src/Stratis.Bitcoin/Utilities/Extensions/IPExtensions.cs
+++ b/src/Stratis.Bitcoin/Utilities/Extensions/IPExtensions.cs
@@ -39,15 +39,8 @@ namespace Stratis.Bitcoin.Utilities.Extensions
         {
             int colon = ipAddress.LastIndexOf(':');
             if (colon >= 0)
-            {
-                int bracket = ipAddress.IndexOf(']');
-
-                if (colon > bracket && int.TryParse(ipAddress.Substring(colon + 1), out var n))
-                {
+                if (colon > ipAddress.IndexOf(']') && int.TryParse(ipAddress.Substring(colon + 1), out port))
                     ipAddress = ipAddress.Substring(0, colon);
-                    port = n;
-                }
-            }
 
             // Checks the validity of the parameters passed or parsed.
             if (port < IPEndPoint.MinPort || port > IPEndPoint.MaxPort)

--- a/src/Stratis.Bitcoin/Utilities/Extensions/IPExtensions.cs
+++ b/src/Stratis.Bitcoin/Utilities/Extensions/IPExtensions.cs
@@ -37,10 +37,6 @@ namespace Stratis.Bitcoin.Utilities.Extensions
         /// <exception cref="FormatException">Thrown in case of the ip address is invalid.</exception>    
         public static IPEndPoint ToIPEndPoint(this string ipAddress, int port)
         {
-            // Checks the validity of the parameters passed.
-            if (port < IPEndPoint.MinPort || port > IPEndPoint.MaxPort)
-                throw new ArgumentException($"Port {port} was outside of the values that can assigned for a port [{IPEndPoint.MinPort}-{IPEndPoint.MaxPort}].");
-
             int colon = ipAddress.LastIndexOf(':');
             if (colon >= 0)
             {
@@ -52,6 +48,10 @@ namespace Stratis.Bitcoin.Utilities.Extensions
                     port = n;
                 }
             }
+
+            // Checks the validity of the parameters passed or parsed.
+            if (port < IPEndPoint.MinPort || port > IPEndPoint.MaxPort)
+                throw new ArgumentException($"Port {port} was outside of the values that can assigned for a port [{IPEndPoint.MinPort}-{IPEndPoint.MaxPort}].");
 
             return new IPEndPoint(IPAddress.Parse(ipAddress), port);
         }

--- a/src/Stratis.Bitcoin/Utilities/Extensions/IPExtensions.cs
+++ b/src/Stratis.Bitcoin/Utilities/Extensions/IPExtensions.cs
@@ -32,7 +32,14 @@ namespace Stratis.Bitcoin.Utilities.Extensions
         /// IP addresses can have a port specified such that the format of <paramref name="ipAddress"/> is as such: address:port.
         /// IPv4 and IPv6 addresses are supported.
         /// In the case where the default port is passed and the IP address has a port specified in it, the IP address's port will take precedence.
-        /// Examples of addresses that are supported are: 15.61.23.23, 15.61.23.23:1500, [1233:3432:2434:2343:3234:2345:6546:4534], [1233:3432:2434:2343:3234:2345:6546:4534]:8333.</remarks>
+        /// Examples of addresses that are supported are: 
+        /// - 15.61.23.23
+        /// - 15.61.23.23:1500
+        /// - [1233:3432:2434:2343:3234:2345:6546:4534]
+        /// - [1233:3432:2434:2343:3234:2345:6546:4534]:8333
+        /// - ::ffff:192.168.4.1
+        /// - ::ffff:192.168.4.1:80
+        /// </remarks>
         /// <exception cref="ArgumentOutOfRangeException">Thrown in case of the port number is out of range.</exception>    
         /// <exception cref="FormatException">Thrown in case of ipAddress is invalid.</exception>    
         public static IPEndPoint ToIPEndPoint(this string ipAddress, int port)
@@ -40,7 +47,7 @@ namespace Stratis.Bitcoin.Utilities.Extensions
             int colon = ipAddress.LastIndexOf(':');
             if (colon >= 0)
             {
-                if (colon > ipAddress.IndexOf(']') && !(colon < ipAddress.IndexOf('.')))
+                if (colon > ipAddress.IndexOf(']') && colon > ipAddress.LastIndexOf('.'))
                 {
                     port = int.Parse(ipAddress.Substring(colon + 1));
                     ipAddress = ipAddress.Substring(0, colon);

--- a/src/Stratis.Bitcoin/Utilities/Extensions/IPExtensions.cs
+++ b/src/Stratis.Bitcoin/Utilities/Extensions/IPExtensions.cs
@@ -34,13 +34,18 @@ namespace Stratis.Bitcoin.Utilities.Extensions
         /// In the case where the default port is passed and the IP address has a port specified in it, the IP address's port will take precedence.
         /// Examples of addresses that are supported are: 15.61.23.23, 15.61.23.23:1500, [1233:3432:2434:2343:3234:2345:6546:4534], [1233:3432:2434:2343:3234:2345:6546:4534]:8333.</remarks>
         /// <exception cref="ArgumentException">Thrown in case of the port number is out of range.</exception>    
-        /// <exception cref="FormatException">Thrown in case of the ip address is invalid.</exception>    
+        /// <exception cref="FormatException">Thrown in case of ipAddress is invalid.</exception>    
         public static IPEndPoint ToIPEndPoint(this string ipAddress, int port)
         {
             int colon = ipAddress.LastIndexOf(':');
             if (colon >= 0)
-                if (colon > ipAddress.IndexOf(']') && int.TryParse(ipAddress.Substring(colon + 1), out port))
+            {
+                if (colon > ipAddress.IndexOf(']'))
+                {
+                    port = int.Parse(ipAddress.Substring(colon + 1));
                     ipAddress = ipAddress.Substring(0, colon);
+                }
+            }
 
             // Checks the validity of the parameters passed or parsed.
             if (port < IPEndPoint.MinPort || port > IPEndPoint.MaxPort)


### PR DESCRIPTION
This PR:
- Moves the `ConvertIpAddressToEndpoint` method from `NodeSettings.cs` to `IPExtensions.cs` and renames the string extension method to `ToIPEndPoint`.