### PR TITLE
Add back removed support for custom node builders in integration tests

### DIFF
--- a/src/Stratis.Bitcoin.IntegrationTests.Common/EnvironmentMockUpHelpers/NodeBuilder.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests.Common/EnvironmentMockUpHelpers/NodeBuilder.cs
@@ -23,6 +23,8 @@ using Stratis.Bitcoin.Tests.Common;
 
 namespace Stratis.Bitcoin.IntegrationTests.Common.EnvironmentMockUpHelpers
 {
+    using NBitcoin.Protocol;
+
     public static class FullNodeExt
     {
         public static WalletManager WalletManager(this FullNode fullNode)
@@ -181,14 +183,16 @@ namespace Stratis.Bitcoin.IntegrationTests.Common.EnvironmentMockUpHelpers
             return node;
         }
 
-        public CoreNode CreateCustomPowNode(bool start, Action<IFullNodeBuilder> callback, Network network)
+        /// <summary>A helper method to create a node instance with a non-standard set of features enabled. The node can be PoW or PoS, as long as the appropriate features are provided.</summary>
+        /// <param name="dataDir">The node's data directory where downloaded chain data gets stored.</param>
+        /// <param name="callback">A callback accepting an instance of <see cref="IFullNodeBuilder"/> that constructs a node with a custom feature set.</param>
+        /// <param name="network">The network the node will be running on.</param>
+        /// <param name="protocolVersion">Use <see cref="ProtocolVersion.PROTOCOL_VERSION"/> for BTC PoW-like networks and <see cref="ProtocolVersion.ALT_PROTOCOL_VERSION"/> for Stratis PoS-like networks.</param>
+        /// <param name="configFileName">The name for the node's configuration file.</param>
+        /// <param name="agent">A user agent string to distinguish different node versions from each other.</param>
+        public CoreNode CreateCustomNode(bool start, Action<IFullNodeBuilder> callback, Network network, ProtocolVersion protocolVersion = ProtocolVersion.PROTOCOL_VERSION, string configFileName = "custom.conf", string agent = "Custom")
         {
-            return CreateNode(new CustomPowRunner(this.GetNextDataFolderName(), callback, network), network, start);
-        }
-
-        public CoreNode CreateCustomPosNode(bool start, Action<IFullNodeBuilder> callback, Network network)
-        {
-            return CreateNode(new CustomPosRunner(this.GetNextDataFolderName(), callback, network), network, start, "stratis.conf");
+            return CreateNode(new CustomNodeRunner(this.GetNextDataFolderName(), callback, network, protocolVersion, configFileName, agent), network, start, configFileName);
         }
 
         private string GetNextDataFolderName()

--- a/src/Stratis.Bitcoin.IntegrationTests.Common/EnvironmentMockUpHelpers/NodeBuilder.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests.Common/EnvironmentMockUpHelpers/NodeBuilder.cs
@@ -153,9 +153,9 @@ namespace Stratis.Bitcoin.IntegrationTests.Common.EnvironmentMockUpHelpers
             return CreateNode(new BitcoinCoreRunner(this.GetNextDataFolderName(), bitcoinDPath), Network.RegTest, start);
         }
 
-        public CoreNode CreateStratisPowNode(bool start = false, Action<IFullNodeBuilder> callback = null)
+        public CoreNode CreateStratisPowNode(bool start = false)
         {
-            return CreateNode(new StratisBitcoinPowRunner(this.GetNextDataFolderName(), callback), Network.RegTest, start);
+            return CreateNode(new StratisBitcoinPowRunner(this.GetNextDataFolderName()), Network.RegTest, start);
         }
 
         public CoreNode CreateStratisPowMiningNode(bool start = false)
@@ -163,9 +163,9 @@ namespace Stratis.Bitcoin.IntegrationTests.Common.EnvironmentMockUpHelpers
             return CreateNode(new StratisProofOfWorkMiningNode(this.GetNextDataFolderName()), Network.RegTest, start, "stratis.conf");
         }
 
-        public CoreNode CreateStratisPosNode(bool start = false, Action<IFullNodeBuilder> callback = null)
+        public CoreNode CreateStratisPosNode(bool start = false)
         {
-            return CreateNode(new StratisBitcoinPosRunner(this.GetNextDataFolderName(), callback), Network.RegTest, start, "stratis.conf");
+            return CreateNode(new StratisBitcoinPosRunner(this.GetNextDataFolderName()), Network.RegTest, start, "stratis.conf");
         }
 
         public CoreNode CreateStratisPosApiNode(bool start = false)
