### PR TITLE
API Integration Test method naming redunancy fix

### DIFF
--- a/src/Stratis.Bitcoin.Features.BlockStore/Models/BlockModel.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/Models/BlockModel.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Linq;
 using NBitcoin;
+using Newtonsoft.Json;
+using Stratis.Bitcoin.Utilities.JsonConverters;
 
 namespace Stratis.Bitcoin.Features.BlockStore.Models
 {
@@ -10,6 +12,7 @@ namespace Stratis.Bitcoin.Features.BlockStore.Models
         public int Size { get; set; }
         public int Version { get; set; }
         public string Bits { get; set; }
+        [JsonConverter(typeof(DateTimeOffsetConverter))]
         public DateTimeOffset Time { get; set; }
         public string[] Transactions { get; set; }
         public double Difficulty { get; set; }
@@ -17,7 +20,7 @@ namespace Stratis.Bitcoin.Features.BlockStore.Models
         public string PreviousBlockHash { get; set; }
         public uint Nonce { get; set; }
 
-        public  BlockModel(Block block)
+        public BlockModel(Block block)
         {
             this.Hash = block.GetHash().ToString();
             this.Size = block.ToBytes().Length;
@@ -30,7 +33,13 @@ namespace Stratis.Bitcoin.Features.BlockStore.Models
             this.Difficulty = block.Header.Bits.Difficulty;
             this.Transactions = block.Transactions.Select(t => t.GetHash().ToString()).ToArray();
         }
-    }
 
-    
+        /// <summary>
+        /// Creates a block model
+        /// Used for deserializing from Json
+        /// </summary>
+        public BlockModel()
+        {
+        }
+    }
 }

--- a/src/Stratis.Bitcoin.IntegrationTests/API/ApiSpecification.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/API/ApiSpecification.cs
@@ -8,7 +8,7 @@ namespace Stratis.Bitcoin.IntegrationTests.API
         public void Getgeneralinfo_returns_json_starting_with_wallet_path()
         {
             Given(a_proof_of_stake_node_with_api_enabled);
-            When(calling_general_info_via_api);
+            When(calling_general_info);
             Then(general_information_about_the_wallet_and_node_is_returned);
         }
 
@@ -16,7 +16,7 @@ namespace Stratis.Bitcoin.IntegrationTests.API
         public void Startstaking_enables_staking_but_nothing_staked()
         {
             Given(a_proof_of_stake_node_with_api_enabled);
-            When(calling_startstaking_via_api);
+            When(calling_startstaking);
             Then(staking_is_enabled_but_nothing_is_staked);
         }
 
@@ -57,124 +57,124 @@ namespace Stratis.Bitcoin.IntegrationTests.API
         }
 
         [Fact]
-        public void Block_with_valid_hash_via_api_returns_transaction_block()
+        public void Block_with_valid_hash_returns_transaction_block()
         {
             Given(two_connected_pow_nodes_with_api_enabled);
             And(a_block_is_mined_creating_spendable_coins);
             And(more_blocks_mined_past_maturity_of_original_block);
             And(a_real_transaction);
             And(the_block_with_the_transaction_is_mined);
-            When(calling_block_with_valid_hash_via_api_returns_block);
+            When(calling_block);
             Then(the_real_block_should_be_retrieved);
             And(the_block_should_contain_the_transaction);
         }
 
         [Fact]
-        public void Getblockcount_via_api_returns_tipheight()
+        public void Getblockcount_returns_tipheight()
         {
             Given(a_pow_node_with_api_enabled);
             And(a_block_is_mined_creating_spendable_coins);
             And(more_blocks_mined_past_maturity_of_original_block);
-            When(calling_getblockcount_via_api_returns_an_int);
+            When(calling_getblockcount);
             Then(the_blockcount_should_match_consensus_tip_height);
         }
 
         [Fact]
-        public void Getpeerinfo_via_api_returns_connected_peer()
+        public void Getpeerinfo_returns_connected_peer()
         {
             Given(two_connected_pow_nodes_with_api_enabled);
-            When(calling_getpeerinfo_via_api);
+            When(calling_getpeerinfo);
             Then(a_single_connected_peer_is_returned);
         }
 
         [Fact]
