### PR TITLE
CHT test: Reorg with 550 blocks and presentation of another chain - issue 27

### DIFF
--- a/src/Stratis.Bitcoin.Tests/Consensus/ChainedHeaderTreeTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Consensus/ChainedHeaderTreeTest.cs
@@ -1080,7 +1080,7 @@ namespace Stratis.Bitcoin.Tests.Consensus
             ChainedHeader initialChainTip = ctx.InitialChainTip;
 
             // Extend the chain (chain A) with max reorg headers (500) + 50 extra.
-            // Example: h1=h2=h3=h4=h5=a6=...=a555.
+            // Example: h1=h2=h3=h4=(h5)=a6=...=a555.
             const int maxReorg = 500;
             ctx.ChainStateMock.Setup(x => x.MaxReorgLength).Returns(maxReorg);
             ChainedHeader chainATip = ctx.ExtendAChain(maxReorg + 50, initialChainTip);
@@ -1100,7 +1100,7 @@ namespace Stratis.Bitcoin.Tests.Consensus
             }
 
             // Create new chain B with 2 headers after the fork point.
-            // Example: h1=h2=h3=h4=h5=b7=b8.
+            // Example: h1=h2=h3=h4=(h5)=b7=b8.
             const int chainBExtension = 2;
             ChainedHeader chainBTip = ctx.ExtendAChain(chainBExtension, initialChainTip);
 

--- a/src/Stratis.Bitcoin.Tests/Consensus/ChainedHeaderTreeTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Consensus/ChainedHeaderTreeTest.cs
@@ -1104,7 +1104,7 @@ namespace Stratis.Bitcoin.Tests.Consensus
             const int chainBExtension = 2;
             ChainedHeader chainBTip = ctx.ExtendAChain(chainBExtension, initialChainTip);
 
-            // Chain A is presented by peer 1.
+            // Chain B is presented by peer 2.
             List<BlockHeader> listOfChainBHeaders = ctx.ChainedHeaderToList(chainBTip, chainBExtension);
             cht.ConnectNewHeaders(2, listOfChainBHeaders);
 

--- a/src/Stratis.Bitcoin.Tests/Consensus/ChainedHeaderTreeTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Consensus/ChainedHeaderTreeTest.cs
@@ -1086,16 +1086,16 @@ namespace Stratis.Bitcoin.Tests.Consensus
             ChainedHeader chainATip = ctx.ExtendAChain(maxReorg + 50, initialChainTip);
 
             // Chain A is presented by peer 1.
-            List<BlockHeader> listOfChainAHeaders = ctx.ChainedHeaderToList(chainATip, maxReorg + 50);
-            cht.ConnectNewHeaders(1, listOfChainAHeaders);
+            List<BlockHeader> listOfChainABlockHeaders = ctx.ChainedHeaderToList(chainATip, maxReorg + 50);
+            List<ChainedHeader> listOfChainAChainHeaders = chainATip.ToList(maxReorg + 50);
+            cht.ConnectNewHeaders(1, listOfChainABlockHeaders);
             
             // Sync 490 blocks from chain A.
-            for (int i = 1; i <= 490; i++)
+            for (int i = 0; i < 490; i++)
             {
-                ChainedHeader currentChainTip = chainATip.GetAncestor(initialChainSize + i);
+                ChainedHeader currentChainTip = listOfChainAChainHeaders[i];
                 cht.BlockDataDownloaded(currentChainTip, currentChainTip.Block);
                 cht.PartialValidationSucceeded(currentChainTip, out bool reorgRequired);
-                // TODO: Fix. Null reference is thrown at height 101, possibly due to KeepBlockDataForLastBlocks = 100
                 cht.ConsensusTipChanged(currentChainTip);
             }
 
@@ -1108,14 +1108,14 @@ namespace Stratis.Bitcoin.Tests.Consensus
             List<BlockHeader> listOfChainBHeaders = ctx.ChainedHeaderToList(chainBTip, chainBExtension);
             cht.ConnectNewHeaders(2, listOfChainBHeaders);
 
-            // Continue syncing remaining bocks from chain B.
+            // Continue syncing remaining blocks from chain A.
             // TODO: add asserts
-            for (int i = 491; i <= 550; i++)
+            for (int i = 490; i < 550; i++)
             {
-                ChainedHeader currentChainTip = chainATip.GetAncestor(initialChainSize + i);
+                ChainedHeader currentChainTip = listOfChainAChainHeaders[i];
                 cht.BlockDataDownloaded(currentChainTip, ctx.CreateBlock());
                 cht.PartialValidationSucceeded(currentChainTip, out bool reorgRequired);
-                cht.ConsensusTipChanged(currentChainTip);
+                List<int> tips = cht.ConsensusTipChanged(currentChainTip);
             }
         }
     }

