### PR TITLE
Added new test to cover issue #13. Presenting chains with different chain work

### DIFF
--- a/src/Stratis.Bitcoin.Tests/Consensus/ChainedHeaderTreeTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Consensus/ChainedHeaderTreeTest.cs
@@ -65,11 +65,10 @@ namespace Stratis.Bitcoin.Tests.Consensus
                                         ? previousHeader.Header.Bits 
                                         : this.ChangeDifficulty(previousHeader, difficultyAdjustmentDivisor);
                     header.Nonce = (uint)new Random().Next(1, 100000);
-                    var newHeader = new ChainedHeader(header, header.GetHash(), previousHeader)
-                    {
-                        Block = Block.Parse(TestBlockHex, Network.StratisTest)
-                    };
-
+                    var newHeader = new ChainedHeader(header, header.GetHash(), previousHeader);
+                    Block block = this.Network.Consensus.ConsensusFactory.CreateBlock();
+                    block.GetSerializedSize();
+                    newHeader.Block = block;
                     previousHeader = newHeader;
                 }
 

--- a/src/Stratis.Bitcoin.Tests/Consensus/ChainedHeaderTreeTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Consensus/ChainedHeaderTreeTest.cs
@@ -33,10 +33,10 @@ namespace Stratis.Bitcoin.Tests.Consensus
                 return this.ChainedHeaderTree;
             }
 
-            internal Target ChangeDifficulty(ChainedHeader header, int difficultyAdjustmentScore)
+            internal Target ChangeDifficulty(ChainedHeader header, int difficultyAdjustmentDivisor)
             {
                 BigInteger newTarget = header.Header.Bits.ToBigInteger();
-                newTarget = newTarget.Divide(BigInteger.ValueOf(difficultyAdjustmentScore)); 
+                newTarget = newTarget.Divide(BigInteger.ValueOf(difficultyAdjustmentDivisor)); 
                 return new Target(newTarget);
             }
 

--- a/src/Stratis.Bitcoin.Tests/Consensus/ChainedHeaderTreeTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Consensus/ChainedHeaderTreeTest.cs
@@ -256,12 +256,12 @@ namespace Stratis.Bitcoin.Tests.Consensus
             List<BlockHeader> listOfChainABlockHeaders = ctx.ChainedHeaderToList(chainATip, commonChainSize + chainAExtension);
             List<BlockHeader> listOfChainBBlockHeaders = ctx.ChainedHeaderToList(chainBTip, commonChainSize + chainBExtension);
 
-            // Chain A is presented by peer 1. DownloadTo should be chain A tip
+            // Chain A is presented by peer 1. DownloadTo should be Chain A tip
             ConnectNewHeadersResult connectNewHeadersResult = cht.ConnectNewHeaders(1, listOfChainABlockHeaders);
             ChainedHeader chainedHeaderTo = connectNewHeadersResult.DownloadTo;
             chainedHeaderTo.HashBlock.Should().Be(chainATip.HashBlock);
 
-            // Chain B is presented by peer 2. DownloadTo should be not set as chain
+            // Chain B is presented by peer 2. DownloadTo should be not set, as Chain
             // B has less chain work
             connectNewHeadersResult = cht.ConnectNewHeaders(2, listOfChainBBlockHeaders);
             chainedHeaderTo = connectNewHeadersResult.DownloadTo;
@@ -272,7 +272,7 @@ namespace Stratis.Bitcoin.Tests.Consensus
             chainBTip = ctx.ExtendAChain(chainBAdditionalBLocks, chainBTip); // ie. (h1=h2=h3=h4)=b5=b6=b7=b8=b9=b10
             listOfChainBBlockHeaders = ctx.ChainedHeaderToList(chainBTip, commonChainSize + chainBExtension + chainBAdditionalBLocks);
 
