### PR TITLE
Remove SetNull() from BlockHeader and make the constructor internal

### DIFF
--- a/src/NBitcoin.Tests/ConstructorsForSerializableClassesTest.cs
+++ b/src/NBitcoin.Tests/ConstructorsForSerializableClassesTest.cs
@@ -14,6 +14,7 @@ namespace NBitcoin.Tests
             // parameterless constructor for a good reason so they should not fail this test.
             var exceptionalTypes = new List<Type>()
             {
+                typeof(BlockHeader),
                 typeof(ExtKey),
                 typeof(ExtPubKey),
                 typeof(PubKey),
@@ -24,7 +25,7 @@ namespace NBitcoin.Tests
             };
 
             IEnumerable<Type> types = AppDomain.CurrentDomain.GetAssemblies()
-                .Where(x =>x.FullName.Contains("Stratis") || x.FullName.Contains("NBitcoin"))
+                .Where(x => x.FullName.Contains("Stratis") || x.FullName.Contains("NBitcoin"))
                 .SelectMany(s => s.GetTypes())
                 .Where(p => typeof(IBitcoinSerializable).IsAssignableFrom(p) && !p.IsInterface && p.IsClass);
 

--- a/src/NBitcoin.Tests/pos_transaction_tests.cs
+++ b/src/NBitcoin.Tests/pos_transaction_tests.cs
@@ -36,35 +36,33 @@ namespace NBitcoin.Tests
         [Trait("UnitTest", "UnitTest")]
         public void CanGetMedianBlock()
         {
-            Network network = Network.StratisMain;
-
             var chain = new ConcurrentChain(Network.StratisMain);
             DateTimeOffset now = DateTimeOffset.UtcNow;
-            chain.SetTip(CreateBlock(network, now, 0, chain));
-            chain.SetTip(CreateBlock(network, now, -1, chain));
-            chain.SetTip(CreateBlock(network, now, 1, chain));
-            Assert.Equal(CreateBlock(network, now, 0).Header.BlockTime, chain.Tip.GetMedianTimePast()); // x -1 0 1
-            chain.SetTip(CreateBlock(network, now, 2, chain));
-            Assert.Equal(CreateBlock(network, now, 0).Header.BlockTime, chain.Tip.GetMedianTimePast()); // x -1 0 1 2
-            chain.SetTip(CreateBlock(network, now, 3, chain));
-            Assert.Equal(CreateBlock(network, now, 1).Header.BlockTime, chain.Tip.GetMedianTimePast()); // x -1 0 1 2 3
-            chain.SetTip(CreateBlock(network, now, 4, chain));
-            chain.SetTip(CreateBlock(network, now, 5, chain));
-            chain.SetTip(CreateBlock(network, now, 6, chain));
-            chain.SetTip(CreateBlock(network, now, 7, chain));
-            chain.SetTip(CreateBlock(network, now, 8, chain));
+            chain.SetTip(CreateBlock(now, 0, chain));
+            chain.SetTip(CreateBlock(now, -1, chain));
+            chain.SetTip(CreateBlock(now, 1, chain));
+            Assert.Equal(CreateBlock(now, 0).Header.BlockTime, chain.Tip.GetMedianTimePast()); // x -1 0 1
+            chain.SetTip(CreateBlock(now, 2, chain));
+            Assert.Equal(CreateBlock(now, 0).Header.BlockTime, chain.Tip.GetMedianTimePast()); // x -1 0 1 2
+            chain.SetTip(CreateBlock(now, 3, chain));
+            Assert.Equal(CreateBlock(now, 1).Header.BlockTime, chain.Tip.GetMedianTimePast()); // x -1 0 1 2 3
+            chain.SetTip(CreateBlock(now, 4, chain));
+            chain.SetTip(CreateBlock(now, 5, chain));
+            chain.SetTip(CreateBlock(now, 6, chain));
+            chain.SetTip(CreateBlock(now, 7, chain));
+            chain.SetTip(CreateBlock(now, 8, chain));
 
-            Assert.Equal(CreateBlock(network, now, 3).Header.BlockTime, chain.Tip.GetMedianTimePast()); // x -1 0 1 2 3 4 5 6 7 8
+            Assert.Equal(CreateBlock(now, 3).Header.BlockTime, chain.Tip.GetMedianTimePast()); // x -1 0 1 2 3 4 5 6 7 8
 
-            chain.SetTip(CreateBlock(network, now, 9, chain));
-            Assert.Equal(CreateBlock(network, now, 4).Header.BlockTime, chain.Tip.GetMedianTimePast()); // x -1 0 1 2 3 4 5 6 7 8 9
-            chain.SetTip(CreateBlock(network, now, 10, chain));
-            Assert.Equal(CreateBlock(network, now, 5).Header.BlockTime, chain.Tip.GetMedianTimePast()); // x -1 0 1 2 3 4 5 6 7 8 9 10
+            chain.SetTip(CreateBlock(now, 9, chain));
+            Assert.Equal(CreateBlock(now, 4).Header.BlockTime, chain.Tip.GetMedianTimePast()); // x -1 0 1 2 3 4 5 6 7 8 9
+            chain.SetTip(CreateBlock(now, 10, chain));
+            Assert.Equal(CreateBlock(now, 5).Header.BlockTime, chain.Tip.GetMedianTimePast()); // x -1 0 1 2 3 4 5 6 7 8 9 10
         }
 
-        private ChainedHeader CreateBlock(Network network, DateTimeOffset now, int offset, ChainBase chain = null)
+        private ChainedHeader CreateBlock(DateTimeOffset now, int offset, ChainBase chain = null)
         {
-            Block block = network.Consensus.ConsensusFactory.CreateBlock();
+            Block block = Network.StratisMain.Consensus.ConsensusFactory.CreateBlock();
             block.Header.BlockTime = now + TimeSpan.FromMinutes(offset);
 
             if (chain != null)
@@ -985,19 +983,17 @@ namespace NBitcoin.Tests
         private void CanVerifySequenceLockCore(Sequence[] sequences, int[] prevHeights, int currentHeight, DateTimeOffset first, bool expected, SequenceLock expectedLock)
         {
             Network network = Network.StratisMain;
-
             BlockHeader blockHeader = network.Consensus.ConsensusFactory.CreateBlockHeader();
             blockHeader.BlockTime = first;
 
-            var chain = new ConcurrentChain(blockHeader);
+            var chain = new ConcurrentChain(blockHeader, network);
             first = first + TimeSpan.FromMinutes(10);
 
             while (currentHeight != chain.Height)
             {
                 BlockHeader header = network.Consensus.ConsensusFactory.CreateBlockHeader();
-                blockHeader.BlockTime = first;
-                blockHeader.HashPrevBlock = chain.Tip.HashBlock;
-
+                header.BlockTime = first;
+                header.HashPrevBlock = chain.Tip.HashBlock;
                 chain.SetTip(header);
                 first = first + TimeSpan.FromMinutes(10);
             }

--- a/src/NBitcoin.Tests/transaction_tests.cs
+++ b/src/NBitcoin.Tests/transaction_tests.cs
@@ -1181,12 +1181,10 @@ namespace NBitcoin.Tests
                 return new Coin(outpoint, new TxOut(amount, scriptPubKey));
             return new ScriptCoin(outpoint, new TxOut(amount, scriptPubKey.Hash), scriptPubKey);
         }
-
         private Coin RandomCoin(Money amount, Key receiver)
         {
             return RandomCoin(amount, receiver.PubKey.GetAddress(Network.Main));
         }
-
         private Coin RandomCoin(Money amount, IDestination receiver)
         {
             OutPoint outpoint = RandOutpoint();
@@ -1234,7 +1232,6 @@ namespace NBitcoin.Tests
             AssertEx.CollectionEquals(Encoders.Hex.DecodeData("0102030405060708090102030405060708090102030405060708090102030405"), bytes.ToArray());
             Assert.True(new uint256("0102030405060708090102030405060708090102030405060708090102030405") == new uint256(new uint256("0102030405060708090102030405060708090102030405060708090102030405")));
         }
-
 #if !NOSOCKET
         [Fact]
         [Trait("UnitTest", "UnitTest")]
@@ -1245,7 +1242,6 @@ namespace NBitcoin.Tests
             Assert.True(Utils.IsIPv4MappedToIPv6(Utils.MapToIPv6(System.Net.IPAddress.Parse("127.0.0.1"))));
         }
 #endif
-
         [Fact]
         [Trait("UnitTest", "UnitTest")]
         public void BitcoinStreamCoverage()
