### PR TITLE
Remove duplicated fee comparison in TxMempoolEntry and TxMemPoolModifiedEntry

### DIFF
--- a/src/NBitcoin/UInt256.cs
+++ b/src/NBitcoin/UInt256.cs
@@ -322,7 +322,7 @@ namespace NBitcoin
             return Comparison(a, b) >= 0;
         }
 
-        private static int Comparison(uint256 a, uint256 b)
+        public static int Comparison(uint256 a, uint256 b)
         {
             if (a == null)
                 throw new ArgumentNullException("a");

--- a/src/Stratis.Bitcoin.Features.MemoryPool.Tests/MemoryPoolTransactionTests.cs
+++ b/src/Stratis.Bitcoin.Features.MemoryPool.Tests/MemoryPoolTransactionTests.cs
@@ -337,7 +337,7 @@ namespace Stratis.Bitcoin.Features.MemoryPool.Tests
             // tx1 and tx5 are both 10000
             // Ties are broken by hash, not timestamp, so determine which
             // hash comes first.
-            if (tx1.GetHash() > tx5.GetHash())
+            if (tx1.GetHash() < tx5.GetHash())
             {
                 sortedOrder.Insert(2, tx1.GetHash().ToString());
                 sortedOrder.Insert(3, tx5.GetHash().ToString());
@@ -358,7 +358,7 @@ namespace Stratis.Bitcoin.Features.MemoryPool.Tests
             int tx6Size = tx6.GetVirtualSize();
             Assert.Equal(6, pool.Size);
             // Ties are broken by hash
-            if (tx3.GetHash() > tx6.GetHash())
+            if (tx3.GetHash() < tx6.GetHash())
                 sortedOrder.Add(tx6.GetHash().ToString());
             else
                 sortedOrder.Insert(sortedOrder.Count - 1, tx6.GetHash().ToString());
@@ -380,7 +380,7 @@ namespace Stratis.Bitcoin.Features.MemoryPool.Tests
 
             sortedOrder.RemoveAt(1);
             // Ties are broken by hash
-            if (tx3.GetHash() > tx6.GetHash())
+            if (tx3.GetHash() < tx6.GetHash())
                 sortedOrder.Remove(sortedOrder.Last());
             else
                 sortedOrder.RemoveAt(sortedOrder.Count - 2);

--- a/src/Stratis.Bitcoin.Features.MemoryPool.Tests/MemoryPoolTransactionTests.cs
+++ b/src/Stratis.Bitcoin.Features.MemoryPool.Tests/MemoryPoolTransactionTests.cs
@@ -337,7 +337,7 @@ namespace Stratis.Bitcoin.Features.MemoryPool.Tests
             // tx1 and tx5 are both 10000
             // Ties are broken by hash, not timestamp, so determine which
             // hash comes first.
-            if (tx1.GetHash() < tx5.GetHash())
+            if (tx1.GetHash() > tx5.GetHash())
             {
                 sortedOrder.Insert(2, tx1.GetHash().ToString());
                 sortedOrder.Insert(3, tx5.GetHash().ToString());
@@ -358,7 +358,7 @@ namespace Stratis.Bitcoin.Features.MemoryPool.Tests
             int tx6Size = tx6.GetVirtualSize();
             Assert.Equal(6, pool.Size);
             // Ties are broken by hash
-            if (tx3.GetHash() < tx6.GetHash())
+            if (tx3.GetHash() > tx6.GetHash())
                 sortedOrder.Add(tx6.GetHash().ToString());
             else
                 sortedOrder.Insert(sortedOrder.Count - 1, tx6.GetHash().ToString());
@@ -380,7 +380,7 @@ namespace Stratis.Bitcoin.Features.MemoryPool.Tests
 
             sortedOrder.RemoveAt(1);
             // Ties are broken by hash
-            if (tx3.GetHash() < tx6.GetHash())
+            if (tx3.GetHash() > tx6.GetHash())
                 sortedOrder.Remove(sortedOrder.Last());
             else
                 sortedOrder.RemoveAt(sortedOrder.Count - 2);

--- a/src/Stratis.Bitcoin.Features.MemoryPool/TxMemPool.cs
+++ b/src/Stratis.Bitcoin.Features.MemoryPool/TxMemPool.cs
@@ -1053,7 +1053,7 @@ namespace Stratis.Bitcoin.Features.MemoryPool
             /// <summary>Gets a collection of memory pool entries ordered by ancestor score.</summary>
             public IEnumerable<TxMempoolEntry> AncestorScore
             {
-                get { return this.Values.OrderByDescending(o => o, new CompareTxMemPoolEntryByAncestorFee()); }
+                get { return this.Values.OrderBy(o => o, new CompareTxMemPoolEntryByAncestorFee()); }
             }
 
             /// <summary>

--- a/src/Stratis.Bitcoin.Features.MemoryPool/TxMemPool.cs
+++ b/src/Stratis.Bitcoin.Features.MemoryPool/TxMemPool.cs
@@ -1053,7 +1053,7 @@ namespace Stratis.Bitcoin.Features.MemoryPool
             /// <summary>Gets a collection of memory pool entries ordered by ancestor score.</summary>
             public IEnumerable<TxMempoolEntry> AncestorScore
             {
-                get { return this.Values.OrderBy(o => o, new CompareTxMemPoolEntryByAncestorFee()); }
+                get { return this.Values.OrderByDescending(o => o, new CompareTxMemPoolEntryByAncestorFee()); }
             }
 
             /// <summary>
@@ -1192,26 +1192,7 @@ namespace Stratis.Bitcoin.Features.MemoryPool
                 /// <inheritdoc />
                 public int Compare(TxMempoolEntry a, TxMempoolEntry b)
                 {
-                    double aFees = a.ModFeesWithAncestors.Satoshi;
-                    double aSize = a.SizeWithAncestors;
-
-                    double bFees = b.ModFeesWithAncestors.Satoshi;
-                    double bSize = b.SizeWithAncestors;
-
-                    // Avoid division by rewriting (a/b > c/d) as (a*d > c*b).
-                    double f1 = aFees * bSize;
-                    double f2 = aSize * bFees;
-
-                    if (f1 == f2)
-                    {
-                        if (a.TransactionHash < b.TransactionHash)
-                            return -1;
-                        return 1;
-                    }
-
-                    if (f1 > f2)
-                        return -1;
-                    return 1;
+                    return TxMempoolEntry.CompareFees(a, b);
                 }
             }
         }
@@ -1224,20 +1205,7 @@ namespace Stratis.Bitcoin.Features.MemoryPool
             /// <inheritdoc />
             public int Compare(TxMempoolEntry a, TxMempoolEntry b)
             {
-                return InnerCompare(a, b);
-            }
-
-            /// <summary>
-            /// Compares transaction hash of two memory pool entries.
-            /// </summary>
-            /// <param name="a">Memory pool entry.</param>
-            /// <param name="b">Memory pool entry.</param>
-            /// <returns>Result of comparison function.</returns>
-            public static int InnerCompare(TxMempoolEntry a, TxMempoolEntry b)
-            {
-                if (a.TransactionHash == b.TransactionHash) return 0;
-                if (a.TransactionHash < b.TransactionHash) return -1;
-                return 1;
+                return a.CompareTo(b);
             }
         }
 

