### PR TITLE
[RF][SmartContracts] Abstract the AddToBlock method

### DIFF
--- a/src/Stratis.Bitcoin.Features.Miner/PosBlockDefinition.cs
+++ b/src/Stratis.Bitcoin.Features.Miner/PosBlockDefinition.cs
@@ -37,6 +37,18 @@ namespace Stratis.Bitcoin.Features.Miner
         }
 
         /// <inheritdoc/>
+        public override void AddToBlock(TxMempoolEntry mempoolEntry)
+        {
+            this.logger.LogTrace("({0}.{1}:'{2}', {3}:{4})", nameof(mempoolEntry), nameof(mempoolEntry.TransactionHash), mempoolEntry.TransactionHash, nameof(mempoolEntry.ModifiedFee), mempoolEntry.ModifiedFee);
+
+            this.AddTransactionToBlock(mempoolEntry.Transaction);
+            this.UpdateBlockStatistics(mempoolEntry);
+            this.UpdateTotalFees(mempoolEntry.Fee);
+
+            this.logger.LogTrace("(-)");
+        }
+
+        /// <inheritdoc/>
         public override BlockTemplate Build(ChainedHeader chainTip, Script scriptPubKey)
         {
             this.logger.LogTrace("({0}:'{1}',{2}.{3}:{4})", nameof(chainTip), chainTip, nameof(scriptPubKey), nameof(scriptPubKey.Length), scriptPubKey.Length);

--- a/src/Stratis.Bitcoin.Features.Miner/PowBlockDefinition.cs
+++ b/src/Stratis.Bitcoin.Features.Miner/PowBlockDefinition.cs
@@ -2,7 +2,6 @@
 using NBitcoin;
 using Stratis.Bitcoin.Consensus;
 using Stratis.Bitcoin.Consensus.Rules;
-using Stratis.Bitcoin.Features.Consensus;
 using Stratis.Bitcoin.Features.Consensus.Interfaces;
 using Stratis.Bitcoin.Features.MemoryPool;
 using Stratis.Bitcoin.Features.MemoryPool.Interfaces;
@@ -14,8 +13,6 @@ namespace Stratis.Bitcoin.Features.Miner
     public class PowBlockDefinition : BlockDefinition
     {
         private readonly IConsensusRules consensusRules;
-
-        /// <summary>Instance logger.</summary>
         private readonly ILogger logger;
 
         public PowBlockDefinition(
@@ -31,6 +28,17 @@ namespace Stratis.Bitcoin.Features.Miner
         {
             this.consensusRules = consensusRules;
             this.logger = loggerFactory.CreateLogger(this.GetType().FullName);
+        }
+
+        public override void AddToBlock(TxMempoolEntry mempoolEntry)
+        {
+            this.logger.LogTrace("({0}.{1}:'{2}', {3}:{4})", nameof(mempoolEntry), nameof(mempoolEntry.TransactionHash), mempoolEntry.TransactionHash, nameof(mempoolEntry.ModifiedFee), mempoolEntry.ModifiedFee);
+
+            this.AddTransactionToBlock(mempoolEntry.Transaction);
+            this.UpdateBlockStatistics(mempoolEntry);
+            this.UpdateTotalFees(mempoolEntry.Fee);
+
+            this.logger.LogTrace("(-)");
         }
 
         /// <inheritdoc/>


### PR DESCRIPTION
In SmartContracts we add transactions to the block differently than how we do pow/pos blocks. We first need to check whether or not the transaction to be added contains SC information and if it does, we execute it to validate and calculate fees etc.

Currently we have to make the `AddToBlock` method in `BlockDefinition` virtual so that we can override its behavior. This needs to be changed to an abstract method so that each block definition implements its own logic to add a transaction to a block.

The logic in the current `AddToBlock` has been split into 3 methods:

1> Add tx to block.
2> Update block stats.
3> Update block fee.