### PR TITLE
Fix SmartContractGasInjector failing gas injection with recursive methods

### DIFF
--- a/src/Stratis.Bitcoin.Features.SmartContracts.Tests/SmartContracts/Recursion.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts.Tests/SmartContracts/Recursion.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using Stratis.SmartContracts;
+
+[Deploy]
+public class Recursion : SmartContract
+{
+    public Recursion(ISmartContractState smartContractState) : base(smartContractState)
+    {
+    }
+
+    public bool DoRecursion()
+    {
+        if (DateTime.Now.Ticks % 7 == 0)
+        {
+            return true;
+        }
+
+        return DoRecursion();
+    }
+}

--- a/src/Stratis.Bitcoin.Features.SmartContracts.Tests/Stratis.Bitcoin.Features.SmartContracts.Tests.csproj
+++ b/src/Stratis.Bitcoin.Features.SmartContracts.Tests/Stratis.Bitcoin.Features.SmartContracts.Tests.csproj
@@ -103,6 +103,9 @@
     <Compile Update="SmartContracts\TryCatch.cs">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Compile>
+    <Compile Update="SmartContracts\Recursion.cs">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Compile>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Stratis.SmartContracts.Executor.Reflection/SmartContractGasInjector.cs
+++ b/src/Stratis.SmartContracts.Executor.Reflection/SmartContractGasInjector.cs
@@ -77,7 +77,8 @@ namespace Stratis.SmartContracts.Executor.Reflection
 
                 IEnumerable<MethodDefinition> referencedMethods = method.Body.Instructions
                         .Select(i => i.Operand)
-                        .OfType<MethodDefinition>();
+                        .OfType<MethodDefinition>()
+                        .ToList();
 
                 InjectSpendGasMethod(method, gasMethodReference);
 


### PR DESCRIPTION
Fixes #1697 

The test contract method is non-deterministic in terms of how many iterations it makes. Seems sufficient in terms of test coverage for this case, but let me know if you disagree.