### PR TITLE
After peer attempt time threshold expires reset counters (#1816)

### DIFF
--- a/src/Stratis.Bitcoin.Tests/P2P/PeerSelectorTests.cs
+++ b/src/Stratis.Bitcoin.Tests/P2P/PeerSelectorTests.cs
@@ -722,11 +722,11 @@ namespace Stratis.Bitcoin.Tests.P2P
         public void SelectPeersForDiscovery_WhenPeerAddressesContainsOwnIPEndoint_DoesNotReturnOwnEndpoint()
         {
             var selfIpEndPoint = new IPEndPoint(new IPAddress(1), 123);
-            var selfPeerAddress = new PeerAddress() {Endpoint = selfIpEndPoint};
+            var selfPeerAddress = new PeerAddress() { Endpoint = selfIpEndPoint };
             selfPeerAddress.SetDiscoveredFrom(DateTime.MinValue);
 
             var otherIpEndPoint = new IPEndPoint(new IPAddress(2), 345);
-            var otherPeerAddress = new PeerAddress() {Endpoint = otherIpEndPoint};
+            var otherPeerAddress = new PeerAddress() { Endpoint = otherIpEndPoint };
             otherPeerAddress.SetDiscoveredFrom(DateTime.MinValue);
 
             var peerAddresses = new ConcurrentDictionary<IPEndPoint, PeerAddress>();
@@ -737,7 +737,7 @@ namespace Stratis.Bitcoin.Tests.P2P
             selfEndpointTracker.Add(selfIpEndPoint);
 
             var peerSelector = new PeerSelector(new DateTimeProvider(), this.LoggerFactory.Object, peerAddresses, selfEndpointTracker);
-             
+
             IEnumerable<PeerAddress> peers = peerSelector.SelectPeersForDiscovery(2);
 
             Assert.Equal(otherPeerAddress, peers.Single());
@@ -759,22 +759,22 @@ namespace Stratis.Bitcoin.Tests.P2P
             peerAddressManager.AddPeer(new IPEndPoint(ipAddress, 80), IPAddress.Loopback);
 
             peerAddressManager.PeerConnected(new IPEndPoint(ipAddress, 80), DateTime.UtcNow.AddSeconds(-80));
-            DateTime firstHandshakeAttemptTime = DateTime.UtcNow.AddSeconds(-80);
+            DateTime handshakeAttempt = DateTime.UtcNow.AddSeconds(-80);
 
             PeerAddress peer = peerAddressManager.Peers[0];
 
             // Peer selected after one handshake failure.
-            peer.SetHandshakeAttempted(firstHandshakeAttemptTime);
+            peer.SetHandshakeAttempted(handshakeAttempt);
             Assert.Equal(1, peer.HandshakedAttempts);
             Assert.Contains(peer, peerAddressManager.PeerSelector.FilterBadHandshakedPeers(peerAddressManager.Peers));
 
             // Peer selected after two handshake failures.
-            peer.SetHandshakeAttempted(firstHandshakeAttemptTime);
+            peer.SetHandshakeAttempted(handshakeAttempt);
             Assert.Equal(2, peer.HandshakedAttempts);
             Assert.Contains(peer, peerAddressManager.PeerSelector.FilterBadHandshakedPeers(peerAddressManager.Peers));
 
             // Peer not selected after three handshake failures.
-            peer.SetHandshakeAttempted(firstHandshakeAttemptTime);
+            peer.SetHandshakeAttempted(handshakeAttempt);
             Assert.Equal(3, peer.HandshakedAttempts);
             Assert.DoesNotContain(peer, peerAddressManager.PeerSelector.FilterBadHandshakedPeers(peerAddressManager.Peers));
         }
@@ -786,30 +786,30 @@ namespace Stratis.Bitcoin.Tests.P2P
             DataFolder peerFolder = CreateDataFolder(this);
             PeerAddressManager peerAddressManager = this.CreatePeerAddressManager(peerFolder);
             peerAddressManager.AddPeer(new IPEndPoint(ipAddress, 80), IPAddress.Loopback);
-            
+
             peerAddressManager.PeerConnected(new IPEndPoint(ipAddress, 80), DateTime.UtcNow.AddSeconds(-80));
-            DateTime firstHandshakeAttemptTime = DateTime.UtcNow.AddSeconds(-80);
+            DateTime handshakeAttempt = DateTime.UtcNow.AddSeconds(-80);
 
             PeerAddress peer = peerAddressManager.Peers[0];
-            
+
             // Peer selected after one handshake failure.
-            peer.SetHandshakeAttempted(firstHandshakeAttemptTime.AddHours(-(PeerAddress.AttempThresholdHours + 4)));
+            peer.SetHandshakeAttempted(handshakeAttempt.AddHours(-(PeerAddress.AttempThresholdHours + 4)));
             Assert.Equal(1, peer.HandshakedAttempts);
             Assert.Contains(peer, peerAddressManager.PeerSelector.FilterBadHandshakedPeers(peerAddressManager.Peers));
 
             // Peer selected after two handshake failures.
-            peer.SetHandshakeAttempted(firstHandshakeAttemptTime.AddHours(-(PeerAddress.AttempThresholdHours + 3)));
+            peer.SetHandshakeAttempted(handshakeAttempt.AddHours(-(PeerAddress.AttempThresholdHours + 3)));
             Assert.Equal(2, peer.HandshakedAttempts);
             Assert.Contains(peer, peerAddressManager.PeerSelector.FilterBadHandshakedPeers(peerAddressManager.Peers));
 
             // Peer selected after two handshake failures when threshold time has elapsed.
-            peer.SetHandshakeAttempted(firstHandshakeAttemptTime.AddHours(-(PeerAddress.AttempThresholdHours + 2)));
+            peer.SetHandshakeAttempted(handshakeAttempt.AddHours(-(PeerAddress.AttempThresholdHours + 2)));
             Assert.Equal(3, peer.HandshakedAttempts);
             Assert.Contains(peer, peerAddressManager.PeerSelector.FilterBadHandshakedPeers(peerAddressManager.Peers));
         }
