### PR TITLE
Chain header tree test to cover issue 14

### DIFF
--- a/src/Stratis.Bitcoin.Tests/Consensus/ChainedHeaderTreeTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Consensus/ChainedHeaderTreeTest.cs
@@ -354,12 +354,17 @@ namespace Stratis.Bitcoin.Tests.Consensus
             extendedChainTip = extendedChainTip.Previous;
             extendedChainTip = ctx.ExtendAChain(newChainExtension, extendedChainTip); 
             List<BlockHeader> listOfNewChainHeaders = ctx.ChainedHeaderToList(extendedChainTip, extendedChainTip.Height);
-            
-            // New chain is presented by peer 1.
+
+            // First 5 blocks are presented by peer 1.
+            // DownloadTo should be set to a checkpoint 1. 
+            ConnectNewHeadersResult result = cht.ConnectNewHeaders(1, listOfNewChainHeaders.Take(5).ToList());
+            result.DownloadTo.HashBlock.Should().Be(checkpoint1.Hash);
+
+            // Remaining 5 blocks are presented by peer 1 which do not cover checkpoint 2.
             // InvalidHeaderException should be thrown.
             Action connectAction = () =>
             {
-                cht.ConnectNewHeaders(1, listOfNewChainHeaders);
+                cht.ConnectNewHeaders(1, listOfNewChainHeaders.Skip(5).ToList());
             };
 
             connectAction.Should().Throw<InvalidHeaderException>();

--- a/src/Stratis.Bitcoin.Tests/Consensus/ChainedHeaderTreeTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Consensus/ChainedHeaderTreeTest.cs
@@ -39,7 +39,7 @@ namespace Stratis.Bitcoin.Tests.Consensus
             internal Target ChangeDifficulty(ChainedHeader header, int difficultyAdjustmentDivisor)
             {
                 BigInteger newTarget = header.Header.Bits.ToBigInteger();
-                newTarget = newTarget.Divide(BigInteger.ValueOf(difficultyAdjustmentDivisor)); 
+                newTarget = newTarget.Divide(BigInteger.ValueOf(difficultyAdjustmentDivisor));
                 return new Target(newTarget);
             }
 
@@ -53,8 +53,8 @@ namespace Stratis.Bitcoin.Tests.Consensus
                 {
                     BlockHeader header = this.Network.Consensus.ConsensusFactory.CreateBlockHeader();
                     header.HashPrevBlock = previousHeader.HashBlock;
-                    header.Bits = difficultyAdjustmentDivisor == 1 
-                                        ? previousHeader.Header.Bits 
+                    header.Bits = difficultyAdjustmentDivisor == 1
+                                        ? previousHeader.Header.Bits
                                         : this.ChangeDifficulty(previousHeader, difficultyAdjustmentDivisor);
                     header.Nonce = (uint)Interlocked.Increment(ref nonceValue);
                     var newHeader = new ChainedHeader(header, header.GetHash(), previousHeader);
@@ -99,7 +99,7 @@ namespace Stratis.Bitcoin.Tests.Consensus
             var testContext = new TestContext();
             ChainedHeaderTree chainedHeaderTree = testContext.CreateChainedHeaderTree();
 
-            Assert.Throws<ConnectHeaderException>(() => chainedHeaderTree.ConnectNewHeaders(1, new List<BlockHeader>(new [] { testContext.Network.GetGenesis().Header})));
+            Assert.Throws<ConnectHeaderException>(() => chainedHeaderTree.ConnectNewHeaders(1, new List<BlockHeader>(new[] { testContext.Network.GetGenesis().Header })));
         }
 
         [Fact]
@@ -189,9 +189,9 @@ namespace Stratis.Bitcoin.Tests.Consensus
             ChainedHeaderTree cht = testContext.CreateChainedHeaderTree();
             ChainedHeader chainTip = testContext.ExtendAChain(10);
             cht.Initialize(chainTip, true);
-            
+
             List<BlockHeader> listOfExistingHeaders = testContext.ChainedHeaderToList(chainTip, 10);
-            
+
             cht.ConnectNewHeaders(1, listOfExistingHeaders);
 
             Dictionary<uint256, HashSet<int>> peerIdsByTipHashBefore = cht.GetPeerIdsByTipHash().ToDictionary(entry => entry.Key, entry => new HashSet<int>(entry.Value));
@@ -238,7 +238,7 @@ namespace Stratis.Bitcoin.Tests.Consensus
             List<BlockHeader> listOfNewBlockHeaders = ctx.ChainedHeaderToList(newChainTip, 7);
 
             // Peer 1 supplies some headers
-            List<BlockHeader> peer1Headers = listOfNewBlockHeaders.GetRange(0,3);
+            List<BlockHeader> peer1Headers = listOfNewBlockHeaders.GetRange(0, 3);
             cht.ConnectNewHeaders(1, peer1Headers);
 
             // Peer 2 supplies some more headers
@@ -247,7 +247,7 @@ namespace Stratis.Bitcoin.Tests.Consensus
             ChainedHeader chainedHeaderFrom = connectNewHeadersResult.DownloadFrom;
             ChainedHeader chainedHeaderTo = connectNewHeadersResult.DownloadTo;
             int headersToDownloadCount = chainedHeaderTo.Height - chainedHeaderFrom.Height + 1; // Inclusive
