### PR TITLE
Assign all Consensus settings directly in inherited networks

### DIFF
--- a/src/NBitcoin/Networks/BitcoinRegTest.cs
+++ b/src/NBitcoin/Networks/BitcoinRegTest.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using NBitcoin.DataEncoders;
 using NBitcoin.Protocol;
 
@@ -10,27 +11,42 @@ namespace NBitcoin.Networks
         {
             this.Name = "RegTest";
             this.AdditionalNames = new List<string> {"reg"};
-            this.Consensus.CoinType = 0;
             this.Magic = 0xDAB5BFFA;
             this.DefaultPort = 18444;
             this.RPCPort = 18332;
             this.CoinTicker = "TBTC";
 
-            this.Consensus.PowAllowMinDifficultyBlocks = true;
-            this.Consensus.PowNoRetargeting = true;
-            this.Consensus.RuleChangeActivationThreshold = 108;
-            this.Consensus.MinerConfirmationWindow = 144;
-            this.Consensus.SubsidyHalvingInterval = 150;
-            this.Consensus.BIP34Hash = new uint256();
-            this.Consensus.PowLimit = new Target(new uint256("7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"));
-            this.Consensus.MinimumChainWork = uint256.Zero;
-            this.Consensus.DefaultAssumeValid = null; // turn off assumevalid for regtest.
-            this.Consensus.BuriedDeployments[BuriedDeployments.BIP34] = 100000000;
-            this.Consensus.BuriedDeployments[BuriedDeployments.BIP65] = 100000000;
-            this.Consensus.BuriedDeployments[BuriedDeployments.BIP66] = 100000000;
-            this.Consensus.BIP9Deployments[BIP9Deployments.TestDummy] = new BIP9DeploymentsParameters(28, 0, 999999999);
-            this.Consensus.BIP9Deployments[BIP9Deployments.CSV] = new BIP9DeploymentsParameters(0, 0, 999999999);
-            this.Consensus.BIP9Deployments[BIP9Deployments.Segwit] = new BIP9DeploymentsParameters(1, BIP9DeploymentsParameters.AlwaysActive, 999999999);
+            // Taken from BitcoinMain Consensus options
+            var consensus = new Consensus();
+            consensus.MajorityEnforceBlockUpgrade = 750;
+            consensus.MajorityRejectBlockOutdated = 950;
+            consensus.MajorityWindow = 1000;
+            consensus.PowTargetTimespan = TimeSpan.FromSeconds(14 * 24 * 60 * 60); // two weeks
+            consensus.PowTargetSpacing = TimeSpan.FromSeconds(10 * 60);
+            consensus.CoinbaseMaturity = 100;
+            consensus.PremineReward = Money.Zero;
+            consensus.ProofOfWorkReward = Money.Coins(50);
+            consensus.ProofOfStakeReward = Money.Zero;
+            consensus.MaxReorgLength = 0;
+            consensus.MaxMoney = 21000000 * Money.COIN;
+
+            // BitcoinRegTest differences
+            consensus.CoinType = 0;
+            consensus.PowAllowMinDifficultyBlocks = true;
+            consensus.PowNoRetargeting = true;
+            consensus.RuleChangeActivationThreshold = 108;
+            consensus.MinerConfirmationWindow = 144;
+            consensus.SubsidyHalvingInterval = 150;
+            consensus.BIP34Hash = new uint256();
+            consensus.PowLimit = new Target(new uint256("7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"));
+            consensus.MinimumChainWork = uint256.Zero;
+            consensus.DefaultAssumeValid = null; // turn off assumevalid for regtest.
+            consensus.BuriedDeployments[BuriedDeployments.BIP34] = 100000000;
+            consensus.BuriedDeployments[BuriedDeployments.BIP65] = 100000000;
+            consensus.BuriedDeployments[BuriedDeployments.BIP66] = 100000000;
+            consensus.BIP9Deployments[BIP9Deployments.TestDummy] = new BIP9DeploymentsParameters(28, 0, 999999999);
+            consensus.BIP9Deployments[BIP9Deployments.CSV] = new BIP9DeploymentsParameters(0, 0, 999999999);
+            consensus.BIP9Deployments[BIP9Deployments.Segwit] = new BIP9DeploymentsParameters(1, BIP9DeploymentsParameters.AlwaysActive, 999999999);
 
             this.Base58Prefixes[(int)Base58Type.PUBKEY_ADDRESS] = new byte[] { (111) };
             this.Base58Prefixes[(int)Base58Type.SCRIPT_ADDRESS] = new byte[] { (196) };
@@ -56,8 +72,11 @@ namespace NBitcoin.Networks
             this.GenesisVersion = 1;
             this.GenesisReward = Money.Coins(50m);
 
-            this.Genesis = CreateBitcoinGenesisBlock(this.Consensus.ConsensusFactory, this.GenesisTime, this.GenesisNonce, this.GenesisBits, this.GenesisVersion, this.GenesisReward);
-            this.Consensus.HashGenesisBlock = this.Genesis.GetHash();
+            this.Genesis = CreateBitcoinGenesisBlock(consensus.ConsensusFactory, this.GenesisTime, this.GenesisNonce, this.GenesisBits, this.GenesisVersion, this.GenesisReward);
+            consensus.HashGenesisBlock = this.Genesis.GetHash();
+
+            this.Consensus = consensus;
+
             Assert(this.Consensus.HashGenesisBlock == uint256.Parse("0x0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206"));
         }
     }