-        
+
         [Fact]
-        public void PeerSelector_ReturnConnectedPeers_AfterHandshakeFailure_HandshakeSucceeded_ResetCounters()
+        public void PeerSelector_ReturnConnectedPeers_AfterHandshakeFailure_HandshakeSucceeded_ResetsCounters()
         {
             IPAddress ipAddress = IPAddress.Parse("::ffff:192.168.0.1");
             DataFolder peerFolder = CreateDataFolder(this);
@@ -817,22 +817,22 @@ namespace Stratis.Bitcoin.Tests.P2P
             peerAddressManager.AddPeer(new IPEndPoint(ipAddress, 80), IPAddress.Loopback);
 
             peerAddressManager.PeerConnected(new IPEndPoint(ipAddress, 80), DateTime.UtcNow.AddSeconds(-80));
-            DateTime firstHandshakeAttemptTime = DateTime.UtcNow.AddSeconds(-80);
+            DateTime handshakeAttempt = DateTime.UtcNow.AddSeconds(-80);
 
             PeerAddress peer = peerAddressManager.Peers[0];
 
             // Peer selected after one handshake failure.
-            peer.SetHandshakeAttempted(firstHandshakeAttemptTime);
+            peer.SetHandshakeAttempted(handshakeAttempt);
             Assert.Equal(1, peer.HandshakedAttempts);
             Assert.Contains(peer, peerAddressManager.PeerSelector.FilterBadHandshakedPeers(peerAddressManager.Peers));
 
             // Peer selected after two handshake failures.
-            peer.SetHandshakeAttempted(firstHandshakeAttemptTime);
+            peer.SetHandshakeAttempted(handshakeAttempt);
             Assert.Equal(2, peer.HandshakedAttempts);
             Assert.Contains(peer, peerAddressManager.PeerSelector.FilterBadHandshakedPeers(peerAddressManager.Peers));
 
             // Peer attempt counter and last attempt reset after successful handshake.
-            peer.SetHandshaked(firstHandshakeAttemptTime);
+            peer.SetHandshaked(handshakeAttempt);
             Assert.Equal(0, peer.HandshakedAttempts);
             Assert.Null(peer.LastHandshakeAttempt);
         }

