### PR TITLE
CHT test: BlockDataDownload for null pointer - issue 23

### DIFF
--- a/src/Stratis.Bitcoin.Tests/Consensus/ChainedHeaderTreeTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Consensus/ChainedHeaderTreeTest.cs
@@ -624,7 +624,6 @@ namespace Stratis.Bitcoin.Tests.Consensus
             const int initialChainSize = 4;
             TestContext ctx = new TestContextBuilder()
                                     .WithInitialChain(initialChainSize, assignBlocks: false)
-                                    .UseCheckpoints()
                                     .Build();
             ChainedHeaderTree cht = ctx.ChainedHeaderTree;
             ChainedHeader initialChainTip = ctx.InitialChainTip;

--- a/src/Stratis.Bitcoin.Tests/Consensus/ChainedHeaderTreeTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Consensus/ChainedHeaderTreeTest.cs
@@ -622,7 +622,10 @@ namespace Stratis.Bitcoin.Tests.Consensus
             // Chain header tree setup. Initial chain has 4 headers with no blocks.
             // Example: h1=h2=h3=h4.
             const int initialChainSize = 4;
-            TestContext ctx = new TestContextBuilder().WithInitialChain(initialChainSize, false).UseCheckpoints().Build();
+            TestContext ctx = new TestContextBuilder()
+                                    .WithInitialChain(initialChainSize, assignBlocks: false)
+                                    .UseCheckpoints()
+                                    .Build();
             ChainedHeaderTree cht = ctx.ChainedHeaderTree;
             ChainedHeader initialChainTip = ctx.InitialChainTip;
 


### PR DESCRIPTION
Block data received (BlockDataDownloaded is called) for already FV block with null pointer. Nothing should be chained, pointer shouldn't be assigned. Should return false

See #1321 (comment)

Preferred reviewers: @Aprogiena or @noescape00