--- a/src/Stratis.Bitcoin.Tests/Consensus/ChainedHeaderTreeTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Consensus/ChainedHeaderTreeTest.cs
@@ -1096,6 +1096,7 @@ namespace Stratis.Bitcoin.Tests.Consensus
                 ChainedHeader currentChainTip = chainAChainHeaders[i];
                 cht.BlockDataDownloaded(currentChainTip, currentChainTip.Block);
                 cht.PartialValidationSucceeded(currentChainTip, out bool reorgRequired);
+                ctx.FinalizedBlockMock.Setup(m => m.GetFinalizedBlockHeight()).Returns(currentChainTip.Height);
                 List<int> peerIds = cht.ConsensusTipChanged(currentChainTip);
                 peerIds.Should().BeEmpty();
             }
@@ -1115,6 +1116,7 @@ namespace Stratis.Bitcoin.Tests.Consensus
                 ChainedHeader currentChainTip = chainAChainHeaders[i];
                 cht.BlockDataDownloaded(currentChainTip, ctx.CreateBlock());
                 cht.PartialValidationSucceeded(currentChainTip, out bool reorgRequired);
+                ctx.FinalizedBlockMock.Setup(m => m.GetFinalizedBlockHeight()).Returns(currentChainTip.Height);
                 List<int> peerIds = cht.ConsensusTipChanged(currentChainTip);
                 if (currentChainTip.Height == maxReorg + initialChainSize)
                 {

--- a/src/Stratis.Bitcoin.Tests/Consensus/ChainedHeaderTreeTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Consensus/ChainedHeaderTreeTest.cs
@@ -1087,13 +1087,13 @@ namespace Stratis.Bitcoin.Tests.Consensus
 
             // Chain A is presented by peer 1.
             List<BlockHeader> listOfChainABlockHeaders = ctx.ChainedHeaderToList(chainATip, maxReorg + 50);
-            List<ChainedHeader> listOfChainAChainHeaders = chainATip.ToList(maxReorg + 50);
+            ChainedHeader[] chainAChainHeaders = chainATip.ToArray(maxReorg + 50);
             cht.ConnectNewHeaders(1, listOfChainABlockHeaders);
             
             // Sync 490 blocks from chain A.
             for (int i = 0; i < maxReorg - 10; i++)
             {
-                ChainedHeader currentChainTip = listOfChainAChainHeaders[i];
+                ChainedHeader currentChainTip = chainAChainHeaders[i];
                 cht.BlockDataDownloaded(currentChainTip, currentChainTip.Block);
                 cht.PartialValidationSucceeded(currentChainTip, out bool reorgRequired);
                 List<int> peerIds = cht.ConsensusTipChanged(currentChainTip);
@@ -1112,7 +1112,7 @@ namespace Stratis.Bitcoin.Tests.Consensus
             // Continue syncing remaining blocks from chain A.
             for (int i = maxReorg - 10; i < maxReorg + 50; i++)
             {
-                ChainedHeader currentChainTip = listOfChainAChainHeaders[i];
+                ChainedHeader currentChainTip = chainAChainHeaders[i];
                 cht.BlockDataDownloaded(currentChainTip, ctx.CreateBlock());
                 cht.PartialValidationSucceeded(currentChainTip, out bool reorgRequired);
                 List<int> peerIds = cht.ConsensusTipChanged(currentChainTip);

--- a/src/Stratis.Bitcoin.Tests/Consensus/ChainedHeaderTreeTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Consensus/ChainedHeaderTreeTest.cs
@@ -1108,7 +1108,8 @@ namespace Stratis.Bitcoin.Tests.Consensus
 
             // Chain B is presented by peer 2.
             List<BlockHeader> listOfChainBHeaders = ctx.ChainedHeaderToList(chainBTip, chainBExtension);
-            cht.ConnectNewHeaders(2, listOfChainBHeaders);
+            Action connectAction = () => cht.ConnectNewHeaders(2, listOfChainBHeaders);
+            connectAction.Should().Throw<MaxReorgViolationException>();
 
             // Continue syncing remaining blocks from chain A.
             for (int i = maxReorg - 10; i < maxReorg + 50; i++)

--- a/src/Stratis.Bitcoin.Tests/Consensus/ChainedHeaderTreeTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Consensus/ChainedHeaderTreeTest.cs
@@ -1125,7 +1125,6 @@ namespace Stratis.Bitcoin.Tests.Consensus
                 {
                     peerIds.Should().BeEmpty();
                 }
-
             }
         }
     }

--- a/src/Stratis.Bitcoin.Tests/Consensus/ConsensusTestExtensions.cs
+++ b/src/Stratis.Bitcoin.Tests/Consensus/ConsensusTestExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using NBitcoin;
 using Stratis.Bitcoin.Consensus;
 using Stratis.Bitcoin.Tests.Common;