--- a/src/NBitcoin/Networks/BitcoinTest.cs
+++ b/src/NBitcoin/Networks/BitcoinTest.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using NBitcoin.DataEncoders;
 using NBitcoin.Protocol;
 
@@ -15,21 +16,37 @@ namespace NBitcoin.Networks
             this.RPCPort = 18332;
             this.CoinTicker = "TBTC";
 
-            this.Consensus.MajorityEnforceBlockUpgrade = 51;
-            this.Consensus.MajorityRejectBlockOutdated = 75;
-            this.Consensus.MajorityWindow = 100;
-            this.Consensus.BIP34Hash = new uint256("0x0000000023b3a96d3484e5abb3755c413e7d41500f8e2a5c3f0dd01299cd8ef8");
-            this.Consensus.MinimumChainWork = new uint256("0x0000000000000000000000000000000000000000000000198b4def2baa9338d6");
-            this.Consensus.DefaultAssumeValid = new uint256("0x000000000000015682a21fc3b1e5420435678cba99cace2b07fe69b668467651"); // 1292762
-            this.Consensus.BuriedDeployments[BuriedDeployments.BIP34] = 21111;
-            this.Consensus.BuriedDeployments[BuriedDeployments.BIP65] = 581885;
-            this.Consensus.BuriedDeployments[BuriedDeployments.BIP66] = 330776;
-            this.Consensus.BIP9Deployments[BIP9Deployments.TestDummy] = new BIP9DeploymentsParameters(28, 1199145601, 1230767999);
-            this.Consensus.BIP9Deployments[BIP9Deployments.CSV] = new BIP9DeploymentsParameters(0, 1456790400, 1493596800);
-            this.Consensus.BIP9Deployments[BIP9Deployments.Segwit] = new BIP9DeploymentsParameters(1, 1462060800, 1493596800);
-            this.Consensus.PowAllowMinDifficultyBlocks = true;
-            this.Consensus.RuleChangeActivationThreshold = 1512; // 75% for testchains
-            this.Consensus.CoinType = 1;
+            // Taken from BitcoinMain Consensus options
+            var consensus = new Consensus();
+            consensus.SubsidyHalvingInterval = 210000;
+            consensus.PowLimit = new Target(new uint256("00000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffff"));
+            consensus.PowTargetTimespan = TimeSpan.FromSeconds(14 * 24 * 60 * 60); // two weeks
+            consensus.PowTargetSpacing = TimeSpan.FromSeconds(10 * 60);
+            consensus.PowNoRetargeting = false;
+            consensus.MinerConfirmationWindow = 2016; // nPowTargetTimespan / nPowTargetSpacing
+            consensus.CoinbaseMaturity = 100;
+            consensus.PremineReward = Money.Zero;
+            consensus.ProofOfWorkReward = Money.Coins(50);
+            consensus.ProofOfStakeReward = Money.Zero;
+            consensus.MaxReorgLength = 0;
+            consensus.MaxMoney = 21000000 * Money.COIN;
+            
+            // BitcoinTest differences
+            consensus.MajorityEnforceBlockUpgrade = 51;
+            consensus.MajorityRejectBlockOutdated = 75;
+            consensus.MajorityWindow = 100;
+            consensus.BIP34Hash = new uint256("0x0000000023b3a96d3484e5abb3755c413e7d41500f8e2a5c3f0dd01299cd8ef8");
+            consensus.MinimumChainWork = new uint256("0x0000000000000000000000000000000000000000000000198b4def2baa9338d6");
+            consensus.DefaultAssumeValid = new uint256("0x000000000000015682a21fc3b1e5420435678cba99cace2b07fe69b668467651"); // 1292762
+            consensus.BuriedDeployments[BuriedDeployments.BIP34] = 21111;
+            consensus.BuriedDeployments[BuriedDeployments.BIP65] = 581885;
+            consensus.BuriedDeployments[BuriedDeployments.BIP66] = 330776;
+            consensus.BIP9Deployments[BIP9Deployments.TestDummy] = new BIP9DeploymentsParameters(28, 1199145601, 1230767999);
+            consensus.BIP9Deployments[BIP9Deployments.CSV] = new BIP9DeploymentsParameters(0, 1456790400, 1493596800);
+            consensus.BIP9Deployments[BIP9Deployments.Segwit] = new BIP9DeploymentsParameters(1, 1462060800, 1493596800);
+            consensus.PowAllowMinDifficultyBlocks = true;
+            consensus.RuleChangeActivationThreshold = 1512; // 75% for testchains
+            consensus.CoinType = 1;
 
             this.Base58Prefixes[(int)Base58Type.PUBKEY_ADDRESS] = new byte[] { (111) };
             this.Base58Prefixes[(int)Base58Type.SCRIPT_ADDRESS] = new byte[] { (196) };