-            // Chain B is presented by peer 2 again. DownloadTo should be now be chain B tip
+            // Chain B is presented by peer 2 again. DownloadTo should now be Chain B tip
             // as B has more chain work than chain A
             connectNewHeadersResult = cht.ConnectNewHeaders(2, listOfChainBBlockHeaders);
             chainedHeaderTo = connectNewHeadersResult.DownloadTo;

--- a/src/Stratis.Bitcoin.Tests/Consensus/ChainedHeaderTreeTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Consensus/ChainedHeaderTreeTest.cs
@@ -51,13 +51,12 @@ namespace Stratis.Bitcoin.Tests.Consensus
 
                 for (int i = 0; i < count; i++)
                 {
-                    Interlocked.Increment(ref nonceValue);
                     BlockHeader header = this.Network.Consensus.ConsensusFactory.CreateBlockHeader();
                     header.HashPrevBlock = previousHeader.HashBlock;
                     header.Bits = difficultyAdjustmentDivisor == 1 
                                         ? previousHeader.Header.Bits 
                                         : this.ChangeDifficulty(previousHeader, difficultyAdjustmentDivisor);
-                    header.Nonce = (uint) nonceValue;
+                    header.Nonce = (uint)Interlocked.Increment(ref nonceValue);
                     var newHeader = new ChainedHeader(header, header.GetHash(), previousHeader);
                     Block block = this.Network.Consensus.ConsensusFactory.CreateBlock();
                     block.GetSerializedSize();

--- a/src/Stratis.Bitcoin.Tests/Consensus/ChainedHeaderTreeTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Consensus/ChainedHeaderTreeTest.cs
@@ -26,7 +26,7 @@ namespace Stratis.Bitcoin.Tests.Consensus
             public Mock<IFinalizedBlockHeight> FinalizedBlockMock = new Mock<IFinalizedBlockHeight>();
             public ConsensusSettings ConsensusSettings = new ConsensusSettings(new NodeSettings(Network.RegTest));
 
-            private static int nonceValue = 0;
+            private static int nonceValue;
 
             internal ChainedHeaderTree ChainedHeaderTree;
 

--- a/src/Stratis.Bitcoin.Tests/Consensus/ChainedHeaderTreeTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Consensus/ChainedHeaderTreeTest.cs
@@ -256,12 +256,12 @@ namespace Stratis.Bitcoin.Tests.Consensus
             List<BlockHeader> listOfChainABlockHeaders = ctx.ChainedHeaderToList(chainATip, commonChainSize + chainAExtension);
             List<BlockHeader> listOfChainBBlockHeaders = ctx.ChainedHeaderToList(chainBTip, commonChainSize + chainBExtension);
 
-            // Chain A is presented by peer 1. DownoadTo should be chain A tip
+            // Chain A is presented by peer 1. DownloadTo should be chain A tip
             ConnectNewHeadersResult connectNewHeadersResult = cht.ConnectNewHeaders(1, listOfChainABlockHeaders);
             ChainedHeader chainedHeaderTo = connectNewHeadersResult.DownloadTo;
             chainedHeaderTo.HashBlock.Should().Be(chainATip.HashBlock);
 
-            // Chain B is presented by peer 2. DownoadTo should be not set as chain
+            // Chain B is presented by peer 2. DownloadTo should be not set as chain
             // B has less chain work
             connectNewHeadersResult = cht.ConnectNewHeaders(2, listOfChainBBlockHeaders);
             chainedHeaderTo = connectNewHeadersResult.DownloadTo;
@@ -272,7 +272,7 @@ namespace Stratis.Bitcoin.Tests.Consensus
             chainBTip = ctx.ExtendAChain(chainBAdditionalBLocks, chainBTip); // ie. (h1=h2=h3=h4)=b5=b6=b7=b8=b9=b10
             listOfChainBBlockHeaders = ctx.ChainedHeaderToList(chainBTip, commonChainSize + chainBExtension + chainBAdditionalBLocks);
 
-            // Chain B is presented by peer 2 again. DownoadTo should be now be chain B tip
+            // Chain B is presented by peer 2 again. DownloadTo should be now be chain B tip
             // as B has more chain work than chain A
             connectNewHeadersResult = cht.ConnectNewHeaders(2, listOfChainBBlockHeaders);
             chainedHeaderTo = connectNewHeadersResult.DownloadTo;

--- a/src/Stratis.Bitcoin.Tests/Consensus/ChainedHeaderTreeTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Consensus/ChainedHeaderTreeTest.cs
@@ -1,8 +1,10 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using FluentAssertions;
 using Moq;
 using NBitcoin;
+using NBitcoin.BouncyCastle.Math;
 using Stratis.Bitcoin.Base;
 using Stratis.Bitcoin.Configuration;
 using Stratis.Bitcoin.Configuration.Logging;
@@ -23,6 +25,18 @@ namespace Stratis.Bitcoin.Tests.Consensus
             public Mock<IFinalizedBlockHeight> FinalizedBlockMock = new Mock<IFinalizedBlockHeight>();
             public ConsensusSettings ConsensusSettings = new ConsensusSettings(new NodeSettings(Network.RegTest));
 
+            private const string TestBlockHex =
+                "07000000867ccd8f8b21f48e1423d2217fdfe0ea5108dcd6f3371933d584e8f250f5c6600fdf4ccef23cbdb6d81e6bde" +
+                "a2f0f45aca69a35a9817590c60b5a4ce4a44d1cc30c644592060041a00000000020100000030c6445901000000000000" +
+                "0000000000000000000000000000000000000000000000000000ffffffff03029423ffffffff01000000000000000000" +
+                "000000000100000030c6445901795088bf033121a794ea35a11d39dbcd2495b64756e6de76d86944fdeea4ddbc020000" +
+                "00484730440220096615c8fdec79ecf477cea2104859f7db98ed883f242b08fef316e3abd41a30022070d82dd743eeed" +
+                "324e90cb3c168144031ba8c8b14a6af167b98253614be3d23c01ffffffff0300000000000000000000011f4a8b000000" +
+                "232102e89f4f5ac02d3e5f9114253470838ee73c9ba507262ba4db7f0b3f840cf0e1d3ac40432e4a8b000000232102e8" +
+                "9f4f5ac02d3e5f9114253470838ee73c9ba507262ba4db7f0b3f840cf0e1d3ac00000000463044022002efd3facb7bc9" +
+                "9407d0f7c6b9c8e80898608f63f3141b06371bbd5e762dd4ab02204f1a5e8cca1a70a5b6dee55746f100042e3479c291" +
+                "68dd9970c1b3147cbd6ed8";
+
             internal ChainedHeaderTree ChainedHeaderTree;
 
             internal ChainedHeaderTree CreateChainedHeaderTree()
@@ -31,16 +45,31 @@ namespace Stratis.Bitcoin.Tests.Consensus
                 return this.ChainedHeaderTree;
             }
 