-            
+
             // ToDownload array of the same size as the amount of headers
             Assert.Equal(headersToDownloadCount, peer2Headers.Count);
         }
@@ -308,6 +308,62 @@ namespace Stratis.Bitcoin.Tests.Consensus
 
             chainedHeaderTo = connectNewHeadersResult.DownloadTo;
             chainedHeaderTo.HashBlock.Should().Be(chainBTip.HashBlock);
+        }
+
+        /// <summary>
+        /// Issue 14 @ Chain exists with checkpoints enabled. There are 2 checkpoints. Peer presents a chain that covers
+        /// first checkpoint. Then it presents a prolongation that doesnt match the 2nd checkpoint. We should discard the chain
+        /// up until the first checkpoint.
+        /// </summary>
+        [Fact]
+        public void ChainHasTwoCheckPoints_ChainConveringOnlyFirstCheckPointIsPresented_ChainIsDiscardedUpUntilFirstCheckpoint()
+        {
+            // Chain header tree setup.
+            const int initialChainSize = 2;
+            const int currentChainExtension = 6;
+            var ctx = new TestContext();
+            ChainedHeaderTree cht = ctx.CreateChainedHeaderTree();
+            ChainedHeader initialChainTip = ctx.ExtendAChain(initialChainSize); // ie. h1=h2
+            cht.Initialize(initialChainTip, true); 
+            ChainedHeader extendedChainTip = ctx.ExtendAChain(currentChainExtension, initialChainTip); // ie. h1=h2=h3=h4=h5=h6=h7=h8
+            ctx.ConsensusSettings.UseCheckpoints = true;
+            List<BlockHeader> listOfCurrentChainHeaders = ctx.ChainedHeaderToList(extendedChainTip, initialChainSize + currentChainExtension);
+
+            // Setup two known checkpoints at header 4 and 7.
+            // Example: h1=h2=h3=(h4)=h5=h6=(h7)=h8.
+            const int firstCheckpointHeight = 4;
+            const int secondCheckpointHeight = 7;
+            var checkpoint1 = new CheckpointInfo(listOfCurrentChainHeaders[firstCheckpointHeight - 1].GetHash());
+            var checkpoint2 = new CheckpointInfo(listOfCurrentChainHeaders[secondCheckpointHeight - 1].GetHash());
+            ctx.CheckpointsMock
+               .Setup(c => c.GetCheckpoint(firstCheckpointHeight))
+               .Returns(checkpoint1);
+            ctx.CheckpointsMock
+               .Setup(c => c.GetCheckpoint(secondCheckpointHeight))
+               .Returns(checkpoint2);
+            ctx.CheckpointsMock
+               .Setup(c => c.GetCheckpoint(It.IsNotIn(firstCheckpointHeight, secondCheckpointHeight)))
+               .Returns((CheckpointInfo)null);
+            ctx.CheckpointsMock
+                .Setup(c => c.GetLastCheckpointHeight())
+                .Returns(secondCheckpointHeight);
+
+            // Setup new chain that only covers first checkpoint but doesn't cover second checkpoint.
+            // Example: h1=h2=h3=(h4)=h5=h6=x7=x8=x9=x10.
+            const int newChainExtension = 4;
+            extendedChainTip = extendedChainTip.Previous; // walk back to block 6
+            extendedChainTip = extendedChainTip.Previous;
+            extendedChainTip = ctx.ExtendAChain(newChainExtension, extendedChainTip); 
+            List<BlockHeader> listOfNewChainHeaders = ctx.ChainedHeaderToList(extendedChainTip, extendedChainTip.Height);
+            
+            // New chain is presented by peer 1.
+            // InvalidHeaderException should be thrown.
+            Action connectAction = () =>
+            {
+                cht.ConnectNewHeaders(1, listOfNewChainHeaders);
+            };
+
+            connectAction.Should().Throw<InvalidHeaderException>();
         }
     }
 }

--- a/src/Stratis.Bitcoin.Tests/Consensus/ChainedHeaderTreeTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Consensus/ChainedHeaderTreeTest.cs
@@ -312,8 +312,7 @@ namespace Stratis.Bitcoin.Tests.Consensus
 
         /// <summary>
         /// Issue 14 @ Chain exists with checkpoints enabled. There are 2 checkpoints. Peer presents a chain that covers
-        /// first checkpoint. Then it presents a prolongation that doesnt match the 2nd checkpoint. We should discard the chain
-        /// up until the first checkpoint.
+        /// first checkpoint with a prolongation that does not match the 2nd checkpoint. Exception should be thrown.
         /// </summary>
         [Fact]
         public void ChainHasTwoCheckPoints_ChainConveringOnlyFirstCheckPointIsPresented_ChainIsDiscardedUpUntilFirstCheckpoint()


### PR DESCRIPTION
Issue 14 @ Chain exists with checkpoints enabled. There are 2 checkpoints. Peer presents a chain that covers first checkpoint with a prolongation that does not match the 2nd checkpoint. Exception should be thrown.

See https://github.com/stratisproject/StratisBitcoinFullNode/issues/1321#issuecomment-389155904.

Preferred reviewers: @Aprogiena or @noescape00 