@@ -67,8 +84,11 @@ namespace NBitcoin.Networks
             this.GenesisVersion = 1;
             this.GenesisReward = Money.Coins(50m);
 
-            this.Genesis = CreateBitcoinGenesisBlock(this.Consensus.ConsensusFactory, this.GenesisTime, this.GenesisNonce, this.GenesisBits, this.GenesisVersion, this.GenesisReward);
-            this.Consensus.HashGenesisBlock = this.Genesis.GetHash();
+            this.Genesis = CreateBitcoinGenesisBlock(consensus.ConsensusFactory, this.GenesisTime, this.GenesisNonce, this.GenesisBits, this.GenesisVersion, this.GenesisReward);
+            consensus.HashGenesisBlock = this.Genesis.GetHash();
+
+            this.Consensus = consensus;
+
             Assert(this.Consensus.HashGenesisBlock == uint256.Parse("0x000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943"));
         }
     }

--- a/src/NBitcoin/Networks/StratisRegTest.cs
+++ b/src/NBitcoin/Networks/StratisRegTest.cs
@@ -28,30 +28,30 @@ namespace NBitcoin.Networks
 
             // Taken from StratisMain Consensus options
             var consensus = new Consensus();
-            consensus.SubsidyHalvingInterval = 210000;
-            consensus.MajorityEnforceBlockUpgrade = 750;
-            consensus.MajorityRejectBlockOutdated = 950;
-            consensus.MajorityWindow = 1000;
-            consensus.BuriedDeployments[BuriedDeployments.BIP34] = 0;
-            consensus.BuriedDeployments[BuriedDeployments.BIP65] = 0;
-            consensus.BuriedDeployments[BuriedDeployments.BIP66] = 0;
-            consensus.BIP34Hash = new uint256("0x000000000000024b89b42a942fe0d9fea3bb44ab7bd1b19115dd6a759c0808b8");
-            consensus.PowTargetTimespan = TimeSpan.FromSeconds(14 * 24 * 60 * 60); // two weeks
-            consensus.PowTargetSpacing = TimeSpan.FromSeconds(10 * 60);
-            consensus.RuleChangeActivationThreshold = 1916; // 95% of 2016
-            consensus.MinerConfirmationWindow = 2016; // nPowTargetTimespan / nPowTargetSpacing
-            consensus.LastPOWBlock = 12500;
-            consensus.IsProofOfStake = true;
+            consensus.SubsidyHalvingInterval = StratisMain.Consensus.SubsidyHalvingInterval;
+            consensus.MajorityEnforceBlockUpgrade = StratisMain.Consensus.MajorityEnforceBlockUpgrade;
+            consensus.MajorityRejectBlockOutdated = StratisMain.Consensus.MajorityRejectBlockOutdated;
+            consensus.MajorityWindow = StratisMain.Consensus.MajorityWindow;
+            consensus.BuriedDeployments[BuriedDeployments.BIP34] = StratisMain.Consensus.BuriedDeployments[BuriedDeployments.BIP34];
+            consensus.BuriedDeployments[BuriedDeployments.BIP65] = StratisMain.Consensus.BuriedDeployments[BuriedDeployments.BIP65];
+            consensus.BuriedDeployments[BuriedDeployments.BIP66] = StratisMain.Consensus.BuriedDeployments[BuriedDeployments.BIP66];
+            consensus.BIP34Hash = StratisMain.Consensus.BIP34Hash;
+            consensus.PowTargetTimespan = StratisMain.Consensus.PowTargetTimespan;
+            consensus.PowTargetSpacing = StratisMain.Consensus.PowTargetSpacing;
+            consensus.RuleChangeActivationThreshold = StratisMain.Consensus.RuleChangeActivationThreshold; // 95% of 2016
+            consensus.MinerConfirmationWindow = StratisMain.Consensus.MinerConfirmationWindow; // nPowTargetTimespan / nPowTargetSpacing
+            consensus.LastPOWBlock = StratisMain.Consensus.LastPOWBlock;
+            consensus.IsProofOfStake = StratisMain.Consensus.IsProofOfStake;
             consensus.ConsensusFactory = new PosConsensusFactory() { Consensus = consensus };
