### PR TITLE
Matching peers : PeerVersion can be null

### DIFF
--- a/src/Stratis.Bitcoin/P2P/Peer/NetworkPeerCollection.cs
+++ b/src/Stratis.Bitcoin/P2P/Peer/NetworkPeerCollection.cs
@@ -103,16 +103,16 @@ namespace Stratis.Bitcoin.P2P.Peer
 
         private static bool Match(IPAddress ip, int? port, INetworkPeer peer)
         {
-            if (port.HasValue)
-            {
-                return ((peer.State == NetworkPeerState.Connected || peer.State == NetworkPeerState.HandShaked) && peer.RemoteSocketAddress.Equals(ip) && 
-                        (peer.RemoteSocketPort == port.Value)) || (peer.PeerVersion.AddressFrom.Address.Equals(ip) && (peer.PeerVersion.AddressFrom.Port == port.Value));
-            }
-            else
-            {
-                return ((peer.State == NetworkPeerState.Connected || peer.State == NetworkPeerState.HandShaked) && 
-                        peer.RemoteSocketAddress.Equals(ip)) || peer.PeerVersion.AddressFrom.Address.Equals(ip);
-            }
+            bool isConnectedOrHandShaked = (peer.State == NetworkPeerState.Connected || peer.State == NetworkPeerState.HandShaked);
+
+            bool isAddressMatching = peer.RemoteSocketAddress.Equals(ip) 
+                                     && (!port.HasValue || port == peer.RemoteSocketPort);
+
+            bool isPeerVersionAddressMatching = peer.PeerVersion?.AddressFrom != null
+                                                && peer.PeerVersion.AddressFrom.Address.Equals(ip)
+                                                && (!port.HasValue || port == peer.PeerVersion.AddressFrom.Port);
+
+            return (isConnectedOrHandShaked && isAddressMatching) || isPeerVersionAddressMatching;
         }
 
         public IEnumerator<INetworkPeer> GetEnumerator()


### PR DESCRIPTION
Hopefully this is exactly the same except that we now check that PeerVersion is not null and has an address
I was getting exceptions when it was 