### PR TITLE
exclude libbitcoinconsensus-0.dll tests when not on windows

### DIFF
--- a/src/NBitcoin.Tests/script_tests.cs
+++ b/src/NBitcoin.Tests/script_tests.cs
@@ -330,11 +330,6 @@ namespace NBitcoin.Tests
         [Trait("Core", "Core")]
         public void script_json_tests()
         {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-                return;
-            }
-
             EnsureHasLibConsensus();
             var tests = TestCase.read_json(TestDataLocations.GetFileFromDataFolder("script_tests.json"));
             foreach(var test in tests)
@@ -379,10 +374,13 @@ namespace NBitcoin.Tests
             var spendingTransaction = CreateSpendingTransaction(wit, scriptSig, creditingTransaction);
             ScriptError actual;
             Script.VerifyScript(Network.Main, scriptSig, scriptPubKey, spendingTransaction, 0, amount, flags, SigHash.Undefined, out actual);
-            Assert.True(expectedError == actual, "Test : " + testIndex + " " + comment);            
+            Assert.True(expectedError == actual, "Test : " + testIndex + " " + comment);
 #if !NOCONSENSUSLIB
-            var ok = Script.VerifyScriptConsensus(scriptPubKey, spendingTransaction, 0, amount, flags);
-            Assert.True(ok == (expectedError == ScriptError.OK), "[ConsensusLib] Test : " + testIndex + " " + comment);
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                var ok = Script.VerifyScriptConsensus(scriptPubKey, spendingTransaction, 0, amount, flags);
+                Assert.True(ok == (expectedError == ScriptError.OK), "[ConsensusLib] Test : " + testIndex + " " + comment);
+            }
 #endif
         }
 
@@ -768,7 +766,10 @@ namespace NBitcoin.Tests
         {
             Assert.False(Script.VerifyScript(Network.Main, scriptPubKey, tx, n, null, flags));
 #if !NOCONSENSUSLIB
-            Assert.False(Script.VerifyScriptConsensus(scriptPubKey, tx, (uint)n, flags));
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                Assert.False(Script.VerifyScriptConsensus(scriptPubKey, tx, (uint)n, flags));
+            }
 #endif
         }
 
@@ -776,7 +777,10 @@ namespace NBitcoin.Tests
         {
             Assert.True(Script.VerifyScript(Network.Main, scriptPubKey, tx, n, null, flags));
 #if !NOCONSENSUSLIB
-            Assert.True(Script.VerifyScriptConsensus(scriptPubKey, tx, (uint)n, flags));
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                Assert.True(Script.VerifyScriptConsensus(scriptPubKey, tx, (uint)n, flags));
+            }
 #endif
         }
 


### PR DESCRIPTION
Check if the tests are running on Windows before executing them.
This will fix the NBitcoin tests relying on libbitcoinconsensus-0.dll.

![image](https://user-images.githubusercontent.com/1867877/41133042-96e4088e-6abc-11e8-8fb4-fb5bc24ed52e.png)