--- a/src/Stratis.Bitcoin/P2P/PeerAddress.cs
+++ b/src/Stratis.Bitcoin/P2P/PeerAddress.cs
@@ -235,6 +235,19 @@ namespace Stratis.Bitcoin.P2P
         }
 
         /// <summary>
+        /// Resets the amount of <see cref="HandshakedAttempts"/>.
+        /// <para>
+        /// This is reset when the amount of failed handshake attempts reaches
+        /// the <see cref="PeerAddress.HandshakedAttempts"/> and the last attempt was
+        /// made more than <see cref="PeerAddress.AttempThresholdHours"/> ago.
+        /// </para>
+        /// </summary>
+        internal void ResetHandshakeAttempts()
+        {
+            this.HandshakedAttempts = 0;
+        }
+
+        /// <summary>
         /// Increments <see cref="ConnectionAttempts"/> and sets the <see cref="LastAttempt"/>.
         /// </summary>
         internal void SetAttempted(DateTime peerAttemptedAt)
@@ -280,7 +293,7 @@ namespace Stratis.Bitcoin.P2P
         /// <summary>Sets the <see cref="LastConnectionHandshake"/> date.</summary>
         internal void SetHandshaked(DateTimeOffset peerHandshakedAt)
         {
-            this.HandshakedAttempts = 0;
+            this.ResetHandshakeAttempts();
             this.LastConnectionHandshake = peerHandshakedAt;
             this.LastHandshakeAttempt = null;
         }

--- a/src/Stratis.Bitcoin/P2P/PeerSelector.cs
+++ b/src/Stratis.Bitcoin/P2P/PeerSelector.cs
@@ -331,6 +331,7 @@ namespace Stratis.Bitcoin.P2P
         {
             IEnumerable<PeerAddress> filteredPeers = peers.Where(p => (p.HandshakedAttempts < PeerAddress.AttemptHandshakeThreshold) ||
                                     p.LastHandshakeAttempt?.AddHours(PeerAddress.AttempThresholdHours) < this.dateTimeProvider.GetUtcNow()).ToList();
+
             foreach (PeerAddress peer in filteredPeers)
             {
                 if (peer.HandshakedAttempts == PeerAddress.AttemptHandshakeThreshold)

--- a/src/Stratis.Bitcoin/P2P/PeerSelector.cs
+++ b/src/Stratis.Bitcoin/P2P/PeerSelector.cs
@@ -329,8 +329,15 @@ namespace Stratis.Bitcoin.P2P
         /// <inheritdoc/>
         public IEnumerable<PeerAddress> FilterBadHandshakedPeers(IEnumerable<PeerAddress> peers)
         {
-            return peers.Where(p => (p.HandshakedAttempts < PeerAddress.AttemptHandshakeThreshold) ||
-                                    p.LastHandshakeAttempt?.AddHours(PeerAddress.AttempThresholdHours) < this.dateTimeProvider.GetUtcNow());
+            IEnumerable<PeerAddress> filteredPeers = peers.Where(p => (p.HandshakedAttempts < PeerAddress.AttemptHandshakeThreshold) ||
+                                    p.LastHandshakeAttempt?.AddHours(PeerAddress.AttempThresholdHours) < this.dateTimeProvider.GetUtcNow()).ToList();
+            foreach (PeerAddress peer in filteredPeers)
+            {
+                if (peer.HandshakedAttempts == PeerAddress.AttemptHandshakeThreshold)
+                    peer.ResetHandshakeAttempts();
+            }
+
+            return filteredPeers;
         }
 
         public IEnumerable<PeerAddress> NotBanned()


### PR DESCRIPTION
- Handshake counter does not get reset to zero until a successful handshake occurs.
- Handshake counter should get reset after threshold time expires.

Preferred: @fassadlr 