### PR TITLE
Utilize BlockSize property in the block store queue

### DIFF
--- a/src/Stratis.Bitcoin.Features.BlockStore.Tests/BlockStoreTests.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore.Tests/BlockStoreTests.cs
@@ -197,7 +197,10 @@ namespace Stratis.Bitcoin.Features.BlockStore.Tests
             for (int i = 1; i < this.chain.Height - 1; i++)
             {
                 lastHeader = this.chain.GetBlock(i);
-                this.blockStoreQueue.AddToPending(new BlockPair(new Block(), lastHeader));
+                Block block = new Block();
+                block.GetSerializedSize();
+
+                this.blockStoreQueue.AddToPending(new BlockPair(block, lastHeader));
             }
 
             await this.WaitUntilQueueIsEmptyAsync().ConfigureAwait(false);
@@ -223,7 +226,10 @@ namespace Stratis.Bitcoin.Features.BlockStore.Tests
             for (int i = 1; i <= this.chain.Height; i++)
             {
                 ChainedHeader lastHeader = this.chain.GetBlock(i);
-                this.blockStoreQueue.AddToPending(new BlockPair(new Block(), lastHeader));
+                Block block = new Block();
+                block.GetSerializedSize();
+
+                this.blockStoreQueue.AddToPending(new BlockPair(block, lastHeader));
             }
 
             await this.WaitUntilQueueIsEmptyAsync().ConfigureAwait(false);
@@ -245,12 +251,22 @@ namespace Stratis.Bitcoin.Features.BlockStore.Tests
             // First present a short chain.
             ConcurrentChain alternativeChain = this.CreateChain(reorgedChainLenght);
             for (int i = 1; i < alternativeChain.Height; i++)
-                this.blockStoreQueue.AddToPending(new BlockPair(new Block(), alternativeChain.GetBlock(i)));
+            {
+                Block block = new Block();
+                block.GetSerializedSize();
+
+                this.blockStoreQueue.AddToPending(new BlockPair(block, alternativeChain.GetBlock(i)));
+            }
 
             // Present second chain which has more work and reorgs blocks from genesis. 
             for (int i = 1; i < realChainLenght; i++)
-                this.blockStoreQueue.AddToPending(new BlockPair(new Block(), this.chain.GetBlock(i)));
-            
+            {
+                Block block = new Block();
+                block.GetSerializedSize();
+
+                this.blockStoreQueue.AddToPending(new BlockPair(block, this.chain.GetBlock(i)));
+            }
+
             await this.WaitUntilQueueIsEmptyAsync().ConfigureAwait(false);
 
             Assert.Equal(this.chainState.BlockStoreTip, this.chain.Genesis);
@@ -282,8 +298,13 @@ namespace Stratis.Bitcoin.Features.BlockStore.Tests
 
             // Sending 500 blocks to the queue.
             for (int i = 1; i < 500; i++)
-                this.blockStoreQueue.AddToPending(new BlockPair(new Block(), this.chain.GetBlock(i)));
-            
+            {
+                Block block = new Block();
+                block.GetSerializedSize();
+
+                this.blockStoreQueue.AddToPending(new BlockPair(block, this.chain.GetBlock(i)));
+            }
+
             // Create alternative chain with fork point at 450.
             ChainedHeader prevBlock = this.chain.GetBlock(450);
             var alternativeBlocks = new List<ChainedHeader>();
@@ -308,7 +329,12 @@ namespace Stratis.Bitcoin.Features.BlockStore.Tests
 
             // Present alternative chain and trigger save.
             foreach (ChainedHeader header in alternativeBlocks)
-                this.blockStoreQueue.AddToPending(new BlockPair(new Block(), header));
+            {
+                Block block = new Block();
+                block.GetSerializedSize();
+
+                this.blockStoreQueue.AddToPending(new BlockPair(block, header));
+            }
 
             await this.WaitUntilQueueIsEmptyAsync().ConfigureAwait(false);
 
@@ -321,7 +347,12 @@ namespace Stratis.Bitcoin.Features.BlockStore.Tests
             this.consensusTip = this.chain.Tip;
 
             for (int i = 451; i <= this.chain.Height; i++)
-                this.blockStoreQueue.AddToPending(new BlockPair(new Block(), this.chain.GetBlock(i)));
+            {
+                Block block = new Block();
+                block.GetSerializedSize();
+
+                this.blockStoreQueue.AddToPending(new BlockPair(block, this.chain.GetBlock(i)));
+            }
 
             await this.WaitUntilQueueIsEmptyAsync().ConfigureAwait(false);
             

--- a/src/Stratis.Bitcoin.Features.BlockStore/BlockStoreQueue.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/BlockStoreQueue.cs
@@ -35,7 +35,7 @@ namespace Stratis.Bitcoin.Features.BlockStore
         internal const int BatchThresholdSizeBytes = 5 * 1000 * 1000;
 
         /// <summary>The current batch size in bytes.</summary>
-        private int currentBatchSizeBytes;
+        private long currentBatchSizeBytes;
 
         /// <summary>The highest stored block in the repository.</summary>
         private ChainedHeader storeTip;
@@ -258,7 +258,7 @@ namespace Stratis.Bitcoin.Features.BlockStore
 
                     batch.Add(item);
 
-                    this.currentBatchSizeBytes += item.Block.GetSerializedSize();
+                    this.currentBatchSizeBytes += item.Block.BlockSize.Value;
 
                     saveBatch = saveBatch || (item.ChainedHeader == this.chain.Tip) || (this.currentBatchSizeBytes >= BatchThresholdSizeBytes);
                 }

--- a/src/Stratis.Bitcoin.Features.Miner/BlockDefinition.cs
+++ b/src/Stratis.Bitcoin.Features.Miner/BlockDefinition.cs
@@ -209,7 +209,7 @@ namespace Stratis.Bitcoin.Features.Miner
         /// </summary>
         /// <param name="chainTip">Tip of the chain that this instance will work with without touching any shared chain resources.</param>
         /// <param name="scriptPubKey">Script that explains what conditions must be met to claim ownership of a coin.</param>
-        /// <returns>The contructed <see cref="Miner.BlockTemplate"/>.</returns>
+        /// <returns>The contructed <see cref="Mining.BlockTemplate"/>.</returns>
         protected void OnBuild(ChainedHeader chainTip, Script scriptPubKey)
         {
             this.Configure();


### PR DESCRIPTION
Minor blockstorequeue optimization which allows us to avoid serialization of every block in order to get block size. 