### PR TITLE
[RF][SmartContracts] Create CoinviewRule base class

### DIFF
--- a/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/CoinviewRule.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/CoinviewRule.cs
@@ -1,0 +1,408 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using NBitcoin;
+using Stratis.Bitcoin.Base.Deployments;
+using Stratis.Bitcoin.Utilities;
+
+namespace Stratis.Bitcoin.Features.Consensus.Rules.CommonRules
+{
+    public abstract class CoinviewRule : ConsensusRule
+    {
+        /// <summary>Consensus options.</summary>
+        public PowConsensusOptions PowConsensusOptions { get; private set; }
+
+        public override void Initialize()
+        {
+            this.Logger.LogTrace("()");
+
+            this.PowConsensusOptions = this.Parent.ConsensusParams.Option<PowConsensusOptions>();
+
+            this.OnInitialize();
+
+            this.Logger.LogTrace("(-)");
+        }
+
+        /// <summary>
+        /// Network specific block verification to ensure that is has a correct coinbase transaction with appropriate reward and fees.
+        /// </summary>
+        /// <param name="context">Context that contains variety of information regarding blocks validation and execution.</param>
+        /// <param name="fees">Total amount of fees from transactions that are included in that block.</param>
+        /// <param name="height">Block's height.</param>
+        /// <param name="block">Block for which reward amount is checked.</param>
+        /// <exception cref="ConsensusErrors.BadCoinbaseAmount">Thrown if coinbase transaction output value is larger than expected.</exception>
+        public abstract void CheckBlockReward(RuleContext context, Money fees, int height, Block block);
+
+        /// <summary>
+        /// Network specific proof of work reward amount for the block at provided height.
+        /// </summary>
+        /// <param name="height">Height of the block that we're calculating the reward for.</param>
+        /// <returns>Reward amount.</returns>
+        public abstract Money GetProofOfWorkReward(int height);
+
+        /// <summary>
+        /// Checks the maturity of UTXOs.
+        /// </summary>
+        /// <param name="coins">UTXOs to check the maturity of.</param>
+        /// <param name="spendHeight">Height at which coins are attempted to be spent.</param>
+        /// <exception cref="ConsensusErrors.BadTransactionPrematureCoinbaseSpending">Thrown if transaction tries to spend coins that are not mature.</exception>
+        public abstract void OnCheckMaturity(UnspentOutputs coins, int spendHeight);
+
+        /// <summary>
+        /// Network specific initialization logic.
+        /// </summary>
+        public abstract void OnInitialize();
+
+        /// <summary>
+        /// Network specific updates to the context's UTXO set.
+        /// </summary>
+        /// <param name="context">Context that contains variety of information regarding blocks validation and execution.</param>
+        /// <param name="transaction">Transaction which outputs will be added to the context's <see cref="UnspentOutputSet"/> and which inputs will be removed from it.</param>
+        public abstract void OnUpdateCoinView(RuleContext context, Transaction transaction);
+
+        /// <inheritdoc />
+        protected async Task OnRunAsync(RuleContext context)
+        {
+            this.Logger.LogTrace("()");
+
+            Block block = context.BlockValidationContext.Block;
+            ChainedHeader index = context.BlockValidationContext.ChainedHeader;
+            DeploymentFlags flags = context.Flags;
+            UnspentOutputSet view = context.Set;
+
+            this.Parent.PerformanceCounter.AddProcessedBlocks(1);
+
+            long sigOpsCost = 0;
+            Money fees = Money.Zero;
+            var checkInputs = new List<Task<bool>>();
+            for (int txIndex = 0; txIndex < block.Transactions.Count; txIndex++)
+            {
+                this.Parent.PerformanceCounter.AddProcessedTransactions(1);
+                Transaction tx = block.Transactions[txIndex];
+                if (!context.SkipValidation)
+                {
+                    // TODO: Simplify this condition.
+                    if (!tx.IsCoinBase && (!context.IsPoS || (context.IsPoS && !tx.IsCoinStake)))
+                    {
+                        if (!view.HaveInputs(tx))
+                        {
+                            this.Logger.LogTrace("(-)[BAD_TX_NO_INPUT]");
+                            ConsensusErrors.BadTransactionMissingInput.Throw();
+                        }
+
+                        var prevheights = new int[tx.Inputs.Count];
+                        // Check that transaction is BIP68 final.
+                        // BIP68 lock checks (as opposed to nLockTime checks) must
+                        // be in ConnectBlock because they require the UTXO set.
+                        for (int j = 0; j < tx.Inputs.Count; j++)
+                        {
+                            prevheights[j] = (int)view.AccessCoins(tx.Inputs[j].PrevOut.Hash).Height;
+                        }
+
+                        if (!tx.CheckSequenceLocks(prevheights, index, flags.LockTimeFlags))
+                        {
+                            this.Logger.LogTrace("(-)[BAD_TX_NON_FINAL]");
+                            ConsensusErrors.BadTransactionNonFinal.Throw();
+                        }
+                    }
+
+                    // GetTransactionSignatureOperationCost counts 3 types of sigops:
+                    // * legacy (always),
+                    // * p2sh (when P2SH enabled in flags and excludes coinbase),
+                    // * witness (when witness enabled in flags and excludes coinbase).
+                    sigOpsCost += this.GetTransactionSignatureOperationCost(tx, view, flags);
+                    if (sigOpsCost > this.PowConsensusOptions.MaxBlockSigopsCost)
+                    {
+                        this.Logger.LogTrace("(-)[BAD_BLOCK_SIG_OPS]");
+                        ConsensusErrors.BadBlockSigOps.Throw();
+                    }
+
+                    // TODO: Simplify this condition.
+                    if (!tx.IsCoinBase && (!context.IsPoS || (context.IsPoS && !tx.IsCoinStake)))
+                    {
+                        this.CheckInputs(tx, view, index.Height);
+                        fees += view.GetValueIn(tx) - tx.TotalOut;
+                        var txData = new PrecomputedTransactionData(tx);
+                        for (int inputIndex = 0; inputIndex < tx.Inputs.Count; inputIndex++)
+                        {
+                            this.Parent.PerformanceCounter.AddProcessedInputs(1);
+                            TxIn input = tx.Inputs[inputIndex];
+                            int inputIndexCopy = inputIndex;
+                            TxOut txout = view.GetOutputFor(input);
+                            var checkInput = new Task<bool>(() =>
+                            {
+                                var checker = new TransactionChecker(tx, inputIndexCopy, txout.Value, txData);
+                                var ctx = new ScriptEvaluationContext(this.Parent.Network);
+                                ctx.ScriptVerify = flags.ScriptFlags;
+                                return ctx.VerifyScript(input.ScriptSig, txout.ScriptPubKey, checker);
+                            });
+                            checkInput.Start();
+                            checkInputs.Add(checkInput);
+                        }
+                    }
+                }
+
+                this.OnUpdateCoinView(context, tx);
+            }
+
+            if (!context.SkipValidation)
+            {
+                this.CheckBlockReward(context, fees, index.Height, block);
+
+                foreach (Task<bool> checkInput in checkInputs)
+                {
+                    if (await checkInput.ConfigureAwait(false))
+                        continue;
+
+                    this.Logger.LogTrace("(-)[BAD_TX_SCRIPT]");
+                    ConsensusErrors.BadTransactionScriptError.Throw();
+                }
+            }
+            else this.Logger.LogTrace("BIP68, SigOp cost, and block reward validation skipped for block at height {0}.", index.Height);
+
+            this.Logger.LogTrace("(-)");
+        }
+
+        /// <summary>
+        /// Checks that transaction's inputs are valid.
+        /// </summary>
+        /// <param name="transaction">Transaction to check.</param>
+        /// <param name="inputs">Map of previous transactions that have outputs we're spending.</param>
+        /// <param name="spendHeight">Height at which we are spending coins.</param>
+        /// <exception cref="ConsensusErrors.BadTransactionMissingInput">Thrown if transaction's inputs are missing.</exception>
+        /// <exception cref="ConsensusErrors.BadTransactionInputValueOutOfRange">Thrown if input value is out of range.</exception>
+        /// <exception cref="ConsensusErrors.BadTransactionInBelowOut">Thrown if transaction inputs are less then outputs.</exception>
+        /// <exception cref="ConsensusErrors.BadTransactionNegativeFee">Thrown if fees sum is negative.</exception>
+        /// <exception cref="ConsensusErrors.BadTransactionFeeOutOfRange">Thrown if fees value is out of range.</exception>
+        public void CheckInputs(Transaction transaction, UnspentOutputSet inputs, int spendHeight)
+        {
+            this.Logger.LogTrace("({0}:{1})", nameof(spendHeight), spendHeight);
+
+            if (!inputs.HaveInputs(transaction))
+                ConsensusErrors.BadTransactionMissingInput.Throw();
+
+            Money valueIn = Money.Zero;
+            Money fees = Money.Zero;
+            for (int i = 0; i < transaction.Inputs.Count; i++)
+            {
+                OutPoint prevout = transaction.Inputs[i].PrevOut;
+                UnspentOutputs coins = inputs.AccessCoins(prevout.Hash);
+
+                this.CheckMaturity(coins, spendHeight);
+
+                // Check for negative or overflow input values.
+                valueIn += coins.TryGetOutput(prevout.N).Value;
+                if (!this.MoneyRange(coins.TryGetOutput(prevout.N).Value) || !this.MoneyRange(valueIn))
+                {
+                    this.Logger.LogTrace("(-)[BAD_TX_INPUT_VALUE]");
+                    ConsensusErrors.BadTransactionInputValueOutOfRange.Throw();
+                }
+            }
+
+            if (valueIn < transaction.TotalOut)
+            {
+                this.Logger.LogTrace("(-)[TX_IN_BELOW_OUT]");
+                ConsensusErrors.BadTransactionInBelowOut.Throw();
+            }
+
+            // Tally transaction fees.
+            Money txFee = valueIn - transaction.TotalOut;
+            if (txFee < 0)
+            {
+                this.Logger.LogTrace("(-)[NEGATIVE_FEE]");
+                ConsensusErrors.BadTransactionNegativeFee.Throw();
+            }
+
+            fees += txFee;
+            if (!this.MoneyRange(fees))
+            {
+                this.Logger.LogTrace("(-)[BAD_FEE]");
+                ConsensusErrors.BadTransactionFeeOutOfRange.Throw();
+            }
+
+            this.Logger.LogTrace("(-)");
+        }
+
+        /// <summary>
+        /// Checks the maturity of UTXOs.
+        /// </summary>
+        /// <param name="coins">UTXOs to check the maturity of.</param>
+        /// <param name="spendHeight">Height at which coins are attempted to be spent.</param>
+        /// <exception cref="ConsensusErrors.BadTransactionPrematureCoinbaseSpending">Thrown if transaction tries to spend coins that are not mature.</exception>
+        protected void CheckMaturity(UnspentOutputs coins, int spendHeight)
+        {
+            this.Logger.LogTrace("({0}:'{1}/{2}',{3}:{4})", nameof(coins), coins.TransactionId, coins.Height, nameof(spendHeight), spendHeight);
+
+            // If prev is coinbase, check that it's matured
+            if (coins.IsCoinbase)
+            {
+                if ((spendHeight - coins.Height) < this.PowConsensusOptions.CoinbaseMaturity)
+                {
+                    this.Logger.LogTrace("Coinbase transaction height {0} spent at height {1}, but maturity is set to {2}.", coins.Height, spendHeight, this.PowConsensusOptions.CoinbaseMaturity);
+                    this.Logger.LogTrace("(-)[COINBASE_PREMATURE_SPENDING]");
+                    ConsensusErrors.BadTransactionPrematureCoinbaseSpending.Throw();
+                }
+            }
+
+            this.Logger.LogTrace("(-)");
+        }
+
+        /// <summary>
+        /// Calculates signature operation cost for single transaction input.
+        /// </summary>
+        /// <param name="scriptPubKey">Script public key.</param>
+        /// <param name="witness">Witness script.</param>
+        /// <param name="flags">Script verification flags.</param>
+        /// <returns>Signature operation cost for single transaction input.</returns>
+        private long CountWitnessSignatureOperation(Script scriptPubKey, WitScript witness, DeploymentFlags flags)
+        {
+            witness = witness ?? WitScript.Empty;
+            if (!flags.ScriptFlags.HasFlag(ScriptVerify.Witness))
+                return 0;
+
+            WitProgramParameters witParams = PayToWitTemplate.Instance.ExtractScriptPubKeyParameters2(this.Parent.Network, scriptPubKey);
+
+            if (witParams?.Version == 0)
+            {
+                if (witParams.Program.Length == 20)
+                    return 1;
+
+                if (witParams.Program.Length == 32 && witness.PushCount > 0)
+                {
+                    Script subscript = Script.FromBytesUnsafe(witness.GetUnsafePush(witness.PushCount - 1));
+                    return subscript.GetSigOpCount(true);
+                }
+            }
+
+            return 0;
+        }
+
+        /// <summary>
+        /// Gets the block weight.
+        /// </summary>
+        /// <remarks>
+        /// This implements the <c>weight = (stripped_size * 4) + witness_size</c> formula, using only serialization with and without witness data.
+        /// As witness_size is equal to total_size - stripped_size, this formula is identical to: <c>weight = (stripped_size * 3) + total_size</c>.
+        /// </remarks>
+        /// <param name="block">Block that we get weight of.</param>
+        /// <returns>Block weight.</returns>
+        /// TODO: this is a duplicate of the same method in BlockSizeRule <see cref="BlockSizeRule.GetBlockWeight"/>
+        public long GetBlockWeight(Block block)
+        {
+            return this.GetSize(block, TransactionOptions.None)
+                   * (this.PowConsensusOptions.WitnessScaleFactor - 1)
+                   + this.GetSize(block, TransactionOptions.Witness);
+        }
+
+        /// <summary>
+        /// Gets serialized size of <paramref name="data"/> in bytes.
+        /// </summary>
+        /// <param name="data">Data that we calculate serialized size of.</param>
+        /// <param name="options">Serialization options.</param>
+        /// <returns>Serialized size of <paramref name="data"/> in bytes.</returns>
+        /// TODO: this is a duplicate of the same method in BlockSizeRule <see cref="BlockSizeRule.GetSize"/>
+        private int GetSize(IBitcoinSerializable data, TransactionOptions options)
+        {
+            var bms = new BitcoinStream(Stream.Null, true);
+            bms.TransactionOptions = options;
+            bms.ConsensusFactory = this.Parent.Network.Consensus.ConsensusFactory;
+            data.ReadWrite(bms);
+            return (int)bms.Counter.WrittenBytes;
+        }
+
+        /// <summary>
+        /// Calculates legacy transaction signature operation cost.
+        /// </summary>
+        /// <param name="transaction">Transaction for which we are computing the cost.</param>
+        /// <returns>Legacy signature operation cost for transaction.</returns>
+        private long GetLegacySignatureOperationsCount(Transaction transaction)
+        {
+            long sigOps = 0;
+            foreach (TxIn txin in transaction.Inputs)
+                sigOps += txin.ScriptSig.GetSigOpCount(false);
+
+            foreach (TxOut txout in transaction.Outputs)
+                sigOps += txout.ScriptPubKey.GetSigOpCount(false);
+
+            return sigOps;
+        }
+
+        /// <summary>
+        /// Calculates pay-to-script-hash (BIP16) transaction signature operation cost.
+        /// </summary>
+        /// <param name="transaction">Transaction for which we are computing the cost.</param>
+        /// <param name="inputs">Map of previous transactions that have outputs we're spending.</param>
+        /// <returns>Signature operation cost for transaction.</returns>
+        private uint GetP2SHSignatureOperationsCount(Transaction transaction, UnspentOutputSet inputs)
+        {
+            if (transaction.IsCoinBase)
+                return 0;
+
+            uint sigOps = 0;
+            for (int i = 0; i < transaction.Inputs.Count; i++)
+            {
+                TxOut prevout = inputs.GetOutputFor(transaction.Inputs[i]);
+                if (prevout.ScriptPubKey.IsPayToScriptHash(this.Parent.Network))
+                    sigOps += prevout.ScriptPubKey.GetSigOpCount(this.Parent.Network, transaction.Inputs[i].ScriptSig);
+            }
+
+            return sigOps;
+        }
+
+        /// <summary>
+        /// Calculates total signature operation cost of a transaction.
+        /// </summary>
+        /// <param name="transaction">Transaction for which we are computing the cost.</param>
+        /// <param name="inputs">Map of previous transactions that have outputs we're spending.</param>
+        /// <param name="flags">Script verification flags.</param>
+        /// <returns>Signature operation cost for all transaction's inputs.</returns>
+        public long GetTransactionSignatureOperationCost(Transaction transaction, UnspentOutputSet inputs, DeploymentFlags flags)
+        {
+            long signatureOperationCost = this.GetLegacySignatureOperationsCount(transaction) * this.PowConsensusOptions.WitnessScaleFactor;
+
+            if (transaction.IsCoinBase)
+                return signatureOperationCost;
+
+            if (flags.ScriptFlags.HasFlag(ScriptVerify.P2SH))
+            {
+                signatureOperationCost += this.GetP2SHSignatureOperationsCount(transaction, inputs) * this.PowConsensusOptions.WitnessScaleFactor;
+            }
+
+            for (int i = 0; i < transaction.Inputs.Count; i++)
+            {
+                TxOut prevout = inputs.GetOutputFor(transaction.Inputs[i]);
+                signatureOperationCost += this.CountWitnessSignatureOperation(prevout.ScriptPubKey, transaction.Inputs[i].WitScript, flags);
+            }
+
+            return signatureOperationCost;
+        }
+
+        /// <summary>
+        /// Checks if value is in range from 0 to <see cref="ConsensusOptions.MaxMoney"/>.
+        /// </summary>
+        /// <param name="value">The value to be checked.</param>
+        /// <returns><c>true</c> if the value is in range. Otherwise <c>false</c>.</returns>
+        private bool MoneyRange(long value)
+        {
+            return ((value >= 0) && (value <= this.PowConsensusOptions.MaxMoney));
+        }
+
+        /// <summary>
+        /// Updates context's UTXO set.
+        /// </summary>
+        /// <param name="context">Context that contains variety of information regarding blocks validation and execution.</param>
+        /// <param name="transaction">Transaction which outputs will be added to the context's <see cref="UnspentOutputSet"/> and which inputs will be removed from it.</param>
+        protected void UpdateCoinView(RuleContext context, Transaction transaction)
+        {
+            this.Logger.LogTrace("()");
+
+            ChainedHeader index = context.BlockValidationContext.ChainedHeader;
+            UnspentOutputSet view = context.Set;
+
+            view.Update(transaction, index.Height);
+
+            this.Logger.LogTrace("(-)");
+        }
+    }
+}