-            consensus.ProofOfStakeLimit = new BigInteger(uint256.Parse("00000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff").ToBytes(false));
-            consensus.ProofOfStakeLimitV2 = new BigInteger(uint256.Parse("000000000000ffffffffffffffffffffffffffffffffffffffffffffffffffff").ToBytes(false));
-            consensus.CoinType = 105;
-            consensus.PremineReward = Money.Coins(98000000);
-            consensus.PremineHeight = 2;
-            consensus.ProofOfWorkReward = Money.Coins(4);
-            consensus.ProofOfStakeReward = Money.COIN;
-            consensus.MaxReorgLength = 500;
-            consensus.MaxMoney = long.MaxValue;
+            consensus.ProofOfStakeLimit = new BigInteger(StratisMain.Consensus.ProofOfStakeLimit.ToByteArray());
+            consensus.ProofOfStakeLimitV2 = new BigInteger(StratisMain.Consensus.ProofOfStakeLimitV2.ToByteArray());
+            consensus.CoinType = StratisMain.Consensus.CoinType;
+            consensus.PremineReward = new Money(StratisMain.Consensus.PremineReward);
+            consensus.PremineHeight = StratisMain.Consensus.PremineHeight;
+            consensus.ProofOfWorkReward = new Money(StratisMain.Consensus.ProofOfWorkReward);
+            consensus.ProofOfStakeReward = new Money(StratisMain.Consensus.ProofOfStakeReward);
+            consensus.MaxReorgLength = StratisMain.Consensus.MaxReorgLength;
+            consensus.MaxMoney = StratisMain.Consensus.MaxMoney;
 
             // StratisRegTest differences
             consensus.PowAllowMinDifficultyBlocks = true;

