### PR TITLE
-reindex command now functions as expected.

### DIFF
--- a/src/Stratis.Bitcoin.Features.BlockStore.Tests/BlockRepositoryInMemory.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore.Tests/BlockRepositoryInMemory.cs
@@ -87,6 +87,11 @@ namespace Stratis.Bitcoin.Features.BlockStore.Tests
             throw new NotImplementedException();
         }
 
+        public Task ReIndexAsync()
+        {
+            throw new NotImplementedException();
+        }
+
         public Task SetTxIndexAsync(bool txIndex)
         {
             this.TxIndex = txIndex;

--- a/src/Stratis.Bitcoin.Features.BlockStore/BlockRepository.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/BlockRepository.cs
@@ -70,7 +70,8 @@ namespace Stratis.Bitcoin.Features.BlockStore
         Task<uint256> GetTrxBlockIdAsync(uint256 trxid);
 
         /// <summary>
-        /// For every block in the database, store the transactions (or don't) according to whether TxIndex is set.
+        /// Iterate over every block in the database. 
+        /// If <see cref="TxIndex"/> is true, we store the block hash alongside the transaction hash in the transaction table, otherwise clear the transaction table.
         /// </summary>
         Task ReIndexAsync();
 
@@ -354,6 +355,8 @@ namespace Stratis.Bitcoin.Features.BlockStore
 
                 using (DBreeze.Transactions.Transaction dbreezeTransaction = this.DBreeze.GetTransaction())
                 {
+                    dbreezeTransaction.SynchronizeTables(BlockTableName, TransactionTableName);
+
                     if (this.TxIndex)
                     {
                         // Insert transactions to database.

--- a/src/Stratis.Bitcoin.Features.BlockStore/BlockStoreQueue.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/BlockStoreQueue.cs
@@ -114,8 +114,8 @@ namespace Stratis.Bitcoin.Features.BlockStore
 
             if (this.storeSettings.ReIndex)
             {
-                this.logger.LogTrace("(-)[REINDEX_NOT_SUPPORTED]");
-                throw new NotSupportedException("Re-indexing the block store in currently not supported.");
+                await this.blockRepository.SetTxIndexAsync(this.storeSettings.TxIndex).ConfigureAwait(false);
+                await this.blockRepository.ReindexAsync().ConfigureAwait(false);
             }
 
             ChainedHeader initializationTip = this.chain.GetBlock(this.blockRepository.BlockHash);

--- a/src/Stratis.Bitcoin.Features.BlockStore/BlockStoreQueue.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/BlockStoreQueue.cs
@@ -131,7 +131,7 @@ namespace Stratis.Bitcoin.Features.BlockStore
                 if (this.storeTip != this.chain.Genesis)
                 {
                     this.logger.LogTrace("(-)[REBUILD_REQUIRED]");
-                    throw new BlockStoreException("You need to rebuild the block store database using -reindex-chainstate to change -txindex");
+                    throw new BlockStoreException("You need to rebuild the block store database using -reindex to change -txindex");
                 }
 
                 if (this.storeSettings.TxIndex)

--- a/src/Stratis.Bitcoin.Features.BlockStore/BlockStoreQueue.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/BlockStoreQueue.cs
@@ -115,7 +115,7 @@ namespace Stratis.Bitcoin.Features.BlockStore
             if (this.storeSettings.ReIndex)
             {
                 await this.blockRepository.SetTxIndexAsync(this.storeSettings.TxIndex).ConfigureAwait(false);
-                await this.blockRepository.ReindexAsync().ConfigureAwait(false);
+                await this.blockRepository.ReIndexAsync().ConfigureAwait(false);
             }
 
             ChainedHeader initializationTip = this.chain.GetBlock(this.blockRepository.BlockHash);
@@ -134,8 +134,9 @@ namespace Stratis.Bitcoin.Features.BlockStore
                     throw new BlockStoreException("You need to rebuild the block store database using -reindex to change -txindex");
                 }
 
-                if (this.storeSettings.TxIndex)
-                    await this.blockRepository.SetTxIndexAsync(this.storeSettings.TxIndex).ConfigureAwait(false);
+                // We only reach here in the case where we are syncing with a database with no blocks.
+                // Always set the TxIndex here.
+                await this.blockRepository.SetTxIndexAsync(this.storeSettings.TxIndex).ConfigureAwait(false);
             }
             
             // Throw if block store was initialized after the consensus.


### PR DESCRIPTION
Fixes #1215.

There is likely potential to reuse code from `OnInsertBlocks` and `OnInsertTransactions`, however for now I believe it makes more sense to have a completely separate method as the logic is slightly different and I don't believe we need to involve the PerformanceCounter in any way. 