--- a/src/Stratis.Bitcoin.Features.MemoryPool/TxMemPoolEntry.cs
+++ b/src/Stratis.Bitcoin.Features.MemoryPool/TxMemPoolEntry.cs
@@ -320,7 +320,7 @@ namespace Stratis.Bitcoin.Features.MemoryPool
             if (f1 == f2)
                 return a.CompareTo(b);
 
-            return (f1 > f2) ? 1 : -1;
+            return (f1 < f2) ? 1 : -1;
         }
     }
 }

--- a/src/Stratis.Bitcoin.Features.MemoryPool/TxMemPoolEntry.cs
+++ b/src/Stratis.Bitcoin.Features.MemoryPool/TxMemPoolEntry.cs
@@ -33,9 +33,18 @@ namespace Stratis.Bitcoin.Features.MemoryPool
     }
 
     /// <summary>
+    /// This interface includes the fields required for fee comparison.
+    /// </summary>
+    public interface ITxMempoolFees
+    {
+        Money ModFeesWithAncestors { get; }
+        long SizeWithAncestors { get; }
+    }
+
+    /// <summary>
     /// A transaction entry in the memory pool.
     /// </summary>
-    public class TxMempoolEntry
+    public class TxMempoolEntry:IComparable, ITxMempoolFees
     {
         /// <summary>Index in memory pools vTxHashes.</summary>
         public volatile uint vTxHashesIdx;
@@ -283,6 +292,35 @@ namespace Stratis.Bitcoin.Features.MemoryPool
         public override string ToString()
         {
             return $"{this.TransactionHash} - {base.ToString()}";
+        }
+
+        /// <summary>
+        /// Default comparator for comparing this object to another TxMemPoolEntry object.
+        /// </summary>
+        /// <param name="other">Memory pool entry to compare to.</param>
+        /// <returns>Result of comparison function.</returns>
+        public int CompareTo(object other)
+        {
+            return uint256.Comparison(this.TransactionHash, (other as TxMempoolEntry).TransactionHash);
+        }
+
+        /// <summary>
+        /// Used to compare fees on objects supporting the IComparable and ITxMempoolFees interfaces.
+        /// </summary>
+        /// <typeparam name="T">A type that supports the IComparable and ITxMempoolFees interfaces.</typeparam>
+        /// <param name="a">The first object to compare.</param>
+        /// <param name="b">The second object to compare.</param>
+        /// <returns>Returns -1 if a less than b, 0 if a equals b, and 1 if a greater than b.</returns>
+        public static int CompareFees<T>(T a, T b) where T:IComparable,ITxMempoolFees
+        {
+            // Avoid division by rewriting (a/b > c/d) as (a*d > c*b).
+            Money f1 = a.ModFeesWithAncestors * b.SizeWithAncestors;
+            Money f2 = b.ModFeesWithAncestors * a.SizeWithAncestors;
+
+            if (f1 == f2)
+                return a.CompareTo(b);
+
+            return (f1 > f2) ? 1 : -1;
         }
     }
 }

