### PR TITLE
Node stops attempting to connect

### DIFF
--- a/src/Stratis.Bitcoin/P2P/PeerAddressManager.cs
+++ b/src/Stratis.Bitcoin/P2P/PeerAddressManager.cs
@@ -101,7 +101,6 @@ namespace Stratis.Bitcoin.P2P
         /// <summary>Logger factory to create loggers.</summary>
         private readonly ILoggerFactory loggerFactory;
 
-        
         /// <summary>Key value store that indexes all discovered peers by their end point.</summary>
         private readonly ConcurrentDictionary<IPEndPoint, PeerAddress> peers;
 

--- a/src/Stratis.Bitcoin/P2P/PeerSelector.cs
+++ b/src/Stratis.Bitcoin/P2P/PeerSelector.cs
@@ -197,9 +197,17 @@ namespace Stratis.Bitcoin.P2P
 
             // If all the selection criteria failed to return a set of peers,
             // then let the caller try again.
-            else
-                this.logger.LogTrace("[RETURN_NO_PEERS]");
+            this.logger.LogTrace("[RETURN_NO_PEERS]");
 
+            int attemptedReachedThresholdCount = this.peerAddresses.Values.Count(p => p.Attempted && p.ConnectionAttempts == PeerAddress.AttemptThreshold && !this.IsBanned(p));
+            bool areAllPeersReachedThreshold = attemptedReachedThresholdCount == this.peerAddresses.Values.Count(p => !this.IsBanned(p));
+            if (areAllPeersReachedThreshold)
+            {
+                // Reset attempts for all the peers since we've ran out of options.
+                foreach (PeerAddress peer in this.peerAddresses.Values.Where(p => !this.IsBanned(p)))
+                    peer.ResetAttempts();
+            }
+            
             return new PeerAddress[] { };
         }
 

--- a/src/Stratis.Bitcoin/P2P/PeerSelector.cs
+++ b/src/Stratis.Bitcoin/P2P/PeerSelector.cs
@@ -199,7 +199,7 @@ namespace Stratis.Bitcoin.P2P
             // then let the caller try again.
             this.logger.LogTrace("[RETURN_NO_PEERS]");
 
-            int attemptedReachedThresholdCount = this.peerAddresses.Values.Count(p => p.Attempted && p.ConnectionAttempts == PeerAddress.AttemptThreshold && !this.IsBanned(p));
+            int attemptedReachedThresholdCount = this.peerAddresses.Values.Count(p => p.ConnectionAttempts == PeerAddress.AttemptThreshold && !this.IsBanned(p));
             bool areAllPeersReachedThreshold = attemptedReachedThresholdCount == this.peerAddresses.Values.Count(p => !this.IsBanned(p));
             if (areAllPeersReachedThreshold)
             {

--- a/src/Stratis.Bitcoin/P2P/PeerSelector.cs
+++ b/src/Stratis.Bitcoin/P2P/PeerSelector.cs
@@ -204,9 +204,11 @@ namespace Stratis.Bitcoin.P2P
                 // Reset attempts for all the peers since we've ran out of options.
                 foreach (PeerAddress peer in this.peerAddresses.Values.Where(p => !this.IsBanned(p)))
                     peer.ResetAttempts();
+                
+                IEnumerable<PeerAddress> addresses = this.peerAddresses.Values.Where(p => !this.IsBanned(p));
 
                 this.logger.LogTrace("(-)[RESET_ATTEMPTS]");
-                return this.peerAddresses.Values.Where(p => !this.IsBanned(p));
+                return addresses;
             }
 
             // If all the selection criteria failed to return a set of peers, then let the caller try again.

--- a/src/Stratis.Bitcoin/P2P/PeerSelector.cs
+++ b/src/Stratis.Bitcoin/P2P/PeerSelector.cs
@@ -194,20 +194,23 @@ namespace Stratis.Bitcoin.P2P
                 this.logger.LogTrace("[RETURN_ATTEMPTED_HC_FAILED]");
                 return attempted;
             }
-
-            // If all the selection criteria failed to return a set of peers,
-            // then let the caller try again.
-            this.logger.LogTrace("[RETURN_NO_PEERS]");
-
+            
             int attemptedReachedThresholdCount = this.peerAddresses.Values.Count(p => p.ConnectionAttempts == PeerAddress.AttemptThreshold && !this.IsBanned(p));
             bool areAllPeersReachedThreshold = attemptedReachedThresholdCount == this.peerAddresses.Values.Count(p => !this.IsBanned(p));
             if (areAllPeersReachedThreshold)
             {
+                this.logger.LogTrace("Resetting attempts for {0} addresses.", attemptedReachedThresholdCount);
+
                 // Reset attempts for all the peers since we've ran out of options.
                 foreach (PeerAddress peer in this.peerAddresses.Values.Where(p => !this.IsBanned(p)))
                     peer.ResetAttempts();
+
+                this.logger.LogTrace("(-)[RESET_ATTEMPTS]");
+                return this.peerAddresses.Values.Where(p => !this.IsBanned(p));
             }
-            
+
+            // If all the selection criteria failed to return a set of peers, then let the caller try again.
+            this.logger.LogTrace("(-)[RETURN_NO_PEERS]");
             return new PeerAddress[] { };
         }
 


### PR DESCRIPTION
This is a bugfix for a bug reported by @maciejzaleski 

The problem is that at some point all the peers in peers.json have maxed out connectionAttempts count and the selector always returns nothing. 

This can happen when node was working without access to the internet for some time or if node was running for a very long time. 

I've added a quick fix that will reset attempts count in case there are no peers to try and all peers from the list that are not banned have their connection attempts count maxed out. 
After resetting the node will recover if any of the peers are still alive. 