### PR TITLE
 ConsensusOptions per Network

### DIFF
--- a/src/NBitcoin/Consensus.cs
+++ b/src/NBitcoin/Consensus.cs
@@ -24,13 +24,6 @@ namespace NBitcoin
     public class Consensus
     {
         /// <summary>
-        /// An extension to <see cref="Consensus"/> to enable additional options to the consensus data.
-        /// </summary>
-        public class ConsensusOptions
-        {
-        }
-
-        /// <summary>
         /// How many blocks should be on top of a coinbase transaction until its outputs are considered spendable.
         /// </summary>
         public long CoinbaseMaturity { get; set; }

--- a/src/NBitcoin/ConsensusOptions.cs
+++ b/src/NBitcoin/ConsensusOptions.cs
@@ -1,0 +1,51 @@
+﻿namespace NBitcoin
+{
+    /// <summary>
+    /// An extension to <see cref="Consensus"/> to enable additional options to the consensus data.
+    /// </summary>
+    public class ConsensusOptions
+    {
+        /// <summary>The maximum allowed size for a serialized block, in bytes (only for buffer size limits).</summary>
+        public int MaxBlockSerializedSize { get; set; }
+
+        /// <summary>The maximum allowed weight for a block, see BIP 141 (network rule)</summary>
+        public int MaxBlockWeight { get; set; }
+
+        public int WitnessScaleFactor { get; set; }
+
+        public int SerializeTransactionNoWitness { get; set; }
+
+        /// <summary>
+        /// Changing the default transaction version requires a two step process:
+        /// <list type="bullet">
+        /// <item>Adapting relay policy by bumping <see cref="MaxStandardVersion"/>,</item>
+        /// <item>and then later date bumping the default CURRENT_VERSION at which point both CURRENT_VERSION and
+        /// <see cref="MaxStandardVersion"/> will be equal.</item>
+        /// </list>
+        /// </summary>
+        public int MaxStandardVersion { get; set; }
+
+        /// <summary>The maximum weight for transactions we're willing to relay/mine.</summary>
+        public int MaxStandardTxWeight { get; set; }
+
+        public int MaxBlockBaseSize { get; set; }
+
+        /// <summary>The maximum allowed number of signature check operations in a block (network rule).</summary>
+        public int MaxBlockSigopsCost { get; set; }
+
+        /// <summary>
+        /// Initializes the default values.
+        /// </summary>
+        public ConsensusOptions()
+        {
+            this.MaxBlockSerializedSize = 4000000;
+            this.MaxBlockWeight = 4000000;
+            this.WitnessScaleFactor = 4;
+            this.SerializeTransactionNoWitness = 0x40000000;
+            this.MaxStandardVersion = 2;
+            this.MaxStandardTxWeight = 400000;
+            this.MaxBlockBaseSize = 1000000;
+            this.MaxBlockSigopsCost = 80000;
+        }
+    }
+}

--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/CommonRules/AssumeValidRuleTest.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/CommonRules/AssumeValidRuleTest.cs
@@ -12,7 +12,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
 
         public AssumeValidRuleTest() : base(Network.TestNet)
         {
-            this.network.Consensus.Options = new PowConsensusOptions();
+            this.network.Consensus.Options = new ConsensusOptions();
             AddBlocksToChain(this.concurrentChain, 5);
             this.rule = this.CreateRule();
         }

--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/CommonRules/BlockSizeRuleTest.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/CommonRules/BlockSizeRuleTest.cs
@@ -10,11 +10,11 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
 {
     public class BlockSizeRuleTest : TestConsensusRulesUnitTestBase
     {
-        private PowConsensusOptions options;
+        private ConsensusOptions options;
 
         public BlockSizeRuleTest()
         {
-            this.options = this.network.Consensus.Option<PowConsensusOptions>();
+            this.options = this.network.Consensus.Options;
             this.ruleContext.Consensus = this.network.Consensus;
         }
 

--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/CommonRules/CheckPowTransactionRuleTest.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/CommonRules/CheckPowTransactionRuleTest.cs
@@ -10,14 +10,14 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
 {
     public class CheckPowTransactionRuleTest : TestConsensusRulesUnitTestBase
     {
-        private PowConsensusOptions options;
+        private ConsensusOptions options;
 
         private NBitcoin.Consensus consensus;
 
         public CheckPowTransactionRuleTest()
         {
             this.consensus = this.network.Consensus;
-            this.options = this.consensus.Option<PowConsensusOptions>();
+            this.options = this.consensus.Options;
         }
 
         [Fact]

--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/CommonRules/CheckSigOpsRuleTest.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/CommonRules/CheckSigOpsRuleTest.cs
@@ -8,11 +8,11 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
 {
     public class CheckSigOpsRuleTest : TestConsensusRulesUnitTestBase
     {
-        private PowConsensusOptions options;
+        private ConsensusOptions options;
 
         public CheckSigOpsRuleTest()
         {
-            this.options = this.network.Consensus.Option<PowConsensusOptions>();
+            this.options = this.network.Consensus.Options;
             this.ruleContext.ValidationContext.Block = this.network.CreateBlock();
             this.ruleContext.Consensus = this.network.Consensus;
         }

--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/ConsensusRuleUnitTestBase.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/ConsensusRuleUnitTestBase.cs
@@ -186,7 +186,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules
     {
         public TestConsensusRulesUnitTestBase() : base(Network.TestNet)
         {
-            this.network.Consensus.Options = new PowConsensusOptions();
+            this.network.Consensus.Options = new ConsensusOptions();
             this.consensusRules = InitializeConsensusRules();
         }
 

--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/TestRulesContext.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/TestRulesContext.cs
@@ -134,7 +134,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules
             testRulesContext.LoggerFactory = testRulesContext.NodeSettings.LoggerFactory;
             testRulesContext.LoggerFactory.AddConsoleWithFilters();
             testRulesContext.DateTimeProvider = DateTimeProvider.Default;
-            network.Consensus.Options = new PowConsensusOptions();
+            network.Consensus.Options = new ConsensusOptions();
 
             var consensusSettings = new ConsensusSettings(testRulesContext.NodeSettings);
             testRulesContext.Checkpoints = new Checkpoints();

--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/TestChainFactory.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/TestChainFactory.cs
@@ -84,7 +84,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests
             testChainContext.LoggerFactory = testChainContext.NodeSettings.LoggerFactory;
             testChainContext.DateTimeProvider = DateTimeProvider.Default;
 
-            network.Consensus.Options = new PowConsensusOptions();
+            network.Consensus.Options = new ConsensusOptions();
 
             var consensusSettings = new ConsensusSettings(testChainContext.NodeSettings);
             testChainContext.Checkpoints = new Checkpoints();
@@ -230,8 +230,8 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests
         {
             var options = new BlockDefinitionOptions
             {
-                BlockMaxWeight = network.Consensus.Option<PowConsensusOptions>().MaxBlockWeight,
-                BlockMaxSize = network.Consensus.Option<PowConsensusOptions>().MaxBlockSerializedSize
+                BlockMaxWeight = network.Consensus.Options.MaxBlockWeight,
+                BlockMaxSize = network.Consensus.Options.MaxBlockSerializedSize
             };
 
             var blockMinFeeRate = new FeeRate(PowMining.DefaultBlockMinTxFee);

--- a/src/Stratis.Bitcoin.Features.Consensus/ConsensusFeature.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/ConsensusFeature.cs
@@ -192,10 +192,10 @@ namespace Stratis.Bitcoin.Features.Consensus
                 .FeatureServices(services =>
                 {
                     // TODO: this should be set on the network build
-                    fullNodeBuilder.Network.Consensus.Options = new PowConsensusOptions();
+                    fullNodeBuilder.Network.Consensus.Options = new ConsensusOptions();
 
                     services.AddSingleton<ICheckpoints, Checkpoints>();
-                    services.AddSingleton<NBitcoin.Consensus.ConsensusOptions, PowConsensusOptions>();
+                    services.AddSingleton<ConsensusOptions, ConsensusOptions>();
                     services.AddSingleton<DBreezeCoinView>();
                     services.AddSingleton<CoinView, CachedCoinView>();
                     services.AddSingleton<LookaheadBlockPuller>().AddSingleton<ILookaheadBlockPuller, LookaheadBlockPuller>(provider => provider.GetService<LookaheadBlockPuller>()); ;

--- a/src/Stratis.Bitcoin.Features.Consensus/ConsensusOptions.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/ConsensusOptions.cs
@@ -6,7 +6,7 @@ namespace Stratis.Bitcoin.Features.Consensus
     // The default setting of values on the consensus options
     // should be removed in to the initialization of each
     // network this are network specific values
-    public class PosConsensusOptions : PowConsensusOptions
+    public class PosConsensusOptions : ConsensusOptions
     {
         /// <summary>Coinstake minimal confirmations softfork activation height for the mainnet.</summary>
         internal const int CoinstakeMinConfirmationActivationHeightMainnet = 1005000;
@@ -32,68 +32,6 @@ namespace Stratis.Bitcoin.Features.Consensus
                 return height < CoinstakeMinConfirmationActivationHeightTestnet ? 10 : 20;
 
             return height < CoinstakeMinConfirmationActivationHeightMainnet ? 50 : 500;
-        }
-    }
-
-    /// <summary>
-    /// A set of options with default values of the Bitcoin network
-    /// This can be easily overridable for alternative networks (i.e Stratis)
-    /// Capital style param nameing is kept to mimic core
-    /// </summary>
-    public class PowConsensusOptions : NBitcoin.Consensus.ConsensusOptions
-    {
-        /// <summary>The maximum allowed size for a serialized block, in bytes (only for buffer size limits).</summary>
-        public int MaxBlockSerializedSize { get; set; }
-
-        /// <summary>The maximum allowed weight for a block, see BIP 141 (network rule)</summary>
-        public int MaxBlockWeight { get; set; }
-
-        public int WitnessScaleFactor { get; set; }
-
-        public int SerializeTransactionNoWitness { get; set; }
-
-        /// <summary>
-        /// Changing the default transaction version requires a two step process:
-        /// <list type="bullet">
-        /// <item>Adapting relay policy by bumping <see cref="MaxStandardVersion"/>,</item>
-        /// <item>and then later date bumping the default CURRENT_VERSION at which point both CURRENT_VERSION and
-        /// <see cref="MaxStandardVersion"/> will be equal.</item>
-        /// </list>
-        /// </summary>
-        public int MaxStandardVersion { get; set; }
-
-        /// <summary>The maximum weight for transactions we're willing to relay/mine.</summary>
-        public int MaxStandardTxWeight { get; set; }
-
-        public int MaxBlockBaseSize { get; set; }
-
-        /// <summary>The maximum allowed number of signature check operations in a block (network rule).</summary>
-        public int MaxBlockSigopsCost { get; set; }
-
-        
-
-        /// <summary>
-        /// Initializes the default values.
-        /// </summary>
-        public PowConsensusOptions()
-        {
-            this.MaxBlockSerializedSize = 4000000;
-            this.MaxBlockWeight = 4000000;
-            this.WitnessScaleFactor = 4;
-            this.SerializeTransactionNoWitness = 0x40000000;
-            this.MaxStandardVersion = 2;
-            this.MaxStandardTxWeight = 400000;
-            this.MaxBlockBaseSize = 1000000;
-            this.MaxBlockSigopsCost = 80000;
-        }
-    }
-
-    public static class ConsensusExtentions
-    {
-        public static T Option<T>(this NBitcoin.Consensus item)
-            where T : NBitcoin.Consensus.ConsensusOptions
-        {
-            return item.Options as T;
         }
     }
 }

--- a/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/BlockSizeRule.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/BlockSizeRule.cs
@@ -19,7 +19,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Rules.CommonRules
         /// <exception cref="ConsensusErrors.BadBlockLength">The block does not contain any transactions.</exception>
         public override Task RunAsync(RuleContext context)
         {
-            var options = context.Consensus.Option<PowConsensusOptions>();
+            var options = context.Consensus.Options;
 
             // After the coinbase witness nonce and commitment are verified,
             // we can check if the block weight passes (before we've checked the
@@ -56,7 +56,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Rules.CommonRules
         /// <param name="block">Block that we get weight of.</param>
         /// <param name="powOptions">The pow options.</param>
         /// <returns>Block weight.</returns>
-        public long GetBlockWeight(Block block, PowConsensusOptions powOptions)
+        public long GetBlockWeight(Block block, ConsensusOptions powOptions)
         {
             return GetSize(this.Parent.Network, block, TransactionOptions.None) * (powOptions.WitnessScaleFactor - 1) + GetSize(this.Parent.Network, block, TransactionOptions.Witness);
         }

--- a/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/CheckPowTransactionRule.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/CheckPowTransactionRule.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using NBitcoin;
 using Stratis.Bitcoin.Consensus.Rules;
+using static NBitcoin.Consensus;
 
 namespace Stratis.Bitcoin.Features.Consensus.Rules.CommonRules
 {
@@ -25,7 +26,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Rules.CommonRules
         public override Task RunAsync(RuleContext context)
         {
             Block block = context.ValidationContext.Block;
-            var options = context.Consensus.Option<PowConsensusOptions>();
+            var options = context.Consensus.Options;
 
             // Check transactions
             foreach (Transaction tx in block.Transactions)
@@ -34,7 +35,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Rules.CommonRules
             return Task.CompletedTask;
         }
 
-        public virtual void CheckTransaction(Network network, PowConsensusOptions options, Transaction tx)
+        public virtual void CheckTransaction(Network network, ConsensusOptions options, Transaction tx)
         {
             // Basic checks that don't depend on any context.
             if (tx.Inputs.Count == 0)

--- a/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/CheckSigOpsRule.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/CheckSigOpsRule.cs
@@ -13,7 +13,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Rules.CommonRules
         public override Task RunAsync(RuleContext context)
         {
             Block block = context.ValidationContext.Block;
-            var options = context.Consensus.Options;
+            ConsensusOptions options = context.Consensus.Options;
 
             long nSigOps = 0;
             foreach (Transaction tx in block.Transactions)

--- a/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/CheckSigOpsRule.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/CheckSigOpsRule.cs
@@ -13,7 +13,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Rules.CommonRules
         public override Task RunAsync(RuleContext context)
         {
             Block block = context.ValidationContext.Block;
-            var options = context.Consensus.Option<PowConsensusOptions>();
+            var options = context.Consensus.Options;
 
             long nSigOps = 0;
             foreach (Transaction tx in block.Transactions)

--- a/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/CoinviewRule.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/CoinviewRule.cs
@@ -19,7 +19,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Rules.CommonRules
     public abstract class CoinViewRule : ConsensusRule
     {
         /// <summary>Consensus options.</summary>
-        public PowConsensusOptions PowConsensusOptions { get; private set; }
+        public ConsensusOptions ConsensusOptions { get; private set; }
 
         /// <summary>The consensus.</summary>
         private NBitcoin.Consensus Consensus { get; set; }
@@ -30,7 +30,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Rules.CommonRules
             this.Logger.LogTrace("()");
 
             this.Consensus = this.Parent.Network.Consensus;
-            this.PowConsensusOptions = this.Parent.Network.Consensus.Option<PowConsensusOptions>();
+            this.ConsensusOptions = this.Parent.Network.Consensus.Options;
 
             this.Logger.LogTrace("(-)");
         }
@@ -85,7 +85,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Rules.CommonRules
                     // * p2sh (when P2SH enabled in flags and excludes coinbase),
                     // * witness (when witness enabled in flags and excludes coinbase).
                     sigOpsCost += this.GetTransactionSignatureOperationCost(tx, view, flags);
-                    if (sigOpsCost > this.PowConsensusOptions.MaxBlockSigopsCost)
+                    if (sigOpsCost > this.ConsensusOptions.MaxBlockSigopsCost)
                     {
                         this.Logger.LogTrace("(-)[BAD_BLOCK_SIG_OPS]");
                         ConsensusErrors.BadBlockSigOps.Throw();
@@ -292,14 +292,14 @@ namespace Stratis.Bitcoin.Features.Consensus.Rules.CommonRules
         /// <returns>Signature operation cost for all transaction's inputs.</returns>
         public long GetTransactionSignatureOperationCost(Transaction transaction, UnspentOutputSet inputs, DeploymentFlags flags)
         {
-            long signatureOperationCost = this.GetLegacySignatureOperationsCount(transaction) * this.PowConsensusOptions.WitnessScaleFactor;
+            long signatureOperationCost = this.GetLegacySignatureOperationsCount(transaction) * this.ConsensusOptions.WitnessScaleFactor;
 
             if (transaction.IsCoinBase)
                 return signatureOperationCost;
 
             if (flags.ScriptFlags.HasFlag(ScriptVerify.P2SH))
             {
-                signatureOperationCost += this.GetP2SHSignatureOperationsCount(transaction, inputs) * this.PowConsensusOptions.WitnessScaleFactor;
+                signatureOperationCost += this.GetP2SHSignatureOperationsCount(transaction, inputs) * this.ConsensusOptions.WitnessScaleFactor;
             }
 
             for (int i = 0; i < transaction.Inputs.Count; i++)
@@ -403,7 +403,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Rules.CommonRules
         public long GetBlockWeight(Block block)
         {
             return this.GetSize(block, TransactionOptions.None)
-                   * (this.PowConsensusOptions.WitnessScaleFactor - 1)
+                   * (this.ConsensusOptions.WitnessScaleFactor - 1)
                    + this.GetSize(block, TransactionOptions.Witness);
         }
 

--- a/src/Stratis.Bitcoin.Features.Consensus/StakeValidator.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/StakeValidator.cs
@@ -81,7 +81,7 @@ namespace Stratis.Bitcoin.Features.Consensus
             this.chain = chain;
             this.coinView = coinView;
             this.network = network;
-            this.consensusOptions = network.Consensus.Option<PosConsensusOptions>();
+            this.consensusOptions = network.Consensus.Options as PosConsensusOptions;
         }
 
         /// <inheritdoc/>

--- a/src/Stratis.Bitcoin.Features.MemoryPool.Tests/MemoryPoolTransactionTests.cs
+++ b/src/Stratis.Bitcoin.Features.MemoryPool.Tests/MemoryPoolTransactionTests.cs
@@ -546,7 +546,7 @@ namespace Stratis.Bitcoin.Features.MemoryPool.Tests
             var options = new ParallelOptions { MaxDegreeOfParallelism = 10 };
             Parallel.ForEach(txs, options, transaction =>
             {
-                var entry = new TxMempoolEntry(transaction, new Money(rand.Next(100)), 0, 0.0, 1, transaction.TotalOut, false, 4, new LockPoints(), new PowConsensusOptions());
+                var entry = new TxMempoolEntry(transaction, new Money(rand.Next(100)), 0, 0.0, 1, transaction.TotalOut, false, 4, new LockPoints(), new ConsensusOptions());
                 tasks.Add(scheduler.WriteAsync(() => pool.AddUnchecked(transaction.GetHash(), entry)));
             });
 
@@ -572,7 +572,7 @@ namespace Stratis.Bitcoin.Features.MemoryPool.Tests
             Money inChainValue = (pool != null && pool.HasNoInputsOf(tx)) ? tx.TotalOut : 0;
 
             return new TxMempoolEntry(tx, this.nFee, this.nTime, this.dPriority, this.nHeight,
-                inChainValue, this.spendsCoinbase, this.sigOpCost, this.lp, new PowConsensusOptions());
+                inChainValue, this.spendsCoinbase, this.sigOpCost, this.lp, new ConsensusOptions());
         }
 
         // Change the default value

--- a/src/Stratis.Bitcoin.Features.MemoryPool.Tests/MempoolManagerTest.cs
+++ b/src/Stratis.Bitcoin.Features.MemoryPool.Tests/MempoolManagerTest.cs
@@ -50,7 +50,7 @@ namespace Stratis.Bitcoin.Features.MemoryPool.Tests
                     i.AcceptToMemoryPoolWithTime(It.IsAny<MempoolValidationState>(), It.IsAny<Transaction>()))
                         .ReturnsAsync((MempoolValidationState state, Transaction tx) =>
                         {
-                            var consensusOptions = new PowConsensusOptions();
+                            var consensusOptions = new ConsensusOptions();
                             mempool.MapTx.Add(new TxMempoolEntry(tx, Money.Zero, 0, 0, 0, Money.Zero, false, 0, null, consensusOptions));
                             return true;
                         }

--- a/src/Stratis.Bitcoin.Features.MemoryPool.Tests/MempoolPersistenceTest.cs
+++ b/src/Stratis.Bitcoin.Features.MemoryPool.Tests/MempoolPersistenceTest.cs
@@ -128,7 +128,7 @@ namespace Stratis.Bitcoin.Features.MemoryPool.Tests
             MempoolManager mempoolManager = CreateTestMempool(settings, out txMemPool);
             Money fee = Money.Satoshis(0.00001m);
 
-            txMemPool.AddUnchecked(tx1_parent.GetHash(), new TxMempoolEntry(tx1_parent, fee, 0, 0.0, 0, tx1_parent.TotalOut + fee, false, 0, null, new PowConsensusOptions()));
+            txMemPool.AddUnchecked(tx1_parent.GetHash(), new TxMempoolEntry(tx1_parent, fee, 0, 0.0, 0, tx1_parent.TotalOut + fee, false, 0, null, new ConsensusOptions()));
             long expectedTx1FeeDelta = 123;
 
             // age of tx = 5 hours
@@ -165,7 +165,7 @@ namespace Stratis.Bitcoin.Features.MemoryPool.Tests
             MempoolManager mempoolManager = CreateTestMempool(settings, out txMemPool);
             Money fee = Money.Satoshis(0.00001m);
 
-            txMemPool.AddUnchecked(tx1_parent.GetHash(), new TxMempoolEntry(tx1_parent, fee, 0, 0.0, 0, tx1_parent.TotalOut + fee, false, 0, null, new PowConsensusOptions()));
+            txMemPool.AddUnchecked(tx1_parent.GetHash(), new TxMempoolEntry(tx1_parent, fee, 0, 0.0, 0, tx1_parent.TotalOut + fee, false, 0, null, new ConsensusOptions()));
             long expectedTx1FeeDelta = 123;
 
             // age of tx = 5 hours past expiry
@@ -244,7 +244,7 @@ namespace Stratis.Bitcoin.Features.MemoryPool.Tests
             {
                 int amountSat = 10 * i;
                 Transaction tx = this.MakeRandomTx(amountSat);
-                var entry = new TxMempoolEntry(tx, Money.FromUnit(0.1m, MoneyUnit.MilliBTC), DateTimeOffset.Now.ToUnixTimeSeconds(), i * 100, i, amountSat, i == 0, 10, null, new PowConsensusOptions());
+                var entry = new TxMempoolEntry(tx, Money.FromUnit(0.1m, MoneyUnit.MilliBTC), DateTimeOffset.Now.ToUnixTimeSeconds(), i * 100, i, amountSat, i == 0, 10, null, new ConsensusOptions());
                 entry.UpdateFeeDelta(numTx - i);
                 entries.Add(entry);
             }

--- a/src/Stratis.Bitcoin.Features.MemoryPool.Tests/TestChainFactory.cs
+++ b/src/Stratis.Bitcoin.Features.MemoryPool.Tests/TestChainFactory.cs
@@ -73,7 +73,7 @@ namespace Stratis.Bitcoin.Features.MemoryPool.Tests
             ILoggerFactory loggerFactory = nodeSettings.LoggerFactory;
             IDateTimeProvider dateTimeProvider = DateTimeProvider.Default;
 
-            network.Consensus.Options = new PowConsensusOptions();
+            network.Consensus.Options = new ConsensusOptions();
             var consensusSettings = new ConsensusSettings(nodeSettings);
             var chain = new ConcurrentChain(network);
             var cachedCoinView = new CachedCoinView(new InMemoryCoinView(chain.Tip.HashBlock), DateTimeProvider.Default, loggerFactory);
@@ -230,8 +230,8 @@ namespace Stratis.Bitcoin.Features.MemoryPool.Tests
         {
             var options = new BlockDefinitionOptions
             {
-                BlockMaxWeight = network.Consensus.Option<PowConsensusOptions>().MaxBlockWeight,
-                BlockMaxSize = network.Consensus.Option<PowConsensusOptions>().MaxBlockSerializedSize
+                BlockMaxWeight = network.Consensus.Options.MaxBlockWeight,
+                BlockMaxSize = network.Consensus.Options.MaxBlockSerializedSize
             };
 
             var blockMinFeeRate = new FeeRate(PowMining.DefaultBlockMinTxFee);

--- a/src/Stratis.Bitcoin.Features.MemoryPool/MempoolOrphans.cs
+++ b/src/Stratis.Bitcoin.Features.MemoryPool/MempoolOrphans.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using NBitcoin;
-using Stratis.Bitcoin.Features.Consensus;
 using Stratis.Bitcoin.Features.Consensus.CoinViews;
 using Stratis.Bitcoin.P2P.Peer;
 using Stratis.Bitcoin.Utilities;
@@ -457,7 +456,7 @@ namespace Stratis.Bitcoin.Features.MemoryPool
                 // 100 orphans, each of which is at most 99,999 bytes big is
                 // at most 10 megabytes of orphans and somewhat more byprev index (in the worst case):
                 int sz = MempoolValidator.GetTransactionWeight(tx, this.Validator.ConsensusOptions);
-                if (sz >= this.chain.Network.Consensus.Option<PowConsensusOptions>().MaxStandardTxWeight)
+                if (sz >= this.chain.Network.Consensus.Options.MaxStandardTxWeight)
                 {
                     this.logger.LogInformation("ignoring large orphan tx (size: {0}, hash: {1})", sz, hash);
                     this.logger.LogTrace("(-)[LARGE_ORPH]:false");

--- a/src/Stratis.Bitcoin.Features.MemoryPool/MempoolValidator.cs
+++ b/src/Stratis.Bitcoin.Features.MemoryPool/MempoolValidator.cs
@@ -9,7 +9,6 @@ using Stratis.Bitcoin.Base.Deployments;
 using Stratis.Bitcoin.Configuration;
 using Stratis.Bitcoin.Consensus;
 using Stratis.Bitcoin.Consensus.Rules;
-using Stratis.Bitcoin.Features.Consensus;
 using Stratis.Bitcoin.Features.Consensus.CoinViews;
 using Stratis.Bitcoin.Features.Consensus.Rules.CommonRules;
 using Stratis.Bitcoin.Features.MemoryPool.Interfaces;
@@ -23,7 +22,7 @@ namespace Stratis.Bitcoin.Features.MemoryPool
     public interface IMempoolValidator
     {
         /// <summary>Gets the proof of work consensus option.</summary>
-        PowConsensusOptions ConsensusOptions { get; }
+        ConsensusOptions ConsensusOptions { get; }
 
         /// <summary>Gets the memory pool performance counter.</summary>
         MempoolPerformanceCounter PerformanceCounter { get; }
@@ -197,7 +196,7 @@ namespace Stratis.Bitcoin.Features.MemoryPool
         public MempoolPerformanceCounter PerformanceCounter { get; }
 
         /// <summary>Gets the consensus options from the <see cref="CoinViewRule"/></summary>
-        public PowConsensusOptions ConsensusOptions => this.network.Consensus.Option<PowConsensusOptions>();
+        public ConsensusOptions ConsensusOptions => this.network.Consensus.Options;
 
         /// <inheritdoc />
         public async Task<bool> AcceptToMemoryPoolWithTime(MempoolValidationState state, Transaction tx)
@@ -378,14 +377,14 @@ namespace Stratis.Bitcoin.Features.MemoryPool
         }
 
         /// <summary>
-        /// Computes the transaction size based on <see cref="PowConsensusOptions"/>.
+        /// Computes the transaction size based on <see cref="ConsensusOptions"/>.
         /// Takes into account witness options in the computation.
         /// </summary>
         /// <param name="tx">Transaction.</param>
         /// <param name="consensusOptions">Proof of work consensus options.</param>
         /// <returns>Transaction weight.</returns>
         /// <seealso cref="Transaction.GetSerializedSize"/>
-        public static int GetTransactionWeight(Transaction tx, PowConsensusOptions consensusOptions)
+        public static int GetTransactionWeight(Transaction tx, ConsensusOptions consensusOptions)
         {
             return tx.GetSerializedSize(
                        (ProtocolVersion)
@@ -402,7 +401,7 @@ namespace Stratis.Bitcoin.Features.MemoryPool
         /// <param name="trx">The transaction.</param>
         /// <param name="consensusOptions">The consensus option, needed to compute the transaction size.</param>
         /// <returns>The new transaction size.</returns>
-        public static int CalculateModifiedSize(int nTxSize, Transaction trx, PowConsensusOptions consensusOptions)
+        public static int CalculateModifiedSize(int nTxSize, Transaction trx, ConsensusOptions consensusOptions)
         {
             // In order to avoid disincentivizing cleaning up the UTXO set we don't count
             // the constant overhead for each txin and up to 110 bytes of scriptSig (which

--- a/src/Stratis.Bitcoin.Features.MemoryPool/TxMemPoolEntry.cs
+++ b/src/Stratis.Bitcoin.Features.MemoryPool/TxMemPoolEntry.cs
@@ -74,7 +74,7 @@ namespace Stratis.Bitcoin.Features.MemoryPool
         public TxMempoolEntry(Transaction transaction, Money nFee,
             long nTime, double entryPriority, int entryHeight,
             Money inChainInputValue, bool spendsCoinbase,
-            long nSigOpsCost, LockPoints lp, PowConsensusOptions consensusOptions)
+            long nSigOpsCost, LockPoints lp, ConsensusOptions consensusOptions)
         {
             this.Transaction = transaction;
             this.TransactionHash = transaction.GetHash();

--- a/src/Stratis.Bitcoin.Features.Miner.Tests/PosBlockAssemblerTest.cs
+++ b/src/Stratis.Bitcoin.Features.Miner.Tests/PosBlockAssemblerTest.cs
@@ -175,7 +175,7 @@ namespace Stratis.Bitcoin.Features.Miner.Tests
         [Fact]
         public void ComputeBlockVersion_UsingChainTipAndConsensus_Bip9DeploymentActive_UpdatesHeightAndVersion()
         {
-            NBitcoin.Consensus.ConsensusOptions options = this.network.Consensus.Options;
+            ConsensusOptions options = this.network.Consensus.Options;
             int minerConfirmationWindow = this.network.Consensus.MinerConfirmationWindow;
             int ruleChangeActivationThreshold = this.network.Consensus.RuleChangeActivationThreshold;
             try
@@ -318,7 +318,7 @@ namespace Stratis.Bitcoin.Features.Miner.Tests
 
         private void ExecuteWithConsensusOptions(PosConsensusOptions newOptions, Action action)
         {
-            NBitcoin.Consensus.ConsensusOptions options = this.network.Consensus.Options;
+            ConsensusOptions options = this.network.Consensus.Options;
             try
             {
                 this.network.Consensus.Options = newOptions;

--- a/src/Stratis.Bitcoin.Features.Miner.Tests/PosMintingTest.cs
+++ b/src/Stratis.Bitcoin.Features.Miner.Tests/PosMintingTest.cs
@@ -49,7 +49,7 @@ namespace Stratis.Bitcoin.Features.Miner.Tests
         {
             this.consensusLoop = new Mock<IConsensusLoop>();
             this.network = Network.StratisTest;
-            this.network.Consensus.Options = new PowConsensusOptions();
+            this.network.Consensus.Options = new ConsensusOptions();
             this.chain = new ConcurrentChain(this.network);
             this.connectionManager = new Mock<IConnectionManager>();
             this.dateTimeProvider = new Mock<IDateTimeProvider>();

--- a/src/Stratis.Bitcoin.Features.Miner.Tests/PowBlockAssemblerTest.cs
+++ b/src/Stratis.Bitcoin.Features.Miner.Tests/PowBlockAssemblerTest.cs
@@ -51,7 +51,7 @@ namespace Stratis.Bitcoin.Features.Miner.Tests
         [Fact]
         public void CreateNewBlock_WithScript_ReturnsBlockTemplate()
         {
-            this.ExecuteWithConsensusOptions(new PowConsensusOptions(), () =>
+            this.ExecuteWithConsensusOptions(new ConsensusOptions(), () =>
             {
                 ConcurrentChain chain = GenerateChainWithHeight(5, this.network, this.key);
                 this.SetupRulesEngine(chain);
@@ -60,7 +60,7 @@ namespace Stratis.Bitcoin.Features.Miner.Tests
                     .Returns(new DateTime(2017, 1, 7, 0, 0, 1, DateTimeKind.Utc).ToUnixTimestamp());
                 Transaction transaction = CreateTransaction(this.network, this.key, 5, new Money(400 * 1000 * 1000), new Key(), new uint256(124124));
                 var txFee = new Money(1000);
-                SetupTxMempool(chain, this.network.Consensus.Options as PowConsensusOptions, txFee, transaction);
+                SetupTxMempool(chain, this.network.Consensus.Options as ConsensusOptions, txFee, transaction);
                 this.consensusRules
                     .Setup(s => s.CreateRuleContext(It.IsAny<ValidationContext>(), It.IsAny<ChainedHeader>()))
                     .Returns(new PowRuleContext());
@@ -103,7 +103,7 @@ namespace Stratis.Bitcoin.Features.Miner.Tests
         [Fact]
         public void CreateNewBlock_WithScript_ValidatesTemplateUsingRuleContext()
         {
-            var newOptions = new PowConsensusOptions() { MaxBlockWeight = 1500 };
+            var newOptions = new ConsensusOptions() { MaxBlockWeight = 1500 };
 
             this.ExecuteWithConsensusOptions(newOptions, () =>
             {
@@ -117,7 +117,7 @@ namespace Stratis.Bitcoin.Features.Miner.Tests
 
                 Transaction transaction = CreateTransaction(this.network, this.key, 5, new Money(400 * 1000 * 1000), new Key(), new uint256(124124));
                 var txFee = new Money(1000);
-                SetupTxMempool(chain, this.network.Consensus.Options as PowConsensusOptions, txFee, transaction);
+                SetupTxMempool(chain, this.network.Consensus.Options as ConsensusOptions, txFee, transaction);
                 ValidationContext validationContext = null;
                 var powRuleContext = new PowRuleContext(new ValidationContext(), this.network.Consensus, chain.Tip, this.dateTimeProvider.Object.GetTimeOffset());
                 this.consensusRules
@@ -132,7 +132,7 @@ namespace Stratis.Bitcoin.Features.Miner.Tests
                 Assert.True(this.callbackRuleContext.MinedBlock);
                 Assert.Equal(blockTemplate.Block.GetHash(), validationContext.Block.GetHash());
                 Assert.Equal(chain.GetBlock(5).HashBlock, powRuleContext.ConsensusTip.HashBlock);
-                Assert.Equal(1500, this.callbackRuleContext.Consensus.Option<PowConsensusOptions>().MaxBlockWeight);
+                Assert.Equal(1500, this.callbackRuleContext.Consensus.Options.MaxBlockWeight);
                 this.consensusLoop.Verify();
             });
         }
@@ -140,7 +140,7 @@ namespace Stratis.Bitcoin.Features.Miner.Tests
         [Fact]
         public void ComputeBlockVersion_UsingChainTipAndConsensus_NoBip9DeploymentActive_UpdatesHeightAndVersion()
         {
-            this.ExecuteWithConsensusOptions(new PowConsensusOptions(), () =>
+            this.ExecuteWithConsensusOptions(new ConsensusOptions(), () =>
             {
                 ConcurrentChain chain = GenerateChainWithHeight(5, this.network, new Key());
 
@@ -157,12 +157,12 @@ namespace Stratis.Bitcoin.Features.Miner.Tests
         [Fact]
         public void ComputeBlockVersion_UsingChainTipAndConsensus_Bip9DeploymentActive_UpdatesHeightAndVersion()
         {
-            NBitcoin.Consensus.ConsensusOptions options = this.network.Consensus.Options;
+            ConsensusOptions options = this.network.Consensus.Options;
             int minerConfirmationWindow = this.network.Consensus.MinerConfirmationWindow;
             int ruleChangeActivationThreshold = this.network.Consensus.RuleChangeActivationThreshold;
             try
             {
-                var newOptions = new PowConsensusOptions();
+                var newOptions = new ConsensusOptions();
                 this.network.Consensus.Options = newOptions;
                 this.network.Consensus.BIP9Deployments[0] = new BIP9DeploymentsParameters(19,
                     new DateTimeOffset(new DateTime(2016, 1, 1, 0, 0, 0, DateTimeKind.Utc)),
@@ -195,7 +195,7 @@ namespace Stratis.Bitcoin.Features.Miner.Tests
         [Fact]
         public void CreateCoinbase_CreatesCoinbaseTemplateTransaction_AddsToBlockTemplate()
         {
-            this.ExecuteWithConsensusOptions(new PowConsensusOptions(), () =>
+            this.ExecuteWithConsensusOptions(new ConsensusOptions(), () =>
             {
                 ConcurrentChain chain = GenerateChainWithHeight(5, this.network, this.key);
                 this.dateTimeProvider.Setup(d => d.GetAdjustedTimeAsUnixTimestamp())
@@ -225,7 +225,7 @@ namespace Stratis.Bitcoin.Features.Miner.Tests
         [Fact]
         public void UpdateHeaders_UsingChainAndNetwork_PreparesBlockHeaders()
         {
-            this.ExecuteWithConsensusOptions(new PowConsensusOptions(), () =>
+            this.ExecuteWithConsensusOptions(new ConsensusOptions(), () =>
             {
                 this.dateTimeProvider.Setup(d => d.GetTimeOffset()).Returns(new DateTimeOffset(new DateTime(2017, 1, 7, 0, 0, 0, DateTimeKind.Utc)));
 
@@ -244,7 +244,7 @@ namespace Stratis.Bitcoin.Features.Miner.Tests
         [Fact]
         public void TestBlockValidity_UsesRuleContextToValidateBlock()
         {
-            var newOptions = new PowConsensusOptions() { MaxBlockWeight = 1500 };
+            var newOptions = new ConsensusOptions() { MaxBlockWeight = 1500 };
 
             this.ExecuteWithConsensusOptions(newOptions, () =>
             {
@@ -265,7 +265,7 @@ namespace Stratis.Bitcoin.Features.Miner.Tests
                 Assert.True(this.callbackRuleContext.MinedBlock);
                 Assert.Equal(block.GetHash(), validationContext.Block.GetHash());
                 Assert.Equal(chain.GetBlock(5).HashBlock, powRuleContext.ConsensusTip.HashBlock);
-                Assert.Equal(1500, this.callbackRuleContext.Consensus.Option<PowConsensusOptions>().MaxBlockWeight);
+                Assert.Equal(1500, this.callbackRuleContext.Consensus.Options.MaxBlockWeight);
                 this.consensusLoop.Verify();
             });
         }
@@ -273,7 +273,7 @@ namespace Stratis.Bitcoin.Features.Miner.Tests
         [Fact]
         public void AddTransactions_WithoutTransactionsInMempool_DoesNotAddEntriesToBlock()
         {
-            var newOptions = new PowConsensusOptions() { MaxBlockWeight = 1500 };
+            var newOptions = new ConsensusOptions() { MaxBlockWeight = 1500 };
 
             this.ExecuteWithConsensusOptions(newOptions, () =>
             {
@@ -298,7 +298,7 @@ namespace Stratis.Bitcoin.Features.Miner.Tests
         [Fact]
         public void AddTransactions_TransactionNotInblock_AddsTransactionToBlock()
         {
-            var newOptions = new PowConsensusOptions() { MaxBlockWeight = 1500 };
+            var newOptions = new ConsensusOptions() { MaxBlockWeight = 1500 };
 
             this.ExecuteWithConsensusOptions(newOptions, () =>
             {
@@ -324,7 +324,7 @@ namespace Stratis.Bitcoin.Features.Miner.Tests
         [Fact]
         public void AddTransactions_TransactionAlreadyInInblock_DoesNotAddTransactionToBlock()
         {
-            var newOptions = new PowConsensusOptions() { MaxBlockWeight = 1500 };
+            var newOptions = new ConsensusOptions() { MaxBlockWeight = 1500 };
 
             this.ExecuteWithConsensusOptions(newOptions, () =>
             {
@@ -346,9 +346,9 @@ namespace Stratis.Bitcoin.Features.Miner.Tests
             });
         }
 
-        private void ExecuteWithConsensusOptions(PowConsensusOptions newOptions, Action action)
+        private void ExecuteWithConsensusOptions(ConsensusOptions newOptions, Action action)
         {
-            NBitcoin.Consensus.ConsensusOptions options = this.network.Consensus.Options;
+            ConsensusOptions options = this.network.Consensus.Options;
             try
             {
                 this.network.Consensus.Options = newOptions;
@@ -440,7 +440,7 @@ namespace Stratis.Bitcoin.Features.Miner.Tests
             this.consensusLoop.SetupGet(x => x.ConsensusRules).Returns(powConsensusRules);
         }
 
-        private TxMempoolEntry[] SetupTxMempool(ConcurrentChain chain, PowConsensusOptions newOptions, Money txFee, params Transaction[] transactions)
+        private TxMempoolEntry[] SetupTxMempool(ConcurrentChain chain, ConsensusOptions newOptions, Money txFee, params Transaction[] transactions)
         {
             uint txTime = Utils.DateTimeToUnixTime(chain.Tip.Header.BlockTime.AddSeconds(25));
             var lockPoints = new LockPoints()

--- a/src/Stratis.Bitcoin.Features.Miner.Tests/PowMiningTest.cs
+++ b/src/Stratis.Bitcoin.Features.Miner.Tests/PowMiningTest.cs
@@ -24,7 +24,7 @@ namespace Stratis.Bitcoin.Features.Miner.Tests
         private ConcurrentChain chain;
         private readonly Mock<IConsensusLoop> consensusLoop;
         private readonly Mock<IConsensusRules> consensusRules;
-        private readonly NBitcoin.Consensus.ConsensusOptions initialNetworkOptions;
+        private readonly ConsensusOptions initialNetworkOptions;
         private readonly PowMiningTestFixture fixture;
         private readonly Mock<ITxMempool> mempool;
         private readonly MempoolSchedulerLock mempoolLock;
@@ -38,7 +38,7 @@ namespace Stratis.Bitcoin.Features.Miner.Tests
 
             this.initialNetworkOptions = this.network.Consensus.Options;
             if (this.initialNetworkOptions == null)
-                this.network.Consensus.Options = new PowConsensusOptions();
+                this.network.Consensus.Options = new ConsensusOptions();
 
             this.asyncLoopFactory = new Mock<IAsyncLoopFactory>();
 

--- a/src/Stratis.Bitcoin.Features.Miner/BlockDefinition.cs
+++ b/src/Stratis.Bitcoin.Features.Miner/BlockDefinition.cs
@@ -137,10 +137,10 @@ namespace Stratis.Bitcoin.Features.Miner
             this.BlockMaxWeight = (uint)Math.Max(4000, Math.Min(PowMining.DefaultBlockMaxWeight - 4000, this.Options.BlockMaxWeight));
 
             // Limit size to between 1K and MAX_BLOCK_SERIALIZED_SIZE-1K for sanity.
-            this.BlockMaxSize = (uint)Math.Max(1000, Math.Min(network.Consensus.Option<PowConsensusOptions>().MaxBlockSerializedSize - 1000, this.Options.BlockMaxSize));
+            this.BlockMaxSize = (uint)Math.Max(1000, Math.Min(network.Consensus.Options.MaxBlockSerializedSize - 1000, this.Options.BlockMaxSize));
 
             // Whether we need to account for byte usage (in addition to weight usage).
-            this.NeedSizeAccounting = (this.BlockMaxSize < network.Consensus.Option<PowConsensusOptions>().MaxBlockSerializedSize - 1000);
+            this.NeedSizeAccounting = (this.BlockMaxSize < network.Consensus.Options.MaxBlockSerializedSize - 1000);
 
             this.Configure();
         }
@@ -514,10 +514,10 @@ namespace Stratis.Bitcoin.Features.Miner
         private bool TestPackage(long packageSize, long packageSigOpsCost)
         {
             // TODO: Switch to weight-based accounting for packages instead of vsize-based accounting.
-            if (this.BlockWeight + this.Network.Consensus.Option<PowConsensusOptions>().WitnessScaleFactor * packageSize >= this.BlockMaxWeight)
+            if (this.BlockWeight + this.Network.Consensus.Options.WitnessScaleFactor * packageSize >= this.BlockMaxWeight)
                 return false;
 
-            if (this.BlockSigOpsCost + packageSigOpsCost >= this.Network.Consensus.Option<PowConsensusOptions>().MaxBlockSigopsCost)
+            if (this.BlockSigOpsCost + packageSigOpsCost >= this.Network.Consensus.Options.MaxBlockSigopsCost)
                 return false;
 
             return true;

--- a/src/Stratis.Bitcoin.Features.Miner/PosMinting.cs
+++ b/src/Stratis.Bitcoin.Features.Miner/PosMinting.cs
@@ -1030,7 +1030,7 @@ namespace Stratis.Bitcoin.Features.Miner
             var res = new List<UtxoStakeDescription>();
 
             long currentValue = 0;
-            long requiredDepth = this.network.Consensus.Option<PosConsensusOptions>().GetStakeMinConfirmations(chainTip.Height + 1, this.network) - 1;
+            long requiredDepth = (this.network.Consensus.Options as PosConsensusOptions).GetStakeMinConfirmations(chainTip.Height + 1, this.network) - 1;
             foreach (UtxoStakeDescription utxoStakeDescription in utxoStakeDescriptions.OrderByDescending(x => x.TxOut.Value))
             {
                 int depth = this.GetDepthInMainChain(utxoStakeDescription);
@@ -1210,7 +1210,7 @@ namespace Stratis.Bitcoin.Features.Miner
             this.logger.LogTrace("({0}:{1})", nameof(utxoCount), utxoCount);
 
             long maturityLimit = this.network.Consensus.CoinbaseMaturity;
-            long coinAgeLimit = this.network.Consensus.Option<PosConsensusOptions>().GetStakeMinConfirmations(chainTip.Height + 1, this.network);
+            long coinAgeLimit = (this.network.Consensus.Options as PosConsensusOptions).GetStakeMinConfirmations(chainTip.Height + 1, this.network);
             long requiredCoinAgeForStaking = Math.Max(maturityLimit, coinAgeLimit);
             this.logger.LogTrace("Required coin age for staking is {0}.", requiredCoinAgeForStaking);
 

--- a/src/Stratis.Bitcoin.Features.SmartContracts.Tests/Consensus/Rules/TestRulesContext.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts.Tests/Consensus/Rules/TestRulesContext.cs
@@ -68,7 +68,7 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Tests.Consensus.Rules
             testRulesContext.LoggerFactory = testRulesContext.NodeSettings.LoggerFactory;
             testRulesContext.LoggerFactory.AddConsoleWithFilters();
             testRulesContext.DateTimeProvider = DateTimeProvider.Default;
-            network.Consensus.Options = new PowConsensusOptions();
+            network.Consensus.Options = new ConsensusOptions();
 
             ConsensusSettings consensusSettings = new ConsensusSettings(testRulesContext.NodeSettings);
             testRulesContext.Checkpoints = new Checkpoints();

--- a/src/Stratis.Bitcoin.Features.SmartContracts/Consensus/Rules/SmartContractCoinviewRule.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts/Consensus/Rules/SmartContractCoinviewRule.cs
@@ -102,7 +102,7 @@ namespace Stratis.Bitcoin.Features.SmartContracts
                     // * p2sh (when P2SH enabled in flags and excludes coinbase),
                     // * witness (when witness enabled in flags and excludes coinbase).
                     sigOpsCost += this.GetTransactionSignatureOperationCost(tx, view, flags);
-                    if (sigOpsCost > this.PowConsensusOptions.MaxBlockSigopsCost)
+                    if (sigOpsCost > this.ConsensusOptions.MaxBlockSigopsCost)
                         ConsensusErrors.BadBlockSigOps.Throw();
 
                     if (!this.IsProtocolTransaction(tx))

--- a/src/Stratis.Bitcoin.Features.SmartContracts/SmartContractFeature.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts/SmartContractFeature.cs
@@ -114,10 +114,10 @@ namespace Stratis.Bitcoin.Features.SmartContracts
                 .DependOn<SmartContractFeature>()
                 .FeatureServices(services =>
                 {
-                    fullNodeBuilder.Network.Consensus.Options = new PowConsensusOptions();
+                    fullNodeBuilder.Network.Consensus.Options = new ConsensusOptions();
 
                     services.AddSingleton<ICheckpoints, Checkpoints>();
-                    services.AddSingleton<NBitcoin.Consensus.ConsensusOptions, PowConsensusOptions>();
+                    services.AddSingleton<ConsensusOptions, ConsensusOptions>();
                     services.AddSingleton<DBreezeCoinView>();
                     services.AddSingleton<CoinView, CachedCoinView>();
                     services.AddSingleton<LookaheadBlockPuller>().AddSingleton<ILookaheadBlockPuller, LookaheadBlockPuller>(provider => provider.GetService<LookaheadBlockPuller>()); ;

--- a/src/Stratis.Bitcoin.IntegrationTests/CoinViewTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/CoinViewTests.cs
@@ -323,12 +323,12 @@ namespace Stratis.Bitcoin.IntegrationTests
                 Flags = consensusFlags,
             };
 
-            Network.Main.Consensus.Options = new PowConsensusOptions();
+            Network.Main.Consensus.Options = new ConsensusOptions();
             context.Consensus = Network.Main.Consensus;
             new WitnessCommitmentsRule().RunAsync(context).GetAwaiter().GetResult();
 
             var rule = new CheckPowTransactionRule();
-            var options = Network.Main.Consensus.Option<PowConsensusOptions>();
+            var options = Network.Main.Consensus.Options;
             foreach (Transaction tx in block.Transactions)
                 rule.CheckTransaction(Network.Main, options, tx);
         }

--- a/src/Stratis.Bitcoin.IntegrationTests/Mempool/MemoryPoolTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/Mempool/MemoryPoolTests.cs
@@ -411,7 +411,7 @@ namespace Stratis.Bitcoin.IntegrationTests.Mempool
             Money inChainValue = (pool != null && pool.HasNoInputsOf(tx)) ? tx.TotalOut : 0;
 
             return new TxMempoolEntry(tx, this.nFee, this.nTime, this.dPriority, this.nHeight,
-                inChainValue, this.spendsCoinbase, this.sigOpCost, this.lp, new PowConsensusOptions());
+                inChainValue, this.spendsCoinbase, this.sigOpCost, this.lp, new ConsensusOptions());
         }
 
         // Change the default value

--- a/src/Stratis.Bitcoin.IntegrationTests/MinerTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/MinerTests.cs
@@ -40,8 +40,8 @@ namespace Stratis.Bitcoin.IntegrationTests
         {
             var options = new BlockDefinitionOptions
             {
-                BlockMaxWeight = testContext.network.Consensus.Option<PowConsensusOptions>().MaxBlockWeight,
-                BlockMaxSize = testContext.network.Consensus.Option<PowConsensusOptions>().MaxBlockSerializedSize,
+                BlockMaxWeight = testContext.network.Consensus.Options.MaxBlockWeight,
+                BlockMaxSize = testContext.network.Consensus.Options.MaxBlockSerializedSize,
                 BlockMinFeeRate = blockMinFeeRate
             };
 
@@ -135,7 +135,7 @@ namespace Stratis.Bitcoin.IntegrationTests
 
                 this.entry = new TestMemPoolEntryHelper();
                 this.chain = new ConcurrentChain(this.network);
-                this.network.Consensus.Options = new PowConsensusOptions();
+                this.network.Consensus.Options = new ConsensusOptions();
                 IDateTimeProvider dateTimeProvider = DateTimeProvider.Default;
 
                 this.cachedCoinView = new CachedCoinView(new InMemoryCoinView(this.chain.Tip.HashBlock), dateTimeProvider, new LoggerFactory());

--- a/src/Stratis.Bitcoin.IntegrationTests/SmartContracts/SmartContractMinerTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/SmartContracts/SmartContractMinerTests.cs
@@ -170,7 +170,7 @@ namespace Stratis.Bitcoin.IntegrationTests.SmartContracts
 
                 this.entry = new TestMemPoolEntryHelper();
                 this.chain = new ConcurrentChain(this.network);
-                this.network.Consensus.Options = new PowConsensusOptions();
+                this.network.Consensus.Options = new ConsensusOptions();
                 IDateTimeProvider dateTimeProvider = DateTimeProvider.Default;
 
                 this.cachedCoinView = new CachedCoinView(new InMemoryCoinView(this.chain.Tip.HashBlock), dateTimeProvider, new LoggerFactory());


### PR DESCRIPTION
This allows us to set current block size settings inside networks. e.g. inside StratisMain.

I planned to fix #1217 but in doing so we really need to make things a little more modular. When we're setting the max block size settings in the constructor for `BlockDefinition`, we actually need to know the maximum block size for the network we're on.

Moreover, when looking at the properties inside `PowConsensusOptions`, they're not specific to Pow at all:
```
            this.MaxBlockSerializedSize = 4000000;
            this.MaxBlockWeight = 4000000;
            this.WitnessScaleFactor = 4;
            this.SerializeTransactionNoWitness = 0x40000000;
            this.MaxStandardVersion = 2;
            this.MaxStandardTxWeight = 400000;
            this.MaxBlockBaseSize = 1000000;
            this.MaxBlockSigopsCost = 80000;
```

Correct me if I'm wrong but these are all settings related to blocks, and are necessary regardless whether we're PoW, PoS, PoA, etc etc.

They could really just be fields on the Consensus object itself but for now this is slightly simpler.

This PR makes the following changes:
* Move ConsensusOptions to be a standalone class in NBitcoin.
* Move all of the properties from PowConsensusOptions to ConsensusOptions
* Remove the hacky `Option<T>` method, and when retrieving `PoSConsensusOptions` use an `as` operator.