### PR TITLE
Move DifficultyAdjustmentInterval calculation

### DIFF
--- a/src/NBitcoin/ChainedHeader.cs
+++ b/src/NBitcoin/ChainedHeader.cs
@@ -431,7 +431,7 @@ namespace NBitcoin
         /// Calculate the difficulty adjustment interval in blocks based on settings defined in <see cref="IConsensus"/>.
         /// </summary>
         /// <returns>The difficulty adjustment interval in blocks.</returns>
-        public long GetDifficultyAdjustmentInterval(IConsensus consensus)
+        private long GetDifficultyAdjustmentInterval(IConsensus consensus)
         {
             return (long)consensus.PowTargetTimespan.TotalSeconds / (long)consensus.PowTargetSpacing.TotalSeconds;
         }

--- a/src/NBitcoin/ChainedHeader.cs
+++ b/src/NBitcoin/ChainedHeader.cs
@@ -374,8 +374,10 @@ namespace NBitcoin
             if (lastBlock == null)
                 return proofOfWorkLimit;
 
+            long difficultyAdjustmentInterval = this.GetDifficultyAdjustmentInterval(consensus);
+
             // Only change once per interval.
-            if ((height) % consensus.DifficultyAdjustmentInterval != 0)
+            if ((height) % difficultyAdjustmentInterval != 0)
             {
                 if (consensus.PowAllowMinDifficultyBlocks)
                 {
@@ -387,7 +389,7 @@ namespace NBitcoin
                  
                     // Return the last non-special-min-difficulty-rules-block.
                     ChainedHeader chainedHeader = lastBlock;
-                    while ((chainedHeader.Previous != null) && ((chainedHeader.Height % consensus.DifficultyAdjustmentInterval) != 0) && (chainedHeader.Header.Bits == proofOfWorkLimit))
+                    while ((chainedHeader.Previous != null) && ((chainedHeader.Height % difficultyAdjustmentInterval) != 0) && (chainedHeader.Header.Bits == proofOfWorkLimit))
                         chainedHeader = chainedHeader.Previous;
 
                     return chainedHeader.Header.Bits;
@@ -397,7 +399,7 @@ namespace NBitcoin
             }
 
             // Go back by what we want to be 14 days worth of blocks.
-            long pastHeight = lastBlock.Height - (consensus.DifficultyAdjustmentInterval - 1);
+            long pastHeight = lastBlock.Height - (difficultyAdjustmentInterval - 1);
 
             ChainedHeader firstChainedHeader = GetAncestor((int)pastHeight);
             if (firstChainedHeader == null)
@@ -423,6 +425,15 @@ namespace NBitcoin
                 finalTarget = proofOfWorkLimit;
 
             return finalTarget;
+        }
+
+        /// <summary>
+        /// Calculate the difficulty adjustment interval in blocks based on settings defined in <see cref="IConsensus"/>.
+        /// </summary>
+        /// <returns>The difficulty adjustment interval in blocks.</returns>
+        public long GetDifficultyAdjustmentInterval(IConsensus consensus)
+        {
+            return (long)consensus.PowTargetTimespan.TotalSeconds / (long)consensus.PowTargetSpacing.TotalSeconds;
         }
 
         /// <summary>

--- a/src/NBitcoin/Consensus.cs
+++ b/src/NBitcoin/Consensus.cs
@@ -59,11 +59,6 @@ namespace NBitcoin
         /// <inheritdoc />
         public uint256 MinimumChainWork { get; }
 
-        public long DifficultyAdjustmentInterval
-        {
-            get { return ((long)this.PowTargetTimespan.TotalSeconds / (long)this.PowTargetSpacing.TotalSeconds); }
-        }
-
         public int MinerConfirmationWindow { get; set; }
 
         public int RuleChangeActivationThreshold { get; set; }


### PR DESCRIPTION
This PR moves the calculation of `DifficultyAdjustmentInterval` closer to its usage. `DifficultyAdjustmentInterval` is only used in one method of `ChainedHeader`.

Moving this also makes it possible for us to use `IConsensus` in place of `Consensus`. I will do this as part of a later PR.