### PR TITLE
Fix compiler warnings and new Block() usage

### DIFF
--- a/src/NBitcoin.Tests/ChainTests.cs
+++ b/src/NBitcoin.Tests/ChainTests.cs
@@ -405,7 +405,7 @@ namespace NBitcoin.Tests
         [Trait("UnitTest", "UnitTest")]
         public void CanForkSidePartialChain()
         {
-            Block genesis = TestUtils.CreateFakeBlock();
+            Block genesis = TestUtils.CreateFakeBlock(this.network);
             var side = new ConcurrentChain(this.network, new ChainedHeader(genesis.Header, genesis.GetHash(), 0));
             var main = new ConcurrentChain(this.network, new ChainedHeader(genesis.Header, genesis.GetHash(), 0));
             this.AppendBlock(side, main);
@@ -488,10 +488,11 @@ namespace NBitcoin.Tests
             ChainedHeader block = mainTip.GetAncestor(branchLength - 1);
             for (int i = 0; i < branchLength; i++)
             {
-                Block newBlock = TestUtils.CreateFakeBlock();
+                Block newBlock = TestUtils.CreateFakeBlock(this.network);
                 newBlock.Header.HashPrevBlock = block.Header.GetHash();
                 block = new ChainedHeader(newBlock.Header, newBlock.Header.GetHash(), block);
             }
+
             ChainedHeader branchTip = block;
 
             // Test 100 random starting points for locators.
@@ -533,7 +534,7 @@ namespace NBitcoin.Tests
 
         private ConcurrentChain CreateChain(int height)
         {
-            return this.CreateChain(TestUtils.CreateFakeBlock().Header, height);
+            return this.CreateChain(TestUtils.CreateFakeBlock(this.network).Header, height);
         }
 
         private ConcurrentChain CreateChain(BlockHeader genesis, int height)
@@ -541,7 +542,7 @@ namespace NBitcoin.Tests
             var chain = new ConcurrentChain(this.network, new ChainedHeader(genesis, genesis.GetHash(), 0));
             for (int i = 0; i < height; i++)
             {
-                Block b = TestUtils.CreateFakeBlock();
+                Block b = TestUtils.CreateFakeBlock(this.network);
                 b.Header.HashPrevBlock = chain.Tip.HashBlock;
                 chain.SetTip(b.Header);
             }
@@ -554,7 +555,7 @@ namespace NBitcoin.Tests
             uint nonce = RandomUtils.GetUInt32();
             foreach (ConcurrentChain chain in chains)
             {
-                Block block = TestUtils.CreateFakeBlock(this.network.CreateTransaction());
+                Block block = TestUtils.CreateFakeBlock(this.network, this.network.CreateTransaction());
                 block.Header.HashPrevBlock = previous == null ? chain.Tip.HashBlock : previous.HashBlock;
                 block.Header.Nonce = nonce;
                 if (!chain.TrySetTip(block.Header, out last))

--- a/src/NBitcoin.Tests/ChainTests.cs
+++ b/src/NBitcoin.Tests/ChainTests.cs
@@ -555,7 +555,7 @@ namespace NBitcoin.Tests
             uint nonce = RandomUtils.GetUInt32();
             foreach (ConcurrentChain chain in chains)
             {
-                Block block = TestUtils.CreateFakeBlock(this.network, this.network.CreateTransaction());
+                Block block = TestUtils.CreateFakeBlock(this.network);
                 block.Header.HashPrevBlock = previous == null ? chain.Tip.HashBlock : previous.HashBlock;
                 block.Header.Nonce = nonce;
                 if (!chain.TrySetTip(block.Header, out last))

--- a/src/NBitcoin.Tests/TestUtils.cs
+++ b/src/NBitcoin.Tests/TestUtils.cs
@@ -1,26 +1,14 @@
-﻿using System;
-using System.IO;
-using System.Threading;
+﻿using System.IO;
 using NBitcoin.DataEncoders;
 
 namespace NBitcoin.Tests
 {
     internal class TestUtils
     {
-        public static void Eventually(Func<bool> act)
-        {
-            var cancel = new CancellationTokenSource(20000);
-            while(!act())
-            {
-                cancel.Token.ThrowIfCancellationRequested();
-                Thread.Sleep(50);
-            }
-        }
-
         public static byte[] ToBytes(string str)
         {
             var result = new byte[str.Length];
-            for(int i = 0; i < str.Length; i++)
+            for (int i = 0; i < str.Length; i++)
             {
                 result[i] = (byte)str[i];
             }
@@ -32,17 +20,17 @@ namespace NBitcoin.Tests
             return Encoders.Hex.DecodeData(data);
         }
 
-        public static Block CreateFakeBlock(Transaction tx)
+        public static Block CreateFakeBlock(Network network, Transaction tx)
         {
-            var block = new Block();
+            Block block = network.CreateBlock();
             block.AddTransaction(tx);
             block.UpdateMerkleRoot();
             return block;
         }
 
-        public static Block CreateFakeBlock()
+        public static Block CreateFakeBlock(Network network)
         {
-            Block block = CreateFakeBlock(new Transaction());
+            Block block = CreateFakeBlock(network, network.CreateTransaction());
             block.Header.HashPrevBlock = new uint256(RandomUtils.GetBytes(32));
             block.Header.Nonce = RandomUtils.GetUInt32();
             return block;
@@ -50,9 +38,10 @@ namespace NBitcoin.Tests
 
         internal static void EnsureNew(string folderName)
         {
-            if(Directory.Exists(folderName))
+            if (Directory.Exists(folderName))
                 Directory.Delete(folderName, true);
-            while(true)
+
+            while (true)
             {
                 try
                 {
@@ -63,7 +52,6 @@ namespace NBitcoin.Tests
                 {
                 }
             }
-
         }
     }
 }

--- a/src/NBitcoin.Tests/checkblock_tests.cs
+++ b/src/NBitcoin.Tests/checkblock_tests.cs
@@ -10,7 +10,7 @@ namespace NBitcoin.Tests
         [Trait("UnitTest", "UnitTest")]
         public void CanCalculateMerkleRoot()
         {
-            var block = new Block();
+            Block block = Network.Main.CreateBlock();
             block.ReadWrite(Encoders.Hex.DecodeData(File.ReadAllText(TestDataLocations.GetFileFromDataFolder("block169482.txt"))), Network.Main.Consensus.ConsensusFactory);
             Assert.Equal(block.Header.HashMerkleRoot, block.GetMerkleRoot().Hash);
         }

--- a/src/NBitcoin.Tests/transaction_tests.cs
+++ b/src/NBitcoin.Tests/transaction_tests.cs
@@ -149,8 +149,8 @@ namespace NBitcoin.Tests
             var secret = new BitcoinSecret("KyJTjvFpPF6DDX4fnT56d2eATPfxjdUPXFFUb85psnCdh34iyXRQ");
 
             var tx = new Transaction();
-            var p2pkh = new TxOut(new Money((UInt64)45000000), secret.GetAddress());
-            var p2pk = new TxOut(new Money((UInt64)80000000), secret.PrivateKey.PubKey);
+            var p2pkh = new TxOut(new Money((ulong)45000000), secret.GetAddress());
+            var p2pk = new TxOut(new Money((ulong)80000000), secret.PrivateKey.PubKey);
 
             tx.AddOutput(p2pkh);
             tx.AddOutput(p2pk);
@@ -168,7 +168,7 @@ namespace NBitcoin.Tests
             var key = new Key();
             Script scriptPubKey = PayToPubkeyHashTemplate.Instance.GenerateScriptPubKey(key.PubKey);
 
-            var tx = this.network.CreateTransaction();
+            Transaction tx = this.network.CreateTransaction();
             tx.AddInput(new TxIn(new OutPoint(tx.GetHash(), 0))
             {
                 ScriptSig = scriptPubKey
@@ -212,14 +212,13 @@ namespace NBitcoin.Tests
             }, Money.Parse("10.0")));
 
             // Should spend all coins belonging to same scriptPubKey
-            var bob = new Key().ScriptPubKey;
-            var alice = new Key().ScriptPubKey;
-            var selected = selector.Select(new ICoin[] { CreateCoin("5", bob), CreateCoin("5", bob) }, Money.Parse("2.0")).ToArray();
+            Script bob = new Key().ScriptPubKey;
+            Script alice = new Key().ScriptPubKey;
+            ICoin[] selected = selector.Select(new ICoin[] { CreateCoin("5", bob), CreateCoin("5", bob) }, Money.Parse("2.0")).ToArray();
             Assert.Equal(2, selected.Length);
 
             selected = selector.Select(new ICoin[] { CreateCoin("5", alice), CreateCoin("5", bob) }, Money.Parse("2.0")).ToArray();
-            Assert.Equal(1, selected.Length);
-            ///////
+            Assert.Single(selected);
         }
 
         private Coin CreateCoin(Money amount, Script scriptPubKey = null)
@@ -1317,7 +1316,7 @@ namespace NBitcoin.Tests
         [Trait("UnitTest", "UnitTest")]
         public void CanSerializeInvalidTransactionsBackAndForth()
         {
-            var before = this.network.CreateTransaction();
+            Transaction before = this.network.CreateTransaction();
             uint versionBefore = before.Version;
             before.Outputs.Add(new TxOut());
             Transaction after = AssertClone(before);
@@ -1491,7 +1490,7 @@ namespace NBitcoin.Tests
             var alice = new Key();
             var bob = new Key();
             //P2SH(P2WSH)
-            var previousTx = this.network.CreateTransaction();
+            Transaction previousTx = this.network.CreateTransaction();
             previousTx.Outputs.Add(new TxOut(Money.Coins(1.0m), alice.PubKey.ScriptPubKey.WitHash.ScriptPubKey.Hash));
             Coin previousCoin = previousTx.Outputs.AsCoins().First();
 
@@ -1524,10 +1523,10 @@ namespace NBitcoin.Tests
 
             foreach (int pushSize in new[] { 2, 10, 20, 32 })
             {
-                a = new Script("1 " + String.Concat(Enumerable.Range(0, pushSize * 2).Select(_ => "0").ToArray()));
+                a = new Script("1 " + string.Concat(Enumerable.Range(0, pushSize * 2).Select(_ => "0").ToArray()));
                 Assert.True(PayToWitTemplate.Instance.CheckScriptPubKey(a));
             }
-            a = new Script("1 " + String.Concat(Enumerable.Range(0, 33 * 2).Select(_ => "0").ToArray()));
+            a = new Script("1 " + string.Concat(Enumerable.Range(0, 33 * 2).Select(_ => "0").ToArray()));
             Assert.False(PayToWitTemplate.Instance.CheckScriptPubKey(a));
         }
 
@@ -1889,7 +1888,7 @@ namespace NBitcoin.Tests
 
             // Create the spend-from-multisig transaction. Since the fund-the-multisig transaction
             // hasn't been sent yet, I need to give txid, scriptPubKey and redeemScript:
-            var spendTransaction = this.network.CreateTransaction();
+            Transaction spendTransaction = this.network.CreateTransaction();
             spendTransaction.Inputs.Add(new TxIn()
             {
                 PrevOut = new OutPoint(fundingTransaction.GetHash(), 0),
@@ -2004,7 +2003,7 @@ namespace NBitcoin.Tests
         [Trait("UnitTest", "UnitTest")]
         public void CanUseLockTime()
         {
-            var tx = this.network.CreateTransaction();
+            Transaction tx = this.network.CreateTransaction();
             tx.LockTime = new LockTime(4);
             Transaction clone = this.network.CreateTransaction(tx.ToBytes());
             Assert.Equal(tx.LockTime, clone.LockTime);
@@ -2790,13 +2789,13 @@ namespace NBitcoin.Tests
                     }
                     scriptParts.Add(scriptOutput.ToString());
                 }
-                coinOutput.Append(String.Join(" ", scriptParts));
+                coinOutput.Append(string.Join(" ", scriptParts));
                 coinOutput.Append("\", ");
                 coinOutput.Append(coin.Amount.Satoshi);
                 coinOutput.Append("]");
                 coinParts.Add(coinOutput.ToString());
             }
-            output.Append(String.Join(",\n", coinParts));
+            output.Append(string.Join(",\n", coinParts));
             output.Append("],\n\"");
             output.Append(result.ToHex());
             output.Append("\", \"P2SH,WITNESS\"],\n\n");
@@ -3004,7 +3003,7 @@ namespace NBitcoin.Tests
             var coins = new CoinsView(this.network);//(coinsDummy);
             Transaction[] dummyTransactions = SetupDummyInputs(coins);//(keystore, coins);
 
-            var t1 = this.network.CreateTransaction();
+            Transaction t1 = this.network.CreateTransaction();
             t1.Inputs.AddRange(Enumerable.Range(0, 3).Select(_ => new TxIn()));
             t1.Inputs[0].PrevOut.Hash = dummyTransactions[0].GetHash();
             t1.Inputs[0].PrevOut.N = 1;
@@ -3081,7 +3080,7 @@ namespace NBitcoin.Tests
 
         private void CreateCreditAndSpend(CKeyStore keystore, Script outscript, ref Transaction output, ref Transaction input, bool success = true)
         {
-            var outputm = this.network.CreateTransaction();
+            Transaction outputm = this.network.CreateTransaction();
             outputm.Version = 1;
             outputm.Inputs.Add(new TxIn());
             outputm.Inputs[0].PrevOut = new OutPoint();
@@ -3099,7 +3098,7 @@ namespace NBitcoin.Tests
             Assert.True(output.Inputs[0].ToBytes().SequenceEqual(outputm.Inputs[0].ToBytes()));
             Assert.True(!output.HasWitness);
 
-            var inputm = this.network.CreateTransaction();
+            Transaction inputm = this.network.CreateTransaction();
             inputm.Version = 1;
             inputm.Inputs.Add(new TxIn());
             inputm.Inputs[0].PrevOut.Hash = output.GetHash();

--- a/src/NBitcoin/Network.cs
+++ b/src/NBitcoin/Network.cs
@@ -697,6 +697,11 @@ namespace NBitcoin
             }
         }
 
+        public Block CreateBlock()
+        {
+            return this.Consensus.ConsensusFactory.CreateBlock();
+        }
+
         public Transaction CreateTransaction()
         {
             return this.Consensus.ConsensusFactory.CreateTransaction();

--- a/src/NBitcoin/Utils.cs
+++ b/src/NBitcoin/Utils.cs
@@ -4,13 +4,13 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Net;
+using System.Net.Sockets;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using NBitcoin.BouncyCastle.Math;
 using NBitcoin.DataEncoders;
 using NBitcoin.Protocol;
-using System.Net.Sockets;
 
 namespace NBitcoin
 {
@@ -711,7 +711,7 @@ namespace NBitcoin
             {
                 address = IPAddress.Parse(ip);
             }
-            catch (FormatException err)
+            catch (FormatException)
             {
                 if (ip.Trim() == string.Empty || Uri.CheckHostName(ip) == UriHostNameType.Unknown)
                     throw;

--- a/src/Stratis.Bitcoin.Features.BlockStore.Tests/BlockStoreCacheTest.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore.Tests/BlockStoreCacheTest.cs
@@ -13,10 +13,12 @@ namespace Stratis.Bitcoin.Features.BlockStore.Tests
         private readonly Mock<IBlockRepository> blockRepository;
         private readonly ILoggerFactory loggerFactory;
         private readonly StoreSettings storeSettings;
+        private readonly Network network;
 
         public BlockStoreCacheTest()
         {
             this.loggerFactory = new LoggerFactory();
+            this.network = Network.StratisMain;
             this.blockRepository = new Mock<IBlockRepository>();
 
             this.storeSettings = new StoreSettings();
@@ -27,7 +29,7 @@ namespace Stratis.Bitcoin.Features.BlockStore.Tests
         [Fact]
         public void GetBlockAsyncBlockInCacheReturnsBlock()
         {
-            var block = new Block();
+            Block block = this.network.CreateBlock();
             block.Header.Version = 1513;
             this.blockStoreCache.AddToCache(block);
 
@@ -41,10 +43,9 @@ namespace Stratis.Bitcoin.Features.BlockStore.Tests
         public void GetBlockAsyncBlockNotInCacheQueriesRepositoryStoresBlockInCacheAndReturnsBlock()
         {
             var blockId = new uint256(2389704);
-            var repositoryBlock = new Block();
+            Block repositoryBlock = this.network.CreateBlock();
             repositoryBlock.Header.Version = 1451;
-            this.blockRepository.Setup(b => b.GetAsync(blockId))
-                .Returns(Task.FromResult(repositoryBlock));
+            this.blockRepository.Setup(b => b.GetAsync(blockId)).Returns(Task.FromResult(repositoryBlock));
 
             this.blockStoreCache = new BlockStoreCache(this.blockRepository.Object, DateTimeProvider.Default, this.loggerFactory, this.storeSettings);
 

--- a/src/Stratis.Bitcoin.Features.BlockStore.Tests/BlockStoreTests.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore.Tests/BlockStoreTests.cs
@@ -28,12 +28,9 @@ namespace Stratis.Bitcoin.Features.BlockStore.Tests
         private int repositoryTotalBlocksDeleted = 0;
 
         private Dictionary<uint256, Block> listOfSavedBlocks;
-
-        private ChainedHeader chainStateBlockStoreTip;
-
         private ChainedHeader consensusTip;
 
-        private string testBlockHex = "07000000af72d939050259913e440b23bee62e3b9604129ec8424d265a6ee4916e060000a5a2cbad28617657336403daf202b797bfc4b9c5cfc65a258f32ec33ec9ad485314ea957ffff0f1e812b07000101000000184ea957010000000000000000000000000000000000000000000000000000000000000000ffffffff03510101ffffffff010084d717000000001976a9140099e795d9ee809dc74dce32c79d26db0265072488ac0000000000";
+        private readonly string testBlockHex = "07000000af72d939050259913e440b23bee62e3b9604129ec8424d265a6ee4916e060000a5a2cbad28617657336403daf202b797bfc4b9c5cfc65a258f32ec33ec9ad485314ea957ffff0f1e812b07000101000000184ea957010000000000000000000000000000000000000000000000000000000000000000ffffffff03510101ffffffff010084d717000000001976a9140099e795d9ee809dc74dce32c79d26db0265072488ac0000000000";
 
         public BlockStoreTests()
         {
@@ -84,7 +81,7 @@ namespace Stratis.Bitcoin.Features.BlockStore.Tests
 
             var chainStateMoq = new Mock<IChainState>();
             chainStateMoq.Setup(x => x.ConsensusTip).Returns(() => this.consensusTip);
-            chainStateMoq.SetupProperty(x => x.BlockStoreTip, this.chainStateBlockStoreTip);
+            chainStateMoq.SetupProperty(x => x.BlockStoreTip, null);
 
             this.chainState = chainStateMoq.Object;
 

--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/CommonRules/BlockHeaderPowContextualRuleTest2.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/CommonRules/BlockHeaderPowContextualRuleTest2.cs
@@ -22,7 +22,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
             this.ruleContext.ConsensusTipHeight = 5;
             this.ruleContext.Time = new DateTimeOffset(new DateTime(2017, 1, 1, 0, 1, 0));
             this.ruleContext.NextWorkRequired = new Target(0x1f111115);
-            this.ruleContext.ValidationContext.Block = new Block();
+            this.ruleContext.ValidationContext.Block = this.network.CreateBlock();
             this.ruleContext.ValidationContext.Block.Header.Bits = new Target(0x1f111114);
 
             ConsensusErrorException exception = await Assert.ThrowsAsync<ConsensusErrorException>(() => this.consensusRules.RegisterRule<BlockHeaderPowContextualRule>().RunAsync(this.ruleContext));
@@ -35,7 +35,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
         {
             this.ruleContext.ConsensusTipHeight = 5;
             this.ruleContext.NextWorkRequired = new Target(0x1f111115);
-            this.ruleContext.ValidationContext.Block = new Block();
+            this.ruleContext.ValidationContext.Block = this.network.CreateBlock();
             this.ruleContext.ValidationContext.Block.Header.Bits = new Target(0x1f111116);
 
             ConsensusErrorException exception = await Assert.ThrowsAsync<ConsensusErrorException>(() => this.consensusRules.RegisterRule<BlockHeaderPowContextualRule>().RunAsync(this.ruleContext));
@@ -50,7 +50,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
             this.ruleContext.ConsensusTip.Header.BlockTime = new DateTimeOffset(new DateTime(2017, 1, 1, 0, 1, 0));
             this.ruleContext.Time = new DateTimeOffset(new DateTime(2017, 1, 1, 0, 1, 0));
             this.ruleContext.NextWorkRequired = new Target(0x1f111115);
-            this.ruleContext.ValidationContext.Block = new Block();
+            this.ruleContext.ValidationContext.Block = this.network.CreateBlock();
             this.ruleContext.ValidationContext.Block.Header.Bits = new Target(0x1f111115);
             this.ruleContext.ValidationContext.Block.Header.BlockTime = new DateTimeOffset(new DateTime(2017, 1, 1, 0, 0, 9));
 
@@ -66,7 +66,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
             this.ruleContext.ConsensusTip.Header.BlockTime = new DateTimeOffset(new DateTime(2017, 1, 1, 0, 1, 0));
             this.ruleContext.Time = new DateTimeOffset(new DateTime(2017, 1, 1, 0, 1, 0));
             this.ruleContext.NextWorkRequired = new Target(0x1f111115);
-            this.ruleContext.ValidationContext.Block = new Block();
+            this.ruleContext.ValidationContext.Block = this.network.CreateBlock();
             this.ruleContext.ValidationContext.Block.Header.Bits = new Target(0x1f111115);
             this.ruleContext.ValidationContext.Block.Header.BlockTime = new DateTimeOffset(new DateTime(2017, 1, 1, 0, 1, 0));
 
@@ -81,7 +81,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
             this.ruleContext.ConsensusTipHeight = 5;
             this.ruleContext.Time = new DateTime(2016, 12, 31, 10, 0, 0);
             this.ruleContext.NextWorkRequired = new Target(0x1f111115);
-            this.ruleContext.ValidationContext.Block = new Block();
+            this.ruleContext.ValidationContext.Block = this.network.CreateBlock();
             this.ruleContext.ValidationContext.Block.Header.Bits = new Target(0x1f111115);
             this.ruleContext.ValidationContext.Block.Header.BlockTime = new DateTimeOffset(new DateTime(2017, 1, 1, 0, 1, 1));
 
@@ -97,7 +97,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
             this.ruleContext.ConsensusTipHeight = this.consensusRules.ConsensusParams.BuriedDeployments[BuriedDeployments.BIP34];
             this.ruleContext.Time = new DateTimeOffset(new DateTime(2017, 1, 1, 0, 1, 0));
             this.ruleContext.NextWorkRequired = new Target(0x1f111115);
-            this.ruleContext.ValidationContext.Block = new Block();
+            this.ruleContext.ValidationContext.Block = this.network.CreateBlock();
             this.ruleContext.ValidationContext.Block.Header.Bits = new Target(0x1f111115);
             this.ruleContext.ValidationContext.Block.Header.BlockTime = new DateTimeOffset(new DateTime(2017, 1, 1, 0, 1, 1));
             this.ruleContext.ValidationContext.Block.Header.Version = 1;
@@ -113,7 +113,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
             this.ruleContext.ConsensusTipHeight = this.consensusRules.ConsensusParams.BuriedDeployments[BuriedDeployments.BIP34] - 1;
             this.ruleContext.Time = new DateTimeOffset(new DateTime(2017, 1, 1, 0, 1, 0));
             this.ruleContext.NextWorkRequired = new Target(0x1f111115);
-            this.ruleContext.ValidationContext.Block = new Block();
+            this.ruleContext.ValidationContext.Block = this.network.CreateBlock();
             this.ruleContext.ValidationContext.Block.Header.Bits = new Target(0x1f111115);
             this.ruleContext.ValidationContext.Block.Header.BlockTime = new DateTimeOffset(new DateTime(2017, 1, 1, 0, 1, 1));
             this.ruleContext.ValidationContext.Block.Header.Version = 1;
@@ -129,7 +129,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
             this.ruleContext.ConsensusTipHeight = this.consensusRules.ConsensusParams.BuriedDeployments[BuriedDeployments.BIP66];
             this.ruleContext.Time = new DateTimeOffset(new DateTime(2017, 1, 1, 0, 1, 0));
             this.ruleContext.NextWorkRequired = new Target(0x1f111115);
-            this.ruleContext.ValidationContext.Block = new Block();
+            this.ruleContext.ValidationContext.Block = this.network.CreateBlock();
             this.ruleContext.ValidationContext.Block.Header.Bits = new Target(0x1f111115);
             this.ruleContext.ValidationContext.Block.Header.BlockTime = new DateTimeOffset(new DateTime(2017, 1, 1, 0, 1, 1));
             this.ruleContext.ValidationContext.Block.Header.Version = 2;
@@ -145,7 +145,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
             this.ruleContext.ConsensusTipHeight = this.consensusRules.ConsensusParams.BuriedDeployments[BuriedDeployments.BIP66] - 1;
             this.ruleContext.Time = new DateTimeOffset(new DateTime(2017, 1, 1, 0, 1, 0));
             this.ruleContext.NextWorkRequired = new Target(0x1f111115);
-            this.ruleContext.ValidationContext.Block = new Block();
+            this.ruleContext.ValidationContext.Block = this.network.CreateBlock();
             this.ruleContext.ValidationContext.Block.Header.Bits = new Target(0x1f111115);
             this.ruleContext.ValidationContext.Block.Header.BlockTime = new DateTimeOffset(new DateTime(2017, 1, 1, 0, 1, 1));
             this.ruleContext.ValidationContext.Block.Header.Version = 2;
@@ -161,7 +161,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
             this.ruleContext.ConsensusTipHeight = this.consensusRules.ConsensusParams.BuriedDeployments[BuriedDeployments.BIP66];
             this.ruleContext.Time = new DateTimeOffset(new DateTime(2017, 1, 1, 0, 1, 0));
             this.ruleContext.NextWorkRequired = new Target(0x1f111115);
-            this.ruleContext.ValidationContext.Block = new Block();
+            this.ruleContext.ValidationContext.Block = this.network.CreateBlock();
             this.ruleContext.ValidationContext.Block.Header.Bits = new Target(0x1f111115);
             this.ruleContext.ValidationContext.Block.Header.BlockTime = new DateTimeOffset(new DateTime(2017, 1, 1, 0, 1, 1));
             this.ruleContext.ValidationContext.Block.Header.Version = 1;
@@ -177,7 +177,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
             this.ruleContext.ConsensusTipHeight = this.consensusRules.ConsensusParams.BuriedDeployments[BuriedDeployments.BIP66] - 1;
             this.ruleContext.Time = new DateTimeOffset(new DateTime(2017, 1, 1, 0, 1, 0));
             this.ruleContext.NextWorkRequired = new Target(0x1f111115);
-            this.ruleContext.ValidationContext.Block = new Block();
+            this.ruleContext.ValidationContext.Block = this.network.CreateBlock();
             this.ruleContext.ValidationContext.Block.Header.Bits = new Target(0x1f111115);
             this.ruleContext.ValidationContext.Block.Header.BlockTime = new DateTimeOffset(new DateTime(2017, 1, 1, 0, 1, 1));
             this.ruleContext.ValidationContext.Block.Header.Version = 1;
@@ -193,7 +193,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
             this.ruleContext.ConsensusTipHeight = this.consensusRules.ConsensusParams.BuriedDeployments[BuriedDeployments.BIP65];
             this.ruleContext.Time = new DateTimeOffset(new DateTime(2017, 1, 1, 0, 1, 0));
             this.ruleContext.NextWorkRequired = new Target(0x1f111115);
-            this.ruleContext.ValidationContext.Block = new Block();
+            this.ruleContext.ValidationContext.Block = this.network.CreateBlock();
             this.ruleContext.ValidationContext.Block.Header.Bits = new Target(0x1f111115);
             this.ruleContext.ValidationContext.Block.Header.BlockTime = new DateTimeOffset(new DateTime(2017, 1, 1, 0, 1, 1));
             this.ruleContext.ValidationContext.Block.Header.Version = 3;
@@ -209,7 +209,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
             this.ruleContext.ConsensusTipHeight = this.consensusRules.ConsensusParams.BuriedDeployments[BuriedDeployments.BIP65] - 1;
             this.ruleContext.Time = new DateTimeOffset(new DateTime(2017, 1, 1, 0, 1, 0));
             this.ruleContext.NextWorkRequired = new Target(0x1f111115);
-            this.ruleContext.ValidationContext.Block = new Block();
+            this.ruleContext.ValidationContext.Block = this.network.CreateBlock();
             this.ruleContext.ValidationContext.Block.Header.Bits = new Target(0x1f111115);
             this.ruleContext.ValidationContext.Block.Header.BlockTime = new DateTimeOffset(new DateTime(2017, 1, 1, 0, 1, 1));
             this.ruleContext.ValidationContext.Block.Header.Version = 3;
@@ -225,7 +225,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
             this.ruleContext.ConsensusTipHeight = this.consensusRules.ConsensusParams.BuriedDeployments[BuriedDeployments.BIP66];
             this.ruleContext.Time = new DateTimeOffset(new DateTime(2017, 1, 1, 0, 1, 0));
             this.ruleContext.NextWorkRequired = new Target(0x1f111115);
-            this.ruleContext.ValidationContext.Block = new Block();
+            this.ruleContext.ValidationContext.Block = this.network.CreateBlock();
             this.ruleContext.ValidationContext.Block.Header.Bits = new Target(0x1f111115);
             this.ruleContext.ValidationContext.Block.Header.BlockTime = new DateTimeOffset(new DateTime(2017, 1, 1, 0, 1, 1));
             this.ruleContext.ValidationContext.Block.Header.Version = 2;
@@ -241,7 +241,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
             this.ruleContext.ConsensusTipHeight = this.consensusRules.ConsensusParams.BuriedDeployments[BuriedDeployments.BIP66] - 1;
             this.ruleContext.Time = new DateTimeOffset(new DateTime(2017, 1, 1, 0, 1, 0));
             this.ruleContext.NextWorkRequired = new Target(0x1f111115);
-            this.ruleContext.ValidationContext.Block = new Block();
+            this.ruleContext.ValidationContext.Block = this.network.CreateBlock();
             this.ruleContext.ValidationContext.Block.Header.Bits = new Target(0x1f111115);
             this.ruleContext.ValidationContext.Block.Header.BlockTime = new DateTimeOffset(new DateTime(2017, 1, 1, 0, 1, 1));
             this.ruleContext.ValidationContext.Block.Header.Version = 2;
@@ -257,7 +257,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
             this.ruleContext.ConsensusTipHeight = this.consensusRules.ConsensusParams.BuriedDeployments[BuriedDeployments.BIP66];
             this.ruleContext.Time = new DateTimeOffset(new DateTime(2017, 1, 1, 0, 1, 0));
             this.ruleContext.NextWorkRequired = new Target(0x1f111115);
-            this.ruleContext.ValidationContext.Block = new Block();
+            this.ruleContext.ValidationContext.Block = this.network.CreateBlock();
             this.ruleContext.ValidationContext.Block.Header.Bits = new Target(0x1f111115);
             this.ruleContext.ValidationContext.Block.Header.BlockTime = new DateTimeOffset(new DateTime(2017, 1, 1, 0, 1, 1));
             this.ruleContext.ValidationContext.Block.Header.Version = 1;
@@ -273,7 +273,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
             this.ruleContext.ConsensusTipHeight = this.consensusRules.ConsensusParams.BuriedDeployments[BuriedDeployments.BIP66] - 1;
             this.ruleContext.Time = new DateTimeOffset(new DateTime(2017, 1, 1, 0, 1, 0));
             this.ruleContext.NextWorkRequired = new Target(0x1f111115);
-            this.ruleContext.ValidationContext.Block = new Block();
+            this.ruleContext.ValidationContext.Block = this.network.CreateBlock();
             this.ruleContext.ValidationContext.Block.Header.Bits = new Target(0x1f111115);
             this.ruleContext.ValidationContext.Block.Header.BlockTime = new DateTimeOffset(new DateTime(2017, 1, 1, 0, 1, 1));
             this.ruleContext.ValidationContext.Block.Header.Version = 1;
@@ -289,7 +289,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
             this.ruleContext.ConsensusTipHeight = this.consensusRules.ConsensusParams.BuriedDeployments[BuriedDeployments.BIP34] - 2;
             this.ruleContext.Time = new DateTimeOffset(new DateTime(2017, 1, 1, 0, 1, 0));
             this.ruleContext.NextWorkRequired = new Target(0x1f111115);
-            this.ruleContext.ValidationContext.Block = new Block();
+            this.ruleContext.ValidationContext.Block = this.network.CreateBlock();
             this.ruleContext.ValidationContext.Block.Header.Bits = new Target(0x1f111115);
             this.ruleContext.ValidationContext.Block.Header.BlockTime = new DateTimeOffset(new DateTime(2017, 1, 1, 0, 1, 1));
             this.ruleContext.ValidationContext.Block.Header.Version = 1;
@@ -303,7 +303,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
             this.ruleContext.ConsensusTipHeight = this.consensusRules.ConsensusParams.BuriedDeployments[BuriedDeployments.BIP66] - 2;
             this.ruleContext.Time = new DateTimeOffset(new DateTime(2017, 1, 1, 0, 1, 0));
             this.ruleContext.NextWorkRequired = new Target(0x1f111115);
-            this.ruleContext.ValidationContext.Block = new Block();
+            this.ruleContext.ValidationContext.Block = this.network.CreateBlock();
             this.ruleContext.ValidationContext.Block.Header.Bits = new Target(0x1f111115);
             this.ruleContext.ValidationContext.Block.Header.BlockTime = new DateTimeOffset(new DateTime(2017, 1, 1, 0, 1, 1));
             this.ruleContext.ValidationContext.Block.Header.Version = 2;
@@ -317,7 +317,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
             this.ruleContext.ConsensusTipHeight = this.consensusRules.ConsensusParams.BuriedDeployments[BuriedDeployments.BIP65] - 2;
             this.ruleContext.Time = new DateTimeOffset(new DateTime(2017, 1, 1, 0, 1, 0));
             this.ruleContext.NextWorkRequired = new Target(0x1f111115);
-            this.ruleContext.ValidationContext.Block = new Block();
+            this.ruleContext.ValidationContext.Block = this.network.CreateBlock();
             this.ruleContext.ValidationContext.Block.Header.Bits = new Target(0x1f111115);
             this.ruleContext.ValidationContext.Block.Header.BlockTime = new DateTimeOffset(new DateTime(2017, 1, 1, 0, 1, 1));
             this.ruleContext.ValidationContext.Block.Header.Version = 3;
@@ -331,7 +331,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
             this.ruleContext.ConsensusTipHeight = this.consensusRules.ConsensusParams.BuriedDeployments[BuriedDeployments.BIP65] + 30;
             this.ruleContext.Time = new DateTimeOffset(new DateTime(2017, 1, 1, 0, 1, 0));
             this.ruleContext.NextWorkRequired = new Target(0x1f111115);
-            this.ruleContext.ValidationContext.Block = new Block();
+            this.ruleContext.ValidationContext.Block = this.network.CreateBlock();
             this.ruleContext.ValidationContext.Block.Header.Bits = new Target(0x1f111115);
             this.ruleContext.ValidationContext.Block.Header.BlockTime = new DateTimeOffset(new DateTime(2017, 1, 1, 0, 1, 1));
             this.ruleContext.ValidationContext.Block.Header.Version = 4;

--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/CommonRules/BlockHeaderRuleTest2.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/CommonRules/BlockHeaderRuleTest2.cs
@@ -20,8 +20,8 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
         [Fact]
         public async Task RunAsync_PrevHashBlockNotConsensusTip_ThrowsInvalidPrevTipConsensusErrorExceptionAsync()
         {
-            var block = new Block();
-            block.AddTransaction(new Transaction());
+            Block block = this.network.CreateBlock();
+            block.AddTransaction(this.network.CreateTransaction());
             block.UpdateMerkleRoot();
             block.Header.BlockTime = new DateTimeOffset(new DateTime(2017, 1, 1, 0, 0, 0, DateTimeKind.Utc).AddDays(5));
             block.Header.HashPrevBlock = this.concurrentChain.GetBlock(3).HashBlock; // invalid
@@ -29,7 +29,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
 
             this.ruleContext.ValidationContext.Block = block;
             this.ruleContext.ConsensusTip = this.concurrentChain.Tip;
-            
+
             ConsensusErrorException exception = await Assert.ThrowsAsync<ConsensusErrorException>(() => this.consensusRules.RegisterRule<BlockHeaderRule>().RunAsync(this.ruleContext));
 
             Assert.Equal(ConsensusErrors.InvalidPrevTip, exception.ConsensusError);
@@ -39,8 +39,8 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
         public async Task RunAsync_ValidBlock_CreatesChainedBlockInBlockValidationContextAsync()
         {
             ChainedHeader tip = this.concurrentChain.Tip;
-            var block = new Block();
-            block.AddTransaction(new Transaction());
+            Block block = this.network.CreateBlock();
+            block.AddTransaction(this.network.CreateTransaction());
             block.UpdateMerkleRoot();
             block.Header.BlockTime = new DateTimeOffset(new DateTime(2017, 1, 1, 0, 0, 0, DateTimeKind.Utc).AddDays(5));
             block.Header.HashPrevBlock = tip.HashBlock;
@@ -48,7 +48,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
 
             this.ruleContext.ValidationContext.Block = block;
             this.ruleContext.ConsensusTip = tip;
-            
+
             await this.consensusRules.RegisterRule<BlockHeaderRule>().RunAsync(this.ruleContext);
 
             ChainedHeader chainedHeader = this.ruleContext.ValidationContext.ChainedHeader;
@@ -65,8 +65,8 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
         public async Task RunAsync_ValidBlock_SetsBestBlockAsync()
         {
             ChainedHeader tip = this.concurrentChain.Tip;
-            var block = new Block();
-            block.AddTransaction(new Transaction());
+            Block block = this.network.CreateBlock();
+            block.AddTransaction(this.network.CreateTransaction());
             block.UpdateMerkleRoot();
             block.Header.BlockTime = new DateTimeOffset(new DateTime(2017, 1, 1, 0, 0, 0, DateTimeKind.Utc).AddDays(5));
             block.Header.HashPrevBlock = tip.HashBlock;
@@ -93,13 +93,13 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
             this.nodeDeployments = new NodeDeployments(this.network, this.concurrentChain);
             this.consensusRules = this.InitializeConsensusRules();
 
-            var block = new Block();
-            block.AddTransaction(new Transaction());
+            Block block = this.network.CreateBlock();
+            block.AddTransaction(this.network.CreateTransaction());
             block.UpdateMerkleRoot();
             block.Header.BlockTime = new DateTimeOffset(new DateTime(2017, 1, 1, 0, 0, 0, DateTimeKind.Utc).AddDays(5));
             block.Header.HashPrevBlock = this.concurrentChain.Tip.HashBlock;
             block.Header.Nonce = RandomUtils.GetUInt32();
-            
+
             this.ruleContext.ValidationContext.Block = block;
             this.ruleContext.ConsensusTip = this.concurrentChain.Tip;
 

--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/CommonRules/BlockSizeRuleTest.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/CommonRules/BlockSizeRuleTest.cs
@@ -31,7 +31,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
         [Fact]
         public async Task RunAsync_ZeroTransactions_ThrowsBadBlockLengthConsensusErrorExceptionAsync()
         {
-            this.ruleContext.ValidationContext.Block = new Block();
+            this.ruleContext.ValidationContext.Block = this.network.CreateBlock();
 
             ConsensusErrorException exception = await Assert.ThrowsAsync<ConsensusErrorException>(() => this.consensusRules.RegisterRule<BlockSizeRule>().RunAsync(this.ruleContext));
 
@@ -41,7 +41,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
         [Fact]
         public async Task RunAsync_TransactionCountAboveMaxBlockBaseSize_ThrowsBadBlockLengthConsensusErrorExceptionAsync()
         {
-            this.ruleContext.ValidationContext.Block = new Block();
+            this.ruleContext.ValidationContext.Block = this.network.CreateBlock();
 
             for (int i = 0; i < this.options.MaxBlockBaseSize + 1; i++)
             {
@@ -93,7 +93,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
         [Fact]
         public async Task TaskAsync_TransactionCountBelowLimit_DoesNotThrowExceptionAsync()
         {
-            this.ruleContext.ValidationContext.Block = new Block();
+            this.ruleContext.ValidationContext.Block = this.network.CreateBlock();
 
             for (int i = 0; i < 10; i++)
             {
@@ -123,7 +123,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
 
         private Block GenerateBlockWithWeight(int weight, TransactionOptions options)
         {
-            var block = new Block();
+            var block = this.network.CreateBlock();
             var transaction = new Transaction();
             transaction.Outputs.Add(new TxOut(new Money(10000000000), new Script()));
             block.Transactions.Add(transaction);

--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/CommonRules/CalculateStakeRuleTest.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/CommonRules/CalculateStakeRuleTest.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using NBitcoin;
 using Stratis.Bitcoin.Consensus;
 using Stratis.Bitcoin.Features.Consensus.Rules.CommonRules;
@@ -18,16 +17,13 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
         [Fact]
         public async Task RunAsync_ProofOfStakeBlock_SetsStake_SetsNextWorkRequiredAsync()
         {
+            Block block = this.network.CreateBlock();
+            Transaction transaction = this.network.CreateTransaction();
+            block.AddTransaction(transaction);
+            block.AddTransaction(CreateCoinStakeTransaction(this.network, new Key(), 6, this.concurrentChain.GetBlock(5).HashBlock));
             this.ruleContext.ValidationContext = new ValidationContext()
             {
-                Block = new Block()
-                {
-                    Transactions = new List<Transaction>()
-                        {
-                            new Transaction(),
-                            CreateCoinStakeTransaction(this.network, new Key(), 6, this.concurrentChain.GetBlock(5).HashBlock)
-                        }
-                },
+                Block = block,
                 ChainedHeader = this.concurrentChain.GetBlock(4)
             };
 
@@ -54,15 +50,13 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
         [Fact]
         public async Task RunAsync_ProofOfWorkBlock_DoNotCheckPow_SetsStake_SetsNextWorkRequiredAsync()
         {
+            Block block = this.network.CreateBlock();
+            Transaction transaction = this.network.CreateTransaction();
+            block.AddTransaction(transaction);
+
             this.ruleContext.ValidationContext = new ValidationContext()
             {
-                Block = new Block()
-                {
-                    Transactions = new List<Transaction>()
-                    {
-                        new Transaction()
-                    }
-                },
+                Block = block,
                 ChainedHeader = this.concurrentChain.GetBlock(4)
             };
             this.ruleContext.MinedBlock = true;
@@ -125,15 +119,13 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
         [Fact]
         public async Task RunAsync_ProofOfWorkBlock_CheckPow_InValidPow_ThrowsHighHashConsensusErrorExceptionAsync()
         {
+            Block block = this.network.CreateBlock();
+            Transaction transaction = this.network.CreateTransaction();
+            block.AddTransaction(transaction);
+
             this.ruleContext.ValidationContext = new ValidationContext()
             {
-                Block = new Block()
-                {
-                    Transactions = new List<Transaction>()
-                    {
-                        new Transaction()
-                    }
-                },
+                Block = block,
                 ChainedHeader = this.concurrentChain.GetBlock(4)
             };
             this.ruleContext.MinedBlock = false;
@@ -145,7 +137,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
 
         private static Transaction CreateCoinStakeTransaction(Network network, Key key, int height, uint256 prevout)
         {
-            var coinStake = new Transaction();
+            var coinStake = network.CreateTransaction();
             coinStake.Time = (uint)18276127;
             coinStake.AddInput(new TxIn(new OutPoint(prevout, 1)));
             coinStake.AddOutput(new TxOut(0, new Script()));

--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/CommonRules/CalculateWorkRuleTest.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/CommonRules/CalculateWorkRuleTest.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using NBitcoin;
 using Stratis.Bitcoin.Consensus;
 using Stratis.Bitcoin.Features.Consensus.Rules.CommonRules;
@@ -50,15 +49,10 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
         [Fact]
         public async Task RunAsync_ProofOfWorkBlock_CheckPow_InValidPow_ThrowsHighHashConsensusErrorExceptionAsync()
         {
+            Block block = this.network.CreateBlock();
             this.ruleContext.ValidationContext = new ValidationContext()
             {
-                Block = new Block()
-                {
-                    Transactions = new List<Transaction>()
-                        {
-                            new NBitcoin.Transaction()
-                        }
-                },
+                Block = block,
                 ChainedHeader = this.concurrentChain.GetBlock(4)
             };
             this.ruleContext.MinedBlock = false;

--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/CommonRules/CheckPosTransactionRuleTest.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/CommonRules/CheckPosTransactionRuleTest.cs
@@ -10,14 +10,10 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
 {
     public class CheckPosTransactionRuleTest : TestPosConsensusRulesUnitTestBase
     {
-        public CheckPosTransactionRuleTest()
-        {
-        }
-
         [Fact]
         public void CheckTransaction_TxOutsAreEmpty_TransactionIsCoinBase_DoesNotThrowException()
         {
-            var transaction = new Transaction();
+            var transaction = this.network.CreateTransaction();
             transaction.Inputs.Add(new TxIn()
             {
                 PrevOut = new OutPoint(),
@@ -34,7 +30,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
         [Fact]
         public void CheckTransaction_TxOutsAreEmpty_TransactionIsCoinStake_DoesNotThrowException()
         {
-            var transaction = new Transaction();
+            var transaction = this.network.CreateTransaction();
             transaction.Inputs.Add(new TxIn()
             {
                 PrevOut = new OutPoint(new uint256(15), 1),
@@ -52,7 +48,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
         [Fact]
         public void CheckTransaction_TxOutsAreNotEmptyDoesNotThrowException()
         {
-            var transaction = new Transaction();
+            var transaction = this.network.CreateTransaction();
             transaction.Inputs.Add(new TxIn()
             {
                 PrevOut = new OutPoint(new uint256(15), 1),
@@ -68,7 +64,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
         [Fact]
         public void CheckTransaction_TxOutsArePartiallyEmpty_TransactionNotCoinBaseOrCoinStake_ThrowsBadTransactionEmptyOutputConsensusErrorException()
         {
-            var transaction = new Transaction();
+            var transaction = this.network.CreateTransaction();
             transaction.Inputs.Add(new TxIn()
             {
                 PrevOut = new OutPoint(new uint256(15), 1),
@@ -88,7 +84,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
         [Fact]
         public async Task RunAsync_BlockPassesCheckTransaction_DoesNotThrowExceptionAsync()
         {
-            var transaction = new Transaction();
+            var transaction = this.network.CreateTransaction();
             transaction.Inputs.Add(new TxIn()
             {
                 PrevOut = new OutPoint(),
@@ -103,7 +99,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
             {
                 ValidationContext = new ValidationContext()
                 {
-                    Block = new Block()
+                    Block = this.network.CreateBlock()
                 }
             };
 
@@ -116,7 +112,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
         [Fact]
         public async Task RunAsync_BlockFailsCheckTransaction_ThrowsBadTransactionEmptyOutputConsensusErrorExceptionAsync()
         {
-            var validTransaction = new Transaction();
+            var validTransaction = this.network.CreateTransaction();
             validTransaction.Inputs.Add(new TxIn()
             {
                 PrevOut = new OutPoint(),
@@ -127,7 +123,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
             Assert.True(validTransaction.IsCoinBase);
             Assert.True(validTransaction.Outputs.All(t => t.IsEmpty));
 
-            var invalidTransaction = new Transaction();
+            var invalidTransaction = this.network.CreateTransaction();
             invalidTransaction.Inputs.Add(new TxIn()
             {
                 PrevOut = new OutPoint(new uint256(15), 1),
@@ -139,7 +135,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
             Assert.False(invalidTransaction.IsCoinBase);
             Assert.False(invalidTransaction.IsCoinStake);
 
-            this.ruleContext.ValidationContext.Block = new Block();
+            this.ruleContext.ValidationContext.Block = this.network.CreateBlock();
             this.ruleContext.ValidationContext.Block.Transactions.Add(validTransaction);
             this.ruleContext.ValidationContext.Block.Transactions.Add(invalidTransaction);
 

--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/CommonRules/CheckPowTransactionRuleTest.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/CommonRules/CheckPowTransactionRuleTest.cs
@@ -208,7 +208,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
             transaction.Outputs.Add(new TxOut(new Money(this.consensus.MaxMoney / 2), (IDestination)null));
             transaction.Outputs.Add(new TxOut(new Money(this.consensus.MaxMoney / 2), (IDestination)null));
 
-            this.ruleContext.ValidationContext.Block = new Block();
+            this.ruleContext.ValidationContext.Block = this.network.CreateBlock();
             this.ruleContext.Consensus = this.network.Consensus;
             this.ruleContext.ValidationContext.Block.Transactions.Add(transaction);
             this.ruleContext.ValidationContext.Block.Transactions.Add(transaction);
@@ -228,7 +228,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
 
             var invalidTransaction = new Transaction();
 
-            this.ruleContext.ValidationContext.Block = new Block();
+            this.ruleContext.ValidationContext.Block = this.network.CreateBlock();
             this.ruleContext.Consensus = this.network.Consensus;
             this.ruleContext.ValidationContext.Block.Transactions.Add(validTransaction);
             this.ruleContext.ValidationContext.Block.Transactions.Add(invalidTransaction);

--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/CommonRules/CheckSigOpsRuleTest.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/CommonRules/CheckSigOpsRuleTest.cs
@@ -13,7 +13,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
         public CheckSigOpsRuleTest()
         {
             this.options = this.network.Consensus.Option<PowConsensusOptions>();
-            this.ruleContext.ValidationContext.Block = new NBitcoin.Block();
+            this.ruleContext.ValidationContext.Block = this.network.CreateBlock();
             this.ruleContext.Consensus = this.network.Consensus;
         }
 

--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/CommonRules/CheckpointsRuleTest.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/CommonRules/CheckpointsRuleTest.cs
@@ -18,7 +18,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
         public async Task RunAsync_CheckpointViolation_ThrowsCheckpointValidationConsensusErrorsExceptionAsync()
         {
             this.ruleContext.ConsensusTipHeight = 1;
-            this.ruleContext.ValidationContext.Block = new Block();
+            this.ruleContext.ValidationContext.Block = this.network.CreateBlock();
 
             this.checkpoints.Setup(c => c.CheckHardened(2, this.ruleContext.ValidationContext.Block.GetHash()))
                 .Returns(false);
@@ -34,7 +34,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
             this.consensusSettings.UseCheckpoints = false;
 
             this.ruleContext.ConsensusTipHeight = 1;
-            this.ruleContext.ValidationContext.Block = new Block();
+            this.ruleContext.ValidationContext.Block = this.network.CreateBlock();
             this.checkpoints.Setup(c => c.CheckHardened(2, this.ruleContext.ValidationContext.Block.GetHash()))
                 .Returns(true);
 
@@ -48,7 +48,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
 
             this.ruleContext.SkipValidation = false;
             this.ruleContext.ConsensusTipHeight = 1;
-            this.ruleContext.ValidationContext.Block = new Block();
+            this.ruleContext.ValidationContext.Block = this.network.CreateBlock();
             this.ruleContext.ValidationContext.ChainedHeader = this.concurrentChain.GetBlock(5);
 
             this.checkpoints.Setup(c => c.CheckHardened(2, this.ruleContext.ValidationContext.Block.GetHash()))
@@ -68,7 +68,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
 
             this.ruleContext.SkipValidation = false;
             this.ruleContext.ConsensusTipHeight = 1;
-            this.ruleContext.ValidationContext.Block = new Block();
+            this.ruleContext.ValidationContext.Block = this.network.CreateBlock();
             this.ruleContext.ValidationContext.ChainedHeader = this.concurrentChain.GetBlock(5);
 
             this.checkpoints.Setup(c => c.CheckHardened(2, this.ruleContext.ValidationContext.Block.GetHash()))
@@ -88,7 +88,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
 
             this.ruleContext.SkipValidation = false;
             this.ruleContext.ConsensusTipHeight = 1;
-            this.ruleContext.ValidationContext.Block = new Block();
+            this.ruleContext.ValidationContext.Block = this.network.CreateBlock();
             this.ruleContext.ValidationContext.ChainedHeader = this.concurrentChain.GetBlock(5);
 
             this.checkpoints.Setup(c => c.CheckHardened(2, this.ruleContext.ValidationContext.Block.GetHash()))

--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/CommonRules/CoinbaseHeightRuleTest.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/CommonRules/CoinbaseHeightRuleTest.cs
@@ -15,7 +15,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
         [Fact]
         public async Task RunAsync_BestBlockAvailable_BadCoinBaseHeight_ThrowsBadCoinbaseHeightConsensusErrorExceptionAsync()
         {
-            this.ruleContext.ValidationContext.Block = new Block();
+            this.ruleContext.ValidationContext.Block = this.network.CreateBlock();
             this.ruleContext.ConsensusTipHeight = 3;
 
             var transaction = new Transaction();
@@ -30,7 +30,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
         [Fact]
         public async Task RunAsync_BestBlockUnAvailable_BadCoinBaseHeight_ThrowsBadCoinbaseHeightConsensusErrorExceptionAsync()
         {
-            this.ruleContext.ValidationContext.Block = new Block();
+            this.ruleContext.ValidationContext.Block = this.network.CreateBlock();
 
             var transaction = new Transaction();
             transaction.Inputs.Add(new TxIn(new Script(Op.GetPushOp(3))));
@@ -44,14 +44,14 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
         [Fact]
         public async Task RunAsync_CorrectCoinBaseHeight_DoesNotThrowExceptionAsync()
         {
-            this.ruleContext.ValidationContext.Block = new Block();
+            this.ruleContext.ValidationContext.Block = this.network.CreateBlock();
             this.ruleContext.ConsensusTipHeight = 3;
 
             var transaction = new Transaction();
             transaction.Inputs.Add(new TxIn(new Script(Op.GetPushOp(4))));
             this.ruleContext.ValidationContext.Block.Transactions.Add(transaction);
 
-            await this.consensusRules.RegisterRule<CoinbaseHeightRule>().RunAsync(this.ruleContext);            
+            await this.consensusRules.RegisterRule<CoinbaseHeightRule>().RunAsync(this.ruleContext);
         }
     }
 }

--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/CommonRules/EnsureCoinbaseRuleTest.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/CommonRules/EnsureCoinbaseRuleTest.cs
@@ -8,14 +8,10 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
 {
     public class EnsureCoinbaseRuleTest : TestConsensusRulesUnitTestBase
     {
-        public EnsureCoinbaseRuleTest()
-        {
-        }
-
         [Fact]
         public async Task RunAsync_BlockWithoutTransactions_ThrowsBadCoinbaseMissingConsensusErrorExceptionAsync()
         {
-            this.ruleContext.ValidationContext.Block = new Block();
+            this.ruleContext.ValidationContext.Block = this.network.CreateBlock();
 
             ConsensusErrorException exception = await Assert.ThrowsAsync<ConsensusErrorException>(() => this.consensusRules.RegisterRule<EnsureCoinbaseRule>().RunAsync(this.ruleContext));
 
@@ -25,9 +21,9 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
         [Fact]
         public async Task RunAsync_FirstTransactionIsNotCoinbase_ThrowsBadCoinbaseMissingConsensusErrorExceptionAsync()
         {
-            this.ruleContext.ValidationContext.Block = new Block();
+            this.ruleContext.ValidationContext.Block = this.network.CreateBlock();
 
-            var transaction = new Transaction();
+            var transaction = this.network.CreateTransaction();
             Assert.False(transaction.IsCoinBase);
             this.ruleContext.ValidationContext.Block.Transactions.Add(transaction);
 
@@ -39,9 +35,9 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
         [Fact]
         public async Task RunAsync_MultipleCoinsBaseTransactions_ThrowsBadMultipleCoinbaseConsensusErrorExceptionAsync()
         {
-            this.ruleContext.ValidationContext.Block = new Block();
+            this.ruleContext.ValidationContext.Block = this.network.CreateBlock();
 
-            var transaction = new Transaction();
+            var transaction = this.network.CreateTransaction();
             transaction.Inputs.Add(new TxIn(new OutPoint(), new Script()));
             transaction.Outputs.Add(new TxOut(new Money(3), (IDestination)null));
 
@@ -57,9 +53,9 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
         [Fact]
         public async Task RunAsync_SingleCoinBaseTransaction_DoesNotThrowExceptionAsync()
         {
-            this.ruleContext.ValidationContext.Block = new Block();
+            this.ruleContext.ValidationContext.Block = this.network.CreateBlock();
 
-            var transaction = new Transaction();
+            var transaction = this.network.CreateTransaction();
             transaction.Inputs.Add(new TxIn(new OutPoint(), new Script()));
             transaction.Outputs.Add(new TxOut(new Money(3), (IDestination)null));
 
@@ -67,7 +63,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
             this.ruleContext.ValidationContext.Block.Transactions.Add(transaction);
             this.ruleContext.ValidationContext.Block.Transactions.Add(new Transaction());
 
-            await this.consensusRules.RegisterRule<EnsureCoinbaseRule>().RunAsync(ruleContext);
+            await this.consensusRules.RegisterRule<EnsureCoinbaseRule>().RunAsync(this.ruleContext);
         }
     }
 }

--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/CommonRules/PosCoinstakeRuleTest.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/CommonRules/PosCoinstakeRuleTest.cs
@@ -10,7 +10,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
     {
         public PosCoinstakeRuleTest()
         {
-            this.ruleContext.ValidationContext.Block = new Block();
+            this.ruleContext.ValidationContext.Block = this.network.CreateBlock();
         }
 
         [Fact]
@@ -18,7 +18,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
         {
             this.ruleContext.ValidationContext.Block.Transactions.Add(new Transaction());
 
-            var transaction = new Transaction();
+            var transaction = this.network.CreateTransaction();
             transaction.Inputs.Add(new TxIn()
             {
                 PrevOut = new OutPoint(new uint256(15), 1),
@@ -38,11 +38,11 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
         [Fact]
         public async Task RunAsync_ProofOfStakeBlock_CoinBaseNotEmpty_TransactionNotEmpty_ThrowsBadStakeBlockConsensusErrorExceptionAsync()
         {
-            var transaction = new Transaction();
+            var transaction = this.network.CreateTransaction();
             transaction.Outputs.Add(new TxOut(new Money(1), (IDestination)null));
             this.ruleContext.ValidationContext.Block.Transactions.Add(transaction);
 
-            transaction = new Transaction();
+            transaction = this.network.CreateTransaction();
             transaction.Inputs.Add(new TxIn()
             {
                 PrevOut = new OutPoint(new uint256(15), 1),
@@ -62,11 +62,11 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
         [Fact]
         public async Task RunAsync_ProofOfStakeBlock_MultipleCoinStakeAfterSecondTransaction_ThrowsBadMultipleCoinstakeConsensusErrorExceptionAsync()
         {
-            var transaction = new Transaction();
+            var transaction = this.network.CreateTransaction();
             transaction.Outputs.Add(new TxOut(Money.Zero, (IDestination)null));
             this.ruleContext.ValidationContext.Block.Transactions.Add(transaction);
 
-            transaction = new Transaction();
+            transaction = this.network.CreateTransaction();
             transaction.Inputs.Add(new TxIn()
             {
                 PrevOut = new OutPoint(new uint256(15), 1),
@@ -87,11 +87,11 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
         [Fact]
         public async Task RunAsync_ProofOfStakeBlock_TransactionTimestampAfterBlockTimeStamp_ThrowsBlockTimeBeforeTrxConsensusErrorExceptionAsync()
         {
-            var transaction = new Transaction();
+            var transaction = this.network.CreateTransaction();
             transaction.Outputs.Add(new TxOut(Money.Zero, (IDestination)null));
             this.ruleContext.ValidationContext.Block.Transactions.Add(transaction);
 
-            transaction = new Transaction();
+            transaction = this.network.CreateTransaction();
             transaction.Inputs.Add(new TxIn()
             {
                 PrevOut = new OutPoint(new uint256(15), 1),
@@ -114,7 +114,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
         [Fact]
         public async Task RunAsync_ProofOfWorkBlock_TransactionTimestampAfterBlockTimeStamp_ThrowsBlockTimeBeforeTrxConsensusErrorExceptionAsync()
         {
-            var transaction = new Transaction();
+            var transaction = this.network.CreateTransaction();
             transaction.Outputs.Add(new TxOut(Money.Zero, (IDestination)null));
             this.ruleContext.ValidationContext.Block.Transactions.Add(transaction);
 
@@ -131,11 +131,11 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
         [Fact]
         public async Task RunAsync_ProofOfStakeBlock_ValidBlock_DoesNotThrowExceptionAsync()
         {
-            var transaction = new Transaction();
+            var transaction = this.network.CreateTransaction();
             transaction.Outputs.Add(new TxOut(Money.Zero, (IDestination)null));
             this.ruleContext.ValidationContext.Block.Transactions.Add(transaction);
 
-            transaction = new Transaction();
+            transaction = this.network.CreateTransaction();
             transaction.Inputs.Add(new TxIn()
             {
                 PrevOut = new OutPoint(new uint256(15), 1),
@@ -157,7 +157,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
         [Fact]
         public async Task RunAsync_ProofOfWorkBlock_ValidBlock_DoesNotThrowExceptionAsync()
         {
-            var transaction = new Transaction();
+            var transaction = this.network.CreateTransaction();
             transaction.Outputs.Add(new TxOut(Money.Zero, (IDestination)null));
             this.ruleContext.ValidationContext.Block.Transactions.Add(transaction);
             this.ruleContext.ValidationContext.Block.Header.Time = (uint)1483747200;

--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/CommonRules/PosFutureDriftRuleTest.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/CommonRules/PosFutureDriftRuleTest.cs
@@ -13,7 +13,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
 
         public PosFutureDriftRuleTest()
         {
-            this.ruleContext.ValidationContext.Block = new Block();
+            this.ruleContext.ValidationContext.Block = this.network.CreateBlock();
         }
 
         [Fact]

--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/CommonRules/PowCoinViewRuleTests.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/CommonRules/PowCoinViewRuleTests.cs
@@ -73,7 +73,10 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
             this.ruleContext.ValidationContext = new ValidationContext();
             BlockHeader blockHeader = this.network.Consensus.ConsensusFactory.CreateBlockHeader();
             this.ruleContext.ValidationContext.ChainedHeader = new ChainedHeader(blockHeader, new uint256("bcd7d5de8d3bcc7b15e7c8e5fe77c0227cdfa6c682ca13dcf4910616f10fdd06"), HeightOfBlockchain);
-            this.ruleContext.ValidationContext.Block = new Block() { Transactions = new List<Transaction>() };
+
+            Block block = this.network.CreateBlock();
+            block.Transactions = new List<Transaction>();
+            this.ruleContext.ValidationContext.Block = block;
         }
 
         protected void WhenExecutingTheRule(ConsensusRule rule, RuleContext ruleContext)

--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/CommonRules/TransactionLocktimeActivationRuleTest.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/CommonRules/TransactionLocktimeActivationRuleTest.cs
@@ -11,7 +11,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
     {
         public TransactionLocktimeActivationRuleTest()
         {
-            this.ruleContext.ValidationContext.Block = new Block();
+            this.ruleContext.ValidationContext.Block = this.network.CreateBlock();
         }
 
         [Fact]

--- a/src/Stratis.Bitcoin.Features.Miner.Tests/PowMiningTest.cs
+++ b/src/Stratis.Bitcoin.Features.Miner.Tests/PowMiningTest.cs
@@ -20,16 +20,16 @@ namespace Stratis.Bitcoin.Features.Miner.Tests
 {
     public class PowMiningTest : LogsTestBase, IClassFixture<PowMiningTestFixture>
     {
-        private Mock<IAsyncLoopFactory> asyncLoopFactory;
+        private readonly Mock<IAsyncLoopFactory> asyncLoopFactory;
         private ConcurrentChain chain;
-        private Mock<IConsensusLoop> consensusLoop;
-        private Mock<IConsensusRules> consensusRules;
-        private NBitcoin.Consensus.ConsensusOptions initialNetworkOptions;
-        private PowMiningTestFixture fixture;
-        private Mock<ITxMempool> mempool;
-        private MempoolSchedulerLock mempoolLock;
-        private Network network;
-        private Mock<INodeLifetime> nodeLifetime;
+        private readonly Mock<IConsensusLoop> consensusLoop;
+        private readonly Mock<IConsensusRules> consensusRules;
+        private readonly NBitcoin.Consensus.ConsensusOptions initialNetworkOptions;
+        private readonly PowMiningTestFixture fixture;
+        private readonly Mock<ITxMempool> mempool;
+        private readonly MempoolSchedulerLock mempoolLock;
+        private readonly Network network;
+        private readonly Mock<INodeLifetime> nodeLifetime;
 
         public PowMiningTest(PowMiningTestFixture fixture)
         {
@@ -44,6 +44,7 @@ namespace Stratis.Bitcoin.Features.Miner.Tests
 
             this.consensusLoop = new Mock<IConsensusLoop>();
             this.consensusLoop.SetupGet(c => c.Tip).Returns(() => this.chain.Tip);
+            this.consensusRules = new Mock<IConsensusRules>();
 
             this.mempool = new Mock<ITxMempool>();
             this.mempool.SetupGet(mp => mp.MapTx).Returns(new TxMempool.IndexedTransactionSet());

--- a/src/Stratis.Bitcoin.Features.Miner.Tests/PowMiningTest.cs
+++ b/src/Stratis.Bitcoin.Features.Miner.Tests/PowMiningTest.cs
@@ -513,7 +513,7 @@ namespace Stratis.Bitcoin.Features.Miner.Tests
                     this.mempool.Object,
                     this.mempoolLock,
                     this.network,
-                    this.consensusRules,
+                    this.consensusRules.Object,
                     null);
         }
 

--- a/src/Stratis.Bitcoin.Features.RPC.Tests/Controller/FullNodeControllerTest.cs
+++ b/src/Stratis.Bitcoin.Features.RPC.Tests/Controller/FullNodeControllerTest.cs
@@ -36,7 +36,6 @@ namespace Stratis.Bitcoin.Features.RPC.Tests.Controller
         private readonly Mock<IConsensusLoop> consensusLoop;
         private readonly Mock<INetworkDifficulty> networkDifficulty;
         private FullNodeController controller;
-        private readonly bool initialBlockSignature;
 
         public FullNodeControllerTest()
         {

--- a/src/Stratis.Bitcoin.Features.Wallet.Tests/Notifications/BlockObserverTest.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet.Tests/Notifications/BlockObserverTest.cs
@@ -13,7 +13,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests.Notifications
         {
             var walletSyncManager = new Mock<IWalletSyncManager>();
             var observer = new BlockObserver(walletSyncManager.Object);
-            var block = new Block();
+            var block = Network.StratisMain.CreateBlock();
 
             observer.OnNext(block);
 

--- a/src/Stratis.Bitcoin.Features.Wallet.Tests/WalletControllerTest.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet.Tests/WalletControllerTest.cs
@@ -606,7 +606,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
             };
 
             var concurrentChain = new ConcurrentChain(this.network);
-            ChainedHeader tip = WalletTestsHelpers.AppendBlock(null, new[] { concurrentChain });
+            ChainedHeader tip = WalletTestsHelpers.AppendBlock(this.network, null, new[] { concurrentChain });
 
             var connectionManagerMock = new Mock<IConnectionManager>();
             connectionManagerMock.Setup(c => c.ConnectedPeers)

--- a/src/Stratis.Bitcoin.Features.Wallet.Tests/WalletManagerTest.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet.Tests/WalletManagerTest.cs
@@ -306,8 +306,8 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
             var walletManager = new WalletManager(loggerFactory.Object, this.network, this.chain, NodeSettings.Default(), new Mock<WalletSettings>().Object,
                                                   dataFolder, new Mock<IWalletFeePolicy>().Object, new Mock<IAsyncLoopFactory>().Object, new NodeLifetime(), DateTimeProvider.Default);
 
-            var concurrentChain = new ConcurrentChain(Network.Main);
-            ChainedHeader tip = WalletTestsHelpers.AppendBlock(null, concurrentChain).ChainedHeader;
+            var concurrentChain = new ConcurrentChain(this.network);
+            ChainedHeader tip = WalletTestsHelpers.AppendBlock(this.network, null, concurrentChain).ChainedHeader;
 
             walletManager.Wallets.Add(WalletTestsHelpers.CreateWallet("wallet1"));
             walletManager.Wallets.Add(WalletTestsHelpers.CreateWallet("wallet2"));
@@ -657,7 +657,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
             Wallet wallet = this.walletFixture.GenerateBlankWallet("testWallet", "password");
             wallet.AccountsRoot.ElementAt(0).Accounts.Clear();
 
-            HdAccount result = wallet.AddNewAccount("password", (CoinType)network.Consensus.CoinType, DateTimeOffset.UtcNow);
+            HdAccount result = wallet.AddNewAccount("password", (CoinType)this.network.Consensus.CoinType, DateTimeOffset.UtcNow);
 
             Assert.Equal(1, wallet.AccountsRoot.ElementAt(0).Accounts.Count);
             var extKey = new ExtKey(Key.Parse(wallet.EncryptedSeed, "password", wallet.Network), wallet.ChainCode);
@@ -680,7 +680,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
             Wallet wallet = this.walletFixture.GenerateBlankWallet("testWallet", "password");
             wallet.AccountsRoot.ElementAt(0).Accounts.Add(new HdAccount { Name = "unused" });
 
-            HdAccount result = wallet.AddNewAccount("password", (CoinType)network.Consensus.CoinType, DateTimeOffset.UtcNow);
+            HdAccount result = wallet.AddNewAccount("password", (CoinType)this.network.Consensus.CoinType, DateTimeOffset.UtcNow);
 
             Assert.Equal(2, wallet.AccountsRoot.ElementAt(0).Accounts.Count);
             var extKey = new ExtKey(Key.Parse(wallet.EncryptedSeed, "password", wallet.Network), wallet.ChainCode);
@@ -1073,8 +1073,8 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
         {
             var chain = new ConcurrentChain(Network.StratisMain);
             uint nonce = RandomUtils.GetUInt32();
-            var block = new Block();
-            block.AddTransaction(new Transaction());
+            var block = this.network.CreateBlock();
+            block.AddTransaction(this.network.CreateTransaction());
             block.UpdateMerkleRoot();
             block.Header.HashPrevBlock = chain.Genesis.HashBlock;
             block.Header.Nonce = nonce;
@@ -1159,8 +1159,8 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
         {
             var chain = new ConcurrentChain(Network.StratisMain);
             uint nonce = RandomUtils.GetUInt32();
-            var block = new Block();
-            block.AddTransaction(new Transaction());
+            var block = this.network.CreateBlock();
+            block.AddTransaction(this.network.CreateTransaction());
             block.UpdateMerkleRoot();
             block.Header.HashPrevBlock = chain.Genesis.HashBlock;
             block.Header.Nonce = nonce;
@@ -2299,10 +2299,10 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
         {
             uint256 trxId = uint256.Parse("21e74d1daed6dec93d58396a3406803c5fc8d220b59f4b4dd185cab5f7a9a22e");
             int trxCount = 0;
-            var concurrentchain = new ConcurrentChain(Network.Main);
-            ChainedHeader chainedHeader = WalletTestsHelpers.AppendBlock(null, concurrentchain).ChainedHeader;
-            chainedHeader = WalletTestsHelpers.AppendBlock(chainedHeader, concurrentchain).ChainedHeader;
-            chainedHeader = WalletTestsHelpers.AppendBlock(chainedHeader, concurrentchain).ChainedHeader;
+            var concurrentchain = new ConcurrentChain(this.network);
+            ChainedHeader chainedHeader = WalletTestsHelpers.AppendBlock(this.network, null, concurrentchain).ChainedHeader;
+            chainedHeader = WalletTestsHelpers.AppendBlock(this.network, chainedHeader, concurrentchain).ChainedHeader;
+            chainedHeader = WalletTestsHelpers.AppendBlock(this.network, chainedHeader, concurrentchain).ChainedHeader;
 
             Wallet wallet = this.walletFixture.GenerateBlankWallet("myWallet1", "password");
             wallet.AccountsRoot.ElementAt(0).Accounts.Add(new HdAccount
@@ -2355,7 +2355,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
         public void ProcessBlockWithoutWalletsSetsWalletTipToBlockHash()
         {
             var concurrentchain = new ConcurrentChain(this.network);
-            (ChainedHeader ChainedHeader, Block Block) blockResult = WalletTestsHelpers.AppendBlock(null, concurrentchain);
+            (ChainedHeader ChainedHeader, Block Block) blockResult = WalletTestsHelpers.AppendBlock(this.network, null, concurrentchain);
 
             var walletManager = new WalletManager(this.LoggerFactory.Object, this.network, this.chain, NodeSettings.Default(), new Mock<WalletSettings>().Object,
                 CreateDataFolder(this), new Mock<IWalletFeePolicy>().Object, new Mock<IAsyncLoopFactory>().Object, new NodeLifetime(), DateTimeProvider.Default);
@@ -2475,7 +2475,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
                 Wallet wallet = this.walletFixture.GenerateBlankWallet("myWallet1", "password");
 
                 var chain = new ConcurrentChain(wallet.Network);
-                (ChainedHeader ChainedHeader, Block Block) chainResult = WalletTestsHelpers.AppendBlock(chain.Genesis, chain);
+                (ChainedHeader ChainedHeader, Block Block) chainResult = WalletTestsHelpers.AppendBlock(this.network, chain.Genesis, chain);
 
                 var walletManager = new WalletManager(this.LoggerFactory.Object, this.network, chain, NodeSettings.Default(), new Mock<WalletSettings>().Object,
                     dataFolder, new Mock<IWalletFeePolicy>().Object, new Mock<IAsyncLoopFactory>().Object, new NodeLifetime(), DateTimeProvider.Default);
@@ -2498,8 +2498,8 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
                 Wallet wallet = this.walletFixture.GenerateBlankWallet("myWallet1", "password");
 
                 var chain = new ConcurrentChain(wallet.Network);
-                (ChainedHeader ChainedHeader, Block Block) chainResult = WalletTestsHelpers.AppendBlock(chain.Genesis, chain);
-                (ChainedHeader ChainedHeader, Block Block) chainResult2 = WalletTestsHelpers.AppendBlock(chainResult.ChainedHeader, chain);
+                (ChainedHeader ChainedHeader, Block Block) chainResult = WalletTestsHelpers.AppendBlock(this.network, chain.Genesis, chain);
+                (ChainedHeader ChainedHeader, Block Block) chainResult2 = WalletTestsHelpers.AppendBlock(this.network, chainResult.ChainedHeader, chain);
 
                 var walletManager = new WalletManager(this.LoggerFactory.Object, this.network, chain, NodeSettings.Default(), new Mock<WalletSettings>().Object,
                     dataFolder, new Mock<IWalletFeePolicy>().Object, new Mock<IAsyncLoopFactory>().Object, new NodeLifetime(), DateTimeProvider.Default);
@@ -2913,7 +2913,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
             Wallet wallet2 = this.walletFixture.GenerateBlankWallet("myWallet2", "password");
 
             var chain = new ConcurrentChain(wallet.Network);
-            ChainedHeader chainedBlock = WalletTestsHelpers.AppendBlock(chain.Genesis, chain).ChainedHeader;
+            ChainedHeader chainedBlock = WalletTestsHelpers.AppendBlock(this.network, chain.Genesis, chain).ChainedHeader;
 
             var walletManager = new WalletManager(this.LoggerFactory.Object, this.network, chain, NodeSettings.Default(), new Mock<WalletSettings>().Object,
                 CreateDataFolder(this), new Mock<IWalletFeePolicy>().Object, new Mock<IAsyncLoopFactory>().Object, new NodeLifetime(), DateTimeProvider.Default);
@@ -2939,7 +2939,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
             Wallet wallet2 = this.walletFixture.GenerateBlankWallet("myWallet2", "password");
 
             var chain = new ConcurrentChain(wallet.Network);
-            ChainedHeader chainedBlock = WalletTestsHelpers.AppendBlock(chain.Genesis, chain).ChainedHeader;
+            ChainedHeader chainedBlock = WalletTestsHelpers.AppendBlock(this.network, chain.Genesis, chain).ChainedHeader;
 
             var walletManager = new WalletManager(this.LoggerFactory.Object, this.network, chain, NodeSettings.Default(), new Mock<WalletSettings>().Object,
                 CreateDataFolder(this), new Mock<IWalletFeePolicy>().Object, new Mock<IAsyncLoopFactory>().Object, new NodeLifetime(), DateTimeProvider.Default);
@@ -2966,7 +2966,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
             wallet.AccountsRoot.ElementAt(0).CoinType = CoinType.Stratis;
 
             var chain = new ConcurrentChain(wallet.Network);
-            ChainedHeader chainedBlock = WalletTestsHelpers.AppendBlock(chain.Genesis, chain).ChainedHeader;
+            ChainedHeader chainedBlock = WalletTestsHelpers.AppendBlock(this.network, chain.Genesis, chain).ChainedHeader;
 
             var walletManager = new WalletManager(this.LoggerFactory.Object, this.network, chain, NodeSettings.Default(), new Mock<WalletSettings>().Object,
                 CreateDataFolder(this), new Mock<IWalletFeePolicy>().Object, new Mock<IAsyncLoopFactory>().Object, new NodeLifetime(), DateTimeProvider.Default);

--- a/src/Stratis.Bitcoin.IntegrationTests.Common/Runners/CustomRunner.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests.Common/Runners/CustomRunner.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using NBitcoin;
 using NBitcoin.Protocol;
 using Stratis.Bitcoin.Builder;
@@ -12,10 +11,9 @@ namespace Stratis.Bitcoin.IntegrationTests.Common.Runners
     {
         private readonly string agent;
         private readonly Action<IFullNodeBuilder> callback;
-        private readonly string configFileName;
         private readonly Network network;
         private readonly ProtocolVersion protocolVersion;
-        private List<string> args;
+        private readonly List<string> args;
 
         public CustomNodeRunner(string dataDir, Action<IFullNodeBuilder> callback, Network network, ProtocolVersion protocolVersion = ProtocolVersion.PROTOCOL_VERSION, List<string> args = null, string agent = "Custom")
             : base(dataDir)

--- a/src/Stratis.Bitcoin.IntegrationTests/BlockStore/BlockStoreTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/BlockStore/BlockStoreTests.cs
@@ -13,38 +13,36 @@ namespace Stratis.Bitcoin.IntegrationTests.BlockStore
 {
     public class BlockStoreTests
     {
-        /// <summary>Factory for creating loggers.</summary>
         protected readonly ILoggerFactory loggerFactory;
+        private readonly Network network;
 
-        /// <summary>
-        /// Initializes logger factory for tests in this class.
-        /// </summary>
         public BlockStoreTests()
         {
             this.loggerFactory = new LoggerFactory();
+            this.network = Network.Main;
             var serializer = new DBreezeSerializer();
-            serializer.Initialize(Network.Main);
+            serializer.Initialize(this.network);
         }
 
         [Fact]
         public void BlockRepositoryPutBatch()
         {
-            using (var blockRepository = new BlockRepository(Network.Main, TestBase.CreateDataFolder(this), DateTimeProvider.Default, this.loggerFactory))
+            using (var blockRepository = new BlockRepository(this.network, TestBase.CreateDataFolder(this), DateTimeProvider.Default, this.loggerFactory))
             {
                 blockRepository.SetTxIndexAsync(true).Wait();
 
                 var blocks = new List<Block>();
                 for (int i = 0; i < 5; i++)
                 {
-                    var block = new Block();
-                    block.AddTransaction(new Transaction());
-                    block.AddTransaction(new Transaction());
+                    Block block = this.network.CreateBlock();
+                    block.AddTransaction(this.network.CreateTransaction());
+                    block.AddTransaction(this.network.CreateTransaction());
                     block.Transactions[0].AddInput(new TxIn(Script.Empty));
                     block.Transactions[0].AddOutput(Money.COIN + i * 2, Script.Empty);
                     block.Transactions[1].AddInput(new TxIn(Script.Empty));
                     block.Transactions[1].AddOutput(Money.COIN + i * 2 + 1, Script.Empty);
                     block.UpdateMerkleRoot();
-                    block.Header.HashPrevBlock = blocks.Any() ? blocks.Last().GetHash() : Network.Main.GenesisHash;
+                    block.Header.HashPrevBlock = blocks.Any() ? blocks.Last().GetHash() : this.network.GenesisHash;
                     blocks.Add(block);
                 }
 
@@ -74,12 +72,12 @@ namespace Stratis.Bitcoin.IntegrationTests.BlockStore
         [Fact]
         public void BlockRepositoryBlockHash()
         {
-            using (var blockRepo = new BlockRepository(Network.Main, TestBase.CreateDataFolder(this), DateTimeProvider.Default, this.loggerFactory))
+            using (var blockRepo = new BlockRepository(this.network, TestBase.CreateDataFolder(this), DateTimeProvider.Default, this.loggerFactory))
             {
                 blockRepo.InitializeAsync().GetAwaiter().GetResult();
 
-                Assert.Equal(Network.Main.GenesisHash, blockRepo.BlockHash);
-                uint256 hash = new Block().GetHash();
+                Assert.Equal(this.network.GenesisHash, blockRepo.BlockHash);
+                uint256 hash = this.network.CreateBlock().GetHash();
                 blockRepo.SetBlockHashAsync(hash).GetAwaiter().GetResult();
                 Assert.Equal(hash, blockRepo.BlockHash);
             }

--- a/src/Stratis.Bitcoin.IntegrationTests/BlockStore/RetrieveFromBlockStoreSteps.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/BlockStore/RetrieveFromBlockStoreSteps.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Threading.Tasks;
 using FluentAssertions;
 using NBitcoin;
 using Stratis.Bitcoin.Features.Wallet;
@@ -122,7 +121,7 @@ namespace Stratis.Bitcoin.IntegrationTests.BlockStore
         }
 
         private void a_real_transaction()
-        {           
+        {
             var transactionBuildContext = new TransactionBuildContext(
                     this.miningWalletAccountReference,
                     new List<Recipient>() { new Recipient() { Amount = this.transferAmount, ScriptPubKey = this.receiverAddress.ScriptPubKey } },
@@ -153,20 +152,18 @@ namespace Stratis.Bitcoin.IntegrationTests.BlockStore
             this.retrievedBlockHashes.Should().OnlyHaveUniqueItems();
         }
 
-        private async Task trying_to_retrieve_the_transactions_by_Id_from_the_blockstore()
+        private void trying_to_retrieve_the_transactions_by_Id_from_the_blockstore()
         {
-            this.retrievedTransaction = await this.node.FullNode.BlockStoreManager().BlockRepository
-                .GetTrxAsync(this.transaction.GetHash());
-            this.wontRetrieveTransaction = await this.node.FullNode.BlockStoreManager().BlockRepository
-                .GetTrxAsync(this.wrongTransactionId);
+            this.retrievedTransaction = this.node.FullNode.BlockStoreManager().BlockRepository.GetTrxAsync(this.transaction.GetHash()).GetAwaiter().GetResult();
+            this.wontRetrieveTransaction = this.node.FullNode.BlockStoreManager().BlockRepository.GetTrxAsync(this.wrongTransactionId).GetAwaiter().GetResult();
         }
 
-        private async Task trying_to_retrieve_the_block_containing_the_transactions_from_the_blockstore()
+        private void trying_to_retrieve_the_block_containing_the_transactions_from_the_blockstore()
         {
-            this.retrievedBlockId = await this.node.FullNode.BlockStoreManager().BlockRepository
-                .GetTrxBlockIdAsync(this.transaction.GetHash());
-            this.wontRetrieveBlockId = await this.node.FullNode.BlockStoreManager().BlockRepository
-                .GetTrxAsync(this.wrongTransactionId);
+            this.retrievedBlockId = this.node.FullNode.BlockStoreManager().BlockRepository
+                .GetTrxBlockIdAsync(this.transaction.GetHash()).GetAwaiter().GetResult();
+            this.wontRetrieveBlockId = this.node.FullNode.BlockStoreManager().BlockRepository
+                .GetTrxAsync(this.wrongTransactionId).GetAwaiter().GetResult();
         }
 
         private void real_blocks_should_be_retrieved()

--- a/src/Stratis.Bitcoin.IntegrationTests/BlockStore/RetrieveFromBlockStoreSteps.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/BlockStore/RetrieveFromBlockStoreSteps.cs
@@ -41,7 +41,6 @@ namespace Stratis.Bitcoin.IntegrationTests.BlockStore
         private uint256 retrievedBlockId;
         private Transaction wontRetrieveBlockId;
 
-
         public RetrieveFromBlockStoreSpecification(ITestOutputHelper output) : base(output)
         {
             this.sharedSteps = new SharedSteps();
@@ -57,7 +56,7 @@ namespace Stratis.Bitcoin.IntegrationTests.BlockStore
             this.builder?.Dispose();
         }
 
-        public void a_pow_node_running()
+        private void a_pow_node_running()
         {
             this.node = this.builder.CreateStratisPowNode();
             this.node.Start();
@@ -89,13 +88,13 @@ namespace Stratis.Bitcoin.IntegrationTests.BlockStore
             this.node.SetDummyMinerSecret(new BitcoinSecret(this.key, this.node.FullNode.Network));
         }
 
-        public void some_real_blocks_with_a_uint256_identifier()
+        private void some_real_blocks_with_a_uint256_identifier()
         {
             this.maturity = (int)this.node.FullNode.Network.Consensus.CoinbaseMaturity;
             this.blockIds = this.node.GenerateStratisWithMiner(this.maturity + 1);
         }
 
-        public void some_blocks_creating_reward()
+        private void some_blocks_creating_reward()
         {
             this.some_real_blocks_with_a_uint256_identifier();
         }
@@ -112,17 +111,17 @@ namespace Stratis.Bitcoin.IntegrationTests.BlockStore
             this.transaction.GetHash().Should().NotBe(this.wrongTransactionId, "it would corrupt the test");
         }
 
-        public void the_node_is_synced()
+        private void the_node_is_synced()
         {
             this.sharedSteps.WaitForNodeToSync(this.node);
         }
 
-        public void the_nodes_are_synced()
+        private void the_nodes_are_synced()
         {
             this.sharedSteps.WaitForNodeToSync(this.node, this.transactionNode);
         }
 
-        public void a_real_transaction()
+        private void a_real_transaction()
         {           
             var transactionBuildContext = new TransactionBuildContext(
                     this.miningWalletAccountReference,
@@ -142,12 +141,10 @@ namespace Stratis.Bitcoin.IntegrationTests.BlockStore
             this.sharedSteps.WaitForNodeToSync(this.node, this.transactionNode);
         }
 
-        public async Task trying_to_retrieve_the_blocks_from_the_blockstore()
+        private void trying_to_retrieve_the_blocks_from_the_blockstore()
         {
             this.retrievedBlocks = this.blockIds.Concat(new[] { this.wrongBlockId })
-                .Select(async id =>
-                    await this.node.FullNode.BlockStoreManager().BlockRepository
-                        .GetAsync(id)).Select(b => b.Result).ToList();
+                .Select(id => this.node.FullNode.BlockStoreManager().BlockRepository.GetAsync(id).GetAwaiter().GetResult()).Select(b => b).ToList();
 
             this.retrievedBlocks.Count(b => b != null).Should().Be(this.blockIds.Count);
             this.retrievedBlocks.Count(b => b == null).Should().Be(1);
@@ -156,7 +153,7 @@ namespace Stratis.Bitcoin.IntegrationTests.BlockStore
             this.retrievedBlockHashes.Should().OnlyHaveUniqueItems();
         }
 
-        public async Task trying_to_retrieve_the_transactions_by_Id_from_the_blockstore()
+        private async Task trying_to_retrieve_the_transactions_by_Id_from_the_blockstore()
         {
             this.retrievedTransaction = await this.node.FullNode.BlockStoreManager().BlockRepository
                 .GetTrxAsync(this.transaction.GetHash());
@@ -164,7 +161,7 @@ namespace Stratis.Bitcoin.IntegrationTests.BlockStore
                 .GetTrxAsync(this.wrongTransactionId);
         }
 
-        public async Task trying_to_retrieve_the_block_containing_the_transactions_from_the_blockstore()
+        private async Task trying_to_retrieve_the_block_containing_the_transactions_from_the_blockstore()
         {
             this.retrievedBlockId = await this.node.FullNode.BlockStoreManager().BlockRepository
                 .GetTrxBlockIdAsync(this.transaction.GetHash());
@@ -172,7 +169,7 @@ namespace Stratis.Bitcoin.IntegrationTests.BlockStore
                 .GetTrxAsync(this.wrongTransactionId);
         }
 
-        public void real_blocks_should_be_retrieved()
+        private void real_blocks_should_be_retrieved()
         {
             this.retrievedBlockHashes.Should().BeEquivalentTo(this.blockIds);
         }
@@ -189,7 +186,6 @@ namespace Stratis.Bitcoin.IntegrationTests.BlockStore
             this.retrievedTransaction.Outputs.Should()
                 .Contain(t => t.Value == this.transferAmount.Satoshi
                               && t.ScriptPubKey.GetDestinationAddress(this.node.FullNode.Network).ScriptPubKey == this.receiverAddress.ScriptPubKey);
-
         }
 
         private void the_wrong_transaction_id_should_return_null()

--- a/src/Stratis.Bitcoin.IntegrationTests/ChainBuilder.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/ChainBuilder.cs
@@ -70,11 +70,12 @@ namespace Stratis.Bitcoin.IntegrationTests
             for (int i = 0; i < blockCount; i++)
             {
                 uint nonce = 0;
-                var block = new Block();
+                var block = this.network.CreateBlock();
                 block.Header.HashPrevBlock = this.Chain.Tip.HashBlock;
                 block.Header.Bits = block.Header.GetWorkRequired(this.network, this.Chain.Tip);
                 block.Header.UpdateTime(now, this.network, this.Chain.Tip);
-                var coinbase = new Transaction();
+
+                var coinbase = this.network.CreateTransaction();
                 coinbase.AddInput(TxIn.CreateCoinbase(this.Chain.Height + 1));
                 coinbase.AddOutput(new TxOut(this.network.GetReward(this.Chain.Height + 1), this.MinerScriptPubKey));
                 block.AddTransaction(coinbase);

--- a/src/Stratis.Bitcoin.IntegrationTests/CoinViewTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/CoinViewTests.cs
@@ -24,10 +24,8 @@ namespace Stratis.Bitcoin.IntegrationTests
 {
     public class CoinViewTests
     {
-        /// <summary>Factory for creating loggers.</summary>
         protected readonly ILoggerFactory loggerFactory;
-
-        /// <summary>Provider of binary (de)serialization for data stored in the database.</summary>
+        private readonly Network network;
         private readonly DBreezeSerializer dbreezeSerializer;
 
         /// <summary>
@@ -36,8 +34,9 @@ namespace Stratis.Bitcoin.IntegrationTests
         public CoinViewTests()
         {
             this.loggerFactory = new LoggerFactory();
+            this.network = Network.Main;
             this.dbreezeSerializer = new DBreezeSerializer();
-            this.dbreezeSerializer.Initialize(Network.Main);
+            this.dbreezeSerializer.Initialize(this.network);
         }
 
         [Fact]
@@ -286,8 +285,8 @@ namespace Stratis.Bitcoin.IntegrationTests
             uint nonce = RandomUtils.GetUInt32();
             foreach (ConcurrentChain chain in chains)
             {
-                var block = new Block();
-                block.AddTransaction(new Transaction());
+                Block block = this.network.CreateBlock();
+                block.AddTransaction(this.network.CreateTransaction());
                 block.UpdateMerkleRoot();
                 block.Header.HashPrevBlock = previous == null ? chain.Tip.HashBlock : previous.HashBlock;
                 block.Header.Nonce = nonce;

--- a/src/Stratis.Bitcoin.IntegrationTests/Wallet/SendingTxWithDoubleSpendSpecification_Steps.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/Wallet/SendingTxWithDoubleSpendSpecification_Steps.cs
@@ -20,7 +20,6 @@ namespace Stratis.Bitcoin.IntegrationTests.Wallet
         private CoreNode stratisSender;
         private CoreNode stratisReceiver;
         private Transaction transaction;
-        private ErrorResult errorResult;
         private MempoolValidationState mempoolValidationState;
         private HdAddress receivingAddress;
 
@@ -65,8 +64,8 @@ namespace Stratis.Bitcoin.IntegrationTests.Wallet
             total.Should().Equals(Money.COIN * 105 * 50);
 
             // sync both nodes
-            this.stratisSender.CreateRPCClient().AddNode(stratisReceiver.Endpoint, true);
-            TestHelper.WaitLoop(() => TestHelper.AreNodesSynced(stratisReceiver, stratisSender));
+            this.stratisSender.CreateRPCClient().AddNode(this.stratisReceiver.Endpoint, true);
+            TestHelper.WaitLoop(() => TestHelper.AreNodesSynced(this.stratisReceiver, this.stratisSender));
         }
 
         private void coins_first_sent_to_receiving_wallet()

--- a/src/Stratis.Bitcoin.Tests.Common/TestBase.cs
+++ b/src/Stratis.Bitcoin.Tests.Common/TestBase.cs
@@ -20,9 +20,9 @@ namespace Stratis.Bitcoin.Tests.Common
         {
             this.Network = network;
             var serializer = new DBreezeSerializer();
-            serializer.Initialize(this.Network); 
+            serializer.Initialize(this.Network);
         }
-        
+
         public static string AssureEmptyDir(string dir)
         {
             int deleteAttempts = 0;
@@ -136,15 +136,15 @@ namespace Stratis.Bitcoin.Tests.Common
 
         public Block CreateBlock(int blockNumber, bool bigBlocks = false)
         {
-            var block = new Block();
+            Block block = this.Network.CreateBlock();
 
             int transactionCount = bigBlocks ? 1000 : 10;
 
             for (int j = 0; j < transactionCount; j++)
             {
-                var trx = new Transaction();
+                Transaction trx = this.Network.CreateTransaction();
 
-                block.AddTransaction(new Transaction());
+                block.AddTransaction(this.Network.CreateTransaction());
 
                 trx.AddInput(new TxIn(Script.Empty));
                 trx.AddOutput(Money.COIN + j + blockNumber, new Script(Enumerable.Range(1, 5).SelectMany(index => Guid.NewGuid().ToByteArray())));

--- a/src/Stratis.Bitcoin.Tests.Wallet.Common/WalletTestsHelpers.cs
+++ b/src/Stratis.Bitcoin.Tests.Wallet.Common/WalletTestsHelpers.cs
@@ -79,14 +79,14 @@ namespace Stratis.Bitcoin.Tests.Wallet.Common
             return address;
         }
 
-        public static ChainedHeader AppendBlock(ChainedHeader previous = null, params ConcurrentChain[] chains)
+        public static ChainedHeader AppendBlock(Network network, ChainedHeader previous = null, params ConcurrentChain[] chains)
         {
             ChainedHeader last = null;
             uint nonce = RandomUtils.GetUInt32();
             foreach (ConcurrentChain chain in chains)
             {
-                var block = new Block();
-                block.AddTransaction(new Transaction());
+                Block block = network.CreateBlock();
+                block.AddTransaction(network.CreateTransaction());
                 block.UpdateMerkleRoot();
                 block.Header.HashPrevBlock = previous == null ? chain.Tip.HashBlock : previous.HashBlock;
                 block.Header.Nonce = nonce;
@@ -96,13 +96,13 @@ namespace Stratis.Bitcoin.Tests.Wallet.Common
             return last;
         }
 
-        public static (ChainedHeader ChainedHeader, Block Block) AppendBlock(ChainedHeader previous, ConcurrentChain chain)
+        public static (ChainedHeader ChainedHeader, Block Block) AppendBlock(Network network, ChainedHeader previous, ConcurrentChain chain)
         {
             ChainedHeader last = null;
             uint nonce = RandomUtils.GetUInt32();
-            var block = new Block();
+            Block block = network.CreateBlock();
 
-            block.AddTransaction(new Transaction());
+            block.AddTransaction(network.CreateTransaction());
             block.UpdateMerkleRoot();
             block.Header.HashPrevBlock = previous == null ? chain.Tip.HashBlock : previous.HashBlock;
             block.Header.Nonce = nonce;

--- a/src/Stratis.Bitcoin.Tests/BlockPulling2/BlockPullerTests.cs
+++ b/src/Stratis.Bitcoin.Tests/BlockPulling2/BlockPullerTests.cs
@@ -972,7 +972,7 @@ namespace Stratis.Bitcoin.Tests.BlockPulling2
             Assert.True(this.puller.AssignedHeadersByPeerId.ContainsKey(peer1.Connection.Id));
 
             foreach (ChainedHeader chainedHeader in this.puller.AssignedHeadersByPeerId.First().Value)
-                Assert.True(headers.Contains(chainedHeader));
+                Assert.Contains(chainedHeader, headers);
 
             Assert.True(this.puller.AssignedHeadersByPeerId[peer1.Connection.Id].Count == headers.Count);
         }
@@ -1062,7 +1062,7 @@ namespace Stratis.Bitcoin.Tests.BlockPulling2
             this.puller.PushBlock(peer1Headers.First().HashBlock, this.helper.GenerateBlock(100), peer2.Connection.Id);
 
             foreach (ChainedHeader chainedHeader in this.puller.AssignedHeadersByPeerId[peer1.Connection.Id])
-                Assert.True(peer1Headers.Contains(chainedHeader));
+                Assert.Contains(chainedHeader, peer1Headers);
             
             Assert.Empty(this.helper.CallbacksCalled);
             Assert.Equal(peer1Headers.Count, this.puller.AssignedDownloadsByHash.Count);

--- a/src/Stratis.Bitcoin.Tests/Consensus/ChainedHeaderTreeTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Consensus/ChainedHeaderTreeTest.cs
@@ -1720,7 +1720,6 @@ namespace Stratis.Bitcoin.Tests.Consensus
             const int chainExtension = 16;
             const int assumeValidHeaderHeight = 25;
             const int headersStartHeight = 15;
-            const int headersEndHeight = 30;
 
             TestContext testContext = new TestContextBuilder().WithInitialChain(initialChainSize).UseCheckpoints(true).Build();
             ChainedHeaderTree chainedHeaderTree = testContext.ChainedHeaderTree;
@@ -1744,7 +1743,6 @@ namespace Stratis.Bitcoin.Tests.Consensus
             // Present chain h15->h30 covering second checkpoint at h20 and assume valid at h25.
             // -----CP1----HEADERS_START----CP2-----AV----HEADERS_END
             // h1---h10--------h15----------h20-----h25------h30-----
-            int headersToPresentCount = (headersEndHeight - headersStartHeight + 1 /* inclusive */);
             listOfChainHeaders = listOfChainHeaders.Skip(headersStartHeight - 1).ToList();
             ConnectNewHeadersResult connectedHeadersResultNew = chainedHeaderTree.ConnectNewHeaders(1, listOfChainHeaders);
 

--- a/src/Stratis.Bitcoin.Tests/Controllers/NodeControllerTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Controllers/NodeControllerTest.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Net;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Logging;
 using Moq;
 using NBitcoin;
 using NBitcoin.DataEncoders;
@@ -35,7 +34,6 @@ namespace Stratis.Bitcoin.Tests.Controllers
         private readonly Mock<IPooledGetUnspentTransaction> pooledGetUnspentTransaction;
         private readonly Mock<IGetUnspentTransaction> getUnspentTransaction;
         private readonly Mock<INetworkDifficulty> networkDifficulty;
-        private readonly Mock<ILoggerFactory> LoggerFactory;
         private NodeController controller;
 
         public NodeControllerTest()
@@ -52,9 +50,6 @@ namespace Stratis.Bitcoin.Tests.Controllers
             this.pooledGetUnspentTransaction = new Mock<IPooledGetUnspentTransaction>();
             this.getUnspentTransaction = new Mock<IGetUnspentTransaction>();
             this.networkDifficulty = new Mock<INetworkDifficulty>();
-            this.LoggerFactory = new Mock<ILoggerFactory>();
-            this.LoggerFactory.Setup(i => i.CreateLogger(It.IsAny<string>())).Returns(new Mock<ILogger>().Object);
-
 
             this.controller = new NodeController(this.fullNode.Object, this.LoggerFactory.Object, 
                 this.dateTimeProvider.Object, this.chainState.Object, this.nodeSettings, 

--- a/src/Stratis.Bitcoin.Tests/P2P/PeerConnectorTests.cs
+++ b/src/Stratis.Bitcoin.Tests/P2P/PeerConnectorTests.cs
@@ -20,7 +20,6 @@ namespace Stratis.Bitcoin.Tests.P2P
     {
         private readonly IAsyncLoopFactory asyncLoopFactory;
         private readonly ExtendedLoggerFactory extendedLoggerFactory;
-        private readonly INetworkPeerFactory networkPeerFactory;
         private readonly NetworkPeerConnectionParameters networkPeerParameters;
         private readonly NodeLifetime nodeLifetime;
         private readonly Network network;
@@ -85,8 +84,8 @@ namespace Stratis.Bitcoin.Tests.P2P
             var nodeSettings = new NodeSettings();
 
             var connectionSettings = new ConnectionManagerSettings(nodeSettings);
-
-            var connector = new PeerConnectorAddNode(this.asyncLoopFactory, DateTimeProvider.Default, this.extendedLoggerFactory, this.network, this.networkPeerFactory, this.nodeLifetime, nodeSettings, connectionSettings, peerAddressManager, new SelfEndpointTracker());
+            var networkPeerFactory = new Mock<INetworkPeerFactory>();
+            var connector = new PeerConnectorAddNode(this.asyncLoopFactory, DateTimeProvider.Default, this.extendedLoggerFactory, this.network, networkPeerFactory.Object, this.nodeLifetime, nodeSettings, connectionSettings, peerAddressManager, new SelfEndpointTracker());
             Assert.True(connector.CanStartConnect);
         }
 
@@ -146,10 +145,11 @@ namespace Stratis.Bitcoin.Tests.P2P
             var nodeSettings = new NodeSettings();
 
             var connectionSettings = new ConnectionManagerSettings(nodeSettings);
-
             connectionSettings.Connect.Add(endpointConnectNode);
 
-            var peerConnector = new PeerConnectorConnectNode(this.asyncLoopFactory, DateTimeProvider.Default, this.extendedLoggerFactory, this.network, this.networkPeerFactory, this.nodeLifetime, nodeSettings, connectionSettings, peerAddressManager, new SelfEndpointTracker());
+            var networkPeerFactory = new Mock<INetworkPeerFactory>();
+
+            var peerConnector = new PeerConnectorConnectNode(this.asyncLoopFactory, DateTimeProvider.Default, this.extendedLoggerFactory, this.network, networkPeerFactory.Object, this.nodeLifetime, nodeSettings, connectionSettings, peerAddressManager, new SelfEndpointTracker());
             Assert.True(peerConnector.CanStartConnect);
         }
 
@@ -160,7 +160,8 @@ namespace Stratis.Bitcoin.Tests.P2P
             var peerAddressManager = new PeerAddressManager(DateTimeProvider.Default, peerFolder, this.extendedLoggerFactory, new SelfEndpointTracker());
             var nodeSettings = new NodeSettings();
             var connectionSettings = new ConnectionManagerSettings(nodeSettings);
-            var peerConnector = new PeerConnectorConnectNode(this.asyncLoopFactory, DateTimeProvider.Default, this.extendedLoggerFactory, this.network, this.networkPeerFactory, this.nodeLifetime, nodeSettings, connectionSettings, peerAddressManager, new SelfEndpointTracker());
+            var networkPeerFactory = new Mock<INetworkPeerFactory>();
+            var peerConnector = new PeerConnectorConnectNode(this.asyncLoopFactory, DateTimeProvider.Default, this.extendedLoggerFactory, this.network, networkPeerFactory.Object, this.nodeLifetime, nodeSettings, connectionSettings, peerAddressManager, new SelfEndpointTracker());
             Assert.False(peerConnector.CanStartConnect);
         }
 
@@ -216,7 +217,8 @@ namespace Stratis.Bitcoin.Tests.P2P
             var peerAddressManager = new PeerAddressManager(DateTimeProvider.Default, peerFolder, this.extendedLoggerFactory, new SelfEndpointTracker());
             var nodeSettings = new NodeSettings();
             var connectionSettings = new ConnectionManagerSettings(nodeSettings);
-            var peerConnector = new PeerConnectorDiscovery(this.asyncLoopFactory, DateTimeProvider.Default, this.extendedLoggerFactory, this.network, this.networkPeerFactory, this.nodeLifetime, nodeSettings, connectionSettings, peerAddressManager, new SelfEndpointTracker());
+            var networkPeerFactory = new Mock<INetworkPeerFactory>();
+            var peerConnector = new PeerConnectorDiscovery(this.asyncLoopFactory, DateTimeProvider.Default, this.extendedLoggerFactory, this.network, networkPeerFactory.Object, this.nodeLifetime, nodeSettings, connectionSettings, peerAddressManager, new SelfEndpointTracker());
             Assert.True(peerConnector.CanStartConnect);
         }
 
@@ -232,8 +234,8 @@ namespace Stratis.Bitcoin.Tests.P2P
 
             DataFolder peerFolder = CreateDataFolder(this);
             var peerAddressManager = new PeerAddressManager(DateTimeProvider.Default, peerFolder, this.extendedLoggerFactory, new SelfEndpointTracker());
-
-            var peerConnector = new PeerConnectorDiscovery(this.asyncLoopFactory, DateTimeProvider.Default, this.extendedLoggerFactory, this.network, this.networkPeerFactory, this.nodeLifetime, nodeSettings, connectionSettings, peerAddressManager, new SelfEndpointTracker());
+            var networkPeerFactory = new Mock<INetworkPeerFactory>();
+            var peerConnector = new PeerConnectorDiscovery(this.asyncLoopFactory, DateTimeProvider.Default, this.extendedLoggerFactory, this.network, networkPeerFactory.Object, this.nodeLifetime, nodeSettings, connectionSettings, peerAddressManager, new SelfEndpointTracker());
             Assert.False(peerConnector.CanStartConnect);
         }
 
@@ -244,7 +246,8 @@ namespace Stratis.Bitcoin.Tests.P2P
             selfEndpointTracker.Setup(x => x.IsSelf(It.IsAny<IPEndPoint>())).Returns(true);
             var peerAddressManager = new Mock<IPeerAddressManager>();
             var nodeSettings = new NodeSettings();
-            var peerConnector = new PeerConnectorDiscovery(this.asyncLoopFactory, DateTimeProvider.Default, this.extendedLoggerFactory, this.network, this.networkPeerFactory, this.nodeLifetime, nodeSettings, new ConnectionManagerSettings(nodeSettings), peerAddressManager.Object, selfEndpointTracker.Object);
+            var networkPeerFactory = new Mock<INetworkPeerFactory>();
+            var peerConnector = new PeerConnectorDiscovery(this.asyncLoopFactory, DateTimeProvider.Default, this.extendedLoggerFactory, this.network, networkPeerFactory.Object, this.nodeLifetime, nodeSettings, new ConnectionManagerSettings(nodeSettings), peerAddressManager.Object, selfEndpointTracker.Object);
 
             peerConnector.ConnectAsync(new PeerAddress()).GetAwaiter().GetResult();
 
@@ -253,11 +256,13 @@ namespace Stratis.Bitcoin.Tests.P2P
 
         private IConnectionManager CreateConnectionManager(NodeSettings nodeSettings, ConnectionManagerSettings connectionSettings, IPeerAddressManager peerAddressManager, IPeerConnector peerConnector)
         {
+            var networkPeerFactory = new Mock<INetworkPeerFactory>();
+
             var connectionManager = new ConnectionManager(
                 DateTimeProvider.Default,
                 this.LoggerFactory.Object,
                 this.network,
-                this.networkPeerFactory,
+                networkPeerFactory.Object,
                 nodeSettings,
                 this.nodeLifetime,
                 this.networkPeerParameters,

--- a/src/Stratis.Bitcoin.Tests/Signals/SignalerTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Signals/SignalerTest.cs
@@ -16,7 +16,7 @@ namespace Stratis.Bitcoin.Tests.Signals
         [Fact]
         public void SubscribeRegistersObserverWithObservable()
         {
-            var block = new Block();
+            var block = Network.StratisMain.CreateBlock();
             var subject = new Mock<ISubject<Block>>();
             var observer = new Mock<IObserver<Block>>();
             subject.Setup(s => s.Subscribe(It.IsAny<IObserver<Block>>()))
@@ -35,7 +35,7 @@ namespace Stratis.Bitcoin.Tests.Signals
         [Fact]
         public void BroadcastSignalsSubject()
         {
-            var block = new Block();
+            var block = Network.StratisMain.CreateBlock();
             var subject = new Mock<ISubject<Block>>();
             var signaler = new Signaler<Block>(subject.Object);
 

--- a/src/Stratis.Bitcoin.Tests/Signals/SignalsTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Signals/SignalsTest.cs
@@ -7,9 +7,9 @@ namespace Stratis.Bitcoin.Tests.Signals
 {
     public class SignalsTest
     {
-        private Mock<ISignaler<Block>> blockSignaler;
-        private Bitcoin.Signals.Signals signals;
-        private Mock<ISignaler<Transaction>> transactionSignaler;
+        private readonly Mock<ISignaler<Block>> blockSignaler;
+        private readonly Bitcoin.Signals.Signals signals;
+        private readonly Mock<ISignaler<Transaction>> transactionSignaler;
 
         public SignalsTest()
         {
@@ -21,7 +21,7 @@ namespace Stratis.Bitcoin.Tests.Signals
         [Fact]
         public void SignalBlockBroadcastsToBlockSignaler()
         {
-            var block = new Block();
+            Block block = Network.StratisMain.CreateBlock();
 
             this.signals.SignalBlock(block);
 
@@ -31,7 +31,7 @@ namespace Stratis.Bitcoin.Tests.Signals
         [Fact]
         public void SignalTransactionBroadcastsToTransactionSignaler()
         {
-            var transaction = new Transaction();
+            Transaction transaction = Network.StratisMain.CreateTransaction();
 
             this.signals.SignalTransaction(transaction);
 


### PR DESCRIPTION
This should be a pretty easy PR to review.

We are now down to 25 compiler warnings.