### PR TITLE
Cht tests fazzdev #1321 45

### DIFF
--- a/src/Stratis.Bitcoin.Tests/Consensus/ChainedHeaderTreeTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Consensus/ChainedHeaderTreeTest.cs
@@ -2113,6 +2113,48 @@ namespace Stratis.Bitcoin.Tests.Consensus
         }
 
         /// <summary>
+        /// Issue 45 @ Node has a reorg of 5 blocks.
+        /// Make sure that headers for the blocks that were reorged away
+        /// have no block pointers and block data availability == headers only.
+        /// </summary>
+        [Fact]
+        public void NodeHasReorg_ReorganisedHeaders_HaveNoBlockPointers_BlockDataAvailability_SetToHeadersOnly()
+        {
+            const int depthOfReorg = 5;
+            const int heightOfFork = 5;
+            const int initialChainSize = 10;
+            const int extensionSize = 20;
+
+            TestContext testContext = new TestContextBuilder().WithInitialChain(initialChainSize).Build();
+            ChainedHeaderTree chainedHeaderTree = testContext.ChainedHeaderTree;
+            ChainedHeader chainTip = testContext.InitialChainTip;
+
+            ChainedHeader forkedBlockHeader = chainTip.GetAncestor(depthOfReorg);
+            ChainedHeader newTip = testContext.ExtendAChain(extensionSize, forkedBlockHeader);
+            List<BlockHeader> listOfExtendedHeaders = testContext.ChainedHeaderToList(newTip, heightOfFork + extensionSize);
+            ConnectNewHeadersResult connectNewHeadersResult = chainedHeaderTree.ConnectNewHeaders(1, listOfExtendedHeaders);
+
+            foreach (ChainedHeader chainedHeader in connectNewHeadersResult.ToHashArray())
+            {
+                chainedHeaderTree.BlockDataDownloaded(chainedHeader, newTip.FindAncestorOrSelf(chainedHeader).Block);
+                chainedHeaderTree.PartialValidationSucceeded(chainedHeader, out bool fullValidationRequired);
+                chainedHeaderTree.ConsensusTipChanged(chainedHeader);
+            }
+
+            // Check status of headers for the blocks that were reorged away.
+            ChainedHeader chainHeader = chainTip;
+            while (chainHeader.Height > forkedBlockHeader.Height)
+            {
+                // Header has no block pointer.
+                Assert.Null(chainHeader.Block);
+
+                // Header block data availability == headers only.
+                Assert.Equal(BlockDataAvailabilityState.HeaderOnly, chainHeader.BlockDataAvailability);
+                chainHeader = chainHeader.Previous;
+            }
+        }
+
+        /// <summary>
         /// Issue 48 @ CT is at 5. AssumeValid is at 10. ConnectNewHeaders called with headers 1 - 9 (from peer1).
         /// Make sure headers 6 - 9 are marked for download. After that ConnectNewHeaders called with headers 5 to 15 (from peer2).
         /// Make sure 9 - 15 are marked for download.


### PR DESCRIPTION
**Cht tests fazzdev #1321 45**

- Node has a reorg of 5 blocks.
- Make sure that headers for the blocks that were reorged away.
- Have no block pointers and block data availability == headers only.

Preferred: @Aprogiena @noescape00 