### PR TITLE
Remove Consensus from ConsensusFactory

### DIFF
--- a/src/NBitcoin/BitcoinCore/Coins.cs
+++ b/src/NBitcoin/BitcoinCore/Coins.cs
@@ -160,7 +160,7 @@ namespace NBitcoin.BitcoinCore
                 // coinbase height
                 stream.ReadWriteAsVarInt(ref this.nHeight);
 
-                if (stream.ConsensusFactory.Consensus.IsProofOfStake)
+                if (stream.ConsensusFactory is PosConsensusFactory)
                 {
                     stream.ReadWrite(ref this.fCoinStake);
                     stream.ReadWrite(ref this.nTime);
@@ -215,7 +215,7 @@ namespace NBitcoin.BitcoinCore
                 //// coinbase height
                 stream.ReadWriteAsVarInt(ref this.nHeight);
 
-                if (stream.ConsensusFactory.Consensus.IsProofOfStake)
+                if (stream.ConsensusFactory is PosConsensusFactory)
                 {
                     stream.ReadWrite(ref this.fCoinStake);
                     stream.ReadWrite(ref this.nTime);

--- a/src/NBitcoin/Consensus.cs
+++ b/src/NBitcoin/Consensus.cs
@@ -99,10 +99,7 @@ namespace NBitcoin
             this.BuriedDeployments = new BuriedDeploymentsArray();
             this.BIP9Deployments = new BIP9DeploymentsArray();
 
-            this.ConsensusFactory = new ConsensusFactory()
-            {
-                Consensus = this
-            };
+            this.ConsensusFactory = new ConsensusFactory();
         }
 
         public BuriedDeploymentsArray BuriedDeployments { get; set; }

--- a/src/NBitcoin/ConsensusFactory.cs
+++ b/src/NBitcoin/ConsensusFactory.cs
@@ -75,12 +75,6 @@ namespace NBitcoin
         }
 
         /// <summary>
-        /// Represents the parent of this class.
-        /// For simplicity (and migration from NBitcoin) I made this a property however this design can be revised later.
-        /// </summary>
-        public Consensus Consensus { get; set; }
-
-        /// <summary>
         /// Check weather a type is assignable within the collection of types in the give dictionary.
         /// </summary>
         /// <typeparam name="T">The generic type to check.</typeparam>

--- a/src/NBitcoin/Networks/StratisMain.cs
+++ b/src/NBitcoin/Networks/StratisMain.cs
@@ -62,7 +62,7 @@ namespace NBitcoin.Networks
             this.Consensus.MinerConfirmationWindow = 2016; // nPowTargetTimespan / nPowTargetSpacing
             this.Consensus.LastPOWBlock = 12500;
             this.Consensus.IsProofOfStake = true;
-            this.Consensus.ConsensusFactory = new PosConsensusFactory() { Consensus = this.Consensus };
+            this.Consensus.ConsensusFactory = new PosConsensusFactory();
             this.Consensus.ProofOfStakeLimit = new BigInteger(uint256.Parse("00000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff").ToBytes(false));
             this.Consensus.ProofOfStakeLimitV2 = new BigInteger(uint256.Parse("000000000000ffffffffffffffffffffffffffffffffffffffffffffffffffff").ToBytes(false));
             this.Consensus.CoinType = 105;

--- a/src/NBitcoin/Networks/StratisRegTest.cs
+++ b/src/NBitcoin/Networks/StratisRegTest.cs
@@ -42,7 +42,7 @@ namespace NBitcoin.Networks
             consensus.MinerConfirmationWindow = 2016; // nPowTargetTimespan / nPowTargetSpacing
             consensus.LastPOWBlock = 12500;
             consensus.IsProofOfStake = true;
-            consensus.ConsensusFactory = new PosConsensusFactory() { Consensus = consensus };
+            consensus.ConsensusFactory = new PosConsensusFactory();
             consensus.ProofOfStakeLimit = new BigInteger(uint256.Parse("00000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff").ToBytes(false));
             consensus.ProofOfStakeLimitV2 = new BigInteger(uint256.Parse("000000000000ffffffffffffffffffffffffffffffffffffffffffffffffffff").ToBytes(false));
             consensus.CoinType = 105;

--- a/src/NBitcoin/Networks/StratisTest.cs
+++ b/src/NBitcoin/Networks/StratisTest.cs
@@ -43,7 +43,7 @@ namespace NBitcoin.Networks
             consensus.MinerConfirmationWindow = 2016; // nPowTargetTimespan / nPowTargetSpacing
             consensus.LastPOWBlock = 12500;
             consensus.IsProofOfStake = true;
-            consensus.ConsensusFactory = new PosConsensusFactory() { Consensus = consensus };
+            consensus.ConsensusFactory = new PosConsensusFactory();
             consensus.ProofOfStakeLimit = new BigInteger(uint256.Parse("00000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff").ToBytes(false));
             consensus.ProofOfStakeLimitV2 = new BigInteger(uint256.Parse("000000000000ffffffffffffffffffffffffffffffffffffffffffffffffffff").ToBytes(false));
             consensus.CoinType = 105;

--- a/src/Stratis.Bitcoin.Features.SmartContracts/Networks/SmartContractsRegTest.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts/Networks/SmartContractsRegTest.cs
@@ -26,7 +26,7 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Networks
             this.MinRelayTxFee = 1000;
 
             var consensus = new NBitcoin.Consensus();
-            consensus.ConsensusFactory = new SmartContractConsensusFactory() { Consensus = consensus };
+            consensus.ConsensusFactory = new SmartContractConsensusFactory();
 
             consensus.SubsidyHalvingInterval = 150;
             consensus.MajorityEnforceBlockUpgrade = 750;

--- a/src/Stratis.Bitcoin.Features.SmartContracts/Networks/SmartContractsTest.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts/Networks/SmartContractsTest.cs
@@ -23,7 +23,7 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Networks
             this.MinRelayTxFee = 1000;
 
             var consensus = new NBitcoin.Consensus();
-            consensus.ConsensusFactory = new SmartContractConsensusFactory() { Consensus = consensus };
+            consensus.ConsensusFactory = new SmartContractConsensusFactory();
 
             consensus.SubsidyHalvingInterval = 210000;
             consensus.MajorityEnforceBlockUpgrade = 51;

--- a/src/Stratis.Bitcoin/P2P/Protocol/Payloads/HeadersPayload.cs
+++ b/src/Stratis.Bitcoin/P2P/Protocol/Payloads/HeadersPayload.cs
@@ -31,7 +31,7 @@ namespace Stratis.Bitcoin.P2P.Protocol.Payloads
                 stream.ReadWrite(ref txCount);
 
                 // Stratis adds an additional byte to the end of a header need to investigate why.
-                if (stream.ConsensusFactory.Consensus.IsProofOfStake)
+                if (stream.ConsensusFactory is PosConsensusFactory)
                     stream.ReadWrite(ref txCount);
             }
         }


### PR DESCRIPTION
`Consensus.ConsensusFactory` was only being used to check if the network is POS. 

This PR:
* Replaces the check for `IsProofOfStake` by looking at the type of `ConsensusFactory`
* Removes the `Consensus` property from `ConsensusFactory`