### PR TITLE
Cleanup network usage in NBitcoin #2

### DIFF
--- a/src/NBitcoin.Tests/pos_transaction_tests.cs
+++ b/src/NBitcoin.Tests/pos_transaction_tests.cs
@@ -170,7 +170,7 @@ namespace NBitcoin.Tests
                 ScriptSig = scriptPubKey
             });
             tx.AddOutput(new TxOut("21", key.PubKey.Hash));
-            Transaction clone = tx.Clone(network: Network.StratisMain);
+            Transaction clone = tx.Clone(Network.StratisMain.Consensus.ConsensusFactory);
             tx.Sign(Network.StratisMain, key, false);
             AssertCorrectlySigned(tx, scriptPubKey);
             clone.Sign(Network.StratisMain, key, true);
@@ -1201,7 +1201,7 @@ namespace NBitcoin.Tests
 
         private Transaction AssertClone(Transaction before)
         {
-            Transaction after = before.Clone(network: Network.StratisMain);
+            Transaction after = before.Clone(Network.StratisMain.Consensus.ConsensusFactory);
             Transaction after2 = null;
 
             var ms = new MemoryStream();
@@ -1652,7 +1652,7 @@ namespace NBitcoin.Tests
 
             spendTransaction.Inputs[0].ScriptSig = redeem; //The redeem should be in the scriptSig before signing
 
-            Transaction partiallySigned = spendTransaction.Clone(network: Network.StratisMain);
+            Transaction partiallySigned = spendTransaction.Clone(Network.StratisMain.Consensus.ConsensusFactory);
             //... Now I can partially sign it using one private key:
 
             partiallySigned.Sign(Network.StratisMain, privKeys[0], true);
@@ -1668,13 +1668,13 @@ namespace NBitcoin.Tests
             AssertCorrectlySigned(gistTransaction, fundingTransaction.Outputs[0].ScriptPubKey, this.allowHighS); //One sig in the hard code tx is high
 
             //Can sign out of order
-            partiallySigned = spendTransaction.Clone(network: Network.StratisMain);
+            partiallySigned = spendTransaction.Clone(Network.StratisMain.Consensus.ConsensusFactory);
             partiallySigned.Sign(Network.StratisMain, privKeys[2], true);
             partiallySigned.Sign(Network.StratisMain, privKeys[0], true);
             AssertCorrectlySigned(partiallySigned, fundingTransaction.Outputs[0].ScriptPubKey);
 
             //Can sign multiple inputs
-            partiallySigned = spendTransaction.Clone(network: Network.StratisMain);
+            partiallySigned = spendTransaction.Clone(Network.StratisMain.Consensus.ConsensusFactory);
             partiallySigned.Inputs.Add(new TxIn()
             {
                 PrevOut = new OutPoint(fundingTransaction.GetHash(), 1),
@@ -1759,7 +1759,7 @@ namespace NBitcoin.Tests
         {
             Transaction tx = Network.StratisMain.Consensus.ConsensusFactory.CreateTransaction();
             tx.LockTime = new LockTime(4);
-            Transaction clone = tx.Clone(network: Network.StratisMain);
+            Transaction clone = tx.Clone(Network.StratisMain.Consensus.ConsensusFactory);
             Assert.Equal(tx.LockTime, clone.LockTime);
 
             Assert.Equal("Height : 0", new LockTime().ToString());
@@ -2287,7 +2287,7 @@ namespace NBitcoin.Tests
 
                             if (flag == SigHash.None)
                             {
-                                Transaction clone = result.Clone(network: Network.StratisMain);
+                                Transaction clone = result.Clone(Network.StratisMain.Consensus.ConsensusFactory);
                                 foreach (TxIn input in clone.Inputs)
                                 {
                                     if (input.PrevOut != signedCoin.Outpoint)
@@ -2703,7 +2703,7 @@ namespace NBitcoin.Tests
             outputm.Outputs[0].Value = Money.Satoshis(1);
             outputm.Outputs[0].ScriptPubKey = outscript;
 
-            output = outputm.Clone(network: Network.StratisMain);
+            output = outputm.Clone(Network.StratisMain.Consensus.ConsensusFactory);
 
             Assert.True(output.Inputs.Count == 1);
             Assert.True(output.Inputs[0].ToBytes().SequenceEqual(outputm.Inputs[0].ToBytes()));
@@ -2723,7 +2723,7 @@ namespace NBitcoin.Tests
             inputm.Outputs[0].ScriptPubKey = Script.Empty;
             bool ret = SignSignature(keystore, output, inputm, 0);
             Assert.True(ret == success);
-            input = inputm.Clone(network: Network.StratisMain);
+            input = inputm.Clone(Network.StratisMain.Consensus.ConsensusFactory);
             Assert.True(input.Inputs.Count == 1);
             Assert.True(input.Inputs[0].ToBytes().SequenceEqual(inputm.Inputs[0].ToBytes()));
             Assert.True(input.Outputs.Count == 1);
@@ -2775,7 +2775,7 @@ namespace NBitcoin.Tests
 
         private void CheckWithFlag(Transaction output, Transaction input, ScriptVerify flags, bool success)
         {
-            Transaction inputi = input.Clone(network: Network.StratisMain);
+            Transaction inputi = input.Clone(Network.StratisMain.Consensus.ConsensusFactory);
             var ctx = new ScriptEvaluationContext(Network.StratisMain);
             ctx.ScriptVerify = flags;
             bool ret = ctx.VerifyScript(inputi.Inputs[0].ScriptSig, output.Outputs[0].ScriptPubKey, new TransactionChecker(inputi, 0, output.Outputs[0].Value));

--- a/src/NBitcoin.Tests/transaction_tests.cs
+++ b/src/NBitcoin.Tests/transaction_tests.cs
@@ -170,7 +170,7 @@ namespace NBitcoin.Tests
                 ScriptSig = scriptPubKey
             });
             tx.AddOutput(new TxOut("21", key.PubKey.Hash));
-            Transaction clone = tx.Clone();
+            Transaction clone = tx.Clone(Network.Main.Consensus.ConsensusFactory);
             tx.Sign(Network.Main, key, false);
             AssertCorrectlySigned(tx, scriptPubKey);
             clone.Sign(Network.Main, key, true);
@@ -444,10 +444,10 @@ namespace NBitcoin.Tests
             tx.AddInput(new TxIn(RandomCoin(Money.Coins(1.0m), new Key()).Outpoint, Script.Empty));
             tx.Inputs[0].WitScript = new WitScript(Op.GetPushOp(3));
             tx.AddOutput(RandomCoin(Money.Coins(1.0m), new Key()).TxOut);
-            var template = tx.Clone();
+            Transaction template = tx.Clone(Network.Main.Consensus.ConsensusFactory);
 
             // If lazy is true, then the cache will be calculated later
-            tx = template.Clone();
+            tx = template.Clone(Network.Main.Consensus.ConsensusFactory);
             var initialHashes = new uint256[] { tx.GetHash(), tx.GetWitHash() };
             tx.PrecomputeHash(false, true);
             tx.Outputs[0].Value = Money.Coins(1.1m);
@@ -458,7 +458,7 @@ namespace NBitcoin.Tests
             /////
 
             // If lazy is false, then the cache is calculated now
-            tx = template.Clone();
+            tx = template.Clone(Network.Main.Consensus.ConsensusFactory);
             initialHashes = new uint256[] { tx.GetHash(), tx.GetWitHash() };
             tx.PrecomputeHash(false, false);
             tx.Outputs[0].Value = Money.Coins(1.1m);
@@ -470,7 +470,7 @@ namespace NBitcoin.Tests
             /////
 
             // If invalidExisting is false, then the cache is not recalculated
-            tx = template.Clone();
+            tx = template.Clone(Network.Main.Consensus.ConsensusFactory);
             initialHashes = new uint256[] { tx.GetHash(), tx.GetWitHash() };
             tx.PrecomputeHash(false, false);
             tx.Outputs[0].Value = Money.Coins(1.1m);
@@ -487,7 +487,7 @@ namespace NBitcoin.Tests
             ///////
 
             // If invalidExisting is true, then the cache is recalculated
-            tx = template.Clone();
+            tx = template.Clone(Network.Main.Consensus.ConsensusFactory);
             initialHashes = new uint256[] { tx.GetHash(), tx.GetWitHash() };
             tx.PrecomputeHash(false, false);
             tx.Outputs[0].Value = Money.Coins(1.1m);
@@ -1318,7 +1318,7 @@ namespace NBitcoin.Tests
 
         private Transaction AssertClone(Transaction before)
         {
-            Transaction after = before.Clone();
+            Transaction after = before.Clone(Network.Main.Consensus.ConsensusFactory);
             Transaction after2 = null;
 
             var ms = new MemoryStream();
@@ -1691,7 +1691,7 @@ namespace NBitcoin.Tests
                     .BuildTransaction(true);
             Assert.False(txBuilder.Verify(tx, "0.0001"));
 
-            Transaction partiallySigned = tx.Clone();
+            Transaction partiallySigned = tx.Clone(Network.Main.Consensus.ConsensusFactory);
 
             txBuilder = new TransactionBuilder(0);
             tx = txBuilder
@@ -1888,7 +1888,7 @@ namespace NBitcoin.Tests
 
             spendTransaction.Inputs[0].ScriptSig = redeem; //The redeem should be in the scriptSig before signing
 
-            Transaction partiallySigned = spendTransaction.Clone();
+            Transaction partiallySigned = spendTransaction.Clone(Network.Main.Consensus.ConsensusFactory);
             //... Now I can partially sign it using one private key:
 
             partiallySigned.Sign(Network.Main, privKeys[0], true);
@@ -1905,13 +1905,13 @@ namespace NBitcoin.Tests
             AssertCorrectlySigned(gistTransaction, fundingTransaction.Outputs[0].ScriptPubKey, this.allowHighS); //One sig in the hard code tx is high
 
             //Can sign out of order
-            partiallySigned = spendTransaction.Clone();
+            partiallySigned = spendTransaction.Clone(Network.Main.Consensus.ConsensusFactory);
             partiallySigned.Sign(Network.Main, privKeys[2], true);
             partiallySigned.Sign(Network.Main, privKeys[0], true);
             AssertCorrectlySigned(partiallySigned, fundingTransaction.Outputs[0].ScriptPubKey);
 
             //Can sign multiple inputs
-            partiallySigned = spendTransaction.Clone();
+            partiallySigned = spendTransaction.Clone(Network.Main.Consensus.ConsensusFactory);
             partiallySigned.Inputs.Add(new TxIn()
             {
                 PrevOut = new OutPoint(fundingTransaction.GetHash(), 1),
@@ -1994,7 +1994,7 @@ namespace NBitcoin.Tests
         {
             var tx = new Transaction();
             tx.LockTime = new LockTime(4);
-            Transaction clone = tx.Clone();
+            Transaction clone = tx.Clone(Network.Main.Consensus.ConsensusFactory);
             Assert.Equal(tx.LockTime, clone.LockTime);
 
             Assert.Equal("Height : 0", new LockTime().ToString());
@@ -2682,7 +2682,7 @@ namespace NBitcoin.Tests
 
                             if (flag == SigHash.None)
                             {
-                                Transaction clone = result.Clone();
+                                Transaction clone = result.Clone(Network.Main.Consensus.ConsensusFactory);
                                 foreach (TxIn input in clone.Inputs)
                                 {
                                     if (input.PrevOut != signedCoin.Outpoint)
@@ -3086,7 +3086,7 @@ namespace NBitcoin.Tests
             outputm.Outputs[0].Value = Money.Satoshis(1);
             outputm.Outputs[0].ScriptPubKey = outscript;
 
-            output = outputm.Clone();
+            output = outputm.Clone(Network.Main.Consensus.ConsensusFactory);
 
             Assert.True(output.Inputs.Count == 1);
             Assert.True(output.Inputs[0].ToBytes().SequenceEqual(outputm.Inputs[0].ToBytes()));
@@ -3105,7 +3105,7 @@ namespace NBitcoin.Tests
             inputm.Outputs[0].ScriptPubKey = Script.Empty;
             bool ret = SignSignature(keystore, output, inputm, 0);
             Assert.True(ret == success);
-            input = inputm.Clone();
+            input = inputm.Clone(Network.Main.Consensus.ConsensusFactory);
             Assert.True(input.Inputs.Count == 1);
             Assert.True(input.Inputs[0].ToBytes().SequenceEqual(inputm.Inputs[0].ToBytes()));
             Assert.True(input.Outputs.Count == 1);
@@ -3157,7 +3157,7 @@ namespace NBitcoin.Tests
 
         private void CheckWithFlag(Transaction output, Transaction input, ScriptVerify flags, bool success)
         {
-            Transaction inputi = input.Clone();
+            Transaction inputi = input.Clone(Network.Main.Consensus.ConsensusFactory);
             var ctx = new ScriptEvaluationContext(Network.Main);
             ctx.ScriptVerify = flags;
             bool ret = ctx.VerifyScript(inputi.Inputs[0].ScriptSig, output.Outputs[0].ScriptPubKey, new TransactionChecker(inputi, 0, output.Outputs[0].Value));

--- a/src/NBitcoin/BitcoinCore/Coins.cs
+++ b/src/NBitcoin/BitcoinCore/Coins.cs
@@ -160,7 +160,7 @@ namespace NBitcoin.BitcoinCore
                 // coinbase height
                 stream.ReadWriteAsVarInt(ref this.nHeight);
 
-                if (stream.ConsensusFactory.Consensus.IsProofOfStake)
+                if (stream.ConsensusFactory.Consensus != null && stream.ConsensusFactory.Consensus.IsProofOfStake)
                 {
                     stream.ReadWrite(ref this.fCoinStake);
                     stream.ReadWrite(ref this.nTime);
@@ -215,7 +215,7 @@ namespace NBitcoin.BitcoinCore
                 //// coinbase height
                 stream.ReadWriteAsVarInt(ref this.nHeight);
 
-                if (stream.ConsensusFactory.Consensus.IsProofOfStake)
+                if (stream.ConsensusFactory.Consensus != null && stream.ConsensusFactory.Consensus.IsProofOfStake)
                 {
                     stream.ReadWrite(ref this.fCoinStake);
                     stream.ReadWrite(ref this.nTime);

--- a/src/NBitcoin/IBitcoinSerializable.cs
+++ b/src/NBitcoin/IBitcoinSerializable.cs
@@ -78,15 +78,25 @@ namespace NBitcoin
             return GetSerializedSize(serializable, version, SerializationType.Disk);
         }
 
-        public static void FromBytes(this IBitcoinSerializable serializable, byte[] bytes, ProtocolVersion version = ProtocolVersion.PROTOCOL_VERSION, Network network = null)
+        public static void FromBytes(this IBitcoinSerializable serializable, byte[] bytes, ProtocolVersion version = ProtocolVersion.PROTOCOL_VERSION)
         {
-            network = network ?? Network.Main;
-
             var bms = new BitcoinStream(bytes)
             {
                 ProtocolVersion = version,
-                ConsensusFactory = network.Consensus.ConsensusFactory
+                ConsensusFactory = new DefaultConsensusFactory()
             };
+
+            serializable.ReadWrite(bms);
+        }
+
+        public static void FromBytes(this IBitcoinSerializable serializable, byte[] bytes, ConsensusFactory consensusFactory, ProtocolVersion version = ProtocolVersion.PROTOCOL_VERSION)
+        {
+            var bms = new BitcoinStream(bytes)
+            {
+                ProtocolVersion = version,
+                ConsensusFactory = consensusFactory
+            };
+
             serializable.ReadWrite(bms);
         }
 
@@ -98,7 +108,7 @@ namespace NBitcoin
             if (instance == null)
                 instance = new T();
 
-            instance.FromBytes(serializable.ToBytes(version, network), version, network);
+            instance.FromBytes(serializable.ToBytes(version, network), network.Consensus.ConsensusFactory, version);
 
             return instance;
         }

--- a/src/NBitcoin/Network.cs
+++ b/src/NBitcoin/Network.cs
@@ -649,7 +649,7 @@ namespace NBitcoin
 
         public Block GetGenesis()
         {
-            return this.Genesis.Clone(network: this);
+            return this.Genesis.Clone(this.Consensus.ConsensusFactory);
         }
 
         public uint256 GenesisHash => this.Consensus.HashGenesisBlock;

--- a/src/NBitcoin/NoSqlRepository.cs
+++ b/src/NBitcoin/NoSqlRepository.cs
@@ -16,7 +16,7 @@ namespace NBitcoin
 
         public Task PutAsync(string key, IBitcoinSerializable obj)
         {
-            return PutBytes(key, obj == null ? null : obj.ToBytes(network: this.network));
+            return PutBytes(key, obj == null ? null : obj.ToBytes(this.network.Consensus.ConsensusFactory));
         }
 
         public void Put(string key, IBitcoinSerializable obj)

--- a/src/NBitcoin/RPC/RPCClient.Wallet.cs
+++ b/src/NBitcoin/RPC/RPCClient.Wallet.cs
@@ -246,7 +246,7 @@ namespace NBitcoin.RPC
                 return tx.ToHex();
 
             // if there is, do this ACK so that NBitcoin does not change the version number
-            return Encoders.Hex.EncodeData(tx.ToBytes(Protocol.ProtocolVersion.WITNESS_VERSION - 1));
+            return Encoders.Hex.EncodeData(tx.ToBytes(version: Protocol.ProtocolVersion.WITNESS_VERSION - 1));
         }
 
         // getreceivedbyaddress

--- a/src/NBitcoin/Transaction.cs
+++ b/src/NBitcoin/Transaction.cs
@@ -1190,7 +1190,7 @@ namespace NBitcoin
                 throw new ArgumentNullException(nameof(network));
 
             Transaction transaction = network.Consensus.ConsensusFactory.CreateTransaction();
-            transaction.FromBytes(Encoders.Hex.DecodeData(hex), version, network);
+            transaction.FromBytes(Encoders.Hex.DecodeData(hex), version);
             return transaction;
         }
 
@@ -1203,7 +1203,7 @@ namespace NBitcoin
                 throw new ArgumentNullException(nameof(network));
 
             Transaction transaction = network.Consensus.ConsensusFactory.CreateTransaction();
-            transaction.FromBytes(bytes, network: network);
+            transaction.FromBytes(bytes);
             return transaction;
         }
 

--- a/src/NBitcoin/TransactionBuilder.cs
+++ b/src/NBitcoin/TransactionBuilder.cs
@@ -1184,7 +1184,7 @@ namespace NBitcoin
                 if(builderList[i].Target == this._SubstractFeeBuilder)
                 {
                     builderList.Remove(builderList[i]);
-                    TxOut newTxOut = this._SubstractFeeBuilder._TxOut.Clone(network: this.Network);
+                    TxOut newTxOut = this._SubstractFeeBuilder._TxOut.Clone();
                     newTxOut.Value -= fees;
                     builderList.Insert(i, new SendBuilder(newTxOut).Build);
                 }

--- a/src/Stratis.Bitcoin.Features.MemoryPool.Tests/TestChainFactory.cs
+++ b/src/Stratis.Bitcoin.Features.MemoryPool.Tests/TestChainFactory.cs
@@ -113,11 +113,11 @@ namespace Stratis.Bitcoin.Features.MemoryPool.Tests
             var srcTxs = new List<Transaction>();
             for (int i = 0; i < blockinfo.Count; ++i)
             {
-                Block currentBlock = newBlock.Block.Clone(); // pointer for convenience
+                Block currentBlock = newBlock.Block.Clone(network.Consensus.ConsensusFactory); // pointer for convenience
                 currentBlock.Header.HashPrevBlock = chain.Tip.HashBlock;
                 currentBlock.Header.Version = 1;
                 currentBlock.Header.Time = Utils.DateTimeToUnixTime(chain.Tip.GetMedianTimePast()) + 1;
-                Transaction txCoinbase = currentBlock.Transactions[0].Clone();
+                Transaction txCoinbase = currentBlock.Transactions[0].Clone(network.Consensus.ConsensusFactory);
                 txCoinbase.Inputs.Clear();
                 txCoinbase.Version = 1;
                 txCoinbase.AddInput(new TxIn(new Script(new[] { Op.GetPushOp(blockinfo[i].extraNonce), Op.GetPushOp(chain.Height) })));

--- a/src/Stratis.Bitcoin.Features.Wallet.Tests/WalletTransactionHandlerTest.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet.Tests/WalletTransactionHandlerTest.cs
@@ -368,7 +368,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
             fundTransaction.Inputs.RemoveAt(1);
             Assert.Single(fundTransaction.Inputs); // 4 inputs
 
-            Transaction fundTransactionClone = fundTransaction.Clone();
+            Transaction fundTransactionClone = fundTransaction.Clone(this.network.Consensus.ConsensusFactory);
             var fundContext = new TransactionBuildContext(walletReference, new List<Recipient>(), "password")
             {
                 MinConfirmations = 0,

--- a/src/Stratis.Bitcoin.IntegrationTests/Wallet/SendingTxWithDoubleSpendSpecification_Steps.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/Wallet/SendingTxWithDoubleSpendSpecification_Steps.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using FluentAssertions;
 using NBitcoin;
@@ -95,7 +94,7 @@ namespace Stratis.Bitcoin.IntegrationTests.Wallet
         private void receiving_node_attempts_to_double_spend_mempool_doesnotaccept()
         {
             var unusedAddress = this.stratisReceiver.FullNode.WalletManager().GetUnusedAddress(new WalletAccountReference("mywallet", "account 0"));
-            var transactionCloned = this.transaction.Clone();
+            var transactionCloned = this.transaction.Clone(this.stratisReceiver.FullNode.Network.Consensus.ConsensusFactory);
             transactionCloned.Outputs[1].ScriptPubKey = unusedAddress.ScriptPubKey;
             this.stratisReceiver.FullNode.MempoolManager().Validator.AcceptToMemoryPool(this.mempoolValidationState, transactionCloned).Result.Should().BeFalse();
         }

--- a/src/Stratis.Bitcoin.IntegrationTests/Wallet/WalletTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/Wallet/WalletTests.cs
@@ -69,7 +69,7 @@ namespace Stratis.Bitcoin.IntegrationTests.Wallet
                 Assert.Null(stratisReceiver.FullNode.WalletManager().GetSpendableTransactionsInWallet("mywallet").First().Transaction.BlockHeight);
 
                 // generate two new blocks do the trx is confirmed
-                stratisSender.GenerateStratis(1, new List<Transaction>(new[] { trx.Clone() }));
+                stratisSender.GenerateStratis(1, new List<Transaction>(new[] { trx.Clone(stratisSender.FullNode.Network.Consensus.ConsensusFactory) }));
                 stratisSender.GenerateStratis(1);
 
                 // wait for block repo for block sync to work

--- a/src/Stratis.Bitcoin.Tests/Utilities/DBreezeTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Utilities/DBreezeTest.cs
@@ -66,7 +66,7 @@ namespace Stratis.Bitcoin.Tests.Utilities
             Block genesis = network.GetGenesis();
             var coins = new Coins(genesis.Transactions[0], 0);
 
-            var result = (Coins)this.dbreezeSerializer.Deserializer(coins.ToBytes(network: Network.StratisRegTest), typeof(Coins));
+            var result = (Coins)this.dbreezeSerializer.Deserializer(coins.ToBytes(Network.StratisRegTest.Consensus.ConsensusFactory), typeof(Coins));
 
             Assert.Equal(coins.CoinBase, result.CoinBase);
             Assert.Equal(coins.Height, result.Height);
@@ -87,7 +87,7 @@ namespace Stratis.Bitcoin.Tests.Utilities
             Block genesis = network.GetGenesis();
             BlockHeader blockHeader = genesis.Header;
 
-            var result = (BlockHeader)this.dbreezeSerializer.Deserializer(blockHeader.ToBytes(network: Network.StratisRegTest), typeof(BlockHeader));
+            var result = (BlockHeader)this.dbreezeSerializer.Deserializer(blockHeader.ToBytes(Network.StratisRegTest.Consensus.ConsensusFactory), typeof(BlockHeader));
 
             Assert.Equal(blockHeader.GetHash(), result.GetHash());
         }
@@ -120,7 +120,7 @@ namespace Stratis.Bitcoin.Tests.Utilities
             Network network = Network.StratisRegTest;
             Block block = network.GetGenesis();
 
-            var result = (Block)this.dbreezeSerializer.Deserializer(block.ToBytes(network: Network.StratisRegTest), typeof(Block));
+            var result = (Block)this.dbreezeSerializer.Deserializer(block.ToBytes(Network.StratisRegTest.Consensus.ConsensusFactory), typeof(Block));
 
             Assert.Equal(block.GetHash(), result.GetHash());
         }

--- a/src/Stratis.Bitcoin/Utilities/DBreezeSerializer.cs
+++ b/src/Stratis.Bitcoin/Utilities/DBreezeSerializer.cs
@@ -32,7 +32,7 @@ namespace Stratis.Bitcoin.Utilities
         {
             var serializable = obj as IBitcoinSerializable;
             if (serializable != null)
-                return serializable.ToBytes(network: this.Network);
+                return serializable.ToBytes(this.Network.Consensus.ConsensusFactory);
 
             var u256 = obj as uint256;
             if (u256 != null)


### PR DESCRIPTION
All instances where we now create `Block`, `BlockHeader` and `Transaction` has to be created by passing in the network's `ConsensusFactory` all other types does not require it.

**This can be reviewed by commit.**

- All unit and integration tests pass.
- Staking working as per normal.
- Synced STRAT testnet
- Synced BTC testnet up until block 100k