--- a/src/NBitcoin/Networks/StratisRegTest.cs
+++ b/src/NBitcoin/Networks/StratisRegTest.cs
@@ -1,6 +1,7 @@
 ﻿
 using System;
 using System.Collections.Generic;
+using NBitcoin.BouncyCastle.Math;
 using NBitcoin.Protocol;
 
 namespace NBitcoin.Networks
@@ -25,11 +26,39 @@ namespace NBitcoin.Networks
             this.MinRelayTxFee = 0;
             this.CoinTicker = "TSTRAT";
 
-            this.Consensus.PowAllowMinDifficultyBlocks = true;
-            this.Consensus.PowNoRetargeting = true;
-            this.Consensus.PowLimit = new Target(new uint256("7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"));
-            this.Consensus.DefaultAssumeValid = null; // turn off assumevalid for regtest.
-            this.Consensus.CoinbaseMaturity = 10;
+            // Taken from StratisMain Consensus options
+            var consensus = new Consensus();
+            consensus.SubsidyHalvingInterval = 210000;
+            consensus.MajorityEnforceBlockUpgrade = 750;
+            consensus.MajorityRejectBlockOutdated = 950;
+            consensus.MajorityWindow = 1000;
+            consensus.BuriedDeployments[BuriedDeployments.BIP34] = 0;
+            consensus.BuriedDeployments[BuriedDeployments.BIP65] = 0;
+            consensus.BuriedDeployments[BuriedDeployments.BIP66] = 0;
+            consensus.BIP34Hash = new uint256("0x000000000000024b89b42a942fe0d9fea3bb44ab7bd1b19115dd6a759c0808b8");
+            consensus.PowTargetTimespan = TimeSpan.FromSeconds(14 * 24 * 60 * 60); // two weeks
+            consensus.PowTargetSpacing = TimeSpan.FromSeconds(10 * 60);
+            consensus.RuleChangeActivationThreshold = 1916; // 95% of 2016
+            consensus.MinerConfirmationWindow = 2016; // nPowTargetTimespan / nPowTargetSpacing
+            consensus.LastPOWBlock = 12500;
+            consensus.IsProofOfStake = true;
+            consensus.ConsensusFactory = new PosConsensusFactory() { Consensus = consensus };
+            consensus.ProofOfStakeLimit = new BigInteger(uint256.Parse("00000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff").ToBytes(false));
+            consensus.ProofOfStakeLimitV2 = new BigInteger(uint256.Parse("000000000000ffffffffffffffffffffffffffffffffffffffffffffffffffff").ToBytes(false));
+            consensus.CoinType = 105;
+            consensus.PremineReward = Money.Coins(98000000);
+            consensus.PremineHeight = 2;
+            consensus.ProofOfWorkReward = Money.Coins(4);
+            consensus.ProofOfStakeReward = Money.COIN;
+            consensus.MaxReorgLength = 500;
+            consensus.MaxMoney = long.MaxValue;
+
+            // StratisRegTest differences
+            consensus.PowAllowMinDifficultyBlocks = true;
+            consensus.PowNoRetargeting = true;
+            consensus.PowLimit = new Target(new uint256("7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"));
+            consensus.DefaultAssumeValid = null; // turn off assumevalid for regtest.
+            consensus.CoinbaseMaturity = 10;
 
             this.Base58Prefixes[(int)Base58Type.PUBKEY_ADDRESS] = new byte[] { (65) };
             this.Base58Prefixes[(int)Base58Type.SCRIPT_ADDRESS] = new byte[] { (196) };
