### PR TITLE
Optional parameter never used optionally

### DIFF
--- a/src/Stratis.Bitcoin.Features.Wallet.Tests/WalletManagerTest.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet.Tests/WalletManagerTest.cs
@@ -2840,7 +2840,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
         [Fact]
         public void CreateBip44PathWithChangeAddressReturnsPath()
         {
-            string result = HdOperations.CreateHdPath((int)CoinType.Stratis, 4, 3, true);
+            string result = HdOperations.CreateHdPath((int)CoinType.Stratis, 4, true, 3);
 
             Assert.Equal("m/44'/105'/4'/1/3", result);
         }
@@ -2848,7 +2848,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
         [Fact]
         public void CreateBip44PathWithoutChangeAddressReturnsPath()
         {
-            string result = HdOperations.CreateHdPath((int)CoinType.Stratis, 4, 3, false);
+            string result = HdOperations.CreateHdPath((int)CoinType.Stratis, 4, false, 3);
 
             Assert.Equal("m/44'/105'/4'/0/3", result);
         }

--- a/src/Stratis.Bitcoin.Features.Wallet/HdOperations.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/HdOperations.cs
@@ -132,11 +132,11 @@ namespace Stratis.Bitcoin.Features.Wallet
         /// </summary>
         /// <param name="coinType">Type of coin in the HD path.</param>
         /// <param name="accountIndex">Index of the account in the HD path.</param>
-        /// <param name="addressIndex">Index of the address in the HD path.</param>
         /// <param name="isChange">A value indicating whether the HD path to generate corresponds to a change address.</param>
+        /// <param name="addressIndex">Index of the address in the HD path.</param>
         /// <returns>The HD path.</returns>
         /// <remarks>Refer to <seealso cref="https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki#path-levels"/> for the format of the HD path.</remarks>
-        public static string CreateHdPath(int coinType, int accountIndex, int addressIndex, bool isChange = false)
+        public static string CreateHdPath(int coinType, int accountIndex, bool isChange, int addressIndex)
         {
             int change = isChange ? 1 : 0;
             return $"m/44'/{coinType}'/{accountIndex}'/{change}/{addressIndex}";

--- a/src/Stratis.Bitcoin.Features.Wallet/Wallet.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Wallet.cs
@@ -617,7 +617,7 @@ namespace Stratis.Bitcoin.Features.Wallet
                 var newAddress = new HdAddress
                 {
                     Index = i,
-                    HdPath = HdOperations.CreateHdPath((int) this.GetCoinType(), this.Index, i, isChange),
+                    HdPath = HdOperations.CreateHdPath((int) this.GetCoinType(), this.Index, isChange, i),
                     ScriptPubKey = address.ScriptPubKey,
                     Pubkey = pubkey.ScriptPubKey,
                     Address = address.ToString(),


### PR DESCRIPTION
Swapped the parameter order to the Create HDAddress path as it had an optional parameter that was never used optionally. Therefore optional changed to explicit.

should be tagged very-low