### PR TITLE
When sending getdata message for tx inventory add appropriate witness flags

### DIFF
--- a/src/Stratis.Bitcoin.Features.MemoryPool/MempoolBehavior.cs
+++ b/src/Stratis.Bitcoin.Features.MemoryPool/MempoolBehavior.cs
@@ -325,7 +325,7 @@ namespace Stratis.Bitcoin.Features.MemoryPool
                     continue;
                 }
 
-                send.Inventory.Add(inv);
+                send.Inventory.Add(new InventoryVector(peer.AddSupportedOptions(InventoryType.MSG_TX), inv.Hash));
             }
 
             // add to known inventory
@@ -339,7 +339,7 @@ namespace Stratis.Bitcoin.Features.MemoryPool
 
             if (peer.IsConnected)
             {
-                this.logger.LogTrace("Sending transaction inventory to peer '{0}'.", peer.RemoteSocketEndpoint);
+                this.logger.LogTrace("Asking for transaction data from peer '{0}'.", peer.RemoteSocketEndpoint);
                 await peer.SendMessageAsync(send).ConfigureAwait(false);
             }
 


### PR DESCRIPTION
Related to issue #631 

I finally think I got to the bottom of this issue. We weren't adding the witness flags when requesting txs using "getdata" after receiving inventory. This is why the peers were sending us invalid txs. This fits with the reasoning that Nicolas mentioned in the original issue. I had missed this location when I had looked at this code previously.

I've been running the bitcoin testnet for a while and haven't seen any of these invalid txs come through yet so I'm hopefully this is the fix.

I will also try syncing from scratch.