@@ -46,11 +75,14 @@ namespace NBitcoin.Networks
             this.GenesisVersion = 1;
             this.GenesisReward = Money.Zero;
 
-            this.Genesis = CreateStratisGenesisBlock(this.Consensus.ConsensusFactory, this.GenesisTime, this.GenesisNonce, this.GenesisBits, this.GenesisVersion, this.GenesisReward);
+            this.Genesis = CreateStratisGenesisBlock(consensus.ConsensusFactory, this.GenesisTime, this.GenesisNonce, this.GenesisBits, this.GenesisVersion, this.GenesisReward);
             this.Genesis.Header.Time = 1494909211;
             this.Genesis.Header.Nonce = 2433759;
-            this.Genesis.Header.Bits = this.Consensus.PowLimit;
-            this.Consensus.HashGenesisBlock = this.Genesis.GetHash();
+            this.Genesis.Header.Bits = consensus.PowLimit;
+            consensus.HashGenesisBlock = this.Genesis.GetHash();
+
+            this.Consensus = consensus;
+
             Assert(this.Consensus.HashGenesisBlock == uint256.Parse("0x93925104d664314f581bc7ecb7b4bad07bcfabd1cfce4256dbd2faddcf53bd1f"));
         }
     }

--- a/src/NBitcoin/Networks/StratisRegTest.cs
+++ b/src/NBitcoin/Networks/StratisRegTest.cs
@@ -28,30 +28,30 @@ namespace NBitcoin.Networks
 
             // Taken from StratisMain Consensus options
             var consensus = new Consensus();
-            consensus.SubsidyHalvingInterval = StratisMain.Consensus.SubsidyHalvingInterval;
-            consensus.MajorityEnforceBlockUpgrade = StratisMain.Consensus.MajorityEnforceBlockUpgrade;
-            consensus.MajorityRejectBlockOutdated = StratisMain.Consensus.MajorityRejectBlockOutdated;
-            consensus.MajorityWindow = StratisMain.Consensus.MajorityWindow;
-            consensus.BuriedDeployments[BuriedDeployments.BIP34] = StratisMain.Consensus.BuriedDeployments[BuriedDeployments.BIP34];
-            consensus.BuriedDeployments[BuriedDeployments.BIP65] = StratisMain.Consensus.BuriedDeployments[BuriedDeployments.BIP65];
-            consensus.BuriedDeployments[BuriedDeployments.BIP66] = StratisMain.Consensus.BuriedDeployments[BuriedDeployments.BIP66];
-            consensus.BIP34Hash = StratisMain.Consensus.BIP34Hash;
-            consensus.PowTargetTimespan = StratisMain.Consensus.PowTargetTimespan;
-            consensus.PowTargetSpacing = StratisMain.Consensus.PowTargetSpacing;
-            consensus.RuleChangeActivationThreshold = StratisMain.Consensus.RuleChangeActivationThreshold; // 95% of 2016
-            consensus.MinerConfirmationWindow = StratisMain.Consensus.MinerConfirmationWindow; // nPowTargetTimespan / nPowTargetSpacing
-            consensus.LastPOWBlock = StratisMain.Consensus.LastPOWBlock;
-            consensus.IsProofOfStake = StratisMain.Consensus.IsProofOfStake;
+            consensus.SubsidyHalvingInterval = 210000;
+            consensus.MajorityEnforceBlockUpgrade = 750;
+            consensus.MajorityRejectBlockOutdated = 950;
+            consensus.MajorityWindow = 1000;
+            consensus.BuriedDeployments[BuriedDeployments.BIP34] = 0;
+            consensus.BuriedDeployments[BuriedDeployments.BIP65] = 0;
+            consensus.BuriedDeployments[BuriedDeployments.BIP66] = 0;
+            consensus.BIP34Hash = new uint256("0x000000000000024b89b42a942fe0d9fea3bb44ab7bd1b19115dd6a759c0808b8");
+            consensus.PowTargetTimespan = TimeSpan.FromSeconds(14 * 24 * 60 * 60); // two weeks
+            consensus.PowTargetSpacing = TimeSpan.FromSeconds(10 * 60);
+            consensus.RuleChangeActivationThreshold = 1916; // 95% of 2016
+            consensus.MinerConfirmationWindow = 2016; // nPowTargetTimespan / nPowTargetSpacing
+            consensus.LastPOWBlock = 12500;
+            consensus.IsProofOfStake = true;
             consensus.ConsensusFactory = new PosConsensusFactory() { Consensus = consensus };