--- a/src/Stratis.Bitcoin.Features.Miner/BlockDefinition.cs
+++ b/src/Stratis.Bitcoin.Features.Miner/BlockDefinition.cs
@@ -360,7 +360,7 @@ namespace Stratis.Bitcoin.Features.Miner
                 var compare = new CompareModifiedEntry();
                 if (mi == null)
                 {
-                    modit = mapModifiedTx.Values.OrderByDescending(o => o, compare).First();
+                    modit = mapModifiedTx.Values.OrderBy(o => o, compare).First();
                     iter = modit.MempoolEntry;
                     fUsingModified = true;
                 }
@@ -369,8 +369,8 @@ namespace Stratis.Bitcoin.Features.Miner
                     // Try to compare the mapTx entry to the mapModifiedTx entry
                     iter = mi;
 
-                    modit = mapModifiedTx.Values.OrderByDescending(o => o, compare).FirstOrDefault();
-                    if ((modit != null) && (compare.Compare(modit, new TxMemPoolModifiedEntry(iter)) > 0))
+                    modit = mapModifiedTx.Values.OrderBy(o => o, compare).FirstOrDefault();
+                    if ((modit != null) && (compare.Compare(modit, new TxMemPoolModifiedEntry(iter)) < 0))
                     {
                         // The best entry in mapModifiedTx has higher score
                         // than the one from mapTx..

--- a/src/Stratis.Bitcoin.Features.Miner/Comparers/CompareModifiedEntry.cs
+++ b/src/Stratis.Bitcoin.Features.Miner/Comparers/CompareModifiedEntry.cs
@@ -1,7 +1,5 @@
 ﻿using System.Collections.Generic;
-using NBitcoin;
 using Stratis.Bitcoin.Features.MemoryPool;
-using static Stratis.Bitcoin.Features.Miner.PowBlockDefinition;
 
 namespace Stratis.Bitcoin.Features.Miner.Comparers
 {
@@ -9,18 +7,11 @@ namespace Stratis.Bitcoin.Features.Miner.Comparers
     /// This matches the calculation in CompareTxMemPoolEntryByAncestorFee,
     /// except operating on CTxMemPoolModifiedEntry.
     /// </summary>
-    /// <remarks>TODO: Refactor to avoid duplication of this logic.</remarks>
     public sealed class CompareModifiedEntry : IComparer<TxMemPoolModifiedEntry>
     {
         public int Compare(TxMemPoolModifiedEntry a, TxMemPoolModifiedEntry b)
         {
-            Money f1 = a.ModFeesWithAncestors * b.SizeWithAncestors;
-            Money f2 = b.ModFeesWithAncestors * a.SizeWithAncestors;
-
-            if (f1 == f2)
-                return TxMempool.CompareIteratorByHash.InnerCompare(a.MempoolEntry, b.MempoolEntry);
-
-            return f1 > f2 ? 1 : -1;
+            return TxMempoolEntry.CompareFees(a, b);
         }
     }
 }

--- a/src/Stratis.Bitcoin.Features.Miner/Comparers/CompareTxIterByAncestorCount.cs
+++ b/src/Stratis.Bitcoin.Features.Miner/Comparers/CompareTxIterByAncestorCount.cs
@@ -17,7 +17,7 @@ namespace Stratis.Bitcoin.Features.Miner.Comparers
             if (a.CountWithAncestors != b.CountWithAncestors)
                 return a.CountWithAncestors < b.CountWithAncestors ? -1 : 1;
 
-            return TxMempool.CompareIteratorByHash.InnerCompare(a, b);
+            return a.CompareTo(b);
         }
     }
 }