-            public ChainedHeader ExtendAChain(int count, ChainedHeader chainedHeader = null)
+            internal Target ChangeDifficulty(ChainedHeader header, int difficultyAdjustmentScore)
             {
+                BigInteger newTarget = header.Header.Bits.ToBigInteger();
+                newTarget = newTarget.Divide(BigInteger.ValueOf(difficultyAdjustmentScore)); 
+                return new Target(newTarget);
+            }
+
+            public ChainedHeader ExtendAChain(int count, ChainedHeader chainedHeader = null, int difficultyAdjustmentDivisor = 1)
+            {
+                if (difficultyAdjustmentDivisor == 0) throw new ArgumentException("Divisor cannot be 0");
                 ChainedHeader previousHeader = chainedHeader ?? new ChainedHeader(this.Network.GetGenesis().Header, this.Network.GenesisHash, 0);
 
                 for (int i = 0; i < count; i++)
                 {
                     BlockHeader header = this.Network.Consensus.ConsensusFactory.CreateBlockHeader();
                     header.HashPrevBlock = previousHeader.HashBlock;
-                    header.Bits = previousHeader.Header.Bits - 1000; // just increase difficulty.
-                    var newHeader = new ChainedHeader(header, header.GetHash(), previousHeader);
+                    header.Bits = difficultyAdjustmentDivisor == 1 
+                                        ? previousHeader.Header.Bits 
+                                        : this.ChangeDifficulty(previousHeader, difficultyAdjustmentDivisor);
+                    header.Nonce = (uint)new Random().Next(1, 100000);
+                    var newHeader = new ChainedHeader(header, header.GetHash(), previousHeader)
+                    {
+                        Block = Block.Parse(TestBlockHex, Network.StratisTest)
+                    };
+
                     previousHeader = newHeader;
                 }
 
@@ -240,13 +269,14 @@ namespace Stratis.Bitcoin.Tests.Consensus
         [Fact]
         public void PresentDifferentChains_AlternativeChainWithMoreChainWorkShouldAlwaysBeMarkedForDownload()
         {
-            // Chain header tree setup
+            // Chain header tree setup.
             var ctx = new TestContext();
             ChainedHeaderTree cht = ctx.CreateChainedHeaderTree();
             ChainedHeader initialChainTip = ctx.ExtendAChain(5);
             cht.Initialize(initialChainTip, true);
+            ctx.ConsensusSettings.UseCheckpoints = false;
 
-            // Chains A and B setup
+            // Chains A and B setup.
             const int commonChainSize = 4;
             const int chainAExtension = 4;
             const int chainBExtension = 2;
@@ -256,25 +286,35 @@ namespace Stratis.Bitcoin.Tests.Consensus
             List<BlockHeader> listOfChainABlockHeaders = ctx.ChainedHeaderToList(chainATip, commonChainSize + chainAExtension);
             List<BlockHeader> listOfChainBBlockHeaders = ctx.ChainedHeaderToList(chainBTip, commonChainSize + chainBExtension);
 
-            // Chain A is presented by peer 1. DownloadTo should be Chain A tip
+            // Chain A is presented by peer 1. DownloadTo should be Chain A tip.
             ConnectNewHeadersResult connectNewHeadersResult = cht.ConnectNewHeaders(1, listOfChainABlockHeaders);
             ChainedHeader chainedHeaderTo = connectNewHeadersResult.DownloadTo;
             chainedHeaderTo.HashBlock.Should().Be(chainATip.HashBlock);
 
+            // Set Chain A tip as a consensus tip
+            cht.ConsensusTipChanged(chainATip);
+
             // Chain B is presented by peer 2. DownloadTo should be not set, as Chain
-            // B has less chain work
+            // B has less chain work.
             connectNewHeadersResult = cht.ConnectNewHeaders(2, listOfChainBBlockHeaders);
-            chainedHeaderTo = connectNewHeadersResult.DownloadTo;
-            chainedHeaderTo.Should().BeNull();
+            connectNewHeadersResult.Should().BeNull();
 
-            // Add more chain work and blocks into chain B
-            const int chainBAdditionalBLocks = 4;
-            chainBTip = ctx.ExtendAChain(chainBAdditionalBLocks, chainBTip); // ie. (h1=h2=h3=h4)=b5=b6=b7=b8=b9=b10
-            listOfChainBBlockHeaders = ctx.ChainedHeaderToList(chainBTip, commonChainSize + chainBExtension + chainBAdditionalBLocks);
+            // Add more chain work and blocks into chain B.
+            const int chainBAdditionalBlocks = 4;
+            chainBTip = ctx.ExtendAChain(chainBAdditionalBlocks, chainBTip); // ie. (h1=h2=h3=h4)=b5=b6=b7=b8=b9=b10
+            listOfChainBBlockHeaders = ctx.ChainedHeaderToList(chainBTip, commonChainSize + chainBExtension + chainBAdditionalBlocks);
+            List<BlockHeader> listOfNewChainBBlockHeaders = listOfChainBBlockHeaders.TakeLast(chainBAdditionalBlocks).ToList();
 
-            // Chain B is presented by peer 2 again. DownloadTo should now be Chain B tip
-            // as B has more chain work than chain A
-            connectNewHeadersResult = cht.ConnectNewHeaders(2, listOfChainBBlockHeaders);
+            // Chain B is presented by peer 2 again.
+            // DownloadTo should now be Chain B as B has more chain work than chain A.
+            // DownloadFrom should be the block where split occurred.
+            // h1=h2=h3=h4=(b5)=b6=b7=b8=b9=(b10) - from b5 to b10.
+            connectNewHeadersResult = cht.ConnectNewHeaders(2, listOfNewChainBBlockHeaders);
+
+            ChainedHeader chainedHeaderFrom = connectNewHeadersResult.DownloadFrom;
+            BlockHeader expectedHeaderFrom = listOfChainBBlockHeaders[commonChainSize];
+            chainedHeaderFrom.Header.GetHash().Should().Be(expectedHeaderFrom.GetHash());
+
             chainedHeaderTo = connectNewHeadersResult.DownloadTo;
             chainedHeaderTo.HashBlock.Should().Be(chainBTip.HashBlock);
         }

--- a/src/Stratis.Bitcoin.Tests/Consensus/ChainedHeaderTreeTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Consensus/ChainedHeaderTreeTest.cs
@@ -289,7 +289,7 @@ namespace Stratis.Bitcoin.Tests.Consensus
             // Chain B is presented by peer 2. DownloadTo should be not set, as chain
             // B has less chain work.
             connectNewHeadersResult = cht.ConnectNewHeaders(2, listOfChainBBlockHeaders);
-            connectNewHeadersResult.Should().BeNull();
+            connectNewHeadersResult.DownloadTo.Should().BeNull();
 
             // Add more chain work and blocks into chain B.
             const int chainBAdditionalBlocks = 4;

--- a/src/Stratis.Bitcoin.Tests/Consensus/ChainedHeaderTreeTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Consensus/ChainedHeaderTreeTest.cs
@@ -25,18 +25,6 @@ namespace Stratis.Bitcoin.Tests.Consensus
             public Mock<IFinalizedBlockHeight> FinalizedBlockMock = new Mock<IFinalizedBlockHeight>();
             public ConsensusSettings ConsensusSettings = new ConsensusSettings(new NodeSettings(Network.RegTest));
 
-            private const string TestBlockHex =
-                "07000000867ccd8f8b21f48e1423d2217fdfe0ea5108dcd6f3371933d584e8f250f5c6600fdf4ccef23cbdb6d81e6bde" +
-                "a2f0f45aca69a35a9817590c60b5a4ce4a44d1cc30c644592060041a00000000020100000030c6445901000000000000" +
-                "0000000000000000000000000000000000000000000000000000ffffffff03029423ffffffff01000000000000000000" +
-                "000000000100000030c6445901795088bf033121a794ea35a11d39dbcd2495b64756e6de76d86944fdeea4ddbc020000" +
-                "00484730440220096615c8fdec79ecf477cea2104859f7db98ed883f242b08fef316e3abd41a30022070d82dd743eeed" +
-                "324e90cb3c168144031ba8c8b14a6af167b98253614be3d23c01ffffffff0300000000000000000000011f4a8b000000" +
-                "232102e89f4f5ac02d3e5f9114253470838ee73c9ba507262ba4db7f0b3f840cf0e1d3ac40432e4a8b000000232102e8" +
-                "9f4f5ac02d3e5f9114253470838ee73c9ba507262ba4db7f0b3f840cf0e1d3ac00000000463044022002efd3facb7bc9" +
-                "9407d0f7c6b9c8e80898608f63f3141b06371bbd5e762dd4ab02204f1a5e8cca1a70a5b6dee55746f100042e3479c291" +
-                "68dd9970c1b3147cbd6ed8";
-
             internal ChainedHeaderTree ChainedHeaderTree;
 
             internal ChainedHeaderTree CreateChainedHeaderTree()

--- a/src/Stratis.Bitcoin.Tests/Consensus/ChainedHeaderTreeTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Consensus/ChainedHeaderTreeTest.cs
@@ -249,9 +249,9 @@ namespace Stratis.Bitcoin.Tests.Consensus
         }
 
         /// <summary>