-            consensus.ProofOfStakeLimit = new BigInteger(StratisMain.Consensus.ProofOfStakeLimit.ToByteArray());
-            consensus.ProofOfStakeLimitV2 = new BigInteger(StratisMain.Consensus.ProofOfStakeLimitV2.ToByteArray());
-            consensus.CoinType = StratisMain.Consensus.CoinType;
-            consensus.PremineReward = new Money(StratisMain.Consensus.PremineReward);
-            consensus.PremineHeight = StratisMain.Consensus.PremineHeight;
-            consensus.ProofOfWorkReward = new Money(StratisMain.Consensus.ProofOfWorkReward);
-            consensus.ProofOfStakeReward = new Money(StratisMain.Consensus.ProofOfStakeReward);
-            consensus.MaxReorgLength = StratisMain.Consensus.MaxReorgLength;
-            consensus.MaxMoney = StratisMain.Consensus.MaxMoney;
+            consensus.ProofOfStakeLimit = new BigInteger(uint256.Parse("00000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff").ToBytes(false));
+            consensus.ProofOfStakeLimitV2 = new BigInteger(uint256.Parse("000000000000ffffffffffffffffffffffffffffffffffffffffffffffffffff").ToBytes(false));
+            consensus.CoinType = 105;
+            consensus.PremineReward = Money.Coins(98000000);
+            consensus.PremineHeight = 2;
+            consensus.ProofOfWorkReward = Money.Coins(4);
+            consensus.ProofOfStakeReward = Money.COIN;
+            consensus.MaxReorgLength = 500;
+            consensus.MaxMoney = long.MaxValue;
 
             // StratisRegTest differences
             consensus.PowAllowMinDifficultyBlocks = true;

--- a/src/NBitcoin/Networks/StratisTest.cs
+++ b/src/NBitcoin/Networks/StratisTest.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Net;
+using NBitcoin.BouncyCastle.Math;
 using NBitcoin.Protocol;
 
 namespace NBitcoin.Networks
@@ -24,10 +25,39 @@ namespace NBitcoin.Networks
             this.DefaultPort = 26178;
             this.RPCPort = 26174;
             this.CoinTicker = "TSTRAT";
