### PR TITLE
Add guidelines around rebasing PRs with conflicts

### DIFF
--- a/Documentation/contributing.md
+++ b/Documentation/contributing.md
@@ -70,6 +70,7 @@ DOs and DON'Ts
 * **DO** keep the discussions focused. When a new or related topic comes up
   it's often better to create new issue than to side track the discussion.
 * **DO** blog and tweet (or whatever) about your contributions, frequently!
+* **DO** favour fixing merge conflicts using `git rebase` over `git merge`.
 
 * **DO NOT** send PRs for style changes. 
 * **DON'T** surprise us with big pull requests. Instead, file an issue and start
@@ -77,7 +78,6 @@ DOs and DON'Ts
   of time.
 * **DON'T** commit code that you didn't write. If you find code that you think is a good fit to add to .NET Core, file an issue and start a discussion before proceeding.
 * **DON'T** submit PRs that alter licensing related files or headers. If you believe there's a problem with them, file an issue and we'll be happy to discuss it.
-* **DO NOT** fix merge conflicts using a merge commit. Prefer `git rebase`.
 
 Copyright
 =========

--- a/Documentation/contributing.md
+++ b/Documentation/contributing.md
@@ -77,6 +77,7 @@ DOs and DON'Ts
   of time.
 * **DON'T** commit code that you didn't write. If you find code that you think is a good fit to add to .NET Core, file an issue and start a discussion before proceeding.
 * **DON'T** submit PRs that alter licensing related files or headers. If you believe there's a problem with them, file an issue and we'll be happy to discuss it.
+* **DO NOT** fix merge conflicts using a merge commit. Prefer `git rebase`.
 
 Copyright
 =========


### PR DESCRIPTION
Proposal to favour rebasing vs. merging from parent branch when PRs become stale.

Reasons:
* Keeps unrelated changes out of PRs, making them easier to review
* History is cleaner/easier to reason about

Guideline taken from [corefx](https://github.com/dotnet/corefx/blob/master/Documentation/project-docs/contributing.md). Bitcoin also do a [similar thing](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md).