-        /// Issue 13 @ Create 2 chains Chain A and Chain B, where Chain A has more chain work than B. Connect both
-        /// chains to chain header tree. Consensus tip should be set to chain A. Now extend / update Chain B to make it have
-        /// more chain work. Attempt to connect B again. Consensus tip should be set to chain B.
+        /// Issue 13 @ Create 2 chains - chain A and chain B, where chain A has more chain work than chain B. Connect both
+        /// chains to chain header tree. Consensus tip should be set to chain A. Now extend / update chain B to make it have
+        /// more chain work. Attempt to connect chain B again. Consensus tip should be set to chain B.
         /// </summary>
         [Fact]
         public void PresentDifferentChains_AlternativeChainWithMoreChainWorkShouldAlwaysBeMarkedForDownload()
@@ -273,15 +273,15 @@ namespace Stratis.Bitcoin.Tests.Consensus
             List<BlockHeader> listOfChainABlockHeaders = ctx.ChainedHeaderToList(chainATip, commonChainSize + chainAExtension);
             List<BlockHeader> listOfChainBBlockHeaders = ctx.ChainedHeaderToList(chainBTip, commonChainSize + chainBExtension);
 
-            // Chain A is presented by peer 1. DownloadTo should be Chain A tip.
+            // Chain A is presented by peer 1. DownloadTo should be chain A tip.
             ConnectNewHeadersResult connectNewHeadersResult = cht.ConnectNewHeaders(1, listOfChainABlockHeaders);
             ChainedHeader chainedHeaderTo = connectNewHeadersResult.DownloadTo;
             chainedHeaderTo.HashBlock.Should().Be(chainATip.HashBlock);
 
