### PR TITLE
CHT Test: Two chains one covering checkpoint and assume valid and another only checkpoint

### DIFF
--- a/src/Stratis.Bitcoin.Tests/Consensus/ChainedHeaderTreeTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Consensus/ChainedHeaderTreeTest.cs
@@ -470,7 +470,7 @@ namespace Stratis.Bitcoin.Tests.Consensus
             // Chain B is presented by peer 2.
             // DownloadFrom should be set to header 5. 
             // DownloadTo should be set to header 10. 
-            result = cht.ConnectNewHeaders(1, listOfChainBBlockHeaders);
+            result = cht.ConnectNewHeaders(2, listOfChainBBlockHeaders);
             result.DownloadFrom.HashBlock.Should().Be(listOfChainBBlockHeaders[checkpointHeight].GetHash());
             result.DownloadTo.HashBlock.Should().Be(listOfChainBBlockHeaders.Last().GetHash());
         }

--- a/src/Stratis.Bitcoin.Tests/Consensus/ChainedHeaderTreeTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Consensus/ChainedHeaderTreeTest.cs
@@ -22,7 +22,7 @@ namespace Stratis.Bitcoin.Tests.Consensus
         {
             public CheckpointFixture(int height, BlockHeader header)
             {
-                if (height < 1) throw new ArgumentException("Height must be greater or equal to 1.");
+                if (height < 1) throw new ArgumentOutOfRangeException(nameof(height), "Height must be greater or equal to 1.");
 
                 Guard.NotNull(header, nameof(header));
 
@@ -46,6 +46,9 @@ namespace Stratis.Bitcoin.Tests.Consensus
 
             internal TestContextBuilder WithInitialChain(int initialChainSize)
             {
+                if (initialChainSize < 0)
+                    throw new ArgumentOutOfRangeException(nameof(initialChainSize), "Size cannot be less than 0.");
+
                 this.testContext.InitialChainTip = this.testContext.ExtendAChain(initialChainSize);
                 return this;
             }
@@ -83,7 +86,8 @@ namespace Stratis.Bitcoin.Tests.Consensus
             public TestContext()
             {
                 this.ChainedHeaderTree = new ChainedHeaderTree(
-                    this.Network, new ExtendedLoggerFactory(), 
+                    this.Network, 
+                    new ExtendedLoggerFactory(), 
                     this.ChainedHeaderValidatorMock.Object, 
                     this.CheckpointsMock.Object, 
                     this.ChainStateMock.Object, 
@@ -299,7 +303,7 @@ namespace Stratis.Bitcoin.Tests.Consensus
         public void ConnectHeaders_SupplyHeaders_ToDownloadArraySizeSameAsNumberOfHeaders()
         {
             // Setup
-            TestContext ctx = new TestContextBuilder().WithInitialChain(10).UseCheckpoints(false).Build();
+            TestContext ctx = new TestContextBuilder().WithInitialChain(5).UseCheckpoints(false).Build();
             ChainedHeaderTree cht = ctx.ChainedHeaderTree;
             ChainedHeader chainTip = ctx.InitialChainTip;
 

--- a/src/Stratis.Bitcoin.Tests/Consensus/ChainedHeaderTreeTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Consensus/ChainedHeaderTreeTest.cs
@@ -452,7 +452,7 @@ namespace Stratis.Bitcoin.Tests.Consensus
             ctx.ConsensusSettings.BlockAssumedValid = listOfCurrentChainHeaders.Last().GetHash();
 
             // Setup two alternative chains A and B. Chain A covers the last checkpoint (4) and "assume valid" (6).
-            // Chain B only covers the last checkpoint (4), but is onger that chain A.
+            // Chain B only covers the last checkpoint (4), but is longer that chain A.
             const int chainAExtensionSize = 2;
             const int chainBExtensionSize = 6;
             ChainedHeader chainATip = ctx.ExtendAChain(chainAExtensionSize, extendedChainTip); // ie. h1=h2=h3=(h4)=h5=[h6]=a7=a8

--- a/src/Stratis.Bitcoin.Tests/Consensus/ChainedHeaderTreeTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Consensus/ChainedHeaderTreeTest.cs
@@ -508,7 +508,7 @@ namespace Stratis.Bitcoin.Tests.Consensus
             ctx.ConsensusSettings.BlockAssumedValid = extendedChainTip.HashBlock;
 
             // Setup two alternative chains A and B. Chain A covers the last checkpoint (4) and "assume valid" (6).
-            // Chain B only covers the last checkpoint (4), but is longer that chain A.
+            // Chain B only covers the last checkpoint (4).
             const int chainAExtensionSize = 2;
             const int chainBExtensionSize = 6;
             ChainedHeader chainATip = ctx.ExtendAChain(chainAExtensionSize, extendedChainTip); // i.e. h1=h2=h3=(h4)=h5=[h6]=a7=a8

--- a/src/Stratis.Bitcoin.Tests/Consensus/ChainedHeaderTreeTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Consensus/ChainedHeaderTreeTest.cs
@@ -58,7 +58,9 @@ namespace Stratis.Bitcoin.Tests.Consensus
 
             internal TestContext Build()
             {
-                this.testContext.ChainedHeaderTree.Initialize(this.testContext.InitialChainTip, true);
+                if (this.testContext.InitialChainTip != null)
+                    this.testContext.ChainedHeaderTree.Initialize(this.testContext.InitialChainTip, true);
+
                 return this.testContext;
             }
         }

--- a/src/Stratis.Bitcoin.Tests/Consensus/ChainedHeaderTreeTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Consensus/ChainedHeaderTreeTest.cs
@@ -567,7 +567,7 @@ namespace Stratis.Bitcoin.Tests.Consensus
             ChainedHeader extendedChainTip = ctx.ExtendAChain(chainExtension, initialChainTip);
             ctx.ConsensusSettings.BlockAssumedValid = extendedChainTip.HashBlock;
 
-            // Setup new chain, which covers the last checkpoint (4), but misses "assumed vaid".
+            // Setup new chain, which covers the last checkpoint (4), but misses "assumed valid".
             const int newChainExtensionSize = 6;
             ChainedHeader newChainTip = ctx.ExtendAChain(newChainExtensionSize, initialChainTip); // i.e. h1=h2=h3=(h4)=b5=b6=b7=b8=b9=b10
             listOfCurrentChainHeaders = ctx.ChainedHeaderToList(newChainTip, initialChainSize + extensionChainSize  + newChainExtensionSize);

--- a/src/Stratis.Bitcoin.Tests/Consensus/ChainedHeaderTreeTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Consensus/ChainedHeaderTreeTest.cs
@@ -175,7 +175,7 @@ namespace Stratis.Bitcoin.Tests.Consensus
         [Fact]
         public void ConnectHeaders_HeadersCantConnect_ShouldFail()
         {
-            var testContext = new TestContext();
+            TestContext testContext = new TestContextBuilder().Build();
             ChainedHeaderTree chainedHeaderTree = testContext.ChainedHeaderTree;
 
             Assert.Throws<ConnectHeaderException>(() => chainedHeaderTree.ConnectNewHeaders(1, new List<BlockHeader>(new[] { testContext.Network.GetGenesis().Header })));

--- a/src/Stratis.Bitcoin.Tests/Consensus/ChainedHeaderTreeTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Consensus/ChainedHeaderTreeTest.cs
@@ -414,9 +414,9 @@ namespace Stratis.Bitcoin.Tests.Consensus
         }
 
         /// <summary>
-        /// Issue 16 @ Checkpoints are enabled. After last checkpoint there is an assume valid. Chain that covers
-        /// them all is presented - marked for download. After that chain that covers last checkpoint but doesnt
-        /// cover assume valid and is longer is presented - marked for download.
+        /// Issue 16 @ Checkpoints are enabled. After the last checkpoint, there is an assumed valid. The chain
+        /// that covers them all is presented - marked for download. After that chain that covers the last checkpoint
+        /// but doesn't cover assume valid and is longer is presented - marked for download.
         /// </summary>
         [Fact]
         public void ChainHasOneCheckPointAndAssumeValid_TwoAlternativeChainsArePresented_BothChainsAreMarkedForDownload()

--- a/src/Stratis.Bitcoin.Tests/Consensus/ChainedHeaderTreeTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Consensus/ChainedHeaderTreeTest.cs
@@ -271,9 +271,9 @@ namespace Stratis.Bitcoin.Tests.Consensus
             const int commonChainSize = 4;
             const int chainAExtension = 4;
             const int chainBExtension = 2;
-            ChainedHeader commonChainTip = ctx.ExtendAChain(commonChainSize, initialChainTip); // ie. h1=h2=h3=h4
-            ChainedHeader chainATip = ctx.ExtendAChain(chainAExtension, commonChainTip); // ie. (h1=h2=h3=h4)=a5=a6=a7=a8
-            ChainedHeader chainBTip = ctx.ExtendAChain(chainBExtension, commonChainTip); // ie. (h1=h2=h3=h4)=b5=b6
+            ChainedHeader commonChainTip = ctx.ExtendAChain(commonChainSize, initialChainTip); // i.e. h1=h2=h3=h4
+            ChainedHeader chainATip = ctx.ExtendAChain(chainAExtension, commonChainTip); // i.e. (h1=h2=h3=h4)=a5=a6=a7=a8
+            ChainedHeader chainBTip = ctx.ExtendAChain(chainBExtension, commonChainTip); // i.e. (h1=h2=h3=h4)=b5=b6
             List<BlockHeader> listOfChainABlockHeaders = ctx.ChainedHeaderToList(chainATip, commonChainSize + chainAExtension);
             List<BlockHeader> listOfChainBBlockHeaders = ctx.ChainedHeaderToList(chainBTip, commonChainSize + chainBExtension);
 
@@ -292,7 +292,7 @@ namespace Stratis.Bitcoin.Tests.Consensus
 
             // Add more chain work and blocks into chain B.
             const int chainBAdditionalBlocks = 4;
-            chainBTip = ctx.ExtendAChain(chainBAdditionalBlocks, chainBTip); // ie. (h1=h2=h3=h4)=b5=b6=b7=b8=b9=b10
+            chainBTip = ctx.ExtendAChain(chainBAdditionalBlocks, chainBTip); // i.e. (h1=h2=h3=h4)=b5=b6=b7=b8=b9=b10
             listOfChainBBlockHeaders = ctx.ChainedHeaderToList(chainBTip, commonChainSize + chainBExtension + chainBAdditionalBlocks);
             List<BlockHeader> listOfNewChainBBlockHeaders = listOfChainBBlockHeaders.TakeLast(chainBAdditionalBlocks).ToList();
 
@@ -322,9 +322,9 @@ namespace Stratis.Bitcoin.Tests.Consensus
             const int currentChainExtension = 6;
             var ctx = new TestContext();
             ChainedHeaderTree cht = ctx.CreateChainedHeaderTree();
-            ChainedHeader initialChainTip = ctx.ExtendAChain(initialChainSize); // ie. h1=h2
+            ChainedHeader initialChainTip = ctx.ExtendAChain(initialChainSize); // i.e. h1=h2
             cht.Initialize(initialChainTip, true); 
-            ChainedHeader extendedChainTip = ctx.ExtendAChain(currentChainExtension, initialChainTip); // ie. h1=h2=h3=h4=h5=h6=h7=h8
+            ChainedHeader extendedChainTip = ctx.ExtendAChain(currentChainExtension, initialChainTip); // i.e. h1=h2=h3=h4=h5=h6=h7=h8
             ctx.ConsensusSettings.UseCheckpoints = true;
             List<BlockHeader> listOfCurrentChainHeaders = ctx.ChainedHeaderToList(extendedChainTip, initialChainSize + currentChainExtension);
 
@@ -391,8 +391,8 @@ namespace Stratis.Bitcoin.Tests.Consensus
 
             // Setup two alternative chains A and B of the same length.
             const int presentedChainSize = 4;
-            ChainedHeader chainATip = ctx.ExtendAChain(presentedChainSize, initialChainTip); // ie. h1=h2=a1=a2=a3=a4
-            ChainedHeader chainBTip = ctx.ExtendAChain(presentedChainSize, initialChainTip); // ie. h1=h2=b1=b2=b3=b4
+            ChainedHeader chainATip = ctx.ExtendAChain(presentedChainSize, initialChainTip); // i.e. h1=h2=a1=a2=a3=a4
+            ChainedHeader chainBTip = ctx.ExtendAChain(presentedChainSize, initialChainTip); // i.e. h1=h2=b1=b2=b3=b4
             List<BlockHeader> listOfChainABlockHeaders = ctx.ChainedHeaderToList(chainATip, initialChainSize + presentedChainSize);
             List<BlockHeader> listOfChainBBlockHeaders = ctx.ChainedHeaderToList(chainBTip, initialChainSize + presentedChainSize);
 
@@ -426,12 +426,12 @@ namespace Stratis.Bitcoin.Tests.Consensus
             const int extensionChainSize = 2;
             var ctx = new TestContext();
             ChainedHeaderTree cht = ctx.CreateChainedHeaderTree();
-            ChainedHeader initialChainTip = ctx.ExtendAChain(initialChainSize); // ie. h1=h2
+            ChainedHeader initialChainTip = ctx.ExtendAChain(initialChainSize); // i.e. h1=h2
             ctx.ConsensusSettings.UseCheckpoints = true;
             cht.Initialize(initialChainTip, true);
 
             // Extend chain with 2 more headers.
-            initialChainTip = ctx.ExtendAChain(extensionChainSize, initialChainTip); // ie. h1=h2=h3=h4
+            initialChainTip = ctx.ExtendAChain(extensionChainSize, initialChainTip); // i.e. h1=h2=h3=h4
             List<BlockHeader> listOfCurrentChainHeaders = ctx.ChainedHeaderToList(initialChainTip, initialChainSize + extensionChainSize);
 
             // Setup a known checkpoint at header 4.
@@ -459,8 +459,8 @@ namespace Stratis.Bitcoin.Tests.Consensus
             // Chain B only covers the last checkpoint (4), but is longer that chain A.
             const int chainAExtensionSize = 2;
             const int chainBExtensionSize = 6;
-            ChainedHeader chainATip = ctx.ExtendAChain(chainAExtensionSize, extendedChainTip); // ie. h1=h2=h3=(h4)=h5=[h6]=a7=a8
-            ChainedHeader chainBTip = ctx.ExtendAChain(chainBExtensionSize, initialChainTip); // ie. h1=h2=h3=(h4)=b5=b6=b7=b8=b9=b10
+            ChainedHeader chainATip = ctx.ExtendAChain(chainAExtensionSize, extendedChainTip); // i.e. h1=h2=h3=(h4)=h5=[h6]=a7=a8
+            ChainedHeader chainBTip = ctx.ExtendAChain(chainBExtensionSize, initialChainTip); // i.e. h1=h2=h3=(h4)=b5=b6=b7=b8=b9=b10
             List<BlockHeader> listOfChainABlockHeaders = ctx.ChainedHeaderToList(chainATip, initialChainSize + extensionChainSize + chainExtension + chainAExtensionSize);
             List<BlockHeader> listOfChainBBlockHeaders = ctx.ChainedHeaderToList(chainBTip, initialChainSize + extensionChainSize + chainBExtensionSize);
 

--- a/src/Stratis.Bitcoin.Tests/Consensus/ChainedHeaderTreeTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Consensus/ChainedHeaderTreeTest.cs
@@ -499,8 +499,7 @@ namespace Stratis.Bitcoin.Tests.Consensus
             // Example: h1=h2=h3=(h4)=h5=[h6].
             const int chainExtension = 2;
             ChainedHeader extendedChainTip = ctx.ExtendAChain(chainExtension, initialChainTip);
-            listOfCurrentChainHeaders = ctx.ChainedHeaderToList(extendedChainTip, extendedChainTip.Height);
-            ctx.ConsensusSettings.BlockAssumedValid = listOfCurrentChainHeaders.Last().GetHash();
+            ctx.ConsensusSettings.BlockAssumedValid = extendedChainTip.HashBlock;
 
             // Setup two alternative chains A and B. Chain A covers the last checkpoint (4) and "assume valid" (6).
             // Chain B only covers the last checkpoint (4), but is longer that chain A.
@@ -556,8 +555,7 @@ namespace Stratis.Bitcoin.Tests.Consensus
             // Example: h1=h2=h3=(h4)=h5=[h6].
             const int chainExtension = 2;
             ChainedHeader extendedChainTip = ctx.ExtendAChain(chainExtension, initialChainTip);
-            listOfCurrentChainHeaders = ctx.ChainedHeaderToList(extendedChainTip, extendedChainTip.Height);
-            ctx.ConsensusSettings.BlockAssumedValid = listOfCurrentChainHeaders.Last().GetHash();
+            ctx.ConsensusSettings.BlockAssumedValid = extendedChainTip.HashBlock;
 
             // Setup new chain, which covers the last checkpoint (4), but misses "assumed vaid".
             const int newChainExtensionSize = 6;

--- a/src/Stratis.Bitcoin.Tests/Consensus/ChainedHeaderTreeTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Consensus/ChainedHeaderTreeTest.cs
@@ -430,7 +430,7 @@ namespace Stratis.Bitcoin.Tests.Consensus
             ctx.ConsensusSettings.UseCheckpoints = true;
             cht.Initialize(initialChainTip, true);
 
-            // Extend chain with 2 more headers
+            // Extend chain with 2 more headers.
             initialChainTip = ctx.ExtendAChain(extensionChainSize, initialChainTip); // ie. h1=h2=h3=h4
             List<BlockHeader> listOfCurrentChainHeaders = ctx.ChainedHeaderToList(initialChainTip, initialChainSize + extensionChainSize);
 


### PR DESCRIPTION
Issue 16 @ Checkpoints are enabled. After the last checkpoint, there is an assumed valid. The chain that covers them all is presented - marked for download. After that chain that covers the last checkpoint but doesn't cover assume valid and is longer is presented - marked for download.
See #1321 (comment)

Preferred reviewers: @Aprogiena or @noescape00