@@ -179,6 +179,16 @@ namespace Stratis.Bitcoin.IntegrationTests.Common.EnvironmentMockUpHelpers
             this.Nodes.Add(node);
             this.Nodes.Remove(cloneNode);
             return node;
+        }
+
+        public CoreNode CreateCustomPowNode(bool start, Action<IFullNodeBuilder> callback, Network network)
+        {
+            return CreateNode(new CustomPowRunner(this.GetNextDataFolderName(), callback, network), network, start);
+        }
+
+        public CoreNode CreateCustomPosNode(bool start, Action<IFullNodeBuilder> callback, Network network)
+        {
+            return CreateNode(new CustomPosRunner(this.GetNextDataFolderName(), callback, network), network, start, "stratis.conf");
         }
 
         private string GetNextDataFolderName()

--- a/src/Stratis.Bitcoin.IntegrationTests.Common/EnvironmentMockUpHelpers/NodeBuilder.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests.Common/EnvironmentMockUpHelpers/NodeBuilder.cs
@@ -11,6 +11,7 @@ using System.Text;
 using System.Threading;
 using NBitcoin;
 using Stratis.Bitcoin.Base;
+using Stratis.Bitcoin.Builder;
 using Stratis.Bitcoin.Features.BlockStore;
 using Stratis.Bitcoin.Features.Consensus;
 using Stratis.Bitcoin.Features.Consensus.CoinViews;
@@ -152,9 +153,9 @@ namespace Stratis.Bitcoin.IntegrationTests.Common.EnvironmentMockUpHelpers
             return CreateNode(new BitcoinCoreRunner(this.GetNextDataFolderName(), bitcoinDPath), Network.RegTest, start);
         }
 
-        public CoreNode CreateStratisPowNode(bool start = false)
+        public CoreNode CreateStratisPowNode(bool start = false, Action<IFullNodeBuilder> callback = null)
         {
-            return CreateNode(new StratisBitcoinPowRunner(this.GetNextDataFolderName()), Network.RegTest, start);
+            return CreateNode(new StratisBitcoinPowRunner(this.GetNextDataFolderName(), callback), Network.RegTest, start);
         }
 
         public CoreNode CreateStratisPowMiningNode(bool start = false)
@@ -162,9 +163,9 @@ namespace Stratis.Bitcoin.IntegrationTests.Common.EnvironmentMockUpHelpers
             return CreateNode(new StratisProofOfWorkMiningNode(this.GetNextDataFolderName()), Network.RegTest, start, "stratis.conf");
         }
 
-        public CoreNode CreateStratisPosNode(bool start = false)
+        public CoreNode CreateStratisPosNode(bool start = false, Action<IFullNodeBuilder> callback = null)
         {
-            return CreateNode(new StratisBitcoinPosRunner(this.GetNextDataFolderName()), Network.RegTest, start, "stratis.conf");
+            return CreateNode(new StratisBitcoinPosRunner(this.GetNextDataFolderName(), callback), Network.RegTest, start, "stratis.conf");
         }
 
         public CoreNode CreateStratisPosApiNode(bool start = false)

