### PR TITLE
CHT tests issues #7, #10

### DIFF
--- a/src/Stratis.Bitcoin.Tests/Consensus/ChainedHeaderTreeTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Consensus/ChainedHeaderTreeTest.cs
@@ -11,6 +11,7 @@ using Stratis.Bitcoin.Configuration;
 using Stratis.Bitcoin.Configuration.Logging;
 using Stratis.Bitcoin.Configuration.Settings;
 using Stratis.Bitcoin.Consensus;
+using Stratis.Bitcoin.Tests.Common;
 using Stratis.Bitcoin.Utilities;
 using Xunit;
 
@@ -428,6 +429,14 @@ namespace Stratis.Bitcoin.Tests.Consensus
             while (chainedHeader.Height > initialChainSize)
             {
                 chainedHeader.BlockValidationState.Should().Be(ValidationState.AssumedValid);
+                chainedHeader = chainedHeader.Previous;
+            }
+
+            // Checking from the checkpoint forward to the end of the chain.
+            chainedHeader = chainedHeaderTree.GetPeerTipChainedHeaderByPeerId(1);
+            while (chainedHeader.Height > checkpoint.Height)
+            {
+                chainedHeader.BlockValidationState.Should().Be(ValidationState.HeaderValidated);
                 chainedHeader = chainedHeader.Previous;
             }
         }

--- a/src/Stratis.Bitcoin.Tests/Consensus/ChainedHeaderTreeTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Consensus/ChainedHeaderTreeTest.cs
@@ -421,46 +421,6 @@ namespace Stratis.Bitcoin.Tests.Consensus
         }
 
         /// <summary>
-        /// Issue 11 @ Create chained header tree component #1321
-        /// When checkpoints are enabled and the first is at block X,
-        /// when we present headers before that- none marked for download.
-        /// When we first present checkpointed header and some after- only
-        /// headers before the first checkpoint(including it) are marked for download
-        /// </summary>
-        [Fact]
-        public void PresentChain_CheckpointsDisabled_DownloadBehaviourIsCorrectB()
-        {
-            throw new System.NotImplementedException();
-        }
-
-        /// <summary>
-        /// Issue 12 @ Create chained header tree component #1321
-        /// Checkpoints are disabled, assumevalid at block X, blocks up to X -
-        /// 10 are marked for download, blocks before x -20 are FV,
-        /// headers up to block X + some more are presented, all from X-10
-        /// are marked for download. Make sure that all blocks before assumevalid block
-        /// that are not FV or PV are marked assumevalid.
-        /// </summary>
-        [Fact]
-        public void PresentChain_CheckpointsDisabled_CheckDownloadBehaviourAndHeaderValidity()
-        {
-            /// setup
-            /// Checkpoints are disabled, assumevalid at block X, blocks up to X -
-            /// 10 are marked for download, blocks before x -20 are FV
-
-
-            //action
-            /// headers up to block X + some more are presented,
-
-
-
-            /// all from X-10  are marked for download.
-            /// Make sure that all blocks before assumevalid block
-            /// that are not FV or PV are marked assumevalid.
-        }
-
-
-        /// <summary>
         /// Issue 13 @ Create 2 chains - chain A and chain B, where chain A has more chain work than chain B. Connect both
         /// chains to chain header tree. Consensus tip should be set to chain A. Now extend / update chain B to make it have
         /// more chain work. Attempt to connect chain B again. Consensus tip should be set to chain B.

--- a/src/Stratis.Bitcoin.Tests/Consensus/ChainedHeaderTreeTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Consensus/ChainedHeaderTreeTest.cs
@@ -345,7 +345,7 @@ namespace Stratis.Bitcoin.Tests.Consensus
         {
             TestContext testContext = new TestContextBuilder().WithInitialChain(5).UseCheckpoints(false).Build();
             ChainedHeaderTree chainedHeaderTree = testContext.ChainedHeaderTree;
-            uint256 peerTipHashBeforeInvalidBlockPresented = testContext.InitialChainTip.HashBlock;
+            ChainedHeader consensusTip = testContext.InitialChainTip;
 
             ChainedHeader invalidChainedHeader = testContext.ExtendAChain(1, testContext.InitialChainTip);
             List<BlockHeader> listContainingInvalidHeader = testContext.ChainedHeaderToList(invalidChainedHeader, 1);
@@ -356,11 +356,11 @@ namespace Stratis.Bitcoin.Tests.Consensus
             Assert.Throws<InvalidHeaderTestException>(() => chainedHeaderTree.ConnectNewHeaders(1, listContainingInvalidHeader));
 
             // Chain's last block shouldn't change.
-            ChainedHeader peerTipAfterInvalidHeaderPresented = chainedHeaderTree.GetPeerTipChainedHeaderByPeerId(-1);
-            Assert.Equal(peerTipHashBeforeInvalidBlockPresented, peerTipAfterInvalidHeaderPresented.HashBlock);
+            ChainedHeader consensusTipAfterInvalidHeaderPresented = chainedHeaderTree.GetPeerTipChainedHeaderByPeerId(-1);
+            Assert.Equal(consensusTip, consensusTipAfterInvalidHeaderPresented);
 
             // Last block shouldn't have a Next.
-            Assert.Empty(peerTipAfterInvalidHeaderPresented.Next);
+            Assert.Empty(consensusTipAfterInvalidHeaderPresented.Next);
         }
 
         /// <summary>
