### PR TITLE
Wallet to work in readonly mode from xpubkey

### DIFF
--- a/src/Stratis.Bitcoin.Features.Wallet.Tests/WalletManagerTest.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet.Tests/WalletManagerTest.cs
@@ -3184,7 +3184,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
             DataFolder dataFolder = CreateDataFolder(this);
 
             Wallet wallet = this.walletFixture.GenerateBlankWallet("testWallet", "password");
-            wallet.IsExtPubKeyWallet = "true";
+            wallet.IsExtPubKeyWallet = true;
             wallet.EncryptedSeed = null;
             wallet.ChainCode = null;
             

--- a/src/Stratis.Bitcoin.Features.Wallet.Tests/WalletManagerTest.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet.Tests/WalletManagerTest.cs
@@ -3178,6 +3178,24 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
             Assert.Equal(30, hdAccount.InternalAddresses.Count);
         }
 
+        [Fact]
+        public void Xpubkey_only_wallet_can_load_without_private_key()
+        {
+            DataFolder dataFolder = CreateDataFolder(this);
+
+            Wallet wallet = this.walletFixture.GenerateBlankWallet("testWallet", "password");
+            wallet.IsExtPubKeyWallet = "true";
+            wallet.EncryptedSeed = null;
+            wallet.ChainCode = null;
+            
+            File.WriteAllText(Path.Combine(dataFolder.WalletPath, "testWallet.wallet.json"), JsonConvert.SerializeObject(wallet, Formatting.Indented, new ByteArrayConverter()));
+
+            var walletManager = new WalletManager(this.LoggerFactory.Object, Network.StratisMain, new Mock<ConcurrentChain>().Object, NodeSettings.Default(), new Mock<WalletSettings>().Object,
+                dataFolder, new Mock<IWalletFeePolicy>().Object, new Mock<IAsyncLoopFactory>().Object, new NodeLifetime(), DateTimeProvider.Default);
+
+            walletManager.LoadWallet("password", "testWallet");
+        }
+
         private WalletManager GetWalletManagerWithCustomConfigParam(DataFolder dataFolder, params string[] cmdLineArgs)
         {
             var nodeSettings = new NodeSettings(Network.RegTest, ProtocolVersion.PROTOCOL_VERSION, "StratisBitcoin", cmdLineArgs);

--- a/src/Stratis.Bitcoin.Features.Wallet.Tests/WalletManagerTest.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet.Tests/WalletManagerTest.cs
@@ -283,7 +283,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
         {
             DataFolder dataFolder = CreateDataFolder(this);
 
-            var walletManager = GetWalletManagerWithCustomConfigParam(dataFolder, "-walletaddressbuffer=100");
+            var walletManager = this.CreateWalletManager(dataFolder, "-walletaddressbuffer=100");
 
             walletManager.CreateWallet("test", "mywallet", new Mnemonic(Wordlist.English, WordCount.Eighteen).ToString());
 
@@ -3160,7 +3160,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
         {
             DataFolder dataFolder = CreateDataFolder(this);
 
-            WalletManager walletManager = this.GetWalletManagerWithCustomConfigParam(dataFolder);
+            WalletManager walletManager = this.CreateWalletManager(dataFolder);
             walletManager.CreateWallet("test", "mywallet", new Mnemonic(Wordlist.English, WordCount.Eighteen).ToString());
 
             // Default of 20 addresses becuause walletaddressbuffer not set
@@ -3169,7 +3169,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
             Assert.Equal(20, hdAccount.InternalAddresses.Count);
             
             // Restart with walletaddressbuffer set
-            walletManager = this.GetWalletManagerWithCustomConfigParam(dataFolder, "-walletaddressbuffer=30");
+            walletManager = this.CreateWalletManager(dataFolder, "-walletaddressbuffer=30");
             walletManager.Start();
 
             // Addresses populated to fill the buffer set
@@ -3190,13 +3190,12 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
             
             File.WriteAllText(Path.Combine(dataFolder.WalletPath, "testWallet.wallet.json"), JsonConvert.SerializeObject(wallet, Formatting.Indented, new ByteArrayConverter()));
 
-            var walletManager = new WalletManager(this.LoggerFactory.Object, Network.StratisMain, new Mock<ConcurrentChain>().Object, NodeSettings.Default(), new Mock<WalletSettings>().Object,
-                dataFolder, new Mock<IWalletFeePolicy>().Object, new Mock<IAsyncLoopFactory>().Object, new NodeLifetime(), DateTimeProvider.Default);
+            var walletManager = this.CreateWalletManager(dataFolder);
 
             walletManager.LoadWallet("password", "testWallet");
         }
 
-        private WalletManager GetWalletManagerWithCustomConfigParam(DataFolder dataFolder, params string[] cmdLineArgs)
+        private WalletManager CreateWalletManager(DataFolder dataFolder, params string[] cmdLineArgs)
         {
             var nodeSettings = new NodeSettings(Network.RegTest, ProtocolVersion.PROTOCOL_VERSION, "StratisBitcoin", cmdLineArgs);
             var walletSettings = new WalletSettings(nodeSettings);

--- a/src/Stratis.Bitcoin.Features.Wallet/Wallet.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Wallet.cs
@@ -29,15 +29,21 @@ namespace Stratis.Bitcoin.Features.Wallet
         public string Name { get; set; }
 
         /// <summary>
+        /// Flag indicating if it is a watch only wallet.
+        /// </summary>
+        [JsonProperty(PropertyName = "isExtPubKeyWallet")]
+        public bool IsExtPubKeyWallet { get; set; }
+
+        /// <summary>
         /// The seed for this wallet, password encrypted.
         /// </summary>
-        [JsonProperty(PropertyName = "encryptedSeed")]
+        [JsonProperty(PropertyName = "encryptedSeed", NullValueHandling = NullValueHandling.Ignore)]
         public string EncryptedSeed { get; set; }
 
         /// <summary>
         /// The chain code.
         /// </summary>
-        [JsonProperty(PropertyName = "chainCode")]
+        [JsonProperty(PropertyName = "chainCode", NullValueHandling = NullValueHandling.Ignore)]
         [JsonConverter(typeof(ByteArrayConverter))]
         public byte[] ChainCode { get; set; }
 
@@ -433,7 +439,7 @@ namespace Stratis.Bitcoin.Features.Wallet
         /// The list of external addresses, typically used for receiving money.
         /// </summary>
         [JsonProperty(PropertyName = "externalAddresses")]
-        public ICollection<HdAddress> ExternalAddresses { get; set; }
+        public ICollection<HdAddress> ExternalAddresses { get ; set; }
 
         /// <summary>
         /// The list of internal addresses, typically used to receive change.

--- a/src/Stratis.Bitcoin.Features.Wallet/WalletManager.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/WalletManager.cs
@@ -268,7 +268,8 @@ namespace Stratis.Bitcoin.Features.Wallet
             // Check the password.
             try
             {
-                Key.Parse(wallet.EncryptedSeed, password, wallet.Network);
+                if (!wallet.IsExtPubKeyWallet)
+                    Key.Parse(wallet.EncryptedSeed, password, wallet.Network);
             }
             catch (Exception ex)
             {
@@ -1118,6 +1119,7 @@ namespace Stratis.Bitcoin.Features.Wallet
 
             return addressesToAdd > 0 ? account.CreateAddresses(this.network, addressesToAdd, isChange) : new List<HdAddress>();
         }
+
         /// <inheritdoc />
         public void DeleteWallet()
         {


### PR DESCRIPTION
Setting isExtPubKeyOnlyWallet to true, allows a wallet.json file without EncrptedPrivateKey and without ChainCode to function normally in readonly mode.

Funds can be received as normal and the wallet can be viewed and interacted with.

Sending and Staking don't work - a wallet UI change is needed to hide the staking option and to hide the password/send box on the Send screens as these aren't supported in this mode.

CAVEATS
----------
Because this is a manual manipulation of the wallet json file - the following crashes can happen if they are used with the current GUIs

If you try to start staking with this wallet - Exception on line 98 (Key.Parse) in MinerController.cs
If you try to Send using this wallet - Line 221 (this.privateKeyCache.TryGetValue) WalletTransactionHandler.cs