--- a/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/PowCoinviewRule.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/PowCoinviewRule.cs
@@ -1,10 +1,8 @@
 ﻿using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using NBitcoin;
-using Stratis.Bitcoin.Base.Deployments;
 using Stratis.Bitcoin.Utilities;
 
 namespace Stratis.Bitcoin.Features.Consensus.Rules.CommonRules
@@ -17,154 +15,29 @@ namespace Stratis.Bitcoin.Features.Consensus.Rules.CommonRules
     /// <exception cref="ConsensusErrors.BadBlockSigOps">Thrown if signature operation cost is greater then maximum block signature operation cost.</exception>
     /// <exception cref="ConsensusErrors.BadTransactionScriptError">Thrown if not all inputs are valid (no double spends, scripts & sigs, amounts).</exception>
     [ExecutionRule]
-    public class PowCoinViewRule : ConsensusRule
+    public class PowCoinViewRule : CoinviewRule
     {
         /// <summary>Consensus parameters.</summary>
         private NBitcoin.Consensus consensusParams;
-            
-        /// <summary>Consensus options.</summary>
-        private PowConsensusOptions consensusOptions;
 
         /// <inheritdoc />
-        public override void Initialize()
+        public override void OnInitialize()
         {
             this.Logger.LogTrace("()");
 
             this.consensusParams = this.Parent.Network.Consensus;
-            this.consensusOptions = this.consensusParams.Option<PowConsensusOptions>();
 
             this.Logger.LogTrace("(-)");
         }
 
         /// <inheritdoc />
-        public override async Task RunAsync(RuleContext context)
+        public async override Task RunAsync(RuleContext context)
         {
-            this.Logger.LogTrace("()");
-
-            Block block = context.BlockValidationContext.Block;
-            ChainedHeader index = context.BlockValidationContext.ChainedHeader;
-            DeploymentFlags flags = context.Flags;
-            UnspentOutputSet view = context.Set;
-
-            this.Parent.PerformanceCounter.AddProcessedBlocks(1);
-
-            long sigOpsCost = 0;
-            Money fees = Money.Zero;
-            var checkInputs = new List<Task<bool>>();
-            for (int txIndex = 0; txIndex < block.Transactions.Count; txIndex++)
-            {
-                this.Parent.PerformanceCounter.AddProcessedTransactions(1);
-                Transaction tx = block.Transactions[txIndex];
-                if (!context.SkipValidation)
-                {
-                    // TODO: Simplify this condition.
-                    if (!tx.IsCoinBase && (!context.IsPoS || (context.IsPoS && !tx.IsCoinStake)))
-                    {
-                        if (!view.HaveInputs(tx))
-                        {
-                            this.Logger.LogTrace("(-)[BAD_TX_NO_INPUT]");
-                            ConsensusErrors.BadTransactionMissingInput.Throw();
-                        }
-
-                        var prevheights = new int[tx.Inputs.Count];
-                        // Check that transaction is BIP68 final.
-                        // BIP68 lock checks (as opposed to nLockTime checks) must
-                        // be in ConnectBlock because they require the UTXO set.
-                        for (int j = 0; j < tx.Inputs.Count; j++)
-                        {
-                            prevheights[j] = (int)view.AccessCoins(tx.Inputs[j].PrevOut.Hash).Height;
-                        }
-
-                        if (!tx.CheckSequenceLocks(prevheights, index, flags.LockTimeFlags))
-                        {
-                            this.Logger.LogTrace("(-)[BAD_TX_NON_FINAL]");
-                            ConsensusErrors.BadTransactionNonFinal.Throw();
-                        }
-                    }
-
-                    // GetTransactionSignatureOperationCost counts 3 types of sigops:
-                    // * legacy (always),
-                    // * p2sh (when P2SH enabled in flags and excludes coinbase),
-                    // * witness (when witness enabled in flags and excludes coinbase).
-                    sigOpsCost += this.GetTransactionSignatureOperationCost(tx, view, flags);
-                    if (sigOpsCost > this.consensusOptions.MaxBlockSigopsCost)
-                    {
-                        this.Logger.LogTrace("(-)[BAD_BLOCK_SIG_OPS]");
-                        ConsensusErrors.BadBlockSigOps.Throw();
-                    }
-
-                    // TODO: Simplify this condition.
-                    if (!tx.IsCoinBase && (!context.IsPoS || (context.IsPoS && !tx.IsCoinStake)))
-                    {
-                        this.CheckInputs(tx, view, index.Height);
-                        fees += view.GetValueIn(tx) - tx.TotalOut;
-                        var txData = new PrecomputedTransactionData(tx);
-                        for (int inputIndex = 0; inputIndex < tx.Inputs.Count; inputIndex++)
-                        {
-                            this.Parent.PerformanceCounter.AddProcessedInputs(1);
-                            TxIn input = tx.Inputs[inputIndex];
-                            int inputIndexCopy = inputIndex;
-                            TxOut txout = view.GetOutputFor(input);
-                            var checkInput = new Task<bool>(() =>
-                            {
-                                var checker = new TransactionChecker(tx, inputIndexCopy, txout.Value, txData);
-                                var ctx = new ScriptEvaluationContext(this.Parent.Network);
-                                ctx.ScriptVerify = flags.ScriptFlags;
-                                return ctx.VerifyScript(input.ScriptSig, txout.ScriptPubKey, checker);
-                            });
-                            checkInput.Start();
-                            checkInputs.Add(checkInput);
-                        }
-                    }
-                }
-
-                this.UpdateCoinView(context, tx);
-            }
-
-            if (!context.SkipValidation)
-            {
-                this.CheckBlockReward(context, fees, index.Height, block);
-
-                foreach (Task<bool> checkInput in checkInputs)
-                {
-                    if (await checkInput.ConfigureAwait(false))
-                        continue;
-
-                    this.Logger.LogTrace("(-)[BAD_TX_SCRIPT]");
-                    ConsensusErrors.BadTransactionScriptError.Throw();
-                }
-            }
-            else this.Logger.LogTrace("BIP68, SigOp cost, and block reward validation skipped for block at height {0}.", index.Height);
-
-            this.Logger.LogTrace("(-)");
+            await base.OnRunAsync(context);
         }
 
-        /// <summary>
-        /// Updates context's UTXO set.
-        /// </summary>
-        /// <param name="context">Context that contains variety of information regarding blocks validation and execution.</param>
-        /// <param name="transaction">Transaction which outputs will be added to the context's <see cref="UnspentOutputSet"/> and which inputs will be removed from it.</param>
-        protected virtual void UpdateCoinView(RuleContext context, Transaction transaction)
-        {
-            this.Logger.LogTrace("()");
-
-            ChainedHeader index = context.BlockValidationContext.ChainedHeader;
-            UnspentOutputSet view = context.Set;
-
-            view.Update(transaction, index.Height);
-
-            this.Logger.LogTrace("(-)");
-        }
-
-        /// <summary>
-        /// Verifies that block has correct coinbase transaction with appropriate reward and fees summ.
-        /// </summary>
-        /// <param name="context">Context that contains variety of information regarding blocks validation and execution.</param>
-        /// <param name="fees">Total amount of fees from transactions that are included in that block.</param>
-        /// <param name="height">Block's height.</param>
-        /// <param name="block">Block for which reward amount is checked.</param>
-        /// <exception cref="ConsensusErrors.BadCoinbaseAmount">Thrown if coinbase transaction output value is larger than expected.</exception>
-        protected virtual void CheckBlockReward(RuleContext context, Money fees, int height, Block block)
+        /// <inheritdoc/>
+        public override void CheckBlockReward(RuleContext context, Money fees, int height, Block block)
         {
             this.Logger.LogTrace("()");
 
@@ -178,246 +51,30 @@ namespace Stratis.Bitcoin.Features.Consensus.Rules.CommonRules
             this.Logger.LogTrace("(-)");
         }
 
-        /// <summary>
-        /// Checks the maturity of UTXOs.
-        /// </summary>
-        /// <param name="coins">UTXOs to check the maturity of.</param>
-        /// <param name="spendHeight">Height at which coins are attempted to be spent.</param>
-        /// <exception cref="ConsensusErrors.BadTransactionPrematureCoinbaseSpending">Thrown if transaction tries to spend coins that are not mature.</exception>
-        protected virtual void CheckMaturity(UnspentOutputs coins, int spendHeight)
+        /// <inheritdoc/>
+        public override void OnCheckMaturity(UnspentOutputs coins, int spendHeight)
         {
-            this.Logger.LogTrace("({0}:'{1}/{2}',{3}:{4})", nameof(coins), coins.TransactionId, coins.Height, nameof(spendHeight), spendHeight);
-
-            // If prev is coinbase, check that it's matured
-            if (coins.IsCoinbase)
-            {
-                if ((spendHeight - coins.Height) < this.consensusOptions.CoinbaseMaturity)
-                {
-                    this.Logger.LogTrace("Coinbase transaction height {0} spent at height {1}, but maturity is set to {2}.", coins.Height, spendHeight, this.consensusOptions.CoinbaseMaturity);
-                    this.Logger.LogTrace("(-)[COINBASE_PREMATURE_SPENDING]");
-                    ConsensusErrors.BadTransactionPrematureCoinbaseSpending.Throw();
-                }
-            }
-
-            this.Logger.LogTrace("(-)");
+            base.CheckMaturity(coins, spendHeight);
         }
 
-        /// <summary>
-        /// Checks that transaction's inputs are valid.
-        /// </summary>
-        /// <param name="transaction">Transaction to check.</param>
-        /// <param name="inputs">Map of previous transactions that have outputs we're spending.</param>
-        /// <param name="spendHeight">Height at which we are spending coins.</param>
-        /// <exception cref="ConsensusErrors.BadTransactionMissingInput">Thrown if transaction's inputs are missing.</exception>
-        /// <exception cref="ConsensusErrors.BadTransactionInputValueOutOfRange">Thrown if input value is out of range.</exception>
-        /// <exception cref="ConsensusErrors.BadTransactionInBelowOut">Thrown if transaction inputs are less then outputs.</exception>
-        /// <exception cref="ConsensusErrors.BadTransactionNegativeFee">Thrown if fees sum is negative.</exception>
-        /// <exception cref="ConsensusErrors.BadTransactionFeeOutOfRange">Thrown if fees value is out of range.</exception>
-        public virtual void CheckInputs(Transaction transaction, UnspentOutputSet inputs, int spendHeight)
+        /// <inheritdoc/>
+        public override void OnUpdateCoinView(RuleContext context, Transaction transaction)
         {
-            this.Logger.LogTrace("({0}:{1})", nameof(spendHeight), spendHeight);
-
-            if (!inputs.HaveInputs(transaction))
-                ConsensusErrors.BadTransactionMissingInput.Throw();
-
-            Money valueIn = Money.Zero;
-            Money fees = Money.Zero;
-            for (int i = 0; i < transaction.Inputs.Count; i++)
-            {
-                OutPoint prevout = transaction.Inputs[i].PrevOut;
-                UnspentOutputs coins = inputs.AccessCoins(prevout.Hash);
-
-                this.CheckMaturity(coins, spendHeight);
-
-                // Check for negative or overflow input values.
-                valueIn += coins.TryGetOutput(prevout.N).Value;
-                if (!this.MoneyRange(coins.TryGetOutput(prevout.N).Value) || !this.MoneyRange(valueIn))
-                {
-                    this.Logger.LogTrace("(-)[BAD_TX_INPUT_VALUE]");
-                    ConsensusErrors.BadTransactionInputValueOutOfRange.Throw();
-                }
-            }
-
-            if (valueIn < transaction.TotalOut)
-            {
-                this.Logger.LogTrace("(-)[TX_IN_BELOW_OUT]");
-                ConsensusErrors.BadTransactionInBelowOut.Throw();
-            }
-
-            // Tally transaction fees.
-            Money txFee = valueIn - transaction.TotalOut;
-            if (txFee < 0)
-            {
-                this.Logger.LogTrace("(-)[NEGATIVE_FEE]");
-                ConsensusErrors.BadTransactionNegativeFee.Throw();
-            }
-
-            fees += txFee;
-            if (!this.MoneyRange(fees))
-            {
-                this.Logger.LogTrace("(-)[BAD_FEE]");
-                ConsensusErrors.BadTransactionFeeOutOfRange.Throw();
-            }
-
-            this.Logger.LogTrace("(-)");
+            base.UpdateCoinView(context, transaction);
         }
 
-        /// <summary>
-        /// Gets the proof of work reward amount for the block at provided height.
-        /// </summary>
-        /// <param name="height">Height of the block that we're calculating the reward for.</param>
-        /// <returns>Reward amount.</returns>
-        public virtual Money GetProofOfWorkReward(int height)
+        /// <inheritdoc/>
+        public override Money GetProofOfWorkReward(int height)
         {
             int halvings = height / this.consensusParams.SubsidyHalvingInterval;
             // Force block reward to zero when right shift is undefined.
             if (halvings >= 64)
                 return 0;
 
-            Money subsidy = this.consensusOptions.ProofOfWorkReward;
+            Money subsidy = this.PowConsensusOptions.ProofOfWorkReward;
             // Subsidy is cut in half every 210,000 blocks which will occur approximately every 4 years.
             subsidy >>= halvings;
             return subsidy;
-        }
-
-        /// <summary>
-        /// Calculates total signature operation cost of a transaction.
-        /// </summary>
-        /// <param name="transaction">Transaction for which we are computing the cost.</param>
-        /// <param name="inputs">Map of previous transactions that have outputs we're spending.</param>
-        /// <param name="flags">Script verification flags.</param>
-        /// <returns>Signature operation cost for all transaction's inputs.</returns>
-        public long GetTransactionSignatureOperationCost(Transaction transaction, UnspentOutputSet inputs, DeploymentFlags flags)
-        {
-            long signatureOperationCost = this.GetLegacySignatureOperationsCount(transaction) * this.consensusOptions.WitnessScaleFactor;
-
-            if (transaction.IsCoinBase)
-                return signatureOperationCost;
-
-            if (flags.ScriptFlags.HasFlag(ScriptVerify.P2SH))
-            {
-                signatureOperationCost += this.GetP2SHSignatureOperationsCount(transaction, inputs) * this.consensusOptions.WitnessScaleFactor;
-            }
-
-            for (int i = 0; i < transaction.Inputs.Count; i++)
-            {
-                TxOut prevout = inputs.GetOutputFor(transaction.Inputs[i]);
-                signatureOperationCost += this.CountWitnessSignatureOperation(prevout.ScriptPubKey, transaction.Inputs[i].WitScript, flags);
-            }
-
-            return signatureOperationCost;
-        }
-
-        /// <summary>
-        /// Calculates signature operation cost for single transaction input.
-        /// </summary>
-        /// <param name="scriptPubKey">Script public key.</param>
-        /// <param name="witness">Witness script.</param>
-        /// <param name="flags">Script verification flags.</param>
-        /// <returns>Signature operation cost for single transaction input.</returns>
-        private long CountWitnessSignatureOperation(Script scriptPubKey, WitScript witness, DeploymentFlags flags)
-        {
-            witness = witness ?? WitScript.Empty;
-            if (!flags.ScriptFlags.HasFlag(ScriptVerify.Witness))
-                return 0;
-
-            WitProgramParameters witParams = PayToWitTemplate.Instance.ExtractScriptPubKeyParameters2(this.Parent.Network, scriptPubKey);
-
-            if (witParams?.Version == 0)
-            {
-                if (witParams.Program.Length == 20)
-                    return 1;
-
-                if (witParams.Program.Length == 32 && witness.PushCount > 0)
-                {
-                    Script subscript = Script.FromBytesUnsafe(witness.GetUnsafePush(witness.PushCount - 1));
-                    return subscript.GetSigOpCount(true);
-                }
-            }
-
-            return 0;
-        }
-
-        /// <summary>
-        /// Calculates pay-to-script-hash (BIP16) transaction signature operation cost.
-        /// </summary>
-        /// <param name="transaction">Transaction for which we are computing the cost.</param>
-        /// <param name="inputs">Map of previous transactions that have outputs we're spending.</param>
-        /// <returns>Signature operation cost for transaction.</returns>
-        private uint GetP2SHSignatureOperationsCount(Transaction transaction, UnspentOutputSet inputs)
-        {
-            if (transaction.IsCoinBase)
-                return 0;
-
-            uint sigOps = 0;
-            for (int i = 0; i < transaction.Inputs.Count; i++)
-            {
-                TxOut prevout = inputs.GetOutputFor(transaction.Inputs[i]);
-                if (prevout.ScriptPubKey.IsPayToScriptHash(this.Parent.Network))
-                    sigOps += prevout.ScriptPubKey.GetSigOpCount(this.Parent.Network, transaction.Inputs[i].ScriptSig);
-            }
-
-            return sigOps;
-        }
-
-        /// <summary>
-        /// Calculates legacy transaction signature operation cost.
-        /// </summary>
-        /// <param name="transaction">Transaction for which we are computing the cost.</param>
-        /// <returns>Legacy signature operation cost for transaction.</returns>
-        private long GetLegacySignatureOperationsCount(Transaction transaction)
-        {
-            long sigOps = 0;
-            foreach (TxIn txin in transaction.Inputs)
-                sigOps += txin.ScriptSig.GetSigOpCount(false);
-
-            foreach (TxOut txout in transaction.Outputs)
-                sigOps += txout.ScriptPubKey.GetSigOpCount(false);
-
-            return sigOps;
-        }
-
-        /// <summary>
-        /// Checks if value is in range from 0 to <see cref="consensusOptions.MaxMoney"/>.
-        /// </summary>
-        /// <param name="value">The value to be checked.</param>
-        /// <returns><c>true</c> if the value is in range. Otherwise <c>false</c>.</returns>
-        private bool MoneyRange(long value)
-        {
-            return ((value >= 0) && (value <= this.consensusOptions.MaxMoney));
-        }
-
-        /// <summary>
-        /// Gets the block weight.
-        /// </summary>
-        /// <remarks>
-        /// This implements the <c>weight = (stripped_size * 4) + witness_size</c> formula, using only serialization with and without witness data.
-        /// As witness_size is equal to total_size - stripped_size, this formula is identical to: <c>weight = (stripped_size * 3) + total_size</c>.
-        /// </remarks>
-        /// <param name="block">Block that we get weight of.</param>
-        /// <returns>Block weight.</returns>
-        /// TODO: this is a duplicate of the same method in BlockSizeRule <see cref="BlockSizeRule.GetBlockWeight"/>
-        public long GetBlockWeight(Block block)  
-        {
-            return this.GetSize(block, TransactionOptions.None) 
-                   * (this.consensusOptions.WitnessScaleFactor - 1) 
-                   + this.GetSize(block, TransactionOptions.Witness);
-        }
-
-        /// <summary>
-        /// Gets serialized size of <paramref name="data"/> in bytes.
-        /// </summary>
-        /// <param name="data">Data that we calculate serialized size of.</param>
-        /// <param name="options">Serialization options.</param>
-        /// <returns>Serialized size of <paramref name="data"/> in bytes.</returns>
-        /// TODO: this is a duplicate of the same method in BlockSizeRule <see cref="BlockSizeRule.GetSize"/>
-        private int GetSize(IBitcoinSerializable data, TransactionOptions options)
-        {
-            var bms = new BitcoinStream(Stream.Null, true);
-            bms.TransactionOptions = options;
-            bms.ConsensusFactory = this.Parent.Network.Consensus.ConsensusFactory;
-            data.ReadWrite(bms);
-            return (int)bms.Counter.WrittenBytes;
         }
 
         /// <summary>

--- a/src/Stratis.Bitcoin.Features.MemoryPool/MempoolValidator.cs
+++ b/src/Stratis.Bitcoin.Features.MemoryPool/MempoolValidator.cs
@@ -546,7 +546,7 @@ namespace Stratis.Bitcoin.Features.MemoryPool
         {
             // TODO: fix this to use dedicated mempool rules.
             new CheckPowTransactionRule { Logger = this.logger }.CheckTransaction(this.network, this.ConsensusOptions, context.Transaction);
-            if(this.chain.Network.Consensus.IsProofOfStake)
+            if (this.chain.Network.Consensus.IsProofOfStake)
                 new CheckPosTransactionRule { Logger = this.logger }.CheckTransaction(context.Transaction);
 
             // Coinbase is only valid in a block, not as a loose transaction
@@ -748,8 +748,7 @@ namespace Stratis.Bitcoin.Features.MemoryPool
             if (context.Transaction.HasWitness && this.mempoolSettings.NodeSettings.RequireStandard && !this.IsWitnessStandard(context.Transaction, context.View))
                 context.State.Invalid(MempoolErrors.NonstandardWitness).Throw();
 
-            context.SigOpsCost = consensusRules.GetRule<PowCoinViewRule>().GetTransactionSignatureOperationCost(context.Transaction, context.View.Set,
-                new DeploymentFlags { ScriptFlags = ScriptVerify.Standard });
+            context.SigOpsCost = this.consensusRules.GetRule<CoinviewRule>().GetTransactionSignatureOperationCost(context.Transaction, context.View.Set, new DeploymentFlags { ScriptFlags = ScriptVerify.Standard });
 
             Money nValueIn = context.View.GetValueIn(context.Transaction);
 
@@ -1040,13 +1039,12 @@ namespace Stratis.Bitcoin.Features.MemoryPool
         /// <param name="scriptVerify">Script verify flag.</param>
         /// <param name="txData">Transaction data.</param>
         /// <returns>Whether inputs are valid.</returns>
-        private bool CheckInputs(MempoolValidationContext context, ScriptVerify scriptVerify,
-            PrecomputedTransactionData txData)
+        private bool CheckInputs(MempoolValidationContext context, ScriptVerify scriptVerify, PrecomputedTransactionData txData)
         {
             Transaction tx = context.Transaction;
             if (!context.Transaction.IsCoinBase)
             {
-                this.consensusRules.GetRule<PowCoinViewRule>().CheckInputs(context.Transaction, context.View.Set, this.chain.Height + 1);
+                this.consensusRules.GetRule<CoinviewRule>().CheckInputs(context.Transaction, context.View.Set, this.chain.Height + 1);
 
                 for (int iInput = 0; iInput < tx.Inputs.Count; iInput++)
                 {

--- a/src/Stratis.Bitcoin.Features.Miner/BlockDefinition.cs
+++ b/src/Stratis.Bitcoin.Features.Miner/BlockDefinition.cs
@@ -255,7 +255,7 @@ namespace Stratis.Bitcoin.Features.Miner
             // pblocktemplate->CoinbaseCommitment = GenerateCoinbaseCommitment(*pblock, pindexPrev, chainparams.GetConsensus());
             this.BlockTemplate.VTxFees[0] = -this.fees;
 
-            var powCoinviewRule = this.ConsensusLoop.ConsensusRules.GetRule<PowCoinViewRule>();
+            var powCoinviewRule = this.ConsensusLoop.ConsensusRules.GetRule<CoinviewRule>();
 
             this.coinbase.Outputs[0].Value = this.fees + powCoinviewRule.GetProofOfWorkReward(this.height);
             this.BlockTemplate.TotalFee = this.fees;


### PR DESCRIPTION
Currently `PosCoinviewRule` inherits and overrides some members and/or methods of `PowCoinviewRule`. As these two classes basically share a lot of logic I want to introduce a base abstract class which holds this logic. Then instead of having virtual overrides for methods like `GetProofOfWork` we implement concrete implementations for each network type, be it Pos or Pow. 

The current implementation breaks some SOLID principles like Liskov as if you had to remove `PosCoinviewRule`'s override of `GetProofOfWorkReward` the node wouldn't certain be concerned otherwise. We need to be more explicit as to each implementation.

As we also require SmartContractCoinviewRule we cannot currently implement this due to the `PosCoinviewRule` inheriting from `PowCoinviewRule` approach.

**There are NO logic changes in this PR but instead only the shared logic was moved to `CoinviewRule`.**

**I confirm a full Testnet sync and staking on Testnet works.**