+            
+            var consensus = new Consensus();
+            consensus.SubsidyHalvingInterval = 210000;
+            consensus.MajorityEnforceBlockUpgrade = 750;
+            consensus.MajorityRejectBlockOutdated = 950;
+            consensus.MajorityWindow = 1000;
+            consensus.BuriedDeployments[BuriedDeployments.BIP34] = 0;
+            consensus.BuriedDeployments[BuriedDeployments.BIP65] = 0;
+            consensus.BuriedDeployments[BuriedDeployments.BIP66] = 0;
+            consensus.BIP34Hash = new uint256("0x000000000000024b89b42a942fe0d9fea3bb44ab7bd1b19115dd6a759c0808b8");
+            consensus.PowTargetTimespan = TimeSpan.FromSeconds(14 * 24 * 60 * 60); // two weeks
+            consensus.PowTargetSpacing = TimeSpan.FromSeconds(10 * 60);
+            consensus.PowAllowMinDifficultyBlocks = false;
+            consensus.PowNoRetargeting = false;
+            consensus.RuleChangeActivationThreshold = 1916; // 95% of 2016
+            consensus.MinerConfirmationWindow = 2016; // nPowTargetTimespan / nPowTargetSpacing
+            consensus.LastPOWBlock = 12500;
+            consensus.IsProofOfStake = true;
+            consensus.ConsensusFactory = new PosConsensusFactory() { Consensus = consensus };
+            consensus.ProofOfStakeLimit = new BigInteger(uint256.Parse("00000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff").ToBytes(false));
+            consensus.ProofOfStakeLimitV2 = new BigInteger(uint256.Parse("000000000000ffffffffffffffffffffffffffffffffffffffffffffffffffff").ToBytes(false));
+            consensus.CoinType = 105;
+            consensus.PremineReward = Money.Coins(98000000);
+            consensus.PremineHeight = 2;
+            consensus.ProofOfWorkReward = Money.Coins(4);
+            consensus.ProofOfStakeReward = Money.COIN;
+            consensus.MaxReorgLength = 500;
+            consensus.MaxMoney = long.MaxValue;
 
-            this.Consensus.PowLimit = new Target(new uint256("0000ffff00000000000000000000000000000000000000000000000000000000"));
-            this.Consensus.DefaultAssumeValid = new uint256("0x98fa6ef0bca5b431f15fd79dc6f879dc45b83ed4b1bbe933a383ef438321958e"); // 372652
-            this.Consensus.CoinbaseMaturity = 10;
+            // StratisTest consensus differences
+            consensus.PowLimit = new Target(new uint256("0000ffff00000000000000000000000000000000000000000000000000000000"));
+            consensus.DefaultAssumeValid = new uint256("0x98fa6ef0bca5b431f15fd79dc6f879dc45b83ed4b1bbe933a383ef438321958e"); // 372652
+            consensus.CoinbaseMaturity = 10;
 
             this.Base58Prefixes[(int)Base58Type.PUBKEY_ADDRESS] = new byte[] { (65) };
             this.Base58Prefixes[(int)Base58Type.SCRIPT_ADDRESS] = new byte[] { (196) };
@@ -70,11 +100,14 @@ namespace NBitcoin.Networks
             this.GenesisVersion = 1;
             this.GenesisReward = Money.Zero;
 
-            this.Genesis = CreateStratisGenesisBlock(this.Consensus.ConsensusFactory, this.GenesisTime, this.GenesisNonce, this.GenesisBits, this.GenesisVersion, this.GenesisReward);
+            this.Genesis = CreateStratisGenesisBlock(consensus.ConsensusFactory, this.GenesisTime, this.GenesisNonce, this.GenesisBits, this.GenesisVersion, this.GenesisReward);
             this.Genesis.Header.Time = 1493909211;
             this.Genesis.Header.Nonce = 2433759;
-            this.Genesis.Header.Bits = this.Consensus.PowLimit;
-            this.Consensus.HashGenesisBlock = this.Genesis.GetHash();
+            this.Genesis.Header.Bits = consensus.PowLimit;
+            consensus.HashGenesisBlock = this.Genesis.GetHash();
+
+            this.Consensus = consensus;
+
             Assert(this.Consensus.HashGenesisBlock == uint256.Parse("0x00000e246d7b73b88c9ab55f2e5e94d9e22d471def3df5ea448f5576b1d156b9"));
         }
     }


### PR DESCRIPTION
Moves the assignment of all Consensus settings into inherited networks BitcoinTest, BitcoinRegTest, StratisTest, and StratisRegTest.

Reasoning:
* All settings are assigned in one place. Much easier to reason about than having to dive into multiple layers of inheritance
* These fields will not change, so it's no problem to have duplication
* Allows us to make `Consensus` immutable in the future

Testing:
✅ NBitcoin Network tests pass
✅ Sync and validate StratisTest (100k blocks)
✅ Sync and validate BitcoinTest (100k blocks)