@@ -424,7 +424,7 @@ namespace Stratis.Bitcoin.Tests.Consensus
             ChainedHeader chainedHeader = chainedHeaderTree.GetChainedHeadersByHash()
                 .SingleOrDefault(x => (x.Value.HashBlock == checkpoint.Header.GetHash())).Value;
 
-            // Checking from the checkpoint back to the initialised chain.
+            // Checking from the checkpoint back to the initialized chain.
             while (chainedHeader.Height > initialChainSize)
             {
                 chainedHeader.BlockValidationState.Should().Be(ValidationState.AssumedValid);

--- a/src/Stratis.Bitcoin.Tests/Consensus/ChainedHeaderTreeTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Consensus/ChainedHeaderTreeTest.cs
@@ -400,7 +400,7 @@ namespace Stratis.Bitcoin.Tests.Consensus
             connectNewHeadersResult.DownloadTo.Should().Be(null);
 
             // Headers up to the last checkpoint are marked as assumevalid.
-            testContext.ConsensusSettings.BlockAssumedValid = listOfCurrentChainHeaders[checkpointHeight - 1].GetHash();
+            testContext.ConsensusSettings.BlockAssumedValid = listOfCurrentChainHeaders.Last().GetHash();
 
             // When we present the checkpointed header and those beyond all previous are a marked for download
             List<BlockHeader> listOfHeadersIncludingAndAfterCheckpoint = listOfCurrentChainHeaders.TakeLast(6).ToList();
@@ -408,7 +408,7 @@ namespace Stratis.Bitcoin.Tests.Consensus
                 chainedHeaderTree.ConnectNewHeaders(1, listOfHeadersIncludingAndAfterCheckpoint.ToList());
 
             connectNewHeadersResult.DownloadFrom.HashBlock.Should().Be(listOfHeadersBeforeCheckpoint.First().GetHash());
-            connectNewHeadersResult.DownloadTo.HashBlock.Should().Be(checkpoint.Header.GetHash());
+            connectNewHeadersResult.DownloadTo.HashBlock.Should().Be(listOfHeadersIncludingAndAfterCheckpoint.Last().GetHash());
 
             const ValidationState expectedState = ValidationState.AssumedValid;
 
@@ -419,6 +419,46 @@ namespace Stratis.Bitcoin.Tests.Consensus
                 consumed = consumed.Previous;
             }
         }
+
+        /// <summary>
+        /// Issue 11 @ Create chained header tree component #1321
+        /// When checkpoints are enabled and the first is at block X,
+        /// when we present headers before that- none marked for download.
+        /// When we first present checkpointed header and some after- only
+        /// headers before the first checkpoint(including it) are marked for download
+        /// </summary>
+        [Fact]
+        public void PresentChain_CheckpointsDisabled_DownloadBehaviourIsCorrectB()
+        {
+            throw new System.NotImplementedException();
+        }
+
+        /// <summary>
+        /// Issue 12 @ Create chained header tree component #1321
+        /// Checkpoints are disabled, assumevalid at block X, blocks up to X -
+        /// 10 are marked for download, blocks before x -20 are FV,
+        /// headers up to block X + some more are presented, all from X-10
+        /// are marked for download. Make sure that all blocks before assumevalid block
+        /// that are not FV or PV are marked assumevalid.
+        /// </summary>
+        [Fact]
+        public void PresentChain_CheckpointsDisabled_CheckDownloadBehaviourAndHeaderValidity()
+        {
+            /// setup
+            /// Checkpoints are disabled, assumevalid at block X, blocks up to X -
+            /// 10 are marked for download, blocks before x -20 are FV
+
+
+            //action
+            /// headers up to block X + some more are presented,
+
+
+
+            /// all from X-10  are marked for download.
+            /// Make sure that all blocks before assumevalid block
+            /// that are not FV or PV are marked assumevalid.
+        }
+
 
         /// <summary>
         /// Issue 13 @ Create 2 chains - chain A and chain B, where chain A has more chain work than chain B. Connect both

--- a/src/Stratis.Bitcoin.Tests/Consensus/ConsensusTestExtensions.cs
+++ b/src/Stratis.Bitcoin.Tests/Consensus/ConsensusTestExtensions.cs
@@ -21,5 +21,9 @@ namespace Stratis.Bitcoin.Tests.Consensus
         {
             return chainedHeaderTree.GetMemberValue("chainedHeadersByHash") as Dictionary<uint256, ChainedHeader>;
         }
+        public static ChainedHeader GetPeerTipChainedHeaderByPeerId(this ChainedHeaderTree chainedHeaderTree, int peer)
+        {
+            return chainedHeaderTree.GetChainedHeadersByHash()[chainedHeaderTree.GetPeerTipsByPeerId()[peer]];
+        }
     }
 }


### PR DESCRIPTION
**Issues 7 & 10** (#1321)
(7)  _We have a chain, someone presents an invalid header. After that our chain's last block shouldn't change and it shouldn't have .Next and it throws_
(10) _When checkpoints are enabled and the only checkpoint is at block X, when we present headers before that- none marked for download. When we first present checkpointed header and some after- all previous are also marked for download & those that are up to the last checkpoint are marked as assumevalid_