-        public void Getbestblockhash_via_api_returns_tip_hash()
+        public void Getbestblockhash_returns_tip_hash()
         {
             Given(a_pow_node_with_api_enabled);
             And(a_block_is_mined_creating_spendable_coins);
             And(more_blocks_mined_past_maturity_of_original_block);
-            When(calling_getbestblockhash_via_api);
+            When(calling_getbestblockhash);
             Then(the_consensus_tip_blockhash_is_returned);
         }
 
         [Fact]
-        public void Getblockhash_via_api_returns_blockhash_at_given_height()
+        public void Getblockhash_returns_blockhash_at_given_height()
         {
             Given(a_pow_node_with_api_enabled);
             And(a_block_is_mined_creating_spendable_coins);
-            When(calling_getblockhash_via_api);
+            When(calling_getblockhash);
             Then(the_blockhash_is_returned);
         }
 
         [Fact]
-        public void Getrawmempool_via_api_finds_mempool_transaction()
+        public void Getrawmempool_finds_mempool_transaction()
         {
             Given(two_connected_pow_nodes_with_api_enabled);
             And(a_block_is_mined_creating_spendable_coins);
             And(more_blocks_mined_past_maturity_of_original_block);
             And(a_real_transaction);
-            When(calling_getrawmempool_via_api);
+            When(calling_getrawmempool);
             Then(the_transaction_is_found_in_mempool);
         }
 
         [Fact]
-        public void Getblockheader_via_api_returns_blockheader()
+        public void Getblockheader_returns_blockheader()
         {
             Given(a_pow_node_with_api_enabled);
             And(a_block_is_mined_creating_spendable_coins);
-            When(calling_getblockheader_via_api);
+            When(calling_getblockheader);
             Then(the_blockheader_is_returned);
         }
 
         [Fact]
-        public void Getrawtransaction_nonverbose_via_api_returns_transaction_hash()
+        public void Getrawtransaction_nonverbose_returns_transaction_hash()
         {
             Given(two_connected_pow_nodes_with_api_enabled);
             And(a_block_is_mined_creating_spendable_coins);
             And(more_blocks_mined_past_maturity_of_original_block);
             And(a_real_transaction);
             And(the_block_with_the_transaction_is_mined);
-            When(calling_getrawtransaction_nonverbose_via_api);
+            When(calling_getrawtransaction_nonverbose);
             Then(the_transaction_hash_is_returned);
         }
 
         [Fact]
-        public void Getrawtransaction_verbose_via_api_returns()
+        public void Getrawtransaction_verbose_returns_full_transaction()
         {
-            Given(two_connected_pow_nodes_with_api_enabled);
+            Given(two_connected_pow_nodes_with_api_enabled);	    
             And(a_block_is_mined_creating_spendable_coins);
             And(more_blocks_mined_past_maturity_of_original_block);
             And(a_real_transaction);
             And(the_block_with_the_transaction_is_mined);
-            When(calling_getrawtransaction_verbose_via_api);
+            When(calling_getrawtransaction_verbose);
             Then(a_verbose_raw_transaction_is_returned);
         }
 
         [Fact]
-        public void Gettxout_nomempool_via_api_returns_txouts()
+        public void Gettxout_nomempool_returns_txouts()
         {
             Given(two_connected_pow_nodes_with_api_enabled);
             And(a_block_is_mined_creating_spendable_coins);
             And(more_blocks_mined_past_maturity_of_original_block);
             And(a_real_transaction);
             And(the_block_with_the_transaction_is_mined);
-            When(calling_gettxout_notmempool_via_api);
+            When(calling_gettxout_notmempool);
             Then(the_txout_is_returned);
         }
 
         [Fact]
-        public void Validateaddress_via_api_confirms_valid_address()
+        public void Validateaddress_confirms_valid_address()
         {
             Given(a_pow_node_with_api_enabled);
-            When(calling_validateaddress_via_api);
+            When(calling_validateaddress);
             Then(a_valid_address_is_validated);
         }
 
         [Fact]
-        public void Status_via_api_returns_status_info()
+        public void Status_returns_status_info()
         {
             Given(a_pow_node_with_api_enabled);
-            When(calling_status_via_api);
+            When(calling_status);
             Then(status_information_is_returned);
         }
     }