@@ -29,18 +30,16 @@ namespace Stratis.Bitcoin.Tests.Consensus
 
         public static List<ChainedHeader> ToList(this ChainedHeader chainedHeader, int headersToTake)
         {
-            var list = new List<ChainedHeader>();
+            var headers = new ChainedHeader[headersToTake];
             ChainedHeader current = chainedHeader;
 
-            for (int i = 0; i < headersToTake; i++)
+            for (int i = headersToTake - 1; i >= 0 && current != null; i--)
             {
-                list.Add(current);
+                headers[i] = current;
                 current = current.Previous;
             }
 
-            list.Reverse();
-
-            return list;
+            return headers.ToList();
         }
     }
 }

--- a/src/Stratis.Bitcoin.Tests/Consensus/ConsensusTestExtensions.cs
+++ b/src/Stratis.Bitcoin.Tests/Consensus/ConsensusTestExtensions.cs
@@ -31,8 +31,7 @@ namespace Stratis.Bitcoin.Tests.Consensus
         {
             var headers = new ChainedHeader[headersToTake];
             ChainedHeader current = chainedHeader;
-            var list = new List<ChainedHeader>();
-            list.Reverse();
+
             for (int i = headersToTake - 1; (i >= 0) && (current != null); i--)
             {
                 headers[i] = current;

--- a/src/Stratis.Bitcoin.Tests/Consensus/ConsensusTestExtensions.cs
+++ b/src/Stratis.Bitcoin.Tests/Consensus/ConsensusTestExtensions.cs
@@ -26,5 +26,21 @@ namespace Stratis.Bitcoin.Tests.Consensus
         {
             return chainedHeaderTree.GetChainedHeadersByHash()[chainedHeaderTree.GetPeerTipsByPeerId()[peer]];
         }
+
+        public static List<ChainedHeader> ToList(this ChainedHeader chainedHeader, int headersToTake)
+        {
+            var list = new List<ChainedHeader>();
+            ChainedHeader current = chainedHeader;
+
+            for (int i = 0; i < headersToTake; i++)
+            {
+                list.Add(current);
+                current = current.Previous;
+            }
+
+            list.Reverse();
+
+            return list;
+        }
     }
 }

--- a/src/Stratis.Bitcoin.Tests/Consensus/ConsensusTestExtensions.cs
+++ b/src/Stratis.Bitcoin.Tests/Consensus/ConsensusTestExtensions.cs
@@ -28,7 +28,7 @@ namespace Stratis.Bitcoin.Tests.Consensus
             return chainedHeaderTree.GetChainedHeadersByHash()[chainedHeaderTree.GetPeerTipsByPeerId()[peer]];
         }
 
-        public static List<ChainedHeader> ToList(this ChainedHeader chainedHeader, int headersToTake)
+        public static ChainedHeader[] ToArray(this ChainedHeader chainedHeader, int headersToTake)
         {
             var headers = new ChainedHeader[headersToTake];
             ChainedHeader current = chainedHeader;
@@ -39,7 +39,7 @@ namespace Stratis.Bitcoin.Tests.Consensus
                 current = current.Previous;
             }
 
-            return headers.ToList();
+            return headers;
         }
     }
 }

--- a/src/Stratis.Bitcoin.Tests/Consensus/ConsensusTestExtensions.cs
+++ b/src/Stratis.Bitcoin.Tests/Consensus/ConsensusTestExtensions.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Linq;
 using NBitcoin;
 using Stratis.Bitcoin.Consensus;
 using Stratis.Bitcoin.Tests.Common;
@@ -32,8 +31,9 @@ namespace Stratis.Bitcoin.Tests.Consensus
         {
             var headers = new ChainedHeader[headersToTake];
             ChainedHeader current = chainedHeader;
-
-            for (int i = headersToTake - 1; i >= 0 && current != null; i--)
+            var list = new List<ChainedHeader>();
+            list.Reverse();
+            for (int i = headersToTake - 1; (i >= 0) && (current != null); i--)
             {
                 headers[i] = current;
                 current = current.Previous;

--- a/src/Stratis.Bitcoin/Consensus/ChainedHeaderTree.cs
+++ b/src/Stratis.Bitcoin/Consensus/ChainedHeaderTree.cs
@@ -531,7 +531,7 @@ namespace Stratis.Bitcoin.Consensus
             ChainedHeader currentBlockToDeleteData = consensusTip.GetAncestor(lastBlockHeightToKeep).Previous;
 
             // Process blocks that were not process before or until the genesis block exclusive.
-            while ((currentBlockToDeleteData.Block == null) || (currentBlockToDeleteData.Previous == null))
+            while ((currentBlockToDeleteData.Block != null) && (currentBlockToDeleteData.Previous != null))
             {
                 currentBlockToDeleteData.Block = null;
                 if (!this.blockStoreAvailable)


### PR DESCRIPTION
Checkpoints are disabled. Chain tip is at header 5. Reorganisation is initiaised with max reorg of 500 blocks plus extra 50 blocks. We start syncing until block 490. Peer 2 presents the alternative chain with 2 headers after fork point at header 5. We then you join the rest of 60 blocks. ConsensusTipChanged should return identifier of the second peer at block number 505.

See #1321 (comment)

Preferred reviewers: @Aprogiena or @noescape00