### PR TITLE
peers in the list are not necessarily connected

### DIFF
--- a/src/Stratis.Bitcoin.IntegrationTests.Common/TestHelper.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests.Common/TestHelper.cs
@@ -50,8 +50,7 @@ namespace Stratis.Bitcoin.IntegrationTests.Common
 
         public static bool IsNodeConnected(CoreNode node)
         {
-            if (node.FullNode.ConnectionManager.ConnectedPeers.Any()) return true;
-            return false;
+            return node.FullNode.ConnectionManager.ConnectedPeers.Any(p => p.IsConnected);
         }
 
         /// <summary>


### PR DESCRIPTION
so if the peers are in the list but disconnected this return the wrong answer