### PR TITLE
Load NLog.config from the DataFolder

### DIFF
--- a/src/Stratis.Bitcoin/Configuration/Logging/LoggingConfiguration.cs
+++ b/src/Stratis.Bitcoin/Configuration/Logging/LoggingConfiguration.cs
@@ -28,7 +28,7 @@ namespace Stratis.Bitcoin.Configuration.Logging
         /// <summary>Provider of console logger.</summary>
         public ConsoleLoggerProvider ConsoleLoggerProvider { get; set; }
 
-        /// <summary>Loads an NLog.config file from the <see cref="DataFolder"/>, if it exists</summary>
+        /// <summary>Loads an NLog.config file from the <see cref="DataFolder"/>, if it exists.</summary>
         public void LoadNLogConfiguration(DataFolder dataFolder)
         {
             if (dataFolder == null)

--- a/src/Stratis.Bitcoin/Configuration/Logging/LoggingConfiguration.cs
+++ b/src/Stratis.Bitcoin/Configuration/Logging/LoggingConfiguration.cs
@@ -28,7 +28,7 @@ namespace Stratis.Bitcoin.Configuration.Logging
         /// <summary>Provider of console logger.</summary>
         public ConsoleLoggerProvider ConsoleLoggerProvider { get; set; }
 
-        /// <summary>Loads an NLog.config file from the <see cref="DataFolder"/>, if it exists.</summary>
+        /// <summary>Loads the NLog.config file from the <see cref="DataFolder"/>, if it exists.</summary>
         public void LoadNLogConfiguration(DataFolder dataFolder)
         {
             if (dataFolder == null)

--- a/src/Stratis.Bitcoin/Configuration/Logging/LoggingConfiguration.cs
+++ b/src/Stratis.Bitcoin/Configuration/Logging/LoggingConfiguration.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Console;
 using NLog;
 using NLog.Config;
+using NLog.Extensions.Logging;
 using NLog.Targets;
 using NLog.Targets.Wrappers;
 using Stratis.Bitcoin.Configuration.Settings;
@@ -19,11 +20,24 @@ namespace Stratis.Bitcoin.Configuration.Logging
     /// </summary>
     public class ExtendedLoggerFactory : LoggerFactory
     {
+        private const string NLogConfigFileName = "NLog.config";
+
         /// <summary>Configuration of console logger.</summary>
         public ConsoleLoggerSettings ConsoleSettings { get; set; }
 
         /// <summary>Provider of console logger.</summary>
         public ConsoleLoggerProvider ConsoleLoggerProvider { get; set; }
+
+        /// <summary>Loads an NLog.config file from the <see cref="DataFolder"/>, if it exists</summary>
+        public void LoadNLogConfiguration(DataFolder dataFolder)
+        {
+            if (dataFolder == null)
+                return;
+
+            string configPath = Path.Combine(dataFolder.RootPath, NLogConfigFileName);
+            if (File.Exists(configPath))
+                this.ConfigureNLog(configPath);
+        }
     }
 
     /// <summary>

--- a/src/Stratis.Bitcoin/Configuration/NodeSettings.cs
+++ b/src/Stratis.Bitcoin/Configuration/NodeSettings.cs
@@ -175,7 +175,7 @@ namespace Stratis.Bitcoin.Configuration
             // Set the data folder.
             this.DataFolder = new DataFolder(this.DataDir);
 
-            // Attempt to load NLog configuration from the DataFolder
+            // Attempt to load NLog configuration from the DataFolder.
             loggerFactory.LoadNLogConfiguration(this.DataFolder);
 
             // Get the configuration file name for the network if it was not specified on the command line.

--- a/src/Stratis.Bitcoin/Configuration/NodeSettings.cs
+++ b/src/Stratis.Bitcoin/Configuration/NodeSettings.cs
@@ -96,7 +96,8 @@ namespace Stratis.Bitcoin.Configuration
             string agent = "StratisBitcoin", string[] args = null)
         {
             // Create the default logger factory and logger.
-            this.LoggerFactory = new ExtendedLoggerFactory();
+            var loggerFactory = new ExtendedLoggerFactory();
+            this.LoggerFactory = loggerFactory;
             this.LoggerFactory.AddConsoleWithFilters();
             this.LoggerFactory.AddNLog();
             this.Logger = this.LoggerFactory.CreateLogger(typeof(NodeSettings).FullName);
@@ -173,6 +174,9 @@ namespace Stratis.Bitcoin.Configuration
 
             // Set the data folder.
             this.DataFolder = new DataFolder(this.DataDir);
+
+            // Attempt to load NLog configuration from the DataFolder
+            loggerFactory.LoadNLogConfiguration(this.DataFolder);
 
             // Get the configuration file name for the network if it was not specified on the command line.
             if (this.ConfigurationFile == null)


### PR DESCRIPTION
Closes #1336.

Adds a method to set up the NLog configuration using the NLog.config in the DataDir. This occurs after we establish the path to the DataDir, but before the programmatic configuration takes place. 

The order of logger config precedence is: 
DataDir NLog.config > Regular [NLog.config path resolution](https://github.com/nlog/NLog/wiki/Configuration-file#configuration-file-locations) > Default empty NLogConfiguration. 
Programmatic rules are always loaded.

There's an existing chicken-and-egg problem where a Logger is initialized and used to log within `NodeSettings` before it has been configured, but can't be configured until after settings are read. Some calls made to logger before configuration do not actually go anywhere. We can move some existing logging to occur after `AddFilters` has been called, otherwise I don't see an easy fix for this.

Filename "NLog.config"is case-sensitive on Unix platforms other than OSX.