--- a/src/Stratis.Bitcoin.IntegrationTests/API/ApiSpecification.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/API/ApiSpecification.cs
@@ -141,7 +141,7 @@ namespace Stratis.Bitcoin.IntegrationTests.API
         [Fact]
         public void Getrawtransaction_verbose_returns_full_transaction()
         {
-            Given(two_connected_pow_nodes_with_api_enabled);	    
+            Given(two_connected_pow_nodes_with_api_enabled);
             And(a_block_is_mined_creating_spendable_coins);
             And(more_blocks_mined_past_maturity_of_original_block);
             And(a_real_transaction);

--- a/src/Stratis.Bitcoin.IntegrationTests/API/ApiSteps.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/API/ApiSteps.cs
@@ -12,7 +12,10 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities;
 using NBitcoin;
 using Newtonsoft.Json.Linq;
+using Stratis.Bitcoin.Connection;
+using Stratis.Bitcoin.Controllers.Models;
 using Stratis.Bitcoin.Features.Api;
+using Stratis.Bitcoin.Features.BlockStore.Models;
 using Stratis.Bitcoin.Features.Miner;
 using Stratis.Bitcoin.Features.Miner.Interfaces;
 using Stratis.Bitcoin.Features.Miner.Models;
@@ -97,7 +100,7 @@ namespace Stratis.Bitcoin.IntegrationTests.API
         {
             a_pow_node_with_api_enabled();
             a_second_pow_node_with_api_enabled();
-            calling_addnode_via_api_connects_two_nodes();
+            calling_addnode_connects_two_nodes();
 
             this.receiverAddress = this.nodes[SecondPowNode].FullNode.WalletManager()
                 .GetUnusedAddress(new WalletAccountReference(SecondaryWalletName, WalletAccountName));
@@ -153,7 +156,7 @@ namespace Stratis.Bitcoin.IntegrationTests.API
             this.nodes[FirstPowNode].GenerateStratisWithMiner(1);
         }
 
-        private void calling_startstaking_via_api()
+        private void calling_startstaking()
         {
             var stakingRequest = new StartStakingRequest() { Name = PrimaryWalletName, Password = WalletPassword };
 
@@ -238,59 +241,58 @@ namespace Stratis.Bitcoin.IntegrationTests.API
         {
             this.send_api_get_request($"api/Wallet/balance?walletname={walletName}&AccountName=account {accountIndex}");
 
-            this.responseText.Should()
-                .Be("{\"balances\":[{\"accountName\":\"account " + accountIndex + "\",\"accountHdPath\":\"m/44'/105'/" + accountIndex + "'\",\"coinType\":105,\"amountConfirmed\":0,\"amountUnconfirmed\":0}]}");
+            this.responseText.Should().Be("{\"balances\":[{\"accountName\":\"account " + accountIndex + "\",\"accountHdPath\":\"m/44'/105'/" + accountIndex + "'\",\"coinType\":105,\"amountConfirmed\":0,\"amountUnconfirmed\":0}]}");
         }
 
-        private void calling_general_info_via_api()
+        private void calling_general_info()
         {
             this.nodes.Last().Value.FullNode.WalletManager().CreateWallet(WalletPassword, PrimaryWalletName);
             this.send_api_get_request($"api/wallet/general-info?name={PrimaryWalletName}");
         }
 
-        private void calling_addnode_via_api_connects_two_nodes()
+        private void calling_addnode_connects_two_nodes()
         {
             this.send_api_get_request($"api/ConnectionManager/addnode?endpoint={this.nodes[SecondPowNode].Endpoint.ToString()}&command=onetry");
             this.responseText.Should().Be("true");
             this.WaitForNodeToSync(this.nodes[FirstPowNode], this.nodes[SecondPowNode]);
         }
 
-        private void calling_block_with_valid_hash_via_api_returns_block()
+        private void calling_block()
         {
             this.send_api_get_request($"api/BlockStore/block?Hash={this.block}&OutputJson=true");
         }
 
-        private void calling_getblockcount_via_api_returns_an_int()
+        private void calling_getblockcount()
         {
             this.send_api_get_request("api/BlockStore/getblockcount");
         }
 
-        private void calling_getbestblockhash_via_api()
+        private void calling_getbestblockhash()
         {
             this.send_api_get_request("api/Consensus/getbestblockhash");
         }
 
-        private void calling_getpeerinfo_via_api()
+        private void calling_getpeerinfo()
         {
             this.send_api_get_request("api/ConnectionManager/getpeerinfo");
         }
 
-        private void calling_getblockhash_via_api()
+        private void calling_getblockhash()
         {
             this.send_api_get_request("api/Consensus/getblockhash?height=0");
         }
 
-        private void calling_getblockheader_via_api()
+        private void calling_getblockheader()
         {
             this.send_api_get_request($"api/Node/getblockheader?hash={Network.RegTest.Consensus.HashGenesisBlock.ToString()}");
         }
 
-        private void calling_status_via_api()
+        private void calling_status()
         {
             this.send_api_get_request("api/Node/status");
         }
 
-        private void calling_validateaddress_via_api()
+        private void calling_validateaddress()
         {
             string address = this.nodes[FirstPowNode].FullNode.WalletManager()
                 .GetUnusedAddress(new WalletAccountReference(PrimaryWalletName, WalletAccountName))
@@ -298,21 +300,22 @@ namespace Stratis.Bitcoin.IntegrationTests.API
             this.send_api_get_request($"api/Node/validateaddress?address={address}");
         }
 
-        private void calling_getrawmempool_via_api()
+        private void calling_getrawmempool()
         {
             this.send_api_get_request("api/Mempool/getrawmempool");
         }
 
-        private void calling_gettxout_notmempool_via_api()
+        private void calling_gettxout_notmempool()
         {
             this.send_api_get_request($"api/Node/gettxout?trxid={this.transaction.GetHash().ToString()}&vout=1&includeMemPool=false");
         }
-        private void calling_getrawtransaction_nonverbose_via_api()
+    
+        private void calling_getrawtransaction_nonverbose()
         {
             this.send_api_get_request($"api/Node/getrawtransaction?trxid={this.transaction.GetHash().ToString()}&verbose=false");
         }
 
-        private void calling_getrawtransaction_verbose_via_api()
+        private void calling_getrawtransaction_verbose()
         {
             this.send_api_get_request($"api/Node/getrawtransaction?trxid={this.transaction.GetHash().ToString()}&verbose=true");
         }
@@ -335,16 +338,14 @@ namespace Stratis.Bitcoin.IntegrationTests.API
 
         private void the_real_block_should_be_retrieved()
         {
-            JObject jObjectResponse = JObject.Parse(this.responseText);
-            jObjectResponse["hash"].Value<string>()
-                .Should().Be(this.block.ToString());
+            var blockResponse = JsonDataSerializer.Instance.Deserialize<BlockModel>(this.responseText);
+            blockResponse.Hash.Should().Be(this.block.ToString());
         }
 
         private void the_block_should_contain_the_transaction()
         {
-            JObject jObjectResponse = JObject.Parse(this.responseText);
-            jObjectResponse["transactions"][1].Value<string>()
-                .Should().Be(this.transaction.GetHash().ToString());
+            var blockResponse = JsonDataSerializer.Instance.Deserialize<BlockModel>(this.responseText);
+            blockResponse.Transactions[1].Should().Be(this.transaction.GetHash().ToString());
         }
 
         private void it_is_rejected_as_forbidden()
@@ -383,30 +384,28 @@ namespace Stratis.Bitcoin.IntegrationTests.API
         private void status_information_is_returned()
         {
             var statusNode = this.nodes[FirstPowNode].FullNode;
-            JObject jObjectResponse = JObject.Parse(this.responseText);
-            jObjectResponse["agent"].Value<string>().Should().Contain(statusNode.Settings.Agent);
-            jObjectResponse["version"].Value<string>().Should().Be(statusNode.Version.ToString());
-            jObjectResponse["network"].Value<string>().Should().Be(statusNode.Network.Name);
-            jObjectResponse["consensusHeight"].Value<int>().Should().Be(0);
-            jObjectResponse["blockStoreHeight"].Value<int>().Should().Be(0);
-            jObjectResponse["protocolVersion"].Value<uint>().Should().Be((uint)(statusNode.Settings.ProtocolVersion));
-            jObjectResponse["relayFee"].Value<decimal>().Should().Be(statusNode.Settings.MinRelayTxFeeRate.FeePerK.ToUnit(MoneyUnit.BTC));
-            jObjectResponse["dataDirectoryPath"].Value<string>().Should().Be(statusNode.Settings.DataDir);
-            JArray jArrayFeatures = jObjectResponse["enabledFeatures"].Value<JArray>();
-            jArrayFeatures.Contains("Stratis.Bitcoin.Base.BaseFeature");
-            jArrayFeatures.Contains("Stratis.Bitcoin.Features.Api.ApiFeature");
-            jArrayFeatures.Contains("Stratis.Bitcoin.Features.BlockStore.BlockStoreFeature");
-            jArrayFeatures.Contains("Stratis.Bitcoin.Features.Consensus.ConsensusFeature");
-            jArrayFeatures.Contains("Stratis.Bitcoin.Features.MemoryPool.MempoolFeature");
-            jArrayFeatures.Contains("Stratis.Bitcoin.Features.Miner.MiningFeature");
-            jArrayFeatures.Contains("Stratis.Bitcoin.Features.RPC.RPCFeature");
-            jArrayFeatures.Contains("Stratis.Bitcoin.Features.Wallet.WalletFeature");
+            var statusResponse = JsonDataSerializer.Instance.Deserialize<StatusModel>(this.responseText);
+            statusResponse.Agent.Should().Contain(statusNode.Settings.Agent);
+            statusResponse.Version.Should().Be(statusNode.Version.ToString());
+            statusResponse.Network.Should().Be(statusNode.Network.Name);
+            statusResponse.ConsensusHeight.Should().Be(0);
+            statusResponse.BlockStoreHeight.Should().Be(0);
+            statusResponse.ProtocolVersion.Should().Be((uint)(statusNode.Settings.ProtocolVersion));
+            statusResponse.RelayFee.Should().Be(statusNode.Settings.MinRelayTxFeeRate.FeePerK.ToUnit(MoneyUnit.BTC));
+            statusResponse.DataDirectoryPath.Should().Be(statusNode.Settings.DataDir);
+            statusResponse.EnabledFeatures.Should().Contain("Stratis.Bitcoin.Base.BaseFeature");
+            statusResponse.EnabledFeatures.Should().Contain("Stratis.Bitcoin.Features.Api.ApiFeature");
+            statusResponse.EnabledFeatures.Should().Contain("Stratis.Bitcoin.Features.BlockStore.BlockStoreFeature");
+            statusResponse.EnabledFeatures.Should().Contain("Stratis.Bitcoin.Features.Consensus.ConsensusFeature");
+            statusResponse.EnabledFeatures.Should().Contain("Stratis.Bitcoin.Features.MemoryPool.MempoolFeature");
+            statusResponse.EnabledFeatures.Should().Contain("Stratis.Bitcoin.Features.Miner.MiningFeature");
+            statusResponse.EnabledFeatures.Should().Contain("Stratis.Bitcoin.Features.RPC.RPCFeature");
+            statusResponse.EnabledFeatures.Should().Contain("Stratis.Bitcoin.Features.Wallet.WalletFeature");
         }
 
         private void general_information_about_the_wallet_and_node_is_returned()
         {
             var generalInfoResponse = JsonDataSerializer.Instance.Deserialize<WalletGeneralInfoModel>(this.responseText);
-
             generalInfoResponse.WalletFilePath.Should().ContainAll(StratisRegTest, $"{PrimaryWalletName}.wallet.json");
             generalInfoResponse.Network.Name.Should().Be(StratisRegTest);
             generalInfoResponse.ChainTip.Should().Be(0);
@@ -417,23 +416,21 @@ namespace Stratis.Bitcoin.IntegrationTests.API
 
         private void the_blockheader_is_returned()
         {
-            JObject jObjectResponse = JObject.Parse(this.responseText);
-            jObjectResponse["previousblockhash"].Value<string>().Should()
+            var blockheaderResponse = JsonDataSerializer.Instance.Deserialize<BlockHeaderModel>(this.responseText);
+            blockheaderResponse.PreviousBlockHash.Should()
                 .Be("0000000000000000000000000000000000000000000000000000000000000000");
         }
 
         private void the_transaction_is_found_in_mempool()
         {
-            JArray jArrayResponse = JArray.Parse(this.responseText);
-            jArrayResponse[0].Value<string>().Should()
-                .Be(this.transaction.GetHash().ToString());
+            List<string> transactionList = JArray.Parse(this.responseText).ToObject<List<string>>();
+            transactionList[0].Should().Be(this.transaction.GetHash().ToString());
         }
 
         private void staking_is_enabled_but_nothing_is_staked()
         {
             var miningRpcController = this.nodes[PosNode].FullNode.NodeService<MiningRPCController>();
             GetStakingInfoModel stakingInfo = miningRpcController.GetStakingInfo();
-
             stakingInfo.Should().NotBeNull();
             stakingInfo.Enabled.Should().BeTrue();
             stakingInfo.Staking.Should().BeFalse();
@@ -446,32 +443,27 @@ namespace Stratis.Bitcoin.IntegrationTests.API
 
         private void a_verbose_raw_transaction_is_returned()
         {
-            JObject jObjectResponse = JObject.Parse(this.responseText);
-            jObjectResponse["hex"].Value<string>().Should().Be(this.transaction.ToHex());
-            jObjectResponse["txid"].Value<string>().Should().Be(this.transaction.GetHash().ToString());
+            var verboseRawTransactionResponse = JsonDataSerializer.Instance.Deserialize<TransactionVerboseModel>(this.responseText);
+            verboseRawTransactionResponse.Hex.Should().Be(this.transaction.ToHex());
+            verboseRawTransactionResponse.TxId.Should().Be(this.transaction.GetHash().ToString());            
         }
 
         private void a_single_connected_peer_is_returned()
         {
-            JArray jArrayResponse = JArray.Parse(this.responseText);
-            jArrayResponse.Count.Should().Be(1);
-            jArrayResponse[0]["id"].Value<int>()
-                .Should().Be(0);
-            jArrayResponse[0]["addr"].Value<string>()
-                .Should().Contain("[::ffff:127.0.0.1]");
+            List<PeerNodeModel> getPeerInfoResponseList = JArray.Parse(this.responseText).ToObject<List<PeerNodeModel>>();            
+            getPeerInfoResponseList.Count.Should().Be(1);
+            getPeerInfoResponseList[0].Id.Should().Be(0);
+            getPeerInfoResponseList[0].Address.Should().Contain("[::ffff:127.0.0.1]");
         }
 
         private void the_txout_is_returned()
         {
-            JObject jObjectResponse = JObject.Parse(this.responseText);
-            jObjectResponse["value"].Value<long>().Should()
-                .Be(this.transferAmount.Satoshi);
+            var txOutResponse = JsonDataSerializer.Instance.Deserialize<GetTxOutModel>(this.responseText);
+            txOutResponse.Value.Should().Be(this.transferAmount);
         }
 
         private void send_api_get_request(string apiendpoint)
         {
-            this.httpClient.DefaultRequestHeaders.Accept.Clear();
-            this.httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue(JsonContentType));
             this.response = this.httpClient.GetAsync($"{this.apiUri}{apiendpoint}").GetAwaiter().GetResult();
             this.response.StatusCode.Should().Be(HttpStatusCode.OK);
             this.responseText = this.response.Content.ReadAsStringAsync().GetAwaiter().GetResult();

--- a/src/Stratis.Bitcoin/Controllers/Models/BlockHeaderModel.cs
+++ b/src/Stratis.Bitcoin/Controllers/Models/BlockHeaderModel.cs
@@ -31,6 +31,14 @@ namespace Stratis.Bitcoin.Controllers.Models
         }
 
         /// <summary>
+        /// Constructs a BlockHeaderModel.
+        /// Used when deserializing block header from Json.
+        /// </summary>
+        public BlockHeaderModel()
+        {
+        }
+
+        /// <summary>
         /// The blocks version number.
         /// </summary>
         [JsonProperty(PropertyName = "version")]

--- a/src/Stratis.Bitcoin/Controllers/Models/GetTxOutModel.cs
+++ b/src/Stratis.Bitcoin/Controllers/Models/GetTxOutModel.cs
@@ -1,6 +1,7 @@
 ﻿using NBitcoin;
 using Newtonsoft.Json;
 using Stratis.Bitcoin.Utilities;
+using Stratis.Bitcoin.Utilities.JsonConverters;
 
 namespace Stratis.Bitcoin.Controllers.Models
 {
@@ -38,6 +39,7 @@ namespace Stratis.Bitcoin.Controllers.Models
 
         /// <summary>The block hash of the consensus tip.</summary>
         [JsonProperty(Order = 0, PropertyName = "bestblock")]
+        [JsonConverter(typeof(UInt256JsonConverter))]
         public uint256 BestBlock { get; set; }
 
         /// <summary>The number of confirmations for the unspent output.</summary>


### PR DESCRIPTION
Per discussion with @majikandy on discord after PR #1635, 2 items were suggested to change with a minor PR:
* Method names had a redundant "_via_api" naming scheme
* Deserialize rather than use JObject

All respective tests are passing.