### PR TITLE
Update Dockerfile with 2.1 sdk

### DIFF
--- a/Docker/Stratis.StratisD.TestNet/Dockerfile
+++ b/Docker/Stratis.StratisD.TestNet/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/dotnet:2.0.0-sdk-jessie
+FROM microsoft/dotnet:2.1-sdk
 
 RUN git clone https://github.com/stratisproject/StratisBitcoinFullNode.git \
     && cd /StratisBitcoinFullNode/src/Stratis.StratisD \


### PR DESCRIPTION
No longer builds with 2.0:

`The current .NET SDK does not support targeting .NET Core 2.1.  Either target .NET Core 2.0 or lower, or use a version of the .NET SDK that supports .NET Core 2.1.`