--- a/src/Stratis.Bitcoin.IntegrationTests.Common/EnvironmentMockUpHelpers/NodeRunners.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests.Common/EnvironmentMockUpHelpers/NodeRunners.cs
@@ -79,40 +79,26 @@ namespace Stratis.Bitcoin.IntegrationTests.Common.EnvironmentMockUpHelpers
 
     public sealed class StratisBitcoinPosRunner : NodeRunner
     {
-        private Action<IFullNodeBuilder> callback;
-
-        public StratisBitcoinPosRunner(string dataDir, Action<IFullNodeBuilder> callback = null)
+        public StratisBitcoinPosRunner(string dataDir)
             : base(dataDir)
         {
-            this.callback = callback;
         }
 
         public override void BuildNode()
         {
             var settings = new NodeSettings(Network.StratisRegTest, ProtocolVersion.ALT_PROTOCOL_VERSION, args: new string[] { "-conf=stratis.conf", "-datadir=" + this.DataFolder }, loadConfiguration: false);
 
-            if (this.callback != null)
-            {
-                var builder = new FullNodeBuilder().UseNodeSettings(settings);
-
-                this.callback(builder);
-
-                this.FullNode = (FullNode)builder.Build();
-            }
-            else
-            {
-                this.FullNode = (FullNode)new FullNodeBuilder()
-                    .UseNodeSettings(settings)
-                    .UseBlockStore()
-                    .UsePosConsensus()
-                    .UseMempool()
-                    .UseWallet()
-                    .AddPowPosMining()
-                    .AddRPC()
-                    .MockIBD()
-                    .SubstituteDateTimeProviderFor<MiningFeature>()
-                    .Build();
-            }
+            this.FullNode = (FullNode)new FullNodeBuilder()
+                .UseNodeSettings(settings)
+                .UseBlockStore()
+                .UsePosConsensus()
+                .UseMempool()
+                .UseWallet()
+                .AddPowPosMining()
+                .AddRPC()
+                .MockIBD()
+                .SubstituteDateTimeProviderFor<MiningFeature>()
+                .Build();
         }
 
         public override void OnStart()
@@ -176,39 +162,25 @@ namespace Stratis.Bitcoin.IntegrationTests.Common.EnvironmentMockUpHelpers
 
     public sealed class StratisBitcoinPowRunner : NodeRunner
     {
-        private Action<IFullNodeBuilder> callback;
-
-        public StratisBitcoinPowRunner(string dataDir, Action<IFullNodeBuilder> callback = null)
+        public StratisBitcoinPowRunner(string dataDir)
             : base(dataDir)
         {
-            this.callback = callback;
         }
 
         public override void BuildNode()
         {
             var settings = new NodeSettings(args: new string[] { "-conf=bitcoin.conf", "-datadir=" + this.DataFolder }, loadConfiguration: false);
 
-            if (this.callback != null)
-            {
-                var builder = new FullNodeBuilder().UseNodeSettings(settings);
-
-                this.callback(builder);
-
-                this.FullNode = (FullNode)builder.Build();
-            }
-            else
-            {
-                this.FullNode = (FullNode)new FullNodeBuilder()
-                    .UseNodeSettings(settings)
-                    .UseBlockStore()
-                    .UsePowConsensus()
-                    .UseMempool()
-                    .AddMining()
-                    .UseWallet()
-                    .AddRPC()
-                    .MockIBD()
-                    .Build();
-            }
+            this.FullNode = (FullNode)new FullNodeBuilder()
+                .UseNodeSettings(settings)
+                .UseBlockStore()
+                .UsePowConsensus()
+                .UseMempool()
+                .AddMining()
+                .UseWallet()
+                .AddRPC()
+                .MockIBD()
+                .Build();
         }
 
         public override void OnStart()
@@ -239,6 +211,62 @@ namespace Stratis.Bitcoin.IntegrationTests.Common.EnvironmentMockUpHelpers
                             .MockIBD()
                             .SubstituteDateTimeProviderFor<MiningFeature>()
                             .Build();
+        }
+
+        public override void OnStart()
+        {
+            this.FullNode.Start();
+        }
+    }
+
+    public sealed class CustomPowRunner : NodeRunner
+    {
+        private Action<IFullNodeBuilder> callback;
+
+        private Network network;
+
+        public CustomPowRunner(string dataDir, Action<IFullNodeBuilder> callback, Network network)
+            : base(dataDir)
+        {
+            this.callback = callback;
+            this.network = network;
+        }
+
+        public override void BuildNode()
+        {
+            var settings = new NodeSettings(this.network, args: new string[] { "-conf=bitcoin.conf", "-datadir=" + this.DataFolder }, loadConfiguration: false);
+            var builder = new FullNodeBuilder().UseNodeSettings(settings);
+
+            this.callback(builder);
+            this.FullNode = (FullNode)builder.Build();
+        }
+
+        public override void OnStart()
+        {
+            this.FullNode.Start();
+        }
+    }
+
+    public sealed class CustomPosRunner : NodeRunner
+    {
+        private Action<IFullNodeBuilder> callback;
+
+        private Network network;
+
+        public CustomPosRunner(string dataDir, Action<IFullNodeBuilder> callback, Network network)
+            : base(dataDir)
+        {
+            this.callback = callback;
+            this.network = network;
+        }
+
+        public override void BuildNode()
+        {
+            var settings = new NodeSettings(this.network, ProtocolVersion.ALT_PROTOCOL_VERSION, args: new string[] { "-conf=stratis.conf", "-datadir=" + this.DataFolder }, loadConfiguration: false);
+            var builder = new FullNodeBuilder().UseNodeSettings(settings);
+
+            this.callback(builder);
+            this.FullNode = (FullNode)builder.Build();
         }
 
         public override void OnStart()

--- a/src/Stratis.Bitcoin.IntegrationTests.Common/EnvironmentMockUpHelpers/NodeRunners.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests.Common/EnvironmentMockUpHelpers/NodeRunners.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics;
+﻿using System;
+using System.Diagnostics;
 using System.IO;
 using NBitcoin;
 using NBitcoin.Protocol;
@@ -78,26 +79,40 @@ namespace Stratis.Bitcoin.IntegrationTests.Common.EnvironmentMockUpHelpers
 
     public sealed class StratisBitcoinPosRunner : NodeRunner
     {
-        public StratisBitcoinPosRunner(string dataDir)
+        private Action<IFullNodeBuilder> callback;
+
+        public StratisBitcoinPosRunner(string dataDir, Action<IFullNodeBuilder> callback = null)
             : base(dataDir)
         {
+            this.callback = callback;
         }
 
         public override void BuildNode()
         {
             var settings = new NodeSettings(Network.StratisRegTest, ProtocolVersion.ALT_PROTOCOL_VERSION, args: new string[] { "-conf=stratis.conf", "-datadir=" + this.DataFolder }, loadConfiguration: false);
 
-            this.FullNode = (FullNode)new FullNodeBuilder()
-                            .UseNodeSettings(settings)
-                            .UseBlockStore()
-                            .UsePosConsensus()
-                            .UseMempool()
-                            .UseWallet()
-                            .AddPowPosMining()
-                            .AddRPC()
-                            .MockIBD()
-                            .SubstituteDateTimeProviderFor<MiningFeature>()
-                            .Build();
+            if (this.callback != null)
+            {
+                var builder = new FullNodeBuilder().UseNodeSettings(settings);
+
+                this.callback(builder);
+
+                this.FullNode = (FullNode)builder.Build();
+            }
+            else
+            {
+                this.FullNode = (FullNode)new FullNodeBuilder()
+                    .UseNodeSettings(settings)
+                    .UseBlockStore()
+                    .UsePosConsensus()
+                    .UseMempool()
+                    .UseWallet()
+                    .AddPowPosMining()
+                    .AddRPC()
+                    .MockIBD()
+                    .SubstituteDateTimeProviderFor<MiningFeature>()
+                    .Build();
+            }
         }
 
         public override void OnStart()
@@ -161,25 +176,39 @@ namespace Stratis.Bitcoin.IntegrationTests.Common.EnvironmentMockUpHelpers
 
     public sealed class StratisBitcoinPowRunner : NodeRunner
     {
-        public StratisBitcoinPowRunner(string dataDir)
+        private Action<IFullNodeBuilder> callback;
+
+        public StratisBitcoinPowRunner(string dataDir, Action<IFullNodeBuilder> callback = null)
             : base(dataDir)
         {
+            this.callback = callback;
         }
 
         public override void BuildNode()
         {
             var settings = new NodeSettings(args: new string[] { "-conf=bitcoin.conf", "-datadir=" + this.DataFolder }, loadConfiguration: false);
 
-            this.FullNode = (FullNode)new FullNodeBuilder()
-                            .UseNodeSettings(settings)
-                            .UseBlockStore()
-                            .UsePowConsensus()
-                            .UseMempool()
-                            .AddMining()
-                            .UseWallet()
-                            .AddRPC()
-                            .MockIBD()
-                            .Build();
+            if (this.callback != null)
+            {
+                var builder = new FullNodeBuilder().UseNodeSettings(settings);
+
+                this.callback(builder);
+
+                this.FullNode = (FullNode)builder.Build();
+            }
+            else
+            {
+                this.FullNode = (FullNode)new FullNodeBuilder()
+                    .UseNodeSettings(settings)
+                    .UseBlockStore()
+                    .UsePowConsensus()
+                    .UseMempool()
+                    .AddMining()
+                    .UseWallet()
+                    .AddRPC()
+                    .MockIBD()
+                    .Build();
+            }
         }
 
         public override void OnStart()

--- a/src/Stratis.Bitcoin.IntegrationTests.Common/EnvironmentMockUpHelpers/NodeRunners.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests.Common/EnvironmentMockUpHelpers/NodeRunners.cs
@@ -219,50 +219,31 @@ namespace Stratis.Bitcoin.IntegrationTests.Common.EnvironmentMockUpHelpers
         }
     }
 
-    public sealed class CustomPowRunner : NodeRunner
+    public sealed class CustomNodeRunner : NodeRunner
     {
         private Action<IFullNodeBuilder> callback;
 
         private Network network;
 
-        public CustomPowRunner(string dataDir, Action<IFullNodeBuilder> callback, Network network)
+        private ProtocolVersion protocolVersion;
+
+        private string configFileName;
+
+        private string agent;
+
+        public CustomNodeRunner(string dataDir, Action<IFullNodeBuilder> callback, Network network, ProtocolVersion protocolVersion = ProtocolVersion.PROTOCOL_VERSION, string configFileName = "custom.conf", string agent = "Custom")
             : base(dataDir)
         {
             this.callback = callback;
             this.network = network;
+            this.protocolVersion = protocolVersion;
+            this.configFileName = configFileName;
+            this.agent = agent;
         }
 
         public override void BuildNode()
         {
-            var settings = new NodeSettings(this.network, args: new string[] { "-conf=bitcoin.conf", "-datadir=" + this.DataFolder });
-            var builder = new FullNodeBuilder().UseNodeSettings(settings);
-
-            this.callback(builder);
-            this.FullNode = (FullNode)builder.Build();
-        }
-
-        public override void OnStart()
-        {
-            this.FullNode.Start();
-        }
-    }
-
-    public sealed class CustomPosRunner : NodeRunner
-    {
-        private Action<IFullNodeBuilder> callback;
-
-        private Network network;
-
-        public CustomPosRunner(string dataDir, Action<IFullNodeBuilder> callback, Network network)
-            : base(dataDir)
-        {
-            this.callback = callback;
-            this.network = network;
-        }
-
-        public override void BuildNode()
-        {
-            var settings = new NodeSettings(this.network, ProtocolVersion.ALT_PROTOCOL_VERSION, args: new string[] { "-conf=stratis.conf", "-datadir=" + this.DataFolder });
+            var settings = new NodeSettings(this.network, this.protocolVersion, this.agent, new string[] { "-conf=" + this.configFileName, "-datadir=" + this.DataFolder });
             var builder = new FullNodeBuilder().UseNodeSettings(settings);
 
             this.callback(builder);

--- a/src/Stratis.Bitcoin.IntegrationTests.Common/EnvironmentMockUpHelpers/NodeRunners.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests.Common/EnvironmentMockUpHelpers/NodeRunners.cs
@@ -234,7 +234,7 @@ namespace Stratis.Bitcoin.IntegrationTests.Common.EnvironmentMockUpHelpers
 
         public override void BuildNode()
         {
-            var settings = new NodeSettings(this.network, args: new string[] { "-conf=bitcoin.conf", "-datadir=" + this.DataFolder }, loadConfiguration: false);
+            var settings = new NodeSettings(this.network, args: new string[] { "-conf=bitcoin.conf", "-datadir=" + this.DataFolder });
             var builder = new FullNodeBuilder().UseNodeSettings(settings);
 
             this.callback(builder);
@@ -262,7 +262,7 @@ namespace Stratis.Bitcoin.IntegrationTests.Common.EnvironmentMockUpHelpers
 
         public override void BuildNode()
         {
-            var settings = new NodeSettings(this.network, ProtocolVersion.ALT_PROTOCOL_VERSION, args: new string[] { "-conf=stratis.conf", "-datadir=" + this.DataFolder }, loadConfiguration: false);
+            var settings = new NodeSettings(this.network, ProtocolVersion.ALT_PROTOCOL_VERSION, args: new string[] { "-conf=stratis.conf", "-datadir=" + this.DataFolder });
             var builder = new FullNodeBuilder().UseNodeSettings(settings);
 
             this.callback(builder);


### PR DESCRIPTION
This is needed for testing node features that are outside the SBFN codebase.