@@ -1267,9 +1263,9 @@ namespace NBitcoin.Tests
                 bs.ReadWrite(ref items);
             });
             BitcoinStreamCoverageCore(new long[] { -1, 1, 2, 3, 4 }, (BitcoinStream bs, ref long[] items) =>
-             {
-                 bs.ReadWrite(ref items);
-             });
+            {
+                bs.ReadWrite(ref items);
+            });
             BitcoinStreamCoverageCore(new byte[] { 1, 2, 3, 4 }, (BitcoinStream bs, ref byte[] items) =>
             {
                 bs.ReadWrite(ref items);
@@ -1967,16 +1963,16 @@ namespace NBitcoin.Tests
             {
                 Op[] ops = input.TxIn.ScriptSig.ToOps().ToArray();
                 foreach (var sig in ops.Select(o =>
-                     {
-                         try
-                         {
-                             return new TransactionSignature(o.PushData);
-                         }
-                         catch
-                         {
-                             return null;
-                         }
-                     })
+                {
+                    try
+                    {
+                        return new TransactionSignature(o.PushData);
+                    }
+                    catch
+                    {
+                        return null;
+                    }
+                })
                     .Select((sig, i) => new
                     {
                         sig,

--- a/src/NBitcoin.Tests/transaction_tests.cs
+++ b/src/NBitcoin.Tests/transaction_tests.cs
@@ -62,17 +62,17 @@ namespace NBitcoin.Tests
 
         private ChainedHeader CreateBlock(DateTimeOffset now, int offset, ChainBase chain = null)
         {
-            var b = new Block(new BlockHeader()
+            Network network = Network.Main;
+            Block block = network.Consensus.ConsensusFactory.CreateBlock();
+            block.Header.BlockTime = now + TimeSpan.FromMinutes(offset);
+
+            if (chain != null)
             {
-                BlockTime = now + TimeSpan.FromMinutes(offset)
-            });
-            if(chain != null)
-            {
-                b.Header.HashPrevBlock = chain.Tip.HashBlock;
-                return new ChainedHeader(b.Header, b.Header.GetHash(), chain.Tip);
+                block.Header.HashPrevBlock = chain.Tip.HashBlock;
+                return new ChainedHeader(block.Header, block.Header.GetHash(), chain.Tip);
             }
             else
-                return new ChainedHeader(b.Header, b.Header.GetHash(), 0);
+                return new ChainedHeader(block.Header, block.Header.GetHash(), 0);
         }
 
         [Fact]
@@ -290,15 +290,15 @@ namespace NBitcoin.Tests
             //You need to get the ScriptCoin, the RedeemScript of you script coin should be k.PubKey.WitHash.ScriptPubKey.
 
             Coin[] coins =
- 	                //Get coins from any block explorer.
+                //Get coins from any block explorer.
                 GetCoins(p2sh)
- 	                //Nobody knows your redeem script, so you add here the information
- 	                //This line is actually optional since 4.0.0.38, as the TransactionBuilder is smart enough to figure out
- 	                //the redeems from the keys added by AddKeys.
- 	                //However, explicitely having the redeem will make code more easy to update to other payment like 2-2
- 	                //.Select(c => c.ToScriptCoin(k.PubKey.WitHash.ScriptPubKey))
+                    //Nobody knows your redeem script, so you add here the information
+                    //This line is actually optional since 4.0.0.38, as the TransactionBuilder is smart enough to figure out
+                    //the redeems from the keys added by AddKeys.
+                    //However, explicitely having the redeem will make code more easy to update to other payment like 2-2
+                    //.Select(c => c.ToScriptCoin(k.PubKey.WitHash.ScriptPubKey))
                     .ToArray();
- 
+
             var builder = new TransactionBuilder();
             builder.AddCoins(coins);
             builder.AddKeys(k);
@@ -308,7 +308,7 @@ namespace NBitcoin.Tests
             Transaction signedTx = builder.BuildTransaction(true);
             Assert.True(builder.Verify(signedTx));
         }
- 
+
         private Coin[] GetCoins(BitcoinScriptAddress p2sh)
         {
             return new Coin[] { new Coin(new uint256(Enumerable.Range(0, 32).Select(i => (byte)0xaa).ToArray()), 0, Money.Coins(2.0m), p2sh.ScriptPubKey) };
@@ -428,7 +428,7 @@ namespace NBitcoin.Tests
 
         private ICoin[] GetCoinSource(Key destination, params Money[] amounts)
         {
-            if(amounts.Length == 0)
+            if (amounts.Length == 0)
                 amounts = new[] { Money.Parse("100.0") };
 
             return amounts
@@ -561,7 +561,7 @@ namespace NBitcoin.Tests
 
 
             IEnumerable<ColoredCoin> cc = ColoredCoin.Find(tx, repo);
-            for(int i = 0; i < 20; i++)
+            for (int i = 0; i < 20; i++)
             {
                 txBuilder = new TransactionBuilder(i);
                 txBuilder.StandardTransactionPolicy = RelayPolicy;
@@ -812,7 +812,7 @@ namespace NBitcoin.Tests
                     .BuildTransaction(true);
                 Assert.False(true, "Should have thrown");
             }
-            catch(NotEnoughFundsException ex) //Not enough dust to send the change
+            catch (NotEnoughFundsException ex) //Not enough dust to send the change
             {
                 Assert.True(((Money)ex.Missing).Satoshi == 2730);
                 var rate = new FeeRate(Money.Coins(0.0004m));
@@ -867,7 +867,7 @@ namespace NBitcoin.Tests
                     .SetChange(bob.PubKey)
                     .BuildTransaction(true);
 
-                foreach(TxOut output in transfer.Outputs)
+                foreach (TxOut output in transfer.Outputs)
                 {
                     Assert.False(TxNullDataTemplate.Instance.CheckScriptPubKey(Network.Main, output.ScriptPubKey));
                     Assert.False(output.Value == output.GetDustThreshold(txBuilder.StandardTransactionPolicy.MinRelayTxFee));
@@ -880,7 +880,7 @@ namespace NBitcoin.Tests
             TxOut txout = tx.Outputs[entry.Index];
             Assert.True(entry.Asset.Id == assetId);
             Assert.True(entry.Asset.Quantity == quantity);
-            if(destination != null)
+            if (destination != null)
                 Assert.True(txout.ScriptPubKey == destination.ScriptPubKey);
         }
 
@@ -1099,23 +1099,26 @@ namespace NBitcoin.Tests
 
         private void CanVerifySequenceLockCore(Sequence[] sequences, int[] prevHeights, int currentHeight, DateTimeOffset first, bool expected, SequenceLock expectedLock)
         {
-            var chain = new ConcurrentChain(new BlockHeader()
-            {
-                BlockTime = first
-            });
+            Network network = Network.Main;
+
+            BlockHeader blockHeader = network.Consensus.ConsensusFactory.CreateBlockHeader();
+            blockHeader.BlockTime = first;
+            var chain = new ConcurrentChain(blockHeader);
             first = first + TimeSpan.FromMinutes(10);
-            while(currentHeight != chain.Height)
+
+            while (currentHeight != chain.Height)
             {
-                chain.SetTip(new BlockHeader()
-                {
-                    BlockTime = first,
-                    HashPrevBlock = chain.Tip.HashBlock
-                });
+                BlockHeader header = network.Consensus.ConsensusFactory.CreateBlockHeader();
+                header.BlockTime = first;
+                header.HashPrevBlock = chain.Tip.HashBlock;
+
+                chain.SetTip(header);
                 first = first + TimeSpan.FromMinutes(10);
             }
-            var tx = new Transaction();
+
+            var tx = network.Consensus.ConsensusFactory.CreateTransaction();
             tx.Version = 2;
-            for(int i = 0; i < sequences.Length; i++)
+            for (int i = 0; i < sequences.Length; i++)
             {
                 var input = new TxIn();
                 input.Sequence = sequences[i];
@@ -1174,14 +1177,16 @@ namespace NBitcoin.Tests
         private Coin RandomCoin(Money amount, Script scriptPubKey, bool p2sh)
         {
             OutPoint outpoint = RandOutpoint();
-            if(!p2sh)
+            if (!p2sh)
                 return new Coin(outpoint, new TxOut(amount, scriptPubKey));
             return new ScriptCoin(outpoint, new TxOut(amount, scriptPubKey.Hash), scriptPubKey);
         }
+
         private Coin RandomCoin(Money amount, Key receiver)
         {
             return RandomCoin(amount, receiver.PubKey.GetAddress(Network.Main));
         }
+
         private Coin RandomCoin(Money amount, IDestination receiver)
         {
             OutPoint outpoint = RandOutpoint();
@@ -1212,7 +1217,7 @@ namespace NBitcoin.Tests
 
             var bytes = new List<byte>();
             a = new uint160("0102030405060708090102030405060708090102");
-            for(int i = 0; i < 20; i++)
+            for (int i = 0; i < 20; i++)
             {
                 bytes.Add(a.GetByte(i));
             }
@@ -1221,7 +1226,7 @@ namespace NBitcoin.Tests
 
             bytes = new List<byte>();
             var b = new uint256("0102030405060708090102030405060708090102030405060708090102030405");
-            for(int i = 0; i < 32; i++)
+            for (int i = 0; i < 32; i++)
             {
                 bytes.Add(b.GetByte(i));
             }
@@ -1229,6 +1234,7 @@ namespace NBitcoin.Tests
             AssertEx.CollectionEquals(Encoders.Hex.DecodeData("0102030405060708090102030405060708090102030405060708090102030405"), bytes.ToArray());
             Assert.True(new uint256("0102030405060708090102030405060708090102030405060708090102030405") == new uint256(new uint256("0102030405060708090102030405060708090102030405060708090102030405")));
         }
+
 #if !NOSOCKET
         [Fact]
         [Trait("UnitTest", "UnitTest")]
@@ -1239,6 +1245,7 @@ namespace NBitcoin.Tests
             Assert.True(Utils.IsIPv4MappedToIPv6(Utils.MapToIPv6(System.Net.IPAddress.Parse("127.0.0.1"))));
         }
 #endif
+
         [Fact]
         [Trait("UnitTest", "UnitTest")]
         public void BitcoinStreamCoverage()
@@ -1291,7 +1298,7 @@ namespace NBitcoin.Tests
             bs = new BitcoinStream(ms, false);
             bs.ConsensusFactory = Network.Main.Consensus.ConsensusFactory;
             roundTrip(bs, ref input);
-            if(!(input is byte[])) //Byte serialization reuse the input array
+            if (!(input is byte[])) //Byte serialization reuse the input array
                 Assert.True(before2 != input);
             AssertEx.CollectionEquals(before, input);
         }
@@ -1505,7 +1512,7 @@ namespace NBitcoin.Tests
             a = new Script("1 033fbe0a2aa8dc28ee3b2e271e3fedc7568529ffa20df179b803bf9073c1");
             Assert.True(PayToWitTemplate.Instance.CheckScriptPubKey(Network.Main, a));
 
-            foreach(int pushSize in new[] { 2, 10, 20, 32 })
+            foreach (int pushSize in new[] { 2, 10, 20, 32 })
             {
                 a = new Script("1 " + String.Concat(Enumerable.Range(0, pushSize * 2).Select(_ => "0").ToArray()));
                 Assert.True(PayToWitTemplate.Instance.CheckScriptPubKey(Network.Main, a));
@@ -1564,16 +1571,16 @@ namespace NBitcoin.Tests
         {
             var k = new Key();
             var tx = new Transaction();
- 
+
             var coin = new Coin(new OutPoint(Rand(), 0), new TxOut(Money.Coins(1.0m), k.PubKey.Hash));
             tx.Inputs.Add(new TxIn(coin.Outpoint));
             TransactionSignature signature = tx.SignInput(Network.Main, k, coin);
- 
+
             var txBuilder = new TransactionBuilder();
             txBuilder.AddCoins(coin);
             txBuilder.AddKnownSignature(k.PubKey, signature);
             txBuilder.SignTransactionInPlace(tx);
- 
+
             Assert.True(tx.Inputs.AsIndexedInputs().First().VerifyScript(Network.Main, coin));
         }
 
@@ -1700,7 +1707,7 @@ namespace NBitcoin.Tests
             txBuilder = new TransactionBuilder(0)
                         .AddCoins(allCoins);
             //Trying with known signature
-            foreach(Coin coin in allCoins)
+            foreach (Coin coin in allCoins)
             {
                 TransactionSignature sig = partiallySigned.SignInput(Network.Main, keys[0], coin);
                 txBuilder.AddKnownSignature(keys[0].PubKey, sig);
@@ -1775,7 +1782,7 @@ namespace NBitcoin.Tests
             Assert.True(txBuilder.Verify(tx));
 
             //Using the same set of coin in 2 group should not use two times the sames coins
-            for(int i = 0; i < 3; i++)
+            for (int i = 0; i < 3; i++)
             {
                 txBuilder = new TransactionBuilder();
                 txBuilder.StandardTransactionPolicy = EasyPolicy;
@@ -1920,7 +1927,7 @@ namespace NBitcoin.Tests
 
         private void AssertCorrectlySigned(Transaction tx, Script scriptPubKey, ScriptVerify scriptVerify = ScriptVerify.Standard)
         {
-            for(int i = 0; i < tx.Inputs.Count; i++)
+            for (int i = 0; i < tx.Inputs.Count; i++)
             {
                 Assert.True(Script.VerifyScript(Network.Main, scriptPubKey, tx, i, null, scriptVerify));
             }
@@ -1956,20 +1963,20 @@ namespace NBitcoin.Tests
             builder.AddCoins(funding.Outputs.AsCoins());
             Assert.True(builder.Verify(spending));
 
-            foreach(IndexedTxIn input in spending.Inputs.AsIndexedInputs())
+            foreach (IndexedTxIn input in spending.Inputs.AsIndexedInputs())
             {
                 Op[] ops = input.TxIn.ScriptSig.ToOps().ToArray();
-                foreach(var sig in ops.Select(o =>
-                    {
-                        try
-                        {
-                            return new TransactionSignature(o.PushData);
-                        }
-                        catch
-                        {
-                            return null;
-                        }
-                    })
+                foreach (var sig in ops.Select(o =>
+                     {
+                         try
+                         {
+                             return new TransactionSignature(o.PushData);
+                         }
+                         catch
+                         {
+                             return null;
+                         }
+                     })
                     .Select((sig, i) => new
                     {
                         sig,
@@ -2080,7 +2087,7 @@ namespace NBitcoin.Tests
             Assert.Equal(2, ctx.Stack.Count);
             byte[][] actual = new[] { ctx.Stack.Top(-2), ctx.Stack.Top(-1) };
             byte[][] expected = new[] { Op.GetPushOp(1).PushData, Op.GetPushOp(3).PushData };
-            for(int i = 0; i < actual.Length; i++)
+            for (int i = 0; i < actual.Length; i++)
             {
                 Assert.True(actual[i].SequenceEqual(expected[i]));
             }
@@ -2112,7 +2119,7 @@ namespace NBitcoin.Tests
                 Op.GetPushOp(1).PushData,
                 Op.GetPushOp(2).PushData,
             };
-            for(int i = 0; i < actual.Length; i++)
+            for (int i = 0; i < actual.Length; i++)
             {
                 Assert.True(actual[i].SequenceEqual(expected[i]));
             }
@@ -2131,7 +2138,7 @@ namespace NBitcoin.Tests
             Assert.Equal(4, ctx.Stack.Count);
             byte[][] actual = new[] { ctx.Stack.Top(-3), ctx.Stack.Top(-2), ctx.Stack.Top(-1) };
             byte[][] expected = new[] { Op.GetPushOp(3).PushData, Op.GetPushOp(2).PushData, Op.GetPushOp(3).PushData };
-            for(int i = 0; i < actual.Length; i++)
+            for (int i = 0; i < actual.Length; i++)
             {
                 Assert.True(actual[i].SequenceEqual(expected[i]));
             }
@@ -2164,7 +2171,7 @@ namespace NBitcoin.Tests
         private static void CanCheckSegwitSigCore(Transaction tx, int input, Money amount, string scriptCodeHex = null)
         {
             Script scriptCode = null;
-            if(scriptCodeHex == null)
+            if (scriptCodeHex == null)
             {
                 PayToWitPubkeyHashScriptSigParameters param1 = PayToWitPubKeyHashTemplate.Instance.ExtractWitScriptParameters(Network.Main, tx.Inputs[input].WitScript);
                 Assert.NotNull(param1);
@@ -2234,9 +2241,9 @@ namespace NBitcoin.Tests
         [Trait("UnitTest", "UnitTest")]
         public void DoNotThrowsWithSatoshiFormatAndNoOutputs()
         {
- 	        Transaction tx = Transaction.Parse("02000000010000000000000000000000000000000000000000000000000000000000000000ffffffff0401700101ffffffff02" +
-                        "00f2052a0100000023210295aefb5b15cd9204f18ceda653ebeaada10c69b6ef7f757450c5d66c0f0ebb8dac0000000000000000266a24aa21a9" +
-                        "ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf900000000");
+            Transaction tx = Transaction.Parse("02000000010000000000000000000000000000000000000000000000000000000000000000ffffffff0401700101ffffffff02" +
+                       "00f2052a0100000023210295aefb5b15cd9204f18ceda653ebeaada10c69b6ef7f757450c5d66c0f0ebb8dac0000000000000000266a24aa21a9" +
+                       "ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf900000000");
 
             tx.ToString(RawFormat.Satoshi);
         }
@@ -2249,7 +2256,7 @@ namespace NBitcoin.Tests
 
             TestCase[] tests = TestCase.read_json(TestDataLocations.GetFileFromDataFolder("can_parse_transaction.json"));
 
-            foreach(dynamic test in tests.Select(t => t.GetDynamic(0)))
+            foreach (dynamic test in tests.Select(t => t.GetDynamic(0)))
             {
                 string raw = test.Raw;
                 Transaction tx = Transaction.Parse(raw);
@@ -2257,20 +2264,20 @@ namespace NBitcoin.Tests
                 Assert.Equal((int)test.JSON.vout_sz, tx.Outputs.Count);
                 Assert.Equal((uint)test.JSON.lock_time, (uint)tx.LockTime);
 
-                for(int i = 0; i < tx.Inputs.Count; i++)
+                for (int i = 0; i < tx.Inputs.Count; i++)
                 {
                     TxIn actualVIn = tx.Inputs[i];
                     dynamic expectedVIn = test.JSON.@in[i];
                     Assert.Equal(uint256.Parse((string)expectedVIn.prev_out.hash), actualVIn.PrevOut.Hash);
                     Assert.Equal((uint)expectedVIn.prev_out.n, actualVIn.PrevOut.N);
-                    if(expectedVIn.sequence != null)
+                    if (expectedVIn.sequence != null)
                         Assert.Equal((uint)expectedVIn.sequence, (uint)actualVIn.Sequence);
                     Assert.Equal((string)expectedVIn.scriptSig, actualVIn.ScriptSig.ToString());
                     //Can parse the string
                     Assert.Equal((string)expectedVIn.scriptSig, (string)expectedVIn.scriptSig.ToString());
                 }
 
-                for(int i = 0; i < tx.Outputs.Count; i++)
+                for (int i = 0; i < tx.Outputs.Count; i++)
                 {
                     TxOut actualVOut = tx.Outputs[i];
                     dynamic expectedVOut = test.JSON.@out[i];
@@ -2316,7 +2323,7 @@ namespace NBitcoin.Tests
             int messageBitLength = message.Length * 8;
             var trunc = new BigInteger(1, message);
 
-            if(n.BitLength < messageBitLength)
+            if (n.BitLength < messageBitLength)
             {
                 trunc = trunc.ShiftRight(messageBitLength - n.BitLength);
             }
@@ -2352,11 +2359,11 @@ namespace NBitcoin.Tests
 
         private IEnumerable<Combinaison> GetCombinaisons()
         {
-            foreach(SigHash sighash in new[] { SigHash.All, SigHash.Single, SigHash.None })
+            foreach (SigHash sighash in new[] { SigHash.All, SigHash.Single, SigHash.None })
             {
-                foreach(bool anyoneCanPay in new[] { false, true })
+                foreach (bool anyoneCanPay in new[] { false, true })
                 {
-                    foreach(bool segwit in new[] { false, true })
+                    foreach (bool segwit in new[] { false, true })
                     {
                         yield return new Combinaison()
                         {
@@ -2373,16 +2380,16 @@ namespace NBitcoin.Tests
         {
             var secret = new BitcoinSecret("L5AQtV2HDm4xGsseLokK2VAT2EtYKcTm3c7HwqnJBFt9LdaQULsM");
             Combinaison[] all = GetCombinaisons().ToArray();
-            while(true)
+            while (true)
             {
                 Utils.Shuffle(all);
-                if(((uint)all[0].SigHash & 0x1f) != (uint)SigHash.All)
+                if (((uint)all[0].SigHash & 0x1f) != (uint)SigHash.All)
                     break;
             }
             int i = 0;
             var tx = new Transaction();
             var coins = new List<ICoin>();
-            foreach(Combinaison combinaison in all)
+            foreach (Combinaison combinaison in all)
             {
                 Script scriptPubKey = combinaison.Segwit ? secret.PubKey.WitHash.ScriptPubKey : secret.PubKey.Hash.ScriptPubKey;
                 ICoin coin = new Coin(
@@ -2517,17 +2524,17 @@ namespace NBitcoin.Tests
             var secret = new BitcoinSecret("L5AQtV2HDm4xGsseLokK2VAT2EtYKcTm3c7HwqnJBFt9LdaQULsM");
             Key key = secret.PrivateKey;
             var output = new StringBuilder();
-            foreach(bool segwit in new[] { false, true })
+            foreach (bool segwit in new[] { false, true })
             {
-                foreach(SigHash flag in new[] { SigHash.Single, SigHash.None, SigHash.All })
+                foreach (SigHash flag in new[] { SigHash.Single, SigHash.None, SigHash.All })
                 {
-                    foreach(bool anyoneCanPay in new[] { true, false })
+                    foreach (bool anyoneCanPay in new[] { true, false })
                     {
                         var invalidChanges = new List<string>();
                         SigHash actualFlag = anyoneCanPay ? flag | SigHash.AnyoneCanPay : flag;
                         var signatures = new List<TransactionSignature>();
                         var transactions = new List<Transaction>();
-                        foreach(HashModification modification in new[] { HashModification.NoModification, HashModification.Modification, HashModification.Invalid })
+                        foreach (HashModification modification in new[] { HashModification.NoModification, HashModification.Modification, HashModification.Invalid })
                         {
                             var knownCoins = new List<Coin>();
 
@@ -2546,9 +2553,9 @@ namespace NBitcoin.Tests
                                 Money.Satoshis(4000), new Script(OpcodeType.OP_TRUE));
 
                             var txx = new Transaction();
-                            if(anyoneCanPay && modification == HashModification.Modification)
+                            if (anyoneCanPay && modification == HashModification.Modification)
                             {
-                                if(flag != SigHash.Single)
+                                if (flag != SigHash.Single)
                                 {
                                     txx.Inputs.Add(new TxIn(coin2.Outpoint));
                                     txx.Inputs.Add(new TxIn(coin1.Outpoint));
@@ -2563,7 +2570,7 @@ namespace NBitcoin.Tests
                                 txx.Inputs.Add(new TxIn(coin4.Outpoint));
                                 knownCoins.Add(coin4);
                             }
-                            else if(!anyoneCanPay && modification == HashModification.Invalid)
+                            else if (!anyoneCanPay && modification == HashModification.Invalid)
                             {
                                 txx.Inputs.Add(new TxIn(coin1.Outpoint));
                                 txx.Inputs.Add(new TxIn(signedCoin.Outpoint));
@@ -2579,20 +2586,20 @@ namespace NBitcoin.Tests
                                 txx.Inputs.Add(new TxIn(coin2.Outpoint));
                             }
 
-                            if(flag == SigHash.All)
+                            if (flag == SigHash.All)
                             {
                                 txx.Outputs.Add(new TxOut(coin1.Amount, new Script(OpcodeType.OP_TRUE)));
                                 txx.Outputs.Add(new TxOut(signedCoin.Amount, new Script(OpcodeType.OP_TRUE)));
                                 txx.Outputs.Add(new TxOut(coin2.Amount, new Script(OpcodeType.OP_TRUE)));
-                                if(modification == HashModification.Invalid)
+                                if (modification == HashModification.Invalid)
                                 {
                                     txx.Outputs[2].Value = coin2.Amount - Money.Satoshis(100);
                                     invalidChanges.Add("third output value changed");
                                 }
                             }
-                            else if(flag == SigHash.None)
+                            else if (flag == SigHash.None)
                             {
-                                if(modification == HashModification.Modification)
+                                if (modification == HashModification.Modification)
                                 {
                                     Money bump = Money.Satoshis(50);
                                     txx.Outputs.Add(new TxOut(coin1.Amount - bump, new Script(OpcodeType.OP_TRUE)));
@@ -2600,34 +2607,34 @@ namespace NBitcoin.Tests
                                     txx.Outputs.Add(new TxOut(coin2.Amount - bump, new Script(OpcodeType.OP_FALSE)));
                                     txx.Outputs.Add(new TxOut(3 * bump, new Script(OpcodeType.OP_TRUE)));
                                 }
-                                else if(modification == HashModification.NoModification)
+                                else if (modification == HashModification.NoModification)
                                 {
                                     txx.Outputs.Add(new TxOut(coin1.Amount, new Script(OpcodeType.OP_TRUE)));
                                     txx.Outputs.Add(new TxOut(signedCoin.Amount, new Script(OpcodeType.OP_TRUE)));
                                     txx.Outputs.Add(new TxOut(coin2.Amount, new Script(OpcodeType.OP_TRUE)));
                                 }
-                                else if(modification == HashModification.Invalid)
+                                else if (modification == HashModification.Invalid)
                                 {
                                     TxIn input = txx.Inputs.FirstOrDefault(i => i.PrevOut == signedCoin.Outpoint);
                                     input.Sequence = 1;
                                     invalidChanges.Add("input sequence changed");
                                 }
                             }
-                            else if(flag == SigHash.Single)
+                            else if (flag == SigHash.Single)
                             {
                                 int index = txx.Inputs.Select((txin, i) => txin.PrevOut == signedCoin.Outpoint ? i : -1).Where(ii => ii != -1).FirstOrDefault();
-                                foreach(Coin coin in knownCoins)
+                                foreach (Coin coin in knownCoins)
                                 {
                                     txx.Outputs.Add(new TxOut(coin.Amount, new Script(OpcodeType.OP_TRUE)));
                                 }
 
-                                if(modification == HashModification.Modification)
+                                if (modification == HashModification.Modification)
                                 {
                                     TxOut signed = txx.Outputs[index];
                                     TxOut[] outputs = txx.Outputs.ToArray();
                                     Utils.Shuffle(outputs, 50);
                                     int newIndex = Array.IndexOf(outputs, signed);
-                                    if(newIndex == index)
+                                    if (newIndex == index)
                                         throw new InvalidOperationException();
                                     TxOut temp = outputs[index];
                                     outputs[index] = signed;
@@ -2635,9 +2642,9 @@ namespace NBitcoin.Tests
                                     txx.Outputs.Clear();
                                     txx.Outputs.AddRange(outputs);
                                     Money bumps = Money.Zero;
-                                    for(int i = 0; i < txx.Outputs.Count; i++)
+                                    for (int i = 0; i < txx.Outputs.Count; i++)
                                     {
-                                        if(i != index)
+                                        if (i != index)
                                         {
                                             Money bump = Money.Satoshis(100);
                                             bumps += bump;
@@ -2646,18 +2653,18 @@ namespace NBitcoin.Tests
                                     }
                                     txx.Outputs.Add(new TxOut(bumps, new Script(OpcodeType.OP_TRUE)));
                                 }
-                                else if(modification == HashModification.Invalid)
+                                else if (modification == HashModification.Invalid)
                                 {
                                     txx.Outputs[index].Value -= Money.Satoshis(100);
                                     invalidChanges.Add("same index output value changed");
                                 }
                             }
 
-                            if(anyoneCanPay & modification == HashModification.Modification)
+                            if (anyoneCanPay & modification == HashModification.Modification)
                             {
-                                foreach(Coin coin in knownCoins)
+                                foreach (Coin coin in knownCoins)
                                 {
-                                    if(coin != signedCoin)
+                                    if (coin != signedCoin)
                                         coin.Amount += Money.Satoshis(100);
                                 }
                             }
@@ -2672,17 +2679,17 @@ namespace NBitcoin.Tests
                             builder.StandardTransactionPolicy.ScriptVerify &= ~ScriptVerify.NullFail;
                             builder.AddKeys(secret);
                             builder.AddCoins(knownCoins);
-                            if(txx.Outputs.Count == 0)
+                            if (txx.Outputs.Count == 0)
                                 txx.Outputs.Add(new TxOut(coin1.Amount, new Script(OpcodeType.OP_TRUE)));
                             Transaction result = builder.SignTransaction(txx, actualFlag);
                             Assert.True(builder.Verify(result));
 
-                            if(flag == SigHash.None)
+                            if (flag == SigHash.None)
                             {
                                 Transaction clone = result.Clone();
-                                foreach(TxIn input in clone.Inputs)
+                                foreach (TxIn input in clone.Inputs)
                                 {
-                                    if(input.PrevOut != signedCoin.Outpoint)
+                                    if (input.PrevOut != signedCoin.Outpoint)
                                         input.Sequence = 2;
                                 }
                                 Assert.True(builder.Verify(clone));
@@ -2693,10 +2700,10 @@ namespace NBitcoin.Tests
 
                             TxIn signedInput = result.Inputs.FirstOrDefault(txin => txin.PrevOut == signedCoin.Outpoint);
                             TransactionSignature sig = PayToPubkeyHashTemplate.Instance.ExtractScriptSigParameters(Network.Main, signedInput.WitScript == WitScript.Empty ? signedInput.ScriptSig : signedInput.WitScript.ToScript()).TransactionSignature;
-                            if(modification != HashModification.Invalid)
+                            if (modification != HashModification.Invalid)
                             {
                                 signatures.Add(sig);
-                                if(actualFlag != SigHash.All)
+                                if (actualFlag != SigHash.All)
                                     Assert.True(transactions.All(s => s.GetHash() != result.GetHash()));
                                 transactions.Add(result);
                                 Assert.True(signatures.All(s => s.ToBytes().SequenceEqual(sig.ToBytes())));
@@ -2706,7 +2713,7 @@ namespace NBitcoin.Tests
                                 Assert.Contains(signatures, s => !s.ToBytes().SequenceEqual(sig.ToBytes()));
                                 TransactionSignature noModifSignature = signatures[0];
                                 Script replacement = PayToPubkeyHashTemplate.Instance.GenerateScriptSig(noModifSignature, secret.PubKey);
-                                if(signedInput.WitScript != WitScript.Empty)
+                                if (signedInput.WitScript != WitScript.Empty)
                                 {
                                     signedInput.WitScript = replacement;
                                 }
@@ -2721,14 +2728,14 @@ namespace NBitcoin.Tests
                                 Assert.True(scriptError.ScriptError == ScriptError.EvalFalse);
                             }
 
-                            if(segwit && actualFlag != SigHash.All && modification == HashModification.Invalid)
+                            if (segwit && actualFlag != SigHash.All && modification == HashModification.Invalid)
                             {
                                 output.Append("[\"Witness with SigHash " + ToString(anyoneCanPay, flag));
-                                if(transactions.Count == 2 && modification != HashModification.Invalid)
+                                if (transactions.Count == 2 && modification != HashModification.Invalid)
                                 {
                                     output.Append(" (same signature as previous)");
                                 }
-                                else if(transactions.Count == 2 && modification == HashModification.Invalid)
+                                else if (transactions.Count == 2 && modification == HashModification.Invalid)
                                 {
                                     string changes = String.Join(", ", invalidChanges);
                                     output.Append(" (" + changes + ")");
@@ -2750,7 +2757,7 @@ namespace NBitcoin.Tests
 
             var coinParts = new List<string>();
             var parts = new List<string>();
-            foreach(Coin coin in knownCoins)
+            foreach (Coin coin in knownCoins)
             {
                 var coinOutput = new StringBuilder();
                 coinOutput.Append("[\"");
@@ -2761,16 +2768,16 @@ namespace NBitcoin.Tests
                 string script = coin.ScriptPubKey.ToString();
                 string[] words = script.Split(' ');
                 var scriptParts = new List<string>();
-                foreach(string word in words)
+                foreach (string word in words)
                 {
                     var scriptOutput = new StringBuilder();
-                    if(word.StartsWith("OP_"))
+                    if (word.StartsWith("OP_"))
                         scriptOutput.Append(word.Substring(3, word.Length - 3));
-                    else if(word == "0")
+                    else if (word == "0")
                         scriptOutput.Append("0x00");
-                    else if(word == "1")
+                    else if (word == "1")
                         scriptOutput.Append("0x51");
-                    else if(word == "16")
+                    else if (word == "16")
                         scriptOutput.Append("0x60");
                     else
                     {
@@ -2795,7 +2802,7 @@ namespace NBitcoin.Tests
 
         private string ToString(bool anyoneCanPay, SigHash flag)
         {
-            if(anyoneCanPay)
+            if (anyoneCanPay)
             {
                 return flag.ToString() + "|AnyoneCanPay";
             }
@@ -2813,14 +2820,14 @@ namespace NBitcoin.Tests
             // or [[[prevout hash, prevout index, prevout scriptPubKey], [input 2], ...],"], serializedTransaction, enforceP2SH
             // ... where all scripts are stringified scripts.
             TestCase[] tests = TestCase.read_json(TestDataLocations.GetFileFromDataFolder("tx_valid.json"));
-            foreach(TestCase test in tests)
+            foreach (TestCase test in tests)
             {
                 string strTest = test.ToString();
                 //Skip comments
-                if(!(test[0] is JArray))
+                if (!(test[0] is JArray))
                     continue;
                 var inputs = (JArray)test[0];
-                if(test.Count != 3 || !(test[1] is string) || !(test[2] is string))
+                if (test.Count != 3 || !(test[1] is string) || !(test[2] is string))
                 {
                     Assert.False(true, "Bad test: " + strTest);
                     continue;
@@ -2828,20 +2835,20 @@ namespace NBitcoin.Tests
 
                 var mapprevOutScriptPubKeys = new Dictionary<OutPoint, Script>();
                 var mapprevOutScriptPubKeysAmount = new Dictionary<OutPoint, Money>();
-                foreach(JToken vinput in inputs)
+                foreach (JToken vinput in inputs)
                 {
                     var outpoint = new OutPoint(uint256.Parse(vinput[0].ToString()), int.Parse(vinput[1].ToString()));
                     mapprevOutScriptPubKeys[outpoint] = script_tests.ParseScript(vinput[2].ToString());
-                    if(vinput.Count() >= 4)
+                    if (vinput.Count() >= 4)
                         mapprevOutScriptPubKeysAmount[outpoint] = Money.Satoshis(vinput[3].Value<long>());
                 }
 
                 Transaction tx = Transaction.Parse((string)test[1]);
 
 
-                for(int i = 0; i < tx.Inputs.Count; i++)
+                for (int i = 0; i < tx.Inputs.Count; i++)
                 {
-                    if(!mapprevOutScriptPubKeys.ContainsKey(tx.Inputs[i].PrevOut))
+                    if (!mapprevOutScriptPubKeys.ContainsKey(tx.Inputs[i].PrevOut))
                     {
                         Assert.False(true, "Bad test: " + strTest);
                         continue;
@@ -2868,7 +2875,7 @@ namespace NBitcoin.Tests
 
             // Note how NOCACHE is not included as it is a runtime-only flag.
             var mapFlagNames = new Dictionary<string, ScriptVerify>();
-            if(mapFlagNames.Count == 0)
+            if (mapFlagNames.Count == 0)
             {
                 mapFlagNames["NONE"] = ScriptVerify.None;
                 mapFlagNames["P2SH"] = ScriptVerify.P2SH;
@@ -2882,9 +2889,9 @@ namespace NBitcoin.Tests
                 mapFlagNames["DISCOURAGE_UPGRADABLE_WITNESS_PROGRAM"] = ScriptVerify.DiscourageUpgradableWitnessProgram;
             }
 
-            foreach(string word in words)
+            foreach (string word in words)
             {
-                if(!mapFlagNames.ContainsKey(word))
+                if (!mapFlagNames.ContainsKey(word))
                     Assert.False(true, "Bad test: unknown verification flag '" + word + "'");
                 flags |= mapFlagNames[word];
             }
@@ -2932,28 +2939,28 @@ namespace NBitcoin.Tests
             // ... where all scripts are stringified scripts.
             TestCase[] tests = TestCase.read_json(TestDataLocations.GetFileFromDataFolder("tx_invalid.json"));
             string comment = null;
-            foreach(TestCase test in tests)
+            foreach (TestCase test in tests)
             {
                 string strTest = test.ToString();
                 //Skip comments
-                if(!(test[0] is JArray))
+                if (!(test[0] is JArray))
                 {
                     comment = test[0].ToString();
                     continue;
                 }
                 var inputs = (JArray)test[0];
-                if(test.Count != 3 || !(test[1] is string) || !(test[2] is string))
+                if (test.Count != 3 || !(test[1] is string) || !(test[2] is string))
                 {
                     Assert.False(true, "Bad test: " + strTest);
                     continue;
                 }
                 var mapprevOutScriptPubKeys = new Dictionary<OutPoint, Script>();
                 var mapprevOutScriptPubKeysAmount = new Dictionary<OutPoint, Money>();
-                foreach(JToken vinput in inputs)
+                foreach (JToken vinput in inputs)
                 {
                     var outpoint = new OutPoint(uint256.Parse(vinput[0].ToString()), int.Parse(vinput[1].ToString()));
                     mapprevOutScriptPubKeys[new OutPoint(uint256.Parse(vinput[0].ToString()), int.Parse(vinput[1].ToString()))] = script_tests.ParseScript(vinput[2].ToString());
-                    if(vinput.Count() >= 4)
+                    if (vinput.Count() >= 4)
                         mapprevOutScriptPubKeysAmount[outpoint] = Money.Satoshis(vinput[3].Value<int>());
                 }
 
@@ -2961,9 +2968,9 @@ namespace NBitcoin.Tests
 
                 bool fValid = true;
                 fValid = tx.Check() == TransactionCheckResult.Success;
-                for(int i = 0; i < tx.Inputs.Count && fValid; i++)
+                for (int i = 0; i < tx.Inputs.Count && fValid; i++)
                 {
-                    if(!mapprevOutScriptPubKeys.ContainsKey(tx.Inputs[i].PrevOut))
+                    if (!mapprevOutScriptPubKeys.ContainsKey(tx.Inputs[i].PrevOut))
                     {
                         Assert.False(true, "Bad test: " + strTest);
                         continue;
@@ -2977,7 +2984,7 @@ namespace NBitcoin.Tests
                        ParseFlags(test[2].ToString())
                        , 0);
                 }
-                if(fValid)
+                if (fValid)
                     Debugger.Break();
                 Assert.True(!fValid, strTest + " failed");
             }
@@ -3107,7 +3114,7 @@ namespace NBitcoin.Tests
             Assert.True(input.Inputs[0].ToBytes().SequenceEqual(inputm.Inputs[0].ToBytes()));
             Assert.True(input.Outputs.Count == 1);
             Assert.True(input.Outputs[0].ToBytes().SequenceEqual(inputm.Outputs[0].ToBytes()));
-            if(!inputm.HasWitness)
+            if (!inputm.HasWitness)
             {
                 Assert.True(!input.HasWitness);
             }
@@ -3164,9 +3171,9 @@ namespace NBitcoin.Tests
         private static Script PushAll(ContextStack<byte[]> values)
         {
             var result = new List<Op>();
-            foreach(byte[] v in values.Reverse())
+            foreach (byte[] v in values.Reverse())
             {
-                if(v.Length == 0)
+                if (v.Length == 0)
                 {
                     result.Add(OpcodeType.OP_0);
                 }
@@ -3390,10 +3397,10 @@ namespace NBitcoin.Tests
         private Script GetScriptForWitness(Script scriptPubKey)
         {
             PubKey pubkey = PayToPubkeyTemplate.Instance.ExtractScriptPubKeyParameters(scriptPubKey);
-            if(pubkey != null)
+            if (pubkey != null)
                 return new Script(OpcodeType.OP_0, Op.GetPushOp(pubkey.Hash.ToBytes()));
             KeyId pkh = PayToPubkeyHashTemplate.Instance.ExtractScriptPubKeyParameters(scriptPubKey);
-            if(pkh != null)
+            if (pkh != null)
                 return new Script(OpcodeType.OP_0, Op.GetPushOp(pkh.ToBytes()));
 
             return new Script(OpcodeType.OP_0, Op.GetPushOp(scriptPubKey.WitHash.ToBytes()));

--- a/src/NBitcoin/BitcoinStream.cs
+++ b/src/NBitcoin/BitcoinStream.cs
@@ -196,9 +196,11 @@ namespace NBitcoin
             T obj = data;
             if (obj == null)
             {
-                if (!this.ConsensusFactory.TryCreateNew<T>(out obj))
+                obj = this.ConsensusFactory.TryCreateNew<T>();
+                if (obj == null)
                     obj = Activator.CreateInstance<T>();
             }
+
             obj.ReadWrite(this);
             if (!this.Serializing)
                 data = obj;
@@ -265,7 +267,7 @@ namespace NBitcoin
         {
             var bytes = new byte[size];
 
-            for(int i = 0; i < size; i++)
+            for (int i = 0; i < size; i++)
             {
                 bytes[i] = (byte)(value >> i * 8);
             }

--- a/src/NBitcoin/Block.cs
+++ b/src/NBitcoin/Block.cs
@@ -30,14 +30,13 @@ namespace NBitcoin
         public Block()
         {
             this.header = new BlockHeader();
-            this.SetNull();
+            this.transactions.Clear();
+            this.BlockSize = null;
         }
 
         [Obsolete("Should use Block.Load outside of ConsensusFactories")]
-        internal Block(BlockHeader blockHeader)
+        internal Block(BlockHeader blockHeader) : this()
         {
-            this.header = new BlockHeader();
-            this.SetNull();
             this.header = blockHeader;
         }
 
@@ -73,18 +72,13 @@ namespace NBitcoin
             }
         }
 
-        private void SetNull()
-        {
-            this.header.SetNull();
-            this.transactions.Clear();
-            this.BlockSize = null;
-        }
-
         public BlockHeader Header => this.header;
 
+        /// <summary>
+        /// A block's hash is it's header's hash.
+        /// </summary>
         public uint256 GetHash()
         {
-            // A Block's hash is it's header's hash.
             return this.header.GetHash();
         }
 

--- a/src/NBitcoin/BlockHeader.cs
+++ b/src/NBitcoin/BlockHeader.cs
@@ -56,9 +56,14 @@ namespace NBitcoin
             }
         }
 
-        public BlockHeader()
+        internal BlockHeader()
         {
-            this.SetNull();
+            this.version = this.CurrentVersion;
+            this.hashPrevBlock = 0;
+            this.hashMerkleRoot = 0;
+            this.time = 0;
+            this.bits = 0;
+            this.nonce = 0;
         }
 
         public static BlockHeader Load(byte[] hex, Network network)
@@ -73,16 +78,6 @@ namespace NBitcoin
             blockHeader.ReadWrite(hex, network: network);
 
             return blockHeader;
-        }
-
-        internal void SetNull()
-        {
-            this.version = this.CurrentVersion;
-            this.hashPrevBlock = 0;
-            this.hashMerkleRoot = 0;
-            this.time = 0;
-            this.bits = 0;
-            this.nonce = 0;
         }
 
         #region IBitcoinSerializable Members

--- a/src/NBitcoin/ConsensusFactory.cs
+++ b/src/NBitcoin/ConsensusFactory.cs
@@ -99,25 +99,22 @@ namespace NBitcoin
         /// <typeparam name="T">The generic type to resolve.</typeparam>
         /// <param name="result">If the type is known it will be initialized.</param>
         /// <returns><c>true</c> if it is known.</returns>
-        public virtual bool TryCreateNew<T>(out T result) where T : IBitcoinSerializable
+        public virtual T TryCreateNew<T>() where T : IBitcoinSerializable
         {
-            result = default(T);
+            object result = null;
             if (IsBlock<T>())
             {
                 result = (T)(object)CreateBlock();
-                return true;
             }
             if (IsBlockHeader<T>())
             {
                 result = (T)(object)CreateBlockHeader();
-                return true;
             }
             if (IsTransaction<T>())
             {
                 result = (T)(object)CreateTransaction();
-                return true;
             }
-            return false;
+            return (T)result;
         }
 
         /// <summary>

--- a/src/NBitcoin/IBitcoinSerializable.cs
+++ b/src/NBitcoin/IBitcoinSerializable.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.IO;
+﻿using System.IO;
 using NBitcoin.Protocol;
 
 namespace NBitcoin
@@ -73,13 +72,13 @@ namespace NBitcoin
             serializable.ReadWrite(bms);
         }
 
-        public static T Clone<T>(this T serializable, ProtocolVersion version = ProtocolVersion.PROTOCOL_VERSION, Network network = null) where T : IBitcoinSerializable
+        public static T Clone<T>(this T serializable, ProtocolVersion version = ProtocolVersion.PROTOCOL_VERSION, Network network = null) where T : IBitcoinSerializable, new()
         {
             network = network ?? Network.Main;
 
             T instance = network.Consensus.ConsensusFactory.TryCreateNew<T>();
             if (instance == null)
-                instance = Activator.CreateInstance<T>();
+                instance = new T();
 
             instance.FromBytes(serializable.ToBytes(version, network), version, network);
 

--- a/src/NBitcoin/IBitcoinSerializable.cs
+++ b/src/NBitcoin/IBitcoinSerializable.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using NBitcoin.Protocol;
 
 namespace NBitcoin
@@ -13,7 +14,7 @@ namespace NBitcoin
         public static void ReadWrite(this IBitcoinSerializable serializable, Stream stream, bool serializing, ProtocolVersion version = ProtocolVersion.PROTOCOL_VERSION, Network network = null)
         {
             network = network ?? Network.Main;
-            
+
             serializable.ReadWrite(new BitcoinStream(stream, serializing)
             {
                 ProtocolVersion = version,
@@ -63,7 +64,7 @@ namespace NBitcoin
         public static void FromBytes(this IBitcoinSerializable serializable, byte[] bytes, ProtocolVersion version = ProtocolVersion.PROTOCOL_VERSION, Network network = null)
         {
             network = network ?? Network.Main;
-            
+
             var bms = new BitcoinStream(bytes)
             {
                 ProtocolVersion = version,
@@ -72,14 +73,16 @@ namespace NBitcoin
             serializable.ReadWrite(bms);
         }
 
-        public static T Clone<T>(this T serializable, ProtocolVersion version = ProtocolVersion.PROTOCOL_VERSION, Network network = null) where T : IBitcoinSerializable, new()
+        public static T Clone<T>(this T serializable, ProtocolVersion version = ProtocolVersion.PROTOCOL_VERSION, Network network = null) where T : IBitcoinSerializable
         {
             network = network ?? Network.Main;
-            
-            if (!network.Consensus.ConsensusFactory.TryCreateNew<T>(out T instance))
-                instance = new T();
+
+            T instance = network.Consensus.ConsensusFactory.TryCreateNew<T>();
+            if (instance == null)
+                instance = Activator.CreateInstance<T>();
 
             instance.FromBytes(serializable.ToBytes(version, network), version, network);
+
             return instance;
         }
 

--- a/src/NBitcoin/NoSqlRepository.cs
+++ b/src/NBitcoin/NoSqlRepository.cs
@@ -27,9 +27,10 @@ namespace NBitcoin
         public async Task<T> GetAsync<T>(string key) where T : IBitcoinSerializable, new()
         {
             byte[] data = await GetBytes(key).ConfigureAwait(false);
-            if(data == null)
+            if (data == null)
                 return default(T);
-            if (!this.network.Consensus.ConsensusFactory.TryCreateNew<T>(out T obj))
+            T obj = this.network.Consensus.ConsensusFactory.TryCreateNew<T>();
+            if (obj == null)
                 obj = Activator.CreateInstance<T>();
             obj.ReadWrite(data, network: this.network);
             return obj;

--- a/src/NBitcoin/Transaction.cs
+++ b/src/NBitcoin/Transaction.cs
@@ -1395,7 +1395,7 @@ namespace NBitcoin
 
         public Transaction Clone(bool cloneCache, Network network = null)
         {
-            Transaction clone = BitcoinSerializableExtensions.Clone(this, network: network);
+            Transaction clone = Load(this.ToHex(), network: network);
             if(cloneCache)
                 clone._Hashes = this._Hashes.ToArray();
             return clone;

--- a/src/Stratis.Bitcoin.Features.BlockStore.Tests/BlockStoreTests.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore.Tests/BlockStoreTests.cs
@@ -39,9 +39,11 @@ namespace Stratis.Bitcoin.Features.BlockStore.Tests
             this.listOfSavedBlocks = new Dictionary<uint256, Block>();
             this.listOfSavedBlocks.Add(uint256.One, Block.Parse(this.testBlockHex, Network.StratisMain));
 
+            this.network = Network.StratisMain;
+
             this.chain = this.CreateChain(10);
             this.consensusTip = null;
-            this.network = Network.StratisMain;
+
             this.nodeLifetime = new NodeLifetime();
 
             var blockRepositoryMock = new Mock<IBlockRepository>();

--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/InitialBlockDownloadTest.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/InitialBlockDownloadTest.cs
@@ -41,7 +41,8 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests
         [Fact]
         public void InIBDIfBehindCheckpoint()
         {
-            this.chainState.ConsensusTip = new ChainedHeader(new BlockHeader(), uint256.Zero, 1000);
+            BlockHeader blockHeader = this.network.Consensus.ConsensusFactory.CreateBlockHeader();
+            this.chainState.ConsensusTip = new ChainedHeader(blockHeader, uint256.Zero, 1000);
             var blockDownloadState = new InitialBlockDownloadState(this.chainState, this.network, this.consensusSettings, this.checkpoints);
             Assert.True(blockDownloadState.IsInitialBlockDownload());
         }
@@ -49,7 +50,8 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests
         [Fact]
         public void InIBDIfChainWorkIsLessThanMinimum()
         {
-            this.chainState.ConsensusTip = new ChainedHeader(new BlockHeader(), uint256.Zero, this.checkpoints.GetLastCheckpointHeight() + 1);
+            BlockHeader blockHeader = this.network.Consensus.ConsensusFactory.CreateBlockHeader();
+            this.chainState.ConsensusTip = new ChainedHeader(blockHeader, uint256.Zero, this.checkpoints.GetLastCheckpointHeight() + 1);
             var blockDownloadState = new InitialBlockDownloadState(this.chainState, this.network, this.consensusSettings, this.checkpoints);
             Assert.True(blockDownloadState.IsInitialBlockDownload());
         }

--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/CommonRules/PowCoinViewRuleTests.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/CommonRules/PowCoinViewRuleTests.cs
@@ -22,6 +22,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
     public class PowCoinViewRuleTests
     {
         private Exception caughtExecption;
+        private readonly Network network;
         private Mock<ILogger> logger;
         private const int HeightOfBlockchain = 1;
         private RuleContext ruleContext;
@@ -31,6 +32,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
 
         public PowCoinViewRuleTests()
         {
+            this.network = Network.RegTest;
             this.rule = new PowCoinviewRule();
         }
 
@@ -69,7 +71,8 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
         {
             this.ruleContext = new PowRuleContext { };
             this.ruleContext.ValidationContext = new ValidationContext();
-            this.ruleContext.ValidationContext.ChainedHeader = new ChainedHeader(new BlockHeader(), new uint256("bcd7d5de8d3bcc7b15e7c8e5fe77c0227cdfa6c682ca13dcf4910616f10fdd06"), HeightOfBlockchain);
+            BlockHeader blockHeader = this.network.Consensus.ConsensusFactory.CreateBlockHeader();
+            this.ruleContext.ValidationContext.ChainedHeader = new ChainedHeader(blockHeader, new uint256("bcd7d5de8d3bcc7b15e7c8e5fe77c0227cdfa6c682ca13dcf4910616f10fdd06"), HeightOfBlockchain);
             this.ruleContext.ValidationContext.Block = new Block() { Transactions = new List<Transaction>() };
         }
 

--- a/src/Stratis.Bitcoin.Features.MemoryPool.Tests/FeeTests.cs
+++ b/src/Stratis.Bitcoin.Features.MemoryPool.Tests/FeeTests.cs
@@ -58,7 +58,7 @@ namespace Stratis.Bitcoin.Features.MemoryPool.Tests
                 { // For each fee
                     for (int k = 0; k < 4; k++)
                     { // add 4 fee txs
-                        Transaction tx = txf.Clone(false);
+                        Transaction tx = txf.Clone(false, Network.Main);
                         tx.Inputs[0].PrevOut.N = (uint)(10000 * blocknum + 100 * j + k); // make transaction unique
                         uint256 hash = tx.GetHash();
                         mpool.AddUnchecked(hash, entry.Fee(feeV[j]).Time(dateTimeSet.GetTime()).Priority(0).Height(blocknum).FromTx(tx, mpool));
@@ -145,7 +145,7 @@ namespace Stratis.Bitcoin.Features.MemoryPool.Tests
                 { // For each fee multiple
                     for (int k = 0; k < 4; k++)
                     { // add 4 fee txs
-                        Transaction tx = txf.Clone(false);
+                        Transaction tx = txf.Clone(false, Network.Main);
                         tx.Inputs[0].PrevOut.N = (uint)(10000 * blocknum + 100 * j + k);
                         uint256 hash = tx.GetHash();
                         mpool.AddUnchecked(hash, entry.Fee(feeV[j]).Time(dateTimeSet.GetTime()).Priority(0).Height(blocknum).FromTx(tx, mpool));
@@ -189,7 +189,7 @@ namespace Stratis.Bitcoin.Features.MemoryPool.Tests
                 { // For each fee multiple
                     for (int k = 0; k < 4; k++)
                     { // add 4 fee txs
-                        Transaction tx = txf.Clone(false);
+                        Transaction tx = txf.Clone(false, Network.Main);
                         tx.Inputs[0].PrevOut.N = (uint)(10000 * blocknum + 100 * j + k);
                         uint256 hash = tx.GetHash();
                         mpool.AddUnchecked(hash, entry.Fee(feeV[j]).Time(dateTimeSet.GetTime()).Priority(0).Height(blocknum).FromTx(tx, mpool));

--- a/src/Stratis.Bitcoin.Features.Miner.Tests/PosMintingTest.cs
+++ b/src/Stratis.Bitcoin.Features.Miner.Tests/PosMintingTest.cs
@@ -205,7 +205,7 @@ namespace Stratis.Bitcoin.Features.Miner.Tests
         [Fact]
         public void GetDifficulty_VeryLowTarget_ReturnsDifficulty()
         {
-            ChainedHeader chainedHeader = CreateChainedBlockWithNBits(0x1f111111);
+            ChainedHeader chainedHeader = CreateChainedBlockWithNBits(this.network, 0x1f111111);
 
             double result = this.posMinting.GetDifficulty(chainedHeader);
 
@@ -215,7 +215,7 @@ namespace Stratis.Bitcoin.Features.Miner.Tests
         [Fact]
         public void GetDifficulty_LowTarget_ReturnsDifficulty()
         {
-            ChainedHeader chainedHeader = CreateChainedBlockWithNBits(0x1ef88f6f);
+            ChainedHeader chainedHeader = CreateChainedBlockWithNBits(this.network, 0x1ef88f6f);
 
             double result = this.posMinting.GetDifficulty(chainedHeader);
 
@@ -225,7 +225,7 @@ namespace Stratis.Bitcoin.Features.Miner.Tests
         [Fact]
         public void GetDifficulty_MidTarget_ReturnsDifficulty()
         {
-            ChainedHeader chainedHeader = CreateChainedBlockWithNBits(0x1df88f6f);
+            ChainedHeader chainedHeader = CreateChainedBlockWithNBits(this.network, 0x1df88f6f);
 
             double result = this.posMinting.GetDifficulty(chainedHeader);
 
@@ -235,7 +235,7 @@ namespace Stratis.Bitcoin.Features.Miner.Tests
         [Fact]
         public void GetDifficulty_HighTarget_ReturnsDifficulty()
         {
-            ChainedHeader chainedHeader = CreateChainedBlockWithNBits(0x1cf88f6f);
+            ChainedHeader chainedHeader = CreateChainedBlockWithNBits(this.network, 0x1cf88f6f);
 
             double result = this.posMinting.GetDifficulty(chainedHeader);
 
@@ -245,7 +245,7 @@ namespace Stratis.Bitcoin.Features.Miner.Tests
         [Fact]
         public void GetDifficulty_VeryHighTarget_ReturnsDifficulty()
         {
-            ChainedHeader chainedHeader = CreateChainedBlockWithNBits(0x12345678);
+            ChainedHeader chainedHeader = CreateChainedBlockWithNBits(this.network, 0x12345678);
 
             double result = this.posMinting.GetDifficulty(chainedHeader);
 
@@ -259,7 +259,7 @@ namespace Stratis.Bitcoin.Features.Miner.Tests
             this.consensusLoop.Setup(c => c.Tip)
                 .Returns(this.chain.Tip);
 
-            ChainedHeader chainedHeader = CreateChainedBlockWithNBits(0x12345678);
+            ChainedHeader chainedHeader = CreateChainedBlockWithNBits(this.network, 0x12345678);
             this.stakeValidator.Setup(s => s.GetLastPowPosChainedBlock(this.stakeChain.Object, It.Is<ChainedHeader>(c => c.HashBlock == this.chain.Tip.HashBlock), false))
                 .Returns(chainedHeader);
 
@@ -354,12 +354,12 @@ namespace Stratis.Bitcoin.Features.Miner.Tests
 
             Assert.Equal(4607763.9659653762, weight);
         }
-       
+
         [Fact]
         public void CoinstakeAge_BeforeActivation_Testnet()
         {
             Assert.True(this.WasUtxoSelectedForStaking(Network.StratisTest, 1000, 1000 - 8)); // utxo depth is 9, mining block at 10
-            
+
             Assert.False(this.WasUtxoSelectedForStaking(Network.StratisTest, 1000, 1000 - 7)); // utxo depth is 8, mining block at 9
         }
 
@@ -372,7 +372,7 @@ namespace Stratis.Bitcoin.Features.Miner.Tests
             int afterActivationHeight = activationHeight + 1000;
 
             Assert.True(this.WasUtxoSelectedForStaking(Network.StratisTest, afterActivationHeight, afterActivationHeight - 18));
-            
+
             Assert.False(this.WasUtxoSelectedForStaking(Network.StratisTest, afterActivationHeight, afterActivationHeight - 17));
         }
 
@@ -384,9 +384,9 @@ namespace Stratis.Bitcoin.Features.Miner.Tests
             int activationHeight = PosConsensusOptions.CoinstakeMinConfirmationActivationHeightTestnet;
 
             Assert.True(this.WasUtxoSelectedForStaking(Network.StratisTest, activationHeight - 2, activationHeight - 10)); // mining block before activation
-            
+
             Assert.True(this.WasUtxoSelectedForStaking(Network.StratisTest, activationHeight - 1, activationHeight - 19)); // mining activation block
-            
+
             Assert.False(this.WasUtxoSelectedForStaking(Network.StratisTest, activationHeight - 1, activationHeight - 18)); // mining activation block
         }
 
@@ -396,7 +396,7 @@ namespace Stratis.Bitcoin.Features.Miner.Tests
         public void CoinstakeAge_BeforeActivation_Mainnet()
         {
             Assert.True(this.WasUtxoSelectedForStaking(Network.StratisMain, 1000, 1000 - 48)); // utxo depth is 49, mining block at 50
-            
+
             Assert.False(this.WasUtxoSelectedForStaking(Network.StratisMain, 1000, 1000 - 47)); // utxo depth is 48, mining block at 49
         }
 
@@ -409,7 +409,7 @@ namespace Stratis.Bitcoin.Features.Miner.Tests
             int afterActivationHeight = activationHeight + 1000;
 
             Assert.True(this.WasUtxoSelectedForStaking(Network.StratisMain, afterActivationHeight, afterActivationHeight - 498));
-            
+
             Assert.False(this.WasUtxoSelectedForStaking(Network.StratisMain, afterActivationHeight, afterActivationHeight - 497));
         }
 
@@ -421,9 +421,9 @@ namespace Stratis.Bitcoin.Features.Miner.Tests
             int activationHeight = PosConsensusOptions.CoinstakeMinConfirmationActivationHeightMainnet;
 
             Assert.True(this.WasUtxoSelectedForStaking(Network.StratisMain, activationHeight - 2, activationHeight - 50)); // mining block before activation
-            
+
             Assert.True(this.WasUtxoSelectedForStaking(Network.StratisMain, activationHeight - 1, activationHeight - 499)); // mining activation block
-            
+
             Assert.False(this.WasUtxoSelectedForStaking(Network.StratisMain, activationHeight - 1, activationHeight - 498)); // mining activation block
         }
 
@@ -550,9 +550,9 @@ namespace Stratis.Bitcoin.Features.Miner.Tests
                 this.LoggerFactory.Object);
         }
 
-        private static ChainedHeader CreateChainedBlockWithNBits(uint bits)
+        private static ChainedHeader CreateChainedBlockWithNBits(Network network, uint bits)
         {
-            var blockHeader = new BlockHeader();
+            BlockHeader blockHeader = network.Consensus.ConsensusFactory.CreateBlockHeader();
             blockHeader.Time = 1269211443;
             blockHeader.Bits = new Target(bits);
             var chainedHeader = new ChainedHeader(blockHeader, blockHeader.GetHash(), 46367);

--- a/src/Stratis.Bitcoin.Features.Notifications.Tests/NotificationsControllerTest.cs
+++ b/src/Stratis.Bitcoin.Features.Notifications.Tests/NotificationsControllerTest.cs
@@ -14,6 +14,13 @@ namespace Stratis.Bitcoin.Features.Notifications.Tests
 {
     public class NotificationsControllerTest : LogsTestBase
     {
+        private readonly Network network;
+
+        public NotificationsControllerTest()
+        {
+            this.network = Network.StratisMain;
+        }
+
         [Theory]
         [InlineData(null)]
         [InlineData("")]
@@ -42,7 +49,7 @@ namespace Stratis.Bitcoin.Features.Notifications.Tests
             string hashLocation = "000000000000000000c03dbe6ee5fedb25877a12e32aa95bc1d3bd480d7a93f9";
             uint256 hash = uint256.Parse(hashLocation);
 
-            var chainedHeader = new ChainedHeader(new BlockHeader(), hash, null);
+            var chainedHeader = new ChainedHeader(this.network.Consensus.ConsensusFactory.CreateBlockHeader(), hash, null);
             var chain = new Mock<ConcurrentChain>();
             chain.Setup(c => c.GetBlock(heightLocation)).Returns(chainedHeader);
             var blockNotification = new Mock<BlockNotification>(this.LoggerFactory.Object, chain.Object, new Mock<ILookaheadBlockPuller>().Object, new Signals.Signals(), new AsyncLoopFactory(new LoggerFactory()), new NodeLifetime());
@@ -64,7 +71,7 @@ namespace Stratis.Bitcoin.Features.Notifications.Tests
             string hashLocation = "000000000000000000c03dbe6ee5fedb25877a12e32aa95bc1d3bd480d7a93f9";
             uint256 hash = uint256.Parse(hashLocation);
 
-            var chainedHeader = new ChainedHeader(new BlockHeader(), hash, null);
+            var chainedHeader = new ChainedHeader(this.network.Consensus.ConsensusFactory.CreateBlockHeader(), hash, null);
             var chain = new Mock<ConcurrentChain>();
             chain.Setup(c => c.GetBlock(uint256.Parse(hashLocation))).Returns(chainedHeader);
             var blockNotification = new Mock<BlockNotification>(this.LoggerFactory.Object, chain.Object, new Mock<ILookaheadBlockPuller>().Object, new Signals.Signals(), new AsyncLoopFactory(new LoggerFactory()), new NodeLifetime());
@@ -83,7 +90,7 @@ namespace Stratis.Bitcoin.Features.Notifications.Tests
         {
             // Set up
             string hashLocation = "000000000000000000c03dbe6ee5fedb25877a12e32aa95bc1d3bd480d7a93f9";
-            
+
             var chain = new Mock<ConcurrentChain>();
             chain.Setup(c => c.GetBlock(uint256.Parse(hashLocation))).Returns((ChainedHeader)null);
             var blockNotification = new Mock<BlockNotification>(this.LoggerFactory.Object, chain.Object, new Mock<ILookaheadBlockPuller>().Object, new Signals.Signals(), new AsyncLoopFactory(new LoggerFactory()), new NodeLifetime());

--- a/src/Stratis.Bitcoin.IntegrationTests/CoinViewTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/CoinViewTests.cs
@@ -253,7 +253,7 @@ namespace Stratis.Bitcoin.IntegrationTests
 
         private ChainedHeader MakeNext(ChainedHeader previous, Network network)
         {
-            BlockHeader header = previous.Header.Clone();
+            BlockHeader header = BlockHeader.Load(previous.Header.ToBytes(network.Consensus.ConsensusFactory), network);
             header.HashPrevBlock = previous.HashBlock;
             return new ChainedHeader(header, header.GetHash(), previous);
         }

--- a/src/Stratis.Bitcoin.IntegrationTests/MinerTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/MinerTests.cs
@@ -86,12 +86,6 @@ namespace Stratis.Bitcoin.IntegrationTests
             {2, 0xbbbeb305}, {2, 0xfe1c810a}
         };
 
-        public ChainedHeader CreateBlockIndex(ChainedHeader prev)
-        {
-            var index = new ChainedHeader(new BlockHeader(), new BlockHeader().GetHash(), prev);
-            return index;
-        }
-
         public bool TestSequenceLocks(TestContext testContext, ChainedHeader chainedHeader, Transaction tx, Transaction.LockTimeFlags flags, LockPoints uselock = null)
         {
             var context = new MempoolValidationContext(tx, new MempoolValidationState(false));
@@ -501,9 +495,22 @@ namespace Stratis.Bitcoin.IntegrationTests
             context.mempool.AddUnchecked(context.hash, context.entry.Fee(context.HIGHFEE).Time(context.DateTimeProvider.GetTime()).SpendsCoinbase(true).FromTx(tx));
             Assert.True(MempoolValidator.CheckFinalTransaction(context.chain, context.DateTimeProvider, tx, flags)); // Locktime passes
             Assert.True(!this.TestSequenceLocks(context, context.chain.Tip, tx, flags)); // Sequence locks fail
-            context.chain.SetTip(new BlockHeader { HashPrevBlock = context.chain.Tip.HashBlock, Time = Utils.DateTimeToUnixTime(context.chain.Tip.GetMedianTimePast()) + 1 });
-            context.chain.SetTip(new BlockHeader { HashPrevBlock = context.chain.Tip.HashBlock, Time = Utils.DateTimeToUnixTime(context.chain.Tip.GetMedianTimePast()) + 1 });
-            context.chain.SetTip(new BlockHeader { HashPrevBlock = context.chain.Tip.HashBlock, Time = Utils.DateTimeToUnixTime(context.chain.Tip.GetMedianTimePast()) + 1 });
+
+            BlockHeader blockHeader = context.network.Consensus.ConsensusFactory.CreateBlockHeader();
+            blockHeader.HashPrevBlock = context.chain.Tip.HashBlock;
+            blockHeader.Time = Utils.DateTimeToUnixTime(context.chain.Tip.GetMedianTimePast()) + 1;
+            context.chain.SetTip(blockHeader);
+
+            blockHeader = context.network.Consensus.ConsensusFactory.CreateBlockHeader();
+            blockHeader.HashPrevBlock = context.chain.Tip.HashBlock;
+            blockHeader.Time = Utils.DateTimeToUnixTime(context.chain.Tip.GetMedianTimePast()) + 1;
+            context.chain.SetTip(blockHeader);
+
+            blockHeader = context.network.Consensus.ConsensusFactory.CreateBlockHeader();
+            blockHeader.HashPrevBlock = context.chain.Tip.HashBlock;
+            blockHeader.Time = Utils.DateTimeToUnixTime(context.chain.Tip.GetMedianTimePast()) + 1;
+            context.chain.SetTip(blockHeader);
+
             SequenceLock locks = tx.CalculateSequenceLocks(prevheights.ToArray(), context.chain.Tip, flags);
             Assert.True(locks.Evaluate(context.chain.Tip)); // Sequence locks pass on 2nd block
         }
@@ -562,7 +569,13 @@ namespace Stratis.Bitcoin.IntegrationTests
             prevheights[0] = context.baseheight + 2;
 
             for (int i = 0; i < MedianTimeSpan; i++)
-                context.chain.SetTip(new BlockHeader { HashPrevBlock = context.chain.Tip.HashBlock, Time = Utils.DateTimeToUnixTime(context.chain.Tip.GetMedianTimePast()) + 512 });
+            {
+                BlockHeader header = context.network.Consensus.ConsensusFactory.CreateBlockHeader();
+                header.HashPrevBlock = context.chain.Tip.HashBlock;
+                header.Time = Utils.DateTimeToUnixTime(context.chain.Tip.GetMedianTimePast()) + 512;
+                context.chain.SetTip(header);
+            }
+
             SequenceLock locks = (tx.CalculateSequenceLocks(prevheights.ToArray(), context.chain.Tip, flags));
             Assert.True(locks.Evaluate(context.chain.Tip));
 
@@ -578,8 +591,17 @@ namespace Stratis.Bitcoin.IntegrationTests
             context.mempool.AddUnchecked(context.hash, context.entry.Time(context.DateTimeProvider.GetTime()).FromTx(tx));
             Assert.True(!MempoolValidator.CheckFinalTransaction(context.chain, context.DateTimeProvider, tx, flags)); // Locktime fails
             Assert.True(this.TestSequenceLocks(context, context.chain.Tip, tx, flags)); // Sequence locks pass
-            context.chain.SetTip(new BlockHeader { HashPrevBlock = context.chain.Tip.HashBlock, Time = Utils.DateTimeToUnixTime(context.chain.Tip.GetMedianTimePast()) + 512 });
-            context.chain.SetTip(new BlockHeader { HashPrevBlock = context.chain.Tip.HashBlock, Time = Utils.DateTimeToUnixTime(context.chain.Tip.GetMedianTimePast()) + 512 });
+
+            BlockHeader blockHeader = context.network.Consensus.ConsensusFactory.CreateBlockHeader();
+            blockHeader.HashPrevBlock = context.chain.Tip.HashBlock;
+            blockHeader.Time = Utils.DateTimeToUnixTime(context.chain.Tip.GetMedianTimePast()) + 512;
+            context.chain.SetTip(blockHeader);
+
+            blockHeader = context.network.Consensus.ConsensusFactory.CreateBlockHeader();
+            blockHeader.HashPrevBlock = context.chain.Tip.HashBlock;
+            blockHeader.Time = Utils.DateTimeToUnixTime(context.chain.Tip.GetMedianTimePast()) + 512;
+            context.chain.SetTip(blockHeader);
+
             Assert.True(tx.IsFinal(context.chain.Tip.GetMedianTimePast(), context.chain.Tip.Height + 2)); // Locktime passes on 2nd block
         }
 
@@ -610,8 +632,17 @@ namespace Stratis.Bitcoin.IntegrationTests
             context.mempool.AddUnchecked(context.hash, context.entry.Time(context.DateTimeProvider.GetTime()).FromTx(tx));
             Assert.True(!MempoolValidator.CheckFinalTransaction(context.chain, context.DateTimeProvider, tx, flags)); // Locktime fails
             Assert.True(this.TestSequenceLocks(context, context.chain.Tip, tx, flags)); // Sequence locks pass
-            context.chain.SetTip(new BlockHeader { HashPrevBlock = context.chain.Tip.HashBlock, Time = Utils.DateTimeToUnixTime(context.chain.Tip.GetMedianTimePast()) + 512 });
-            context.chain.SetTip(new BlockHeader { HashPrevBlock = context.chain.Tip.HashBlock, Time = Utils.DateTimeToUnixTime(context.chain.Tip.GetMedianTimePast()) + 512 });
+
+            BlockHeader blockHeader = context.network.Consensus.ConsensusFactory.CreateBlockHeader();
+            blockHeader.HashPrevBlock = context.chain.Tip.HashBlock;
+            blockHeader.Time = Utils.DateTimeToUnixTime(context.chain.Tip.GetMedianTimePast()) + 512;
+            context.chain.SetTip(blockHeader);
+
+            blockHeader = context.network.Consensus.ConsensusFactory.CreateBlockHeader();
+            blockHeader.HashPrevBlock = context.chain.Tip.HashBlock;
+            blockHeader.Time = Utils.DateTimeToUnixTime(context.chain.Tip.GetMedianTimePast()) + 512;
+            context.chain.SetTip(blockHeader);
+
             Assert.True(tx.IsFinal(context.chain.Tip.GetMedianTimePast().AddMinutes(2), context.chain.Tip.Height + 2)); // Locktime passes 2 min later
         }
 


### PR DESCRIPTION
This PR was to remove the `SetNull()` method in `BlockHeader` as we override this in smart contracts. A better implementation would be to set all these values in the constructor.

As part of this PR I had to fix a lot of tests as we now correctly create the block header via the consensus factory everywhere.

All unit and integration tests pass. Busy syncing....