--- a/src/Stratis.Bitcoin.Features.Miner/TxMemPoolModifiedEntry.cs
+++ b/src/Stratis.Bitcoin.Features.Miner/TxMemPoolModifiedEntry.cs
@@ -1,4 +1,5 @@
-﻿using NBitcoin;
+﻿using System;
+using NBitcoin;
 using Stratis.Bitcoin.Features.MemoryPool;
 
 namespace Stratis.Bitcoin.Features.Miner
@@ -6,15 +7,18 @@ namespace Stratis.Bitcoin.Features.Miner
     /// <summary>
     /// Container for tracking updates to ancestor feerate as we include (parent) transactions in a block.
     /// </summary>
-    public sealed class TxMemPoolModifiedEntry
+    public sealed class TxMemPoolModifiedEntry:IComparable, ITxMempoolFees
     {
         public readonly TxMempoolEntry MempoolEntry;
 
-        public Money ModFeesWithAncestors;
+        /// <summary>
+        /// Gets the size of the transaction with it's ancestors.</summary>
+        public long SizeWithAncestors { get; set; }
+
+        /// <summary>Gets the total fees of the transaction including it's ancestors.</summary>
+        public Money ModFeesWithAncestors { get; set; }
 
         public long SigOpCostWithAncestors;
-
-        public long SizeWithAncestors;
 
         public TxMemPoolModifiedEntry(TxMempoolEntry entry)
         {
@@ -22,6 +26,16 @@ namespace Stratis.Bitcoin.Features.Miner
             this.ModFeesWithAncestors = entry.ModFeesWithAncestors;
             this.SigOpCostWithAncestors = entry.SigOpCostWithAncestors;
             this.SizeWithAncestors = entry.SizeWithAncestors;
+        }
+
+        /// <summary>
+        /// Default comparator for comparing this object to another TxMemPoolModifiedEntry object.
+        /// </summary>
+        /// <param name="other">Modified memory pool entry to compare to.</param>
+        /// <returns>Result of comparison function.</returns>
+        public int CompareTo(object other)
+        {
+            return uint256.Comparison(this.MempoolEntry.TransactionHash, (other as TxMemPoolModifiedEntry).MempoolEntry.TransactionHash);
         }
     }
 }


### PR DESCRIPTION
This PR:

- Removes the duplicated fee comparison in TxMempoolEntry and TxMemPoolModifiedEntry

See https://github.com/stratisproject/StratisBitcoinFullNode/issues/1441.