### PR TITLE
CHT test: Present headers from different portion of the chain with Assume Valid - issue 48

### DIFF
--- a/src/Stratis.Bitcoin.Tests/Consensus/ChainedHeaderTreeTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Consensus/ChainedHeaderTreeTest.cs
@@ -1654,9 +1654,9 @@ namespace Stratis.Bitcoin.Tests.Consensus
         }
 
         /// <summary>
-        /// Issue 48 @ CT is at 5. AssumeValid is at 10. ConnectNewHeaders called with 4 new headers (from peer1).
-        /// Make sure headers 6 - 9 are marked for download. After that ConnectNewHeaders called with headers 6 to 15 (from peer2).
-        /// Make sure 10 - 15 are marked for download.
+        /// Issue 48 @ CT is at 5. AssumeValid is at 10. ConnectNewHeaders called with headers 1 - 9(from peer1).
+        /// Make sure headers 6 - 9 are marked for download. After that ConnectNewHeaders called with headers 5 to 15 (from peer2).
+        /// Make sure 9 - 15 are marked for download.
         /// </summary>
         [Fact]
         public void ConsensusTipAtHeight5_AssumedValidIsAt10_WhenConnectingHeadersByDifferentPeers_CorrectHeadersAreMarkedForDownload()
@@ -1673,22 +1673,22 @@ namespace Stratis.Bitcoin.Tests.Consensus
             // Example: h1=h2=h3=h4=h5=h6=h7=h8=h9=(h10)=h11=h12=h13=h14=h15.
             const int extensionSize = 10;
             chainTip = ctx.ExtendAChain(extensionSize, chainTip); 
-            List<BlockHeader> listOfChainBlockHeaders = ctx.ChainedHeaderToList(chainTip, extensionSize);
-            ctx.ConsensusSettings.BlockAssumedValid = listOfChainBlockHeaders[4].GetHash();
+            List<BlockHeader> listOfChainBlockHeaders = ctx.ChainedHeaderToList(chainTip, initialChainSize + extensionSize);
+            ctx.ConsensusSettings.BlockAssumedValid = listOfChainBlockHeaders[9].GetHash();
 
-            ChainedHeader[] originalHeaders = chainTip.ToArray(extensionSize);
+            ChainedHeader[] originalHeaders = chainTip.ToArray(initialChainSize + extensionSize);
 
             // Peer 1 presents 4 headers: h6, h7, h8 and h9.
             // Headers 6-9 should be marked for download.
-            ConnectNewHeadersResult connectNewHeadersResult = cht.ConnectNewHeaders(1, listOfChainBlockHeaders.Take(4).ToList());
-            connectNewHeadersResult.DownloadFrom.HashBlock.Should().Be(originalHeaders[0].HashBlock); // h6
-            connectNewHeadersResult.DownloadTo.HashBlock.Should().Be(originalHeaders[3].HashBlock); // h9
+            ConnectNewHeadersResult connectNewHeadersResult = cht.ConnectNewHeaders(1, listOfChainBlockHeaders.Take(9).ToList());
+            connectNewHeadersResult.DownloadFrom.HashBlock.Should().Be(originalHeaders[5].HashBlock); // h6
+            connectNewHeadersResult.DownloadTo.HashBlock.Should().Be(originalHeaders[8].HashBlock); // h9
 
             // Peer 2 presents 10 headers: h6 - h15.
             // Headers 10-15 should be marked for download.
-            connectNewHeadersResult = cht.ConnectNewHeaders(2, listOfChainBlockHeaders.ToList());
-            connectNewHeadersResult.DownloadFrom.HashBlock.Should().Be(originalHeaders[4].HashBlock); // h9
-            connectNewHeadersResult.DownloadTo.HashBlock.Should().Be(originalHeaders[9].HashBlock); // h15
+            connectNewHeadersResult = cht.ConnectNewHeaders(2, listOfChainBlockHeaders.Skip(5).ToList());
+            connectNewHeadersResult.DownloadFrom.HashBlock.Should().Be(originalHeaders[8].HashBlock); // h9
+            connectNewHeadersResult.DownloadTo.HashBlock.Should().Be(originalHeaders[14].HashBlock); // h15
         }
     }
 }


### PR DESCRIPTION
CT is at 5. AssumeValid is at 10. ConnectNewHeaders called with headers 1 - 9(from peer1). Make sure headers 6 - 9 are marked for download. After that ConnectNewHeaders called with headers 5 to 15 (from peer2). Make sure 9 - 15 are marked for download.

See #1321 (comment)

Preferred reviewers: @Aprogiena or @noescape00