### PR TITLE
Generic logs controller to view logs in browser on full node

### DIFF
--- a/src/Stratis.Bitcoin/Controllers/DashboardController.cs
+++ b/src/Stratis.Bitcoin/Controllers/DashboardController.cs
@@ -1,4 +1,4 @@
-﻿using Stratis.Bitcoin.Configuration;
+﻿using Microsoft.AspNetCore.Mvc;
 
 namespace Stratis.Bitcoin.Controllers
 {
@@ -9,14 +9,25 @@ namespace Stratis.Bitcoin.Controllers
     [Route("[controller]")]
     public class DashboardController : Controller
     {
-
         private readonly IFullNode fullNode;
-        private NodeSettings nodeSettings;
 
-        public DashboardController(IFullNode fullNode, NodeSettings nodeSettings)
+        public DashboardController(IFullNode fullNode)
         {
             this.fullNode = fullNode;
-            this.nodeSettings = nodeSettings;
+        }
+
+        /// <summary>
+        /// Provides simple navigation
+        /// </summary>
+        /// <returns>text/html content</returns>
+        [HttpGet]
+        [Route("")]
+        public IActionResult Home()
+        {
+            string statsLink = "<a href='Stats'>Node Stats</a>";
+            string logsLink = "<a href='Logs'>Node Logs</a>";
+
+            return this.Content($"{statsLink} <br/><br/> {logsLink}", "text/html");
         }
 
         /// <summary>
@@ -24,34 +35,11 @@ namespace Stratis.Bitcoin.Controllers
         /// </summary>
         /// <returns>text/html content</returns>
         [HttpGet]
-        [Route("")]
         [Route("Stats")]
         public IActionResult Stats()
         {
             string content = (this.fullNode as FullNode).LastLogOutput;
             return this.Content(content);
-        }
-
-        /// <summary>
-        /// Returns a web page view over the SmartContract Logs
-        /// </summary>
-        /// <returns>text/html content</returns>
-        [HttpGet]
-        [Route("SmartContracts/{numberOfLogEntriesToShow?}")]
-        public IActionResult SmartContractLogs(int numberOfLogEntriesToShow = 30)
-        {
-            string logPath = Path.Combine(this.nodeSettings.DataDir, @"Logs\smartcontracts.txt");
-
-            if (!System.IO.File.Exists(logPath))
-            {
-                return this.Content($"There is no log file at: {logPath}. An nlog.config file is needed in the daemon directory.");
-            }
-
-            string[] logLines = System.IO.File.ReadAllLines(logPath);
-
-            int entriesToSkip = logLines.Length < numberOfLogEntriesToShow ? 0 : logLines.Length - numberOfLogEntriesToShow;
-
-            return this.Content(string.Join("\r\n", logLines.Skip(entriesToSkip)));
         }
     }
 }

--- a/src/Stratis.Bitcoin/Controllers/LogsController.cs
+++ b/src/Stratis.Bitcoin/Controllers/LogsController.cs
@@ -1,0 +1,60 @@
+﻿using System.IO;
+using System.Linq;
+using Microsoft.AspNetCore.Mvc;
+using Stratis.Bitcoin.Configuration;
+
+namespace Stratis.Bitcoin.Controllers
+{
+    /// <summary>
+    /// Controller providing access to logs in the browser
+    /// </summary>
+    [Route("")]
+    [Route("[controller]")]
+    public class LogsController : Controller
+    {
+        private readonly NodeSettings nodeSettings;
+
+        public LogsController(NodeSettings nodeSettings)
+        {
+            this.nodeSettings = nodeSettings;
+        }
+
+        /// <summary>
+        /// Lists the logs available
+        /// </summary>
+        /// <returns>text/html content</returns>
+        [HttpGet]
+        [Route("Logs")]
+        public IActionResult Logs()
+        {
+            string logPath = Path.Combine(this.nodeSettings.DataDir, @"Logs");
+
+            if (!Directory.Exists(logPath))
+                return this.Content($"There is no directory at {logPath}.");
+
+            return this.Content(string.Join("<br/><br/>", Directory.GetFiles(logPath).Select(x => $"<a href='/Logs/{Path.GetFileNameWithoutExtension(x)}'>{x}</a>")), "text/html");
+        }
+
+        /// <summary>
+        /// Returns a web page view over the any log file in the data directory
+        /// </summary>
+        /// <returns>text/html content</returns>
+        [HttpGet]
+        [Route("Logs/{logfileName}/{numberOfLogEntriesToShow?}")]
+        public IActionResult Logs(string logfileName, int numberOfLogEntriesToShow = 30)
+        {
+            string logPath = Path.Combine(this.nodeSettings.DataDir, @"Logs", $"{logfileName}.txt");
+
+            if (!System.IO.File.Exists(logPath))
+            {
+                return this.Content($"There is no log file at: {logPath}. An nlog.config file is needed in the daemon directory.");
+            }
+
+            string[] logLines = System.IO.File.ReadAllLines(logPath);
+
+            int entriesToSkip = logLines.Length < numberOfLogEntriesToShow ? 0 : logLines.Length - numberOfLogEntriesToShow;
+
+            return this.Content(string.Join("\r\n", logLines.Skip(entriesToSkip)));
+        }
+    }
+}


### PR DESCRIPTION
Rather than move into smart contracts, I made it generic so it will work with any log file (just use the name  in the url).

I added hyperlinks to make this easier and changed the root to have 2 links, one to stats and one to logs