### PR TITLE
Remove pass-by-reference of Network in BitcoinAddress types

### DIFF
--- a/src/NBitcoin/BitcoinAddress.cs
+++ b/src/NBitcoin/BitcoinAddress.cs
@@ -10,20 +10,20 @@ namespace NBitcoin
     public class BitcoinScriptAddress : BitcoinAddress, IBase58Data
     {
         public BitcoinScriptAddress(string base58, Network expectedNetwork)
-            : base(Validate(base58, ref expectedNetwork), expectedNetwork)
+            : base(Validate(base58, expectedNetwork), expectedNetwork)
         {
             byte[] decoded = Encoders.Base58Check.DecodeData(base58);
             this._Hash = new ScriptId(new uint160(decoded.Skip(expectedNetwork.GetVersionBytes(Base58Type.SCRIPT_ADDRESS, true).Length).ToArray()));
         }
 
-        private static string Validate(string base58, ref Network expectedNetwork)
+        private static string Validate(string base58, Network expectedNetwork)
         {
-            if (IsValid(base58, ref expectedNetwork))
+            if (IsValid(base58, expectedNetwork))
                 return base58;
             throw new FormatException("Invalid BitcoinScriptAddress");
         }
 
-        public static bool IsValid(string base58, ref Network expectedNetwork)
+        public static bool IsValid(string base58, Network expectedNetwork)
         {
             if (base58 == null)
                 throw new ArgumentNullException("base58");

--- a/src/NBitcoin/BitcoinPubKeyAddress.cs
+++ b/src/NBitcoin/BitcoinPubKeyAddress.cs
@@ -10,20 +10,20 @@ namespace NBitcoin
     public class BitcoinPubKeyAddress : BitcoinAddress, IBase58Data
     {
         public BitcoinPubKeyAddress(string base58, Network expectedNetwork)
-            : base(Validate(base58, ref expectedNetwork), expectedNetwork)
+            : base(Validate(base58, expectedNetwork), expectedNetwork)
         {
             byte[] decoded = Encoders.Base58Check.DecodeData(base58);
             this._KeyId = new KeyId(new uint160(decoded.Skip(expectedNetwork.GetVersionBytes(Base58Type.PUBKEY_ADDRESS, true).Length).ToArray()));
         }
 
-        private static string Validate(string base58, ref Network expectedNetwork)
+        private static string Validate(string base58, Network expectedNetwork)
         {
-            if (IsValid(base58, ref expectedNetwork))
+            if (IsValid(base58, expectedNetwork))
                 return base58;
             throw new FormatException("Invalid BitcoinPubKeyAddress");
         }
 
-        public static bool IsValid(string base58, ref Network expectedNetwork)
+        public static bool IsValid(string base58, Network expectedNetwork)
         {
             if (base58 == null)
                 throw new ArgumentNullException("base58");

--- a/src/NBitcoin/BitcoinSegwitAddress.cs
+++ b/src/NBitcoin/BitcoinSegwitAddress.cs
@@ -6,7 +6,7 @@ namespace NBitcoin
     public class BitcoinWitPubKeyAddress : BitcoinAddress, IBech32Data
     {
         public BitcoinWitPubKeyAddress(string bech32, Network expectedNetwork)
-                : base(Validate(bech32, ref expectedNetwork), expectedNetwork)
+                : base(Validate(bech32, expectedNetwork), expectedNetwork)
         {
             Bech32Encoder encoder = expectedNetwork.GetBech32Encoder(Bech32Type.WITNESS_PUBKEY_ADDRESS, true);
             byte witVersion;
@@ -14,9 +14,9 @@ namespace NBitcoin
             this._Hash = new WitKeyId(decoded);
         }
 
-        private static string Validate(string bech32, ref Network expectedNetwork)
+        private static string Validate(string bech32, Network expectedNetwork)
         {
-            bool isValid = IsValid(bech32, ref expectedNetwork, out Exception exception);
+            bool isValid = IsValid(bech32, expectedNetwork, out Exception exception);
 
             if (exception != null)
                 throw exception;
@@ -27,7 +27,7 @@ namespace NBitcoin
             throw new FormatException("Invalid BitcoinWitPubKeyAddress");
         }
 
-        public static bool IsValid(string bech32, ref Network expectedNetwork, out Exception exception)
+        public static bool IsValid(string bech32, Network expectedNetwork, out Exception exception)
         {
             exception = null;
 
@@ -111,7 +111,7 @@ namespace NBitcoin
     public class BitcoinWitScriptAddress : BitcoinAddress, IBech32Data
     {
         public BitcoinWitScriptAddress(string bech32, Network expectedNetwork = null)
-                : base(Validate(bech32, ref expectedNetwork), expectedNetwork)
+                : base(Validate(bech32, expectedNetwork), expectedNetwork)
         {
             Bech32Encoder encoder = expectedNetwork.GetBech32Encoder(Bech32Type.WITNESS_SCRIPT_ADDRESS, true);
             byte witVersion;
@@ -119,9 +119,9 @@ namespace NBitcoin
             this._Hash = new WitScriptId(decoded);
         }
 
-        private static string Validate(string bech32, ref Network expectedNetwork)
+        private static string Validate(string bech32, Network expectedNetwork)
         {
-            bool isValid = IsValid(bech32, ref expectedNetwork, out Exception exception);
+            bool isValid = IsValid(bech32, expectedNetwork, out Exception exception);
 
             if (exception != null)
                 throw exception;
@@ -132,7 +132,7 @@ namespace NBitcoin
             throw new FormatException("Invalid BitcoinWitScriptAddress");
         }
 
-        public static bool IsValid(string bech32, ref Network expectedNetwork, out Exception exception)
+        public static bool IsValid(string bech32, Network expectedNetwork, out Exception exception)
         {
             exception = null;
 

--- a/src/Stratis.Bitcoin.Features.RPC/Controllers/FullNodeController.cs
+++ b/src/Stratis.Bitcoin.Features.RPC/Controllers/FullNodeController.cs
@@ -250,22 +250,22 @@ namespace Stratis.Bitcoin.Features.RPC.Controllers
             res.IsValid = false;
 
             // P2WPKH
-            if (BitcoinWitPubKeyAddress.IsValid(address, ref this.Network, out Exception _))
+            if (BitcoinWitPubKeyAddress.IsValid(address, this.Network, out Exception _))
             {
                 res.IsValid = true;
             }
             // P2WSH
-            else if (BitcoinWitScriptAddress.IsValid(address, ref this.Network, out Exception _))
+            else if (BitcoinWitScriptAddress.IsValid(address, this.Network, out Exception _))
             {
                 res.IsValid = true;
             }
             // P2PKH
-            else if (BitcoinPubKeyAddress.IsValid(address, ref this.Network))
+            else if (BitcoinPubKeyAddress.IsValid(address, this.Network))
             {
                 res.IsValid = true;
             }
             // P2SH
-            else if (BitcoinScriptAddress.IsValid(address, ref this.Network))
+            else if (BitcoinScriptAddress.IsValid(address, this.Network))
             {
                 res.IsValid = true;
             }

--- a/src/Stratis.Bitcoin/Controllers/NodeController.cs
+++ b/src/Stratis.Bitcoin/Controllers/NodeController.cs
@@ -271,22 +271,22 @@ namespace Stratis.Bitcoin.Controllers
                 var res = new ValidatedAddress();
                 res.IsValid = false;
                 // P2WPKH
-                if (BitcoinWitPubKeyAddress.IsValid(address, ref this.network, out Exception _))
+                if (BitcoinWitPubKeyAddress.IsValid(address, this.network, out Exception _))
                 {
                     res.IsValid = true;
                 }
                 // P2WSH
-                else if (BitcoinWitScriptAddress.IsValid(address, ref this.network, out Exception _))
+                else if (BitcoinWitScriptAddress.IsValid(address, this.network, out Exception _))
                 {
                     res.IsValid = true;
                 }
                 // P2PKH
-                else if (BitcoinPubKeyAddress.IsValid(address, ref this.network))
+                else if (BitcoinPubKeyAddress.IsValid(address, this.network))
                 {
                     res.IsValid = true;
                 }
                 // P2SH
-                else if (BitcoinScriptAddress.IsValid(address, ref this.network))
+                else if (BitcoinScriptAddress.IsValid(address, this.network))
                 {
                     res.IsValid = true;
                 }


### PR DESCRIPTION
The BitcoinAddress types all unnecessarily pass Network by reference. This is dangerous, as it means they can change the Network object pointed to by `reference`.

✅All tests pass except SmartContracts integration tests (failing in master), AddNewAccount_for_xpub_only_wallet_informs_user_to_create_new_wallet_ (failing in master), and CreateExtPubKeyOnlyWallet_creates_wallet_with_extra_flag (failing in master)

 