-            // Set Chain A tip as a consensus tip
+            // Set chain A tip as a consensus tip
             cht.ConsensusTipChanged(chainATip);
 
-            // Chain B is presented by peer 2. DownloadTo should be not set, as Chain
+            // Chain B is presented by peer 2. DownloadTo should be not set, as chain
             // B has less chain work.
             connectNewHeadersResult = cht.ConnectNewHeaders(2, listOfChainBBlockHeaders);
             connectNewHeadersResult.Should().BeNull();
@@ -293,7 +293,7 @@ namespace Stratis.Bitcoin.Tests.Consensus
             List<BlockHeader> listOfNewChainBBlockHeaders = listOfChainBBlockHeaders.TakeLast(chainBAdditionalBlocks).ToList();
 
             // Chain B is presented by peer 2 again.
-            // DownloadTo should now be Chain B as B has more chain work than chain A.
+            // DownloadTo should now be chain B as B has more chain work than chain A.
             // DownloadFrom should be the block where split occurred.
             // h1=h2=h3=h4=(b5)=b6=b7=b8=b9=(b10) - from b5 to b10.
             connectNewHeadersResult = cht.ConnectNewHeaders(2, listOfNewChainBBlockHeaders);


### PR DESCRIPTION
Create 2 chains Chain A and Chain B, where Chain A has more chain work than B. Connect both chains to chain header tree. Consensus tip should be set to chain A. Now extend / update Chain B to make it have more chain work. Attempt to connect B again. Consensus tip should be set to chain B.

See https://github.com/stratisproject/StratisBitcoinFullNode/issues/1321#issuecomment-389155904