### PR TITLE
Use same Network in NodeGroupBuilder when creating nodes

### DIFF
--- a/src/Stratis.Bitcoin.IntegrationTests.Common/Builders/NodeGroupBuilder.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests.Common/Builders/NodeGroupBuilder.cs
@@ -11,12 +11,14 @@ namespace Stratis.Bitcoin.IntegrationTests.Common.Builders
         private readonly NodeBuilder nodeBuilder;
         private readonly Dictionary<string, CoreNode> nodes;
         public readonly Dictionary<string, Mnemonic> NodeMnemonics;
+        private readonly Network network;
 
-        public NodeGroupBuilder(string testFolder)
+        public NodeGroupBuilder(string testFolder, Network network)
         {
             this.nodeBuilder = NodeBuilder.Create(testFolder);
             this.nodes = new Dictionary<string, CoreNode>();
             this.NodeMnemonics = new Dictionary<string, Mnemonic>();
+            this.network = network;
         }
 
         public void Dispose()
@@ -31,31 +33,31 @@ namespace Stratis.Bitcoin.IntegrationTests.Common.Builders
 
         public NodeGroupBuilder StratisPowNode(string nodeName)
         {
-            this.nodes.Add(nodeName, this.nodeBuilder.CreateStratisPowNode());
+            this.nodes.Add(nodeName, this.nodeBuilder.CreateStratisPowNode(this.network));
             return this;
         }
 
         public NodeGroupBuilder StratisCustomPowNode(string nodeName, NodeConfigParameters configParameters)
         {
-            this.nodes.Add(nodeName, this.nodeBuilder.CreateStratisCustomPowNode(configParameters));
+            this.nodes.Add(nodeName, this.nodeBuilder.CreateStratisCustomPowNode(this.network, configParameters));
             return this;
         }
 
         public NodeGroupBuilder CreateStratisPowApiNode(string nodeName)
         {
-            this.nodes.Add(nodeName, this.nodeBuilder.CreateStratisPowApiNode());
+            this.nodes.Add(nodeName, this.nodeBuilder.CreateStratisPowApiNode(this.network));
             return this;
         }
 
         public NodeGroupBuilder CreateStratisPosNode(string nodeName)
         {
-            this.nodes.Add(nodeName, this.nodeBuilder.CreateStratisPosNode());
+            this.nodes.Add(nodeName, this.nodeBuilder.CreateStratisPosNode(this.network));
             return this;
         }
 
         public NodeGroupBuilder CreateStratisPosApiNode(string nodeName)
         {
-            this.nodes.Add(nodeName, this.nodeBuilder.CreateStratisPosApiNode());
+            this.nodes.Add(nodeName, this.nodeBuilder.CreateStratisPosApiNode(this.network));
             return this;
         }
 

--- a/src/Stratis.Bitcoin.IntegrationTests.Common/EnvironmentMockUpHelpers/NodeBuilder.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests.Common/EnvironmentMockUpHelpers/NodeBuilder.cs
@@ -86,7 +86,7 @@ namespace Stratis.Bitcoin.IntegrationTests.Common.EnvironmentMockUpHelpers
 
         public CoreNode CreateStratisPowNode(bool start = false)
         {
-            return CreateNode(new StratisBitcoinPowRunner(this.GetNextDataFolderName()), start);
+            return CreateNode(new StratisBitcoinPowRunner(this.GetNextDataFolderName(), KnownNetworks.RegTest), start);
         }
 
         public CoreNode CreateStratisPowNode(Network network, bool start = false)
@@ -136,7 +136,7 @@ namespace Stratis.Bitcoin.IntegrationTests.Common.EnvironmentMockUpHelpers
 
         public CoreNode CloneStratisNode(CoreNode cloneNode)
         {
-            var node = new CoreNode(new StratisBitcoinPowRunner(cloneNode.FullNode.Settings.DataFolder.RootPath), this, "bitcoin.conf");
+            var node = new CoreNode(new StratisBitcoinPowRunner(cloneNode.FullNode.Settings.DataFolder.RootPath, cloneNode.FullNode.Network), this, "bitcoin.conf");
             this.Nodes.Add(node);
             this.Nodes.Remove(cloneNode);
             return node;

--- a/src/Stratis.Bitcoin.IntegrationTests.Common/EnvironmentMockUpHelpers/NodeBuilder.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests.Common/EnvironmentMockUpHelpers/NodeBuilder.cs
@@ -84,10 +84,10 @@ namespace Stratis.Bitcoin.IntegrationTests.Common.EnvironmentMockUpHelpers
             return CreateNode(new BitcoinCoreRunner(this.GetNextDataFolderName(), bitcoinDPath), start: false, useCookieAuth: useCookieAuth);
         }
 
-        public CoreNode CreateStratisPowNode(bool start = false)
-        {
-            return CreateNode(new StratisBitcoinPowRunner(this.GetNextDataFolderName(), KnownNetworks.RegTest), start);
-        }
+        //public CoreNode CreateStratisPowNode(Network network, bool start = false)
+        //{
+        //    return CreateNode(new StratisBitcoinPowRunner(this.GetNextDataFolderName(), KnownNetworks.RegTest), start);
+        //}
 
         public CoreNode CreateStratisPowNode(Network network, bool start = false)
         {

--- a/src/Stratis.Bitcoin.IntegrationTests.Common/EnvironmentMockUpHelpers/NodeBuilder.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests.Common/EnvironmentMockUpHelpers/NodeBuilder.cs
@@ -84,11 +84,6 @@ namespace Stratis.Bitcoin.IntegrationTests.Common.EnvironmentMockUpHelpers
             return CreateNode(new BitcoinCoreRunner(this.GetNextDataFolderName(), bitcoinDPath), start: false, useCookieAuth: useCookieAuth);
         }
 
-        //public CoreNode CreateStratisPowNode(Network network, bool start = false)
-        //{
-        //    return CreateNode(new StratisBitcoinPowRunner(this.GetNextDataFolderName(), KnownNetworks.RegTest), start);
-        //}
-
         public CoreNode CreateStratisPowNode(Network network, bool start = false)
         {
             return CreateNode(new StratisBitcoinPowRunner(this.GetNextDataFolderName(), network), start);

--- a/src/Stratis.Bitcoin.IntegrationTests.Common/EnvironmentMockUpHelpers/NodeBuilder.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests.Common/EnvironmentMockUpHelpers/NodeBuilder.cs
@@ -113,12 +113,6 @@ namespace Stratis.Bitcoin.IntegrationTests.Common.EnvironmentMockUpHelpers
             return CreateNode(new StratisBitcoinPowApiRunner(this.GetNextDataFolderName(), network), start);
         }
 
-        public CoreNode CreateStratisPosNode()
-        {
-            return CreateNode(new StratisBitcoinPosRunner(this.GetNextDataFolderName()), false, "stratis.conf");
-        }
-
-
         public CoreNode CreateStratisPosNode(Network network)
         {
             return CreateNode(new StratisBitcoinPosRunner(this.GetNextDataFolderName(), network), false, "stratis.conf");

--- a/src/Stratis.Bitcoin.IntegrationTests.Common/EnvironmentMockUpHelpers/NodeBuilder.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests.Common/EnvironmentMockUpHelpers/NodeBuilder.cs
@@ -89,7 +89,12 @@ namespace Stratis.Bitcoin.IntegrationTests.Common.EnvironmentMockUpHelpers
             return CreateNode(new StratisBitcoinPowRunner(this.GetNextDataFolderName()), start);
         }
 
-        public CoreNode CreateStratisCustomPowNode(NodeConfigParameters configParameters, bool start = false)
+        public CoreNode CreateStratisPowNode(Network network, bool start = false)
+        {
+            return CreateNode(new StratisBitcoinPowRunner(this.GetNextDataFolderName(), network), start);
+        }
+
+        public CoreNode CreateStratisCustomPowNode(Network network, NodeConfigParameters configParameters, bool start = false)
         {
             var callback = new Action<IFullNodeBuilder>(builder => builder
                .UseBlockStore()
@@ -100,12 +105,12 @@ namespace Stratis.Bitcoin.IntegrationTests.Common.EnvironmentMockUpHelpers
                .AddRPC()
                .MockIBD());
 
-            return CreateCustomNode(start, callback, KnownNetworks.RegTest, ProtocolVersion.PROTOCOL_VERSION, configParameters: configParameters);
+            return CreateCustomNode(start, callback, network, ProtocolVersion.PROTOCOL_VERSION, configParameters: configParameters);
         }
 
-        public CoreNode CreateStratisPowApiNode(bool start = false)
+        public CoreNode CreateStratisPowApiNode(Network network, bool start = false)
         {
-            return CreateNode(new StratisBitcoinPowApiRunner(this.GetNextDataFolderName()), start);
+            return CreateNode(new StratisBitcoinPowApiRunner(this.GetNextDataFolderName(), network), start);
         }
 
         public CoreNode CreateStratisPosNode()
@@ -113,9 +118,15 @@ namespace Stratis.Bitcoin.IntegrationTests.Common.EnvironmentMockUpHelpers
             return CreateNode(new StratisBitcoinPosRunner(this.GetNextDataFolderName()), false, "stratis.conf");
         }
 
-        public CoreNode CreateStratisPosApiNode()
+
+        public CoreNode CreateStratisPosNode(Network network)
         {
-            return CreateNode(new StratisPosApiRunner(this.GetNextDataFolderName()), false, "stratis.conf");
+            return CreateNode(new StratisBitcoinPosRunner(this.GetNextDataFolderName(), network), false, "stratis.conf");
+        }
+
+        public CoreNode CreateStratisPosApiNode(Network network)
+        {
+            return CreateNode(new StratisPosApiRunner(this.GetNextDataFolderName(), network), false, "stratis.conf");
         }
 
         public CoreNode CreateSmartContractNode()

--- a/src/Stratis.Bitcoin.IntegrationTests.Common/Runners/StratisBitcoinPosRunner.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests.Common/Runners/StratisBitcoinPosRunner.cs
@@ -8,18 +8,11 @@ using Stratis.Bitcoin.Features.MemoryPool;
 using Stratis.Bitcoin.Features.Miner;
 using Stratis.Bitcoin.Features.RPC;
 using Stratis.Bitcoin.Features.Wallet;
-using Stratis.Bitcoin.Tests.Common;
 
 namespace Stratis.Bitcoin.IntegrationTests.Common.Runners
 {
     public sealed class StratisBitcoinPosRunner : NodeRunner
     {
-        public StratisBitcoinPosRunner(string dataDir)
-            : base(dataDir)
-        {
-            this.Network = KnownNetworks.StratisRegTest;
-        }
-
         public StratisBitcoinPosRunner(string dataDir, Network network)
             : base(dataDir)
         {

--- a/src/Stratis.Bitcoin.IntegrationTests.Common/Runners/StratisBitcoinPosRunner.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests.Common/Runners/StratisBitcoinPosRunner.cs
@@ -1,4 +1,5 @@
-﻿using NBitcoin.Protocol;
+﻿using NBitcoin;
+using NBitcoin.Protocol;
 using Stratis.Bitcoin.Builder;
 using Stratis.Bitcoin.Configuration;
 using Stratis.Bitcoin.Features.BlockStore;
@@ -17,6 +18,12 @@ namespace Stratis.Bitcoin.IntegrationTests.Common.Runners
             : base(dataDir)
         {
             this.Network = KnownNetworks.StratisRegTest;
+        }
+
+        public StratisBitcoinPosRunner(string dataDir, Network network)
+            : base(dataDir)
+        {
+            this.Network = network;
         }
 
         public override void BuildNode()

--- a/src/Stratis.Bitcoin.IntegrationTests.Common/Runners/StratisBitcoinPowApiRunner.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests.Common/Runners/StratisBitcoinPowApiRunner.cs
@@ -8,18 +8,11 @@ using Stratis.Bitcoin.Features.MemoryPool;
 using Stratis.Bitcoin.Features.Miner;
 using Stratis.Bitcoin.Features.RPC;
 using Stratis.Bitcoin.Features.Wallet;
-using Stratis.Bitcoin.Tests.Common;
 
 namespace Stratis.Bitcoin.IntegrationTests.Common.Runners
 {
     public sealed class StratisBitcoinPowApiRunner : NodeRunner
     {
-        public StratisBitcoinPowApiRunner(string dataDir)
-            : base(dataDir)
-        {
-            this.Network = KnownNetworks.RegTest;
-        }
-
         public StratisBitcoinPowApiRunner(string dataDir, Network network)
             : base(dataDir)
         {

--- a/src/Stratis.Bitcoin.IntegrationTests.Common/Runners/StratisBitcoinPowApiRunner.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests.Common/Runners/StratisBitcoinPowApiRunner.cs
@@ -1,4 +1,5 @@
-﻿using Stratis.Bitcoin.Builder;
+﻿using NBitcoin;
+using Stratis.Bitcoin.Builder;
 using Stratis.Bitcoin.Configuration;
 using Stratis.Bitcoin.Features.Api;
 using Stratis.Bitcoin.Features.BlockStore;
@@ -19,9 +20,15 @@ namespace Stratis.Bitcoin.IntegrationTests.Common.Runners
             this.Network = KnownNetworks.RegTest;
         }
 
+        public StratisBitcoinPowApiRunner(string dataDir, Network network)
+            : base(dataDir)
+        {
+            this.Network = network;
+        }
+
         public override void BuildNode()
         {
-            var settings = new NodeSettings(args: new string[] { "-conf=bitcoin.conf", "-datadir=" + this.DataFolder });
+            var settings = new NodeSettings(this.Network, args: new string[] { "-conf=bitcoin.conf", "-datadir=" + this.DataFolder });
 
             this.FullNode = (FullNode)new FullNodeBuilder()
                 .UseNodeSettings(settings)

--- a/src/Stratis.Bitcoin.IntegrationTests.Common/Runners/StratisBitcoinPowRunner.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests.Common/Runners/StratisBitcoinPowRunner.cs
@@ -7,18 +7,11 @@ using Stratis.Bitcoin.Features.MemoryPool;
 using Stratis.Bitcoin.Features.Miner;
 using Stratis.Bitcoin.Features.RPC;
 using Stratis.Bitcoin.Features.Wallet;
-using Stratis.Bitcoin.Tests.Common;
 
 namespace Stratis.Bitcoin.IntegrationTests.Common.Runners
 {
     public sealed class StratisBitcoinPowRunner : NodeRunner
     {
-        public StratisBitcoinPowRunner(string dataDir)
-            : base(dataDir)
-        {
-            this.Network = KnownNetworks.RegTest;
-        }
-
         public StratisBitcoinPowRunner(string dataDir, Network network)
             : base(dataDir)
         {

--- a/src/Stratis.Bitcoin.IntegrationTests.Common/Runners/StratisBitcoinPowRunner.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests.Common/Runners/StratisBitcoinPowRunner.cs
@@ -1,4 +1,5 @@
-﻿using Stratis.Bitcoin.Builder;
+﻿using NBitcoin;
+using Stratis.Bitcoin.Builder;
 using Stratis.Bitcoin.Configuration;
 using Stratis.Bitcoin.Features.BlockStore;
 using Stratis.Bitcoin.Features.Consensus;
@@ -18,9 +19,15 @@ namespace Stratis.Bitcoin.IntegrationTests.Common.Runners
             this.Network = KnownNetworks.RegTest;
         }
 
+        public StratisBitcoinPowRunner(string dataDir, Network network)
+            : base(dataDir)
+        {
+            this.Network = network;
+        }
+
         public override void BuildNode()
         {
-            var settings = new NodeSettings(args: new string[] { "-conf=bitcoin.conf", "-datadir=" + this.DataFolder });
+            var settings = new NodeSettings(this.Network, args: new string[] { "-conf=bitcoin.conf", "-datadir=" + this.DataFolder });
 
             this.FullNode = (FullNode)new FullNodeBuilder()
                 .UseNodeSettings(settings)

--- a/src/Stratis.Bitcoin.IntegrationTests.Common/Runners/StratisPosApiRunner.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests.Common/Runners/StratisPosApiRunner.cs
@@ -9,18 +9,11 @@ using Stratis.Bitcoin.Features.MemoryPool;
 using Stratis.Bitcoin.Features.Miner;
 using Stratis.Bitcoin.Features.RPC;
 using Stratis.Bitcoin.Features.Wallet;
-using Stratis.Bitcoin.Tests.Common;
 
 namespace Stratis.Bitcoin.IntegrationTests.Common.Runners
 {
     public sealed class StratisPosApiRunner : NodeRunner
     {
-        public StratisPosApiRunner(string dataDir)
-            : base(dataDir)
-        {
-            this.Network = KnownNetworks.StratisRegTest;
-        }
-
         public StratisPosApiRunner(string dataDir, Network network)
             : base(dataDir)
         {

--- a/src/Stratis.Bitcoin.IntegrationTests.Common/Runners/StratisPosApiRunner.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests.Common/Runners/StratisPosApiRunner.cs
@@ -1,4 +1,5 @@
-﻿using NBitcoin.Protocol;
+﻿using NBitcoin;
+using NBitcoin.Protocol;
 using Stratis.Bitcoin.Builder;
 using Stratis.Bitcoin.Configuration;
 using Stratis.Bitcoin.Features.Api;
@@ -18,6 +19,12 @@ namespace Stratis.Bitcoin.IntegrationTests.Common.Runners
             : base(dataDir)
         {
             this.Network = KnownNetworks.StratisRegTest;
+        }
+
+        public StratisPosApiRunner(string dataDir, Network network)
+            : base(dataDir)
+        {
+            this.Network = network;
         }
 
         public override void BuildNode()

--- a/src/Stratis.Bitcoin.IntegrationTests/API/ApiSteps.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/API/ApiSteps.cs
@@ -54,7 +54,8 @@ namespace Stratis.Bitcoin.IntegrationTests.API
         private int maturity;
         private HdAddress receiverAddress;
         private readonly Money transferAmount = Money.COIN * 1;
-        private NodeGroupBuilder nodeGroupBuilder;
+        private NodeGroupBuilder powNodeGroupBuilder;
+        private NodeGroupBuilder posNodeGroupBuilder;
         private SharedSteps sharedSteps;
         private Transaction transaction;
         private uint256 block;
@@ -72,7 +73,8 @@ namespace Stratis.Bitcoin.IntegrationTests.API
             this.httpClient.DefaultRequestHeaders.Accept.Clear();
             this.httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue(JsonContentType));
 
-            this.nodeGroupBuilder = new NodeGroupBuilder(Path.Combine(this.GetType().Name, this.CurrentTest.DisplayName));
+            this.powNodeGroupBuilder = new NodeGroupBuilder(Path.Combine(this.GetType().Name, this.CurrentTest.DisplayName), KnownNetworks.RegTest);
+            this.posNodeGroupBuilder = new NodeGroupBuilder(Path.Combine(this.GetType().Name, this.CurrentTest.DisplayName), KnownNetworks.StratisRegTest);
         }
 
         protected override void AfterTest()
@@ -83,12 +85,13 @@ namespace Stratis.Bitcoin.IntegrationTests.API
                 this.httpClient = null;
             }
 
-            this.nodeGroupBuilder.Dispose();
+            this.powNodeGroupBuilder.Dispose();
+            this.posNodeGroupBuilder.Dispose();
         }
 
         private void a_proof_of_stake_node_with_api_enabled()
         {
-            this.nodes = this.nodeGroupBuilder.CreateStratisPosApiNode(PosNode)
+            this.nodes = this.posNodeGroupBuilder.CreateStratisPosApiNode(PosNode)
                 .Start()
                 .Build();
 
@@ -110,7 +113,7 @@ namespace Stratis.Bitcoin.IntegrationTests.API
 
         private void a_pow_node_with_api_enabled()
         {
-            this.nodes = this.nodeGroupBuilder
+            this.nodes = this.powNodeGroupBuilder
                 .CreateStratisPowApiNode(FirstPowNode)
                 .Start()
                 .NotInIBD()
@@ -129,7 +132,7 @@ namespace Stratis.Bitcoin.IntegrationTests.API
 
         private void a_second_pow_node_with_api_enabled()
         {
-            this.nodes = this.nodeGroupBuilder
+            this.nodes = this.powNodeGroupBuilder
                 .CreateStratisPowApiNode(SecondPowNode)
                 .Start()
                 .NotInIBD()

--- a/src/Stratis.Bitcoin.IntegrationTests/BlockStore/BlockStoreTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/BlockStore/BlockStoreTests.cs
@@ -16,12 +16,14 @@ namespace Stratis.Bitcoin.IntegrationTests.BlockStore
     {
         protected readonly ILoggerFactory loggerFactory;
         private readonly Network network;
+        private readonly Network regTest;
 
         public BlockStoreTests()
         {
             this.loggerFactory = new LoggerFactory();
 
             this.network = KnownNetworks.Main;
+            this.regTest = KnownNetworks.RegTest;
             var serializer = new DBreezeSerializer();
             serializer.Initialize(this.network);
         }
@@ -90,9 +92,9 @@ namespace Stratis.Bitcoin.IntegrationTests.BlockStore
         {
             using (NodeBuilder builder = NodeBuilder.Create(this))
             {
-                CoreNode stratisNodeSync = builder.CreateStratisPowNode(this.network);
-                CoreNode stratisNode1 = builder.CreateStratisPowNode(this.network);
-                CoreNode stratisNode2 = builder.CreateStratisPowNode(this.network);
+                CoreNode stratisNodeSync = builder.CreateStratisPowNode(this.regTest);
+                CoreNode stratisNode1 = builder.CreateStratisPowNode(this.regTest);
+                CoreNode stratisNode2 = builder.CreateStratisPowNode(this.regTest);
                 builder.StartAll();
                 stratisNodeSync.NotInIBD();
                 stratisNode1.NotInIBD();
@@ -132,7 +134,7 @@ namespace Stratis.Bitcoin.IntegrationTests.BlockStore
         {
             using (NodeBuilder builder = NodeBuilder.Create(this))
             {
-                CoreNode stratisNodeSync = builder.CreateStratisPowNode(this.network);
+                CoreNode stratisNodeSync = builder.CreateStratisPowNode(this.regTest);
                 builder.StartAll();
                 stratisNodeSync.NotInIBD();
 
@@ -164,9 +166,9 @@ namespace Stratis.Bitcoin.IntegrationTests.BlockStore
         {
             using (NodeBuilder builder = NodeBuilder.Create(this))
             {
-                CoreNode stratisNodeSync = builder.CreateStratisPowNode(this.network);
-                CoreNode stratisNode1 = builder.CreateStratisPowNode(this.network);
-                CoreNode stratisNode2 = builder.CreateStratisPowNode(this.network);
+                CoreNode stratisNodeSync = builder.CreateStratisPowNode(this.regTest);
+                CoreNode stratisNode1 = builder.CreateStratisPowNode(this.regTest);
+                CoreNode stratisNode2 = builder.CreateStratisPowNode(this.regTest);
                 builder.StartAll();
                 stratisNodeSync.NotInIBD();
                 stratisNode1.NotInIBD();
@@ -217,8 +219,8 @@ namespace Stratis.Bitcoin.IntegrationTests.BlockStore
         {
             using (NodeBuilder builder = NodeBuilder.Create(this))
             {
-                CoreNode stratisNode1 = builder.CreateStratisPowNode(this.network);
-                CoreNode stratisNode2 = builder.CreateStratisPowNode(this.network);
+                CoreNode stratisNode1 = builder.CreateStratisPowNode(this.regTest);
+                CoreNode stratisNode2 = builder.CreateStratisPowNode(this.regTest);
                 builder.StartAll();
                 stratisNode1.NotInIBD();
                 stratisNode2.NotInIBD();

--- a/src/Stratis.Bitcoin.IntegrationTests/BlockStore/BlockStoreTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/BlockStore/BlockStoreTests.cs
@@ -20,6 +20,7 @@ namespace Stratis.Bitcoin.IntegrationTests.BlockStore
         public BlockStoreTests()
         {
             this.loggerFactory = new LoggerFactory();
+
             this.network = KnownNetworks.Main;
             var serializer = new DBreezeSerializer();
             serializer.Initialize(this.network);
@@ -89,9 +90,9 @@ namespace Stratis.Bitcoin.IntegrationTests.BlockStore
         {
             using (NodeBuilder builder = NodeBuilder.Create(this))
             {
-                CoreNode stratisNodeSync = builder.CreateStratisPowNode(KnownNetworks.RegTest);
-                CoreNode stratisNode1 = builder.CreateStratisPowNode(KnownNetworks.RegTest);
-                CoreNode stratisNode2 = builder.CreateStratisPowNode(KnownNetworks.RegTest);
+                CoreNode stratisNodeSync = builder.CreateStratisPowNode(this.network);
+                CoreNode stratisNode1 = builder.CreateStratisPowNode(this.network);
+                CoreNode stratisNode2 = builder.CreateStratisPowNode(this.network);
                 builder.StartAll();
                 stratisNodeSync.NotInIBD();
                 stratisNode1.NotInIBD();
@@ -131,7 +132,7 @@ namespace Stratis.Bitcoin.IntegrationTests.BlockStore
         {
             using (NodeBuilder builder = NodeBuilder.Create(this))
             {
-                CoreNode stratisNodeSync = builder.CreateStratisPowNode(KnownNetworks.RegTest);
+                CoreNode stratisNodeSync = builder.CreateStratisPowNode(this.network);
                 builder.StartAll();
                 stratisNodeSync.NotInIBD();
 
@@ -163,9 +164,9 @@ namespace Stratis.Bitcoin.IntegrationTests.BlockStore
         {
             using (NodeBuilder builder = NodeBuilder.Create(this))
             {
-                CoreNode stratisNodeSync = builder.CreateStratisPowNode(KnownNetworks.RegTest);
-                CoreNode stratisNode1 = builder.CreateStratisPowNode(KnownNetworks.RegTest);
-                CoreNode stratisNode2 = builder.CreateStratisPowNode(KnownNetworks.RegTest);
+                CoreNode stratisNodeSync = builder.CreateStratisPowNode(this.network);
+                CoreNode stratisNode1 = builder.CreateStratisPowNode(this.network);
+                CoreNode stratisNode2 = builder.CreateStratisPowNode(this.network);
                 builder.StartAll();
                 stratisNodeSync.NotInIBD();
                 stratisNode1.NotInIBD();
@@ -216,8 +217,8 @@ namespace Stratis.Bitcoin.IntegrationTests.BlockStore
         {
             using (NodeBuilder builder = NodeBuilder.Create(this))
             {
-                CoreNode stratisNode1 = builder.CreateStratisPowNode(KnownNetworks.RegTest);
-                CoreNode stratisNode2 = builder.CreateStratisPowNode(KnownNetworks.RegTest);
+                CoreNode stratisNode1 = builder.CreateStratisPowNode(this.network);
+                CoreNode stratisNode2 = builder.CreateStratisPowNode(this.network);
                 builder.StartAll();
                 stratisNode1.NotInIBD();
                 stratisNode2.NotInIBD();

--- a/src/Stratis.Bitcoin.IntegrationTests/BlockStore/BlockStoreTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/BlockStore/BlockStoreTests.cs
@@ -89,9 +89,9 @@ namespace Stratis.Bitcoin.IntegrationTests.BlockStore
         {
             using (NodeBuilder builder = NodeBuilder.Create(this))
             {
-                CoreNode stratisNodeSync = builder.CreateStratisPowNode();
-                CoreNode stratisNode1 = builder.CreateStratisPowNode();
-                CoreNode stratisNode2 = builder.CreateStratisPowNode();
+                CoreNode stratisNodeSync = builder.CreateStratisPowNode(KnownNetworks.RegTest);
+                CoreNode stratisNode1 = builder.CreateStratisPowNode(KnownNetworks.RegTest);
+                CoreNode stratisNode2 = builder.CreateStratisPowNode(KnownNetworks.RegTest);
                 builder.StartAll();
                 stratisNodeSync.NotInIBD();
                 stratisNode1.NotInIBD();
@@ -131,7 +131,7 @@ namespace Stratis.Bitcoin.IntegrationTests.BlockStore
         {
             using (NodeBuilder builder = NodeBuilder.Create(this))
             {
-                CoreNode stratisNodeSync = builder.CreateStratisPowNode();
+                CoreNode stratisNodeSync = builder.CreateStratisPowNode(KnownNetworks.RegTest);
                 builder.StartAll();
                 stratisNodeSync.NotInIBD();
 
@@ -163,9 +163,9 @@ namespace Stratis.Bitcoin.IntegrationTests.BlockStore
         {
             using (NodeBuilder builder = NodeBuilder.Create(this))
             {
-                CoreNode stratisNodeSync = builder.CreateStratisPowNode();
-                CoreNode stratisNode1 = builder.CreateStratisPowNode();
-                CoreNode stratisNode2 = builder.CreateStratisPowNode();
+                CoreNode stratisNodeSync = builder.CreateStratisPowNode(KnownNetworks.RegTest);
+                CoreNode stratisNode1 = builder.CreateStratisPowNode(KnownNetworks.RegTest);
+                CoreNode stratisNode2 = builder.CreateStratisPowNode(KnownNetworks.RegTest);
                 builder.StartAll();
                 stratisNodeSync.NotInIBD();
                 stratisNode1.NotInIBD();
@@ -216,8 +216,8 @@ namespace Stratis.Bitcoin.IntegrationTests.BlockStore
         {
             using (NodeBuilder builder = NodeBuilder.Create(this))
             {
-                CoreNode stratisNode1 = builder.CreateStratisPowNode();
-                CoreNode stratisNode2 = builder.CreateStratisPowNode();
+                CoreNode stratisNode1 = builder.CreateStratisPowNode(KnownNetworks.RegTest);
+                CoreNode stratisNode2 = builder.CreateStratisPowNode(KnownNetworks.RegTest);
                 builder.StartAll();
                 stratisNode1.NotInIBD();
                 stratisNode2.NotInIBD();

--- a/src/Stratis.Bitcoin.IntegrationTests/BlockStore/ProofOfWorkSpendingSteps.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/BlockStore/ProofOfWorkSpendingSteps.cs
@@ -10,6 +10,7 @@ using Stratis.Bitcoin.Features.Wallet.Models;
 using Stratis.Bitcoin.IntegrationTests.Common;
 using Stratis.Bitcoin.IntegrationTests.Common.Builders;
 using Stratis.Bitcoin.IntegrationTests.Common.EnvironmentMockUpHelpers;
+using Stratis.Bitcoin.Tests.Common;
 using Xunit.Abstractions;
 
 namespace Stratis.Bitcoin.IntegrationTests.BlockStore
@@ -34,7 +35,7 @@ namespace Stratis.Bitcoin.IntegrationTests.BlockStore
 
         protected override void BeforeTest()
         {
-            this.nodeGroupBuilder = new NodeGroupBuilder(Path.Combine(this.GetType().Name, this.CurrentTest.DisplayName));
+            this.nodeGroupBuilder = new NodeGroupBuilder(Path.Combine(this.GetType().Name, this.CurrentTest.DisplayName), KnownNetworks.RegTest);
             this.sharedSteps = new SharedSteps();
         }
 

--- a/src/Stratis.Bitcoin.IntegrationTests/BlockStore/ReorgToLongestChainSteps.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/BlockStore/ReorgToLongestChainSteps.cs
@@ -9,6 +9,7 @@ using Stratis.Bitcoin.Features.Wallet.Models;
 using Stratis.Bitcoin.IntegrationTests.Common;
 using Stratis.Bitcoin.IntegrationTests.Common.Builders;
 using Stratis.Bitcoin.IntegrationTests.Common.EnvironmentMockUpHelpers;
+using Stratis.Bitcoin.Tests.Common;
 using Xunit.Abstractions;
 
 namespace Stratis.Bitcoin.IntegrationTests.BlockStore
@@ -36,7 +37,7 @@ namespace Stratis.Bitcoin.IntegrationTests.BlockStore
         protected override void BeforeTest()
         {
             this.sharedSteps = new SharedSteps();
-            this.nodeGroupBuilder = new NodeGroupBuilder(Path.Combine(this.GetType().Name, this.CurrentTest.DisplayName));
+            this.nodeGroupBuilder = new NodeGroupBuilder(Path.Combine(this.GetType().Name, this.CurrentTest.DisplayName), KnownNetworks.RegTest);
         }
 
         protected override void AfterTest()

--- a/src/Stratis.Bitcoin.IntegrationTests/BlockStore/RetrieveFromBlockStoreSteps.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/BlockStore/RetrieveFromBlockStoreSteps.cs
@@ -40,6 +40,7 @@ namespace Stratis.Bitcoin.IntegrationTests.BlockStore
         private Transaction wontRetrieveTransaction;
         private uint256 retrievedBlockId;
         private Transaction wontRetrieveBlockId;
+        private readonly Network network = KnownNetworks.RegTest;
 
         public RetrieveFromBlockStoreSpecification(ITestOutputHelper output) : base(output)
         {
@@ -58,14 +59,14 @@ namespace Stratis.Bitcoin.IntegrationTests.BlockStore
 
         private void a_pow_node_running()
         {
-            this.node = this.builder.CreateStratisPowNode(KnownNetworks.RegTest);
+            this.node = this.builder.CreateStratisPowNode(this.network);
             this.node.Start();
             this.node.NotInIBD();
         }
 
         private void a_pow_node_to_transact_with()
         {
-            this.transactionNode = this.builder.CreateStratisPowNode(KnownNetworks.RegTest);
+            this.transactionNode = this.builder.CreateStratisPowNode(this.network);
             this.transactionNode.Start();
             this.transactionNode.NotInIBD();
 

--- a/src/Stratis.Bitcoin.IntegrationTests/BlockStore/RetrieveFromBlockStoreSteps.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/BlockStore/RetrieveFromBlockStoreSteps.cs
@@ -8,6 +8,7 @@ using Stratis.Bitcoin.Features.Wallet.Controllers;
 using Stratis.Bitcoin.Features.Wallet.Models;
 using Stratis.Bitcoin.IntegrationTests.Common;
 using Stratis.Bitcoin.IntegrationTests.Common.EnvironmentMockUpHelpers;
+using Stratis.Bitcoin.Tests.Common;
 using Stratis.Bitcoin.Tests.Common.TestFramework;
 using Xunit.Abstractions;
 
@@ -57,14 +58,14 @@ namespace Stratis.Bitcoin.IntegrationTests.BlockStore
 
         private void a_pow_node_running()
         {
-            this.node = this.builder.CreateStratisPowNode();
+            this.node = this.builder.CreateStratisPowNode(KnownNetworks.RegTest);
             this.node.Start();
             this.node.NotInIBD();
         }
 
         private void a_pow_node_to_transact_with()
         {
-            this.transactionNode = this.builder.CreateStratisPowNode();
+            this.transactionNode = this.builder.CreateStratisPowNode(KnownNetworks.RegTest);
             this.transactionNode.Start();
             this.transactionNode.NotInIBD();
 

--- a/src/Stratis.Bitcoin.IntegrationTests/CoinViewTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/CoinViewTests.cs
@@ -174,7 +174,7 @@ namespace Stratis.Bitcoin.IntegrationTests
         {
             using (NodeBuilder builder = NodeBuilder.Create(this))
             {
-                CoreNode stratisNode = builder.CreateStratisPowNode();
+                CoreNode stratisNode = builder.CreateStratisPowNode(KnownNetworks.RegTest);
                 CoreNode coreNode1 = builder.CreateBitcoinCoreNode();
                 CoreNode coreNode2 = builder.CreateBitcoinCoreNode();
                 builder.StartAll();

--- a/src/Stratis.Bitcoin.IntegrationTests/CoinViewTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/CoinViewTests.cs
@@ -174,7 +174,7 @@ namespace Stratis.Bitcoin.IntegrationTests
         {
             using (NodeBuilder builder = NodeBuilder.Create(this))
             {
-                CoreNode stratisNode = builder.CreateStratisPowNode(KnownNetworks.RegTest);
+                CoreNode stratisNode = builder.CreateStratisPowNode(this.regTest);
                 CoreNode coreNode1 = builder.CreateBitcoinCoreNode();
                 CoreNode coreNode2 = builder.CreateBitcoinCoreNode();
                 builder.StartAll();

--- a/src/Stratis.Bitcoin.IntegrationTests/Mempool/MemoryPoolTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/Mempool/MemoryPoolTests.cs
@@ -7,6 +7,7 @@ using Stratis.Bitcoin.Features.Consensus;
 using Stratis.Bitcoin.Features.MemoryPool;
 using Stratis.Bitcoin.IntegrationTests.Common;
 using Stratis.Bitcoin.IntegrationTests.Common.EnvironmentMockUpHelpers;
+using Stratis.Bitcoin.Tests.Common;
 using Stratis.Bitcoin.Utilities;
 using Xunit;
 
@@ -35,7 +36,7 @@ namespace Stratis.Bitcoin.IntegrationTests.Mempool
         {
             using (NodeBuilder builder = NodeBuilder.Create(this))
             {
-                CoreNode stratisNodeSync = builder.CreateStratisPowNode();
+                CoreNode stratisNodeSync = builder.CreateStratisPowNode(KnownNetworks.RegTest);
                 builder.StartAll();
 
                 stratisNodeSync.SetDummyMinerSecret(new BitcoinSecret(new Key(), stratisNodeSync.FullNode.Network));
@@ -64,7 +65,7 @@ namespace Stratis.Bitcoin.IntegrationTests.Mempool
         {
             using (NodeBuilder builder = NodeBuilder.Create(this))
             {
-                CoreNode stratisNodeSync = builder.CreateStratisPowNode();
+                CoreNode stratisNodeSync = builder.CreateStratisPowNode(KnownNetworks.RegTest);
                 builder.StartAll();
                 stratisNodeSync.NotInIBD();
 
@@ -108,7 +109,7 @@ namespace Stratis.Bitcoin.IntegrationTests.Mempool
         {
             using (NodeBuilder builder = NodeBuilder.Create(this))
             {
-                CoreNode stratisNodeSync = builder.CreateStratisPowNode();
+                CoreNode stratisNodeSync = builder.CreateStratisPowNode(KnownNetworks.RegTest);
                 builder.StartAll();
                 stratisNodeSync.NotInIBD();
 
@@ -146,7 +147,7 @@ namespace Stratis.Bitcoin.IntegrationTests.Mempool
         {
             using (NodeBuilder builder = NodeBuilder.Create(this))
             {
-                CoreNode stratisNodeSync = builder.CreateStratisPowNode();
+                CoreNode stratisNodeSync = builder.CreateStratisPowNode(KnownNetworks.RegTest);
                 builder.StartAll();
                 stratisNodeSync.NotInIBD();
                 stratisNodeSync.FullNode.NodeService<MempoolSettings>().RequireStandard = true; // make sure to test standard tx
@@ -221,7 +222,7 @@ namespace Stratis.Bitcoin.IntegrationTests.Mempool
 
             using (NodeBuilder builder = NodeBuilder.Create(this))
             {
-                CoreNode stratisNode = builder.CreateStratisPowNode();
+                CoreNode stratisNode = builder.CreateStratisPowNode(KnownNetworks.RegTest);
                 builder.StartAll();
 
                 stratisNode.SetDummyMinerSecret(new BitcoinSecret(new Key(), stratisNode.FullNode.Network));
@@ -288,7 +289,7 @@ namespace Stratis.Bitcoin.IntegrationTests.Mempool
         {
             using (NodeBuilder builder = NodeBuilder.Create(this))
             {
-                CoreNode stratisNodeSync = builder.CreateStratisPowNode();
+                CoreNode stratisNodeSync = builder.CreateStratisPowNode(KnownNetworks.RegTest);
                 builder.StartAll();
                 stratisNodeSync.NotInIBD();
 
@@ -330,9 +331,9 @@ namespace Stratis.Bitcoin.IntegrationTests.Mempool
         {
             using (NodeBuilder builder = NodeBuilder.Create(this))
             {
-                CoreNode stratisNodeSync = builder.CreateStratisPowNode();
-                CoreNode stratisNode1 = builder.CreateStratisPowNode();
-                CoreNode stratisNode2 = builder.CreateStratisPowNode();
+                CoreNode stratisNodeSync = builder.CreateStratisPowNode(KnownNetworks.RegTest);
+                CoreNode stratisNode1 = builder.CreateStratisPowNode(KnownNetworks.RegTest);
+                CoreNode stratisNode2 = builder.CreateStratisPowNode(KnownNetworks.RegTest);
                 builder.StartAll();
 
                 stratisNodeSync.NotInIBD();

--- a/src/Stratis.Bitcoin.IntegrationTests/Mempool/MemoryPoolTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/Mempool/MemoryPoolTests.cs
@@ -15,6 +15,13 @@ namespace Stratis.Bitcoin.IntegrationTests.Mempool
 {
     public class MemoryPoolTests
     {
+        private readonly Network network;
+
+        public MemoryPoolTests()
+        {
+            this.network = KnownNetworks.RegTest;
+        }
+
         public class DateTimeProviderSet : DateTimeProvider
         {
             public long time;
@@ -36,7 +43,7 @@ namespace Stratis.Bitcoin.IntegrationTests.Mempool
         {
             using (NodeBuilder builder = NodeBuilder.Create(this))
             {
-                CoreNode stratisNodeSync = builder.CreateStratisPowNode(KnownNetworks.RegTest);
+                CoreNode stratisNodeSync = builder.CreateStratisPowNode(this.network);
                 builder.StartAll();
 
                 stratisNodeSync.SetDummyMinerSecret(new BitcoinSecret(new Key(), stratisNodeSync.FullNode.Network));
@@ -65,7 +72,7 @@ namespace Stratis.Bitcoin.IntegrationTests.Mempool
         {
             using (NodeBuilder builder = NodeBuilder.Create(this))
             {
-                CoreNode stratisNodeSync = builder.CreateStratisPowNode(KnownNetworks.RegTest);
+                CoreNode stratisNodeSync = builder.CreateStratisPowNode(this.network);
                 builder.StartAll();
                 stratisNodeSync.NotInIBD();
 
@@ -109,7 +116,7 @@ namespace Stratis.Bitcoin.IntegrationTests.Mempool
         {
             using (NodeBuilder builder = NodeBuilder.Create(this))
             {
-                CoreNode stratisNodeSync = builder.CreateStratisPowNode(KnownNetworks.RegTest);
+                CoreNode stratisNodeSync = builder.CreateStratisPowNode(this.network);
                 builder.StartAll();
                 stratisNodeSync.NotInIBD();
 
@@ -147,7 +154,7 @@ namespace Stratis.Bitcoin.IntegrationTests.Mempool
         {
             using (NodeBuilder builder = NodeBuilder.Create(this))
             {
-                CoreNode stratisNodeSync = builder.CreateStratisPowNode(KnownNetworks.RegTest);
+                CoreNode stratisNodeSync = builder.CreateStratisPowNode(this.network);
                 builder.StartAll();
                 stratisNodeSync.NotInIBD();
                 stratisNodeSync.FullNode.NodeService<MempoolSettings>().RequireStandard = true; // make sure to test standard tx
@@ -222,7 +229,7 @@ namespace Stratis.Bitcoin.IntegrationTests.Mempool
 
             using (NodeBuilder builder = NodeBuilder.Create(this))
             {
-                CoreNode stratisNode = builder.CreateStratisPowNode(KnownNetworks.RegTest);
+                CoreNode stratisNode = builder.CreateStratisPowNode(this.network);
                 builder.StartAll();
 
                 stratisNode.SetDummyMinerSecret(new BitcoinSecret(new Key(), stratisNode.FullNode.Network));
@@ -289,7 +296,7 @@ namespace Stratis.Bitcoin.IntegrationTests.Mempool
         {
             using (NodeBuilder builder = NodeBuilder.Create(this))
             {
-                CoreNode stratisNodeSync = builder.CreateStratisPowNode(KnownNetworks.RegTest);
+                CoreNode stratisNodeSync = builder.CreateStratisPowNode(this.network);
                 builder.StartAll();
                 stratisNodeSync.NotInIBD();
 
@@ -331,9 +338,9 @@ namespace Stratis.Bitcoin.IntegrationTests.Mempool
         {
             using (NodeBuilder builder = NodeBuilder.Create(this))
             {
-                CoreNode stratisNodeSync = builder.CreateStratisPowNode(KnownNetworks.RegTest);
-                CoreNode stratisNode1 = builder.CreateStratisPowNode(KnownNetworks.RegTest);
-                CoreNode stratisNode2 = builder.CreateStratisPowNode(KnownNetworks.RegTest);
+                CoreNode stratisNodeSync = builder.CreateStratisPowNode(this.network);
+                CoreNode stratisNode1 = builder.CreateStratisPowNode(this.network);
+                CoreNode stratisNode2 = builder.CreateStratisPowNode(this.network);
                 builder.StartAll();
 
                 stratisNodeSync.NotInIBD();

--- a/src/Stratis.Bitcoin.IntegrationTests/Mempool/MempoolRelaySpecification_Steps.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/Mempool/MempoolRelaySpecification_Steps.cs
@@ -7,6 +7,7 @@ using Stratis.Bitcoin.Connection;
 using Stratis.Bitcoin.Features.RPC;
 using Stratis.Bitcoin.IntegrationTests.Common;
 using Stratis.Bitcoin.IntegrationTests.Common.EnvironmentMockUpHelpers;
+using Stratis.Bitcoin.Tests.Common;
 using Xunit.Abstractions;
 
 namespace Stratis.Bitcoin.IntegrationTests.Mempool
@@ -37,9 +38,9 @@ namespace Stratis.Bitcoin.IntegrationTests.Mempool
 
         protected void nodeA_nodeB_and_nodeC()
         {
-            this.nodeA = this.nodeBuilder.CreateStratisPowNode();
-            this.nodeB = this.nodeBuilder.CreateStratisPowNode();
-            this.nodeC = this.nodeBuilder.CreateStratisPowNode();
+            this.nodeA = this.nodeBuilder.CreateStratisPowNode(KnownNetworks.RegTest);
+            this.nodeB = this.nodeBuilder.CreateStratisPowNode(KnownNetworks.RegTest);
+            this.nodeC = this.nodeBuilder.CreateStratisPowNode(KnownNetworks.RegTest);
 
             this.nodeBuilder.StartAll();
             this.nodeA.NotInIBD();

--- a/src/Stratis.Bitcoin.IntegrationTests/Mempool/MempoolRelaySpecification_Steps.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/Mempool/MempoolRelaySpecification_Steps.cs
@@ -38,9 +38,11 @@ namespace Stratis.Bitcoin.IntegrationTests.Mempool
 
         protected void nodeA_nodeB_and_nodeC()
         {
-            this.nodeA = this.nodeBuilder.CreateStratisPowNode(KnownNetworks.RegTest);
-            this.nodeB = this.nodeBuilder.CreateStratisPowNode(KnownNetworks.RegTest);
-            this.nodeC = this.nodeBuilder.CreateStratisPowNode(KnownNetworks.RegTest);
+            Network regTest = KnownNetworks.RegTest;
+
+            this.nodeA = this.nodeBuilder.CreateStratisPowNode(regTest);
+            this.nodeB = this.nodeBuilder.CreateStratisPowNode(regTest);
+            this.nodeC = this.nodeBuilder.CreateStratisPowNode(regTest);
 
             this.nodeBuilder.StartAll();
             this.nodeA.NotInIBD();

--- a/src/Stratis.Bitcoin.IntegrationTests/MinerTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/MinerTests.cs
@@ -643,7 +643,7 @@ namespace Stratis.Bitcoin.IntegrationTests
         {
             using (NodeBuilder builder = NodeBuilder.Create(this))
             {
-                CoreNode node = builder.CreateStratisPowNode();
+                CoreNode node = builder.CreateStratisPowNode(KnownNetworks.RegTest);
                 builder.StartAll();
                 node.NotInIBD();
 

--- a/src/Stratis.Bitcoin.IntegrationTests/NodeSyncTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/NodeSyncTests.cs
@@ -30,8 +30,8 @@ namespace Stratis.Bitcoin.IntegrationTests
         {
             using (NodeBuilder builder = NodeBuilder.Create(this))
             {
-                CoreNode node1 = builder.CreateStratisPowNode();
-                CoreNode node2 = builder.CreateStratisPowNode();
+                CoreNode node1 = builder.CreateStratisPowNode(KnownNetworks.RegTest);
+                CoreNode node2 = builder.CreateStratisPowNode(KnownNetworks.RegTest);
                 builder.StartAll();
                 Assert.Empty(node1.FullNode.ConnectionManager.ConnectedPeers);
                 Assert.Empty(node2.FullNode.ConnectionManager.ConnectedPeers);
@@ -54,7 +54,7 @@ namespace Stratis.Bitcoin.IntegrationTests
         {
             using (NodeBuilder builder = NodeBuilder.Create(this))
             {
-                CoreNode stratisNode = builder.CreateStratisPowNode();
+                CoreNode stratisNode = builder.CreateStratisPowNode(KnownNetworks.RegTest);
                 CoreNode coreNode = builder.CreateBitcoinCoreNode();
                 builder.StartAll();
 
@@ -85,8 +85,8 @@ namespace Stratis.Bitcoin.IntegrationTests
         {
             using (NodeBuilder builder = NodeBuilder.Create(this))
             {
-                CoreNode stratisNode = builder.CreateStratisPowNode();
-                CoreNode stratisNodeSync = builder.CreateStratisPowNode();
+                CoreNode stratisNode = builder.CreateStratisPowNode(KnownNetworks.RegTest);
+                CoreNode stratisNodeSync = builder.CreateStratisPowNode(KnownNetworks.RegTest);
                 CoreNode coreCreateNode = builder.CreateBitcoinCoreNode();
                 builder.StartAll();
 
@@ -117,7 +117,7 @@ namespace Stratis.Bitcoin.IntegrationTests
         {
             using (NodeBuilder builder = NodeBuilder.Create(this))
             {
-                CoreNode stratisNode = builder.CreateStratisPowNode();
+                CoreNode stratisNode = builder.CreateStratisPowNode(KnownNetworks.RegTest);
                 CoreNode coreNodeSync = builder.CreateBitcoinCoreNode();
                 CoreNode coreCreateNode = builder.CreateBitcoinCoreNode();
                 builder.StartAll();

--- a/src/Stratis.Bitcoin.IntegrationTests/NodeSyncTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/NodeSyncTests.cs
@@ -18,11 +18,13 @@ namespace Stratis.Bitcoin.IntegrationTests
 {
     public class NodeSyncTests
     {
-        private Network network;
+        private readonly Network posNetwork;
+        private readonly Network powNetwork;
 
         public NodeSyncTests()
         {
-            this.network = KnownNetworks.StratisRegTest;
+            this.posNetwork = KnownNetworks.StratisRegTest;
+            this.powNetwork = KnownNetworks.RegTest;
         }
 
         [Fact]
@@ -30,8 +32,8 @@ namespace Stratis.Bitcoin.IntegrationTests
         {
             using (NodeBuilder builder = NodeBuilder.Create(this))
             {
-                CoreNode node1 = builder.CreateStratisPowNode(KnownNetworks.RegTest);
-                CoreNode node2 = builder.CreateStratisPowNode(KnownNetworks.RegTest);
+                CoreNode node1 = builder.CreateStratisPowNode(this.powNetwork);
+                CoreNode node2 = builder.CreateStratisPowNode(this.powNetwork);
                 builder.StartAll();
                 Assert.Empty(node1.FullNode.ConnectionManager.ConnectedPeers);
                 Assert.Empty(node2.FullNode.ConnectionManager.ConnectedPeers);
@@ -54,7 +56,7 @@ namespace Stratis.Bitcoin.IntegrationTests
         {
             using (NodeBuilder builder = NodeBuilder.Create(this))
             {
-                CoreNode stratisNode = builder.CreateStratisPowNode(KnownNetworks.RegTest);
+                CoreNode stratisNode = builder.CreateStratisPowNode(this.powNetwork);
                 CoreNode coreNode = builder.CreateBitcoinCoreNode();
                 builder.StartAll();
 
@@ -85,8 +87,8 @@ namespace Stratis.Bitcoin.IntegrationTests
         {
             using (NodeBuilder builder = NodeBuilder.Create(this))
             {
-                CoreNode stratisNode = builder.CreateStratisPowNode(KnownNetworks.RegTest);
-                CoreNode stratisNodeSync = builder.CreateStratisPowNode(KnownNetworks.RegTest);
+                CoreNode stratisNode = builder.CreateStratisPowNode(this.powNetwork);
+                CoreNode stratisNodeSync = builder.CreateStratisPowNode(this.powNetwork);
                 CoreNode coreCreateNode = builder.CreateBitcoinCoreNode();
                 builder.StartAll();
 
@@ -117,7 +119,7 @@ namespace Stratis.Bitcoin.IntegrationTests
         {
             using (NodeBuilder builder = NodeBuilder.Create(this))
             {
-                CoreNode stratisNode = builder.CreateStratisPowNode(KnownNetworks.RegTest);
+                CoreNode stratisNode = builder.CreateStratisPowNode(this.powNetwork);
                 CoreNode coreNodeSync = builder.CreateBitcoinCoreNode();
                 CoreNode coreCreateNode = builder.CreateBitcoinCoreNode();
                 builder.StartAll();
@@ -150,9 +152,9 @@ namespace Stratis.Bitcoin.IntegrationTests
         {
             using (NodeBuilder builder = NodeBuilder.Create(this))
             {
-                CoreNode stratisMiner = builder.CreateStratisPosNode(this.network);
-                CoreNode stratisSyncer = builder.CreateStratisPosNode(this.network);
-                CoreNode stratisReorg = builder.CreateStratisPosNode(this.network);
+                CoreNode stratisMiner = builder.CreateStratisPosNode(this.posNetwork);
+                CoreNode stratisSyncer = builder.CreateStratisPosNode(this.posNetwork);
+                CoreNode stratisReorg = builder.CreateStratisPosNode(this.posNetwork);
 
                 builder.StartAll();
                 stratisMiner.NotInIBD();
@@ -235,10 +237,10 @@ namespace Stratis.Bitcoin.IntegrationTests
             using (NodeBuilder builder = NodeBuilder.Create(this))
             {
                 // This represents local node.
-                CoreNode stratisMinerLocal = builder.CreateStratisPosNode(this.network);
+                CoreNode stratisMinerLocal = builder.CreateStratisPosNode(this.posNetwork);
 
                 // This represents remote, which blocks are received by local node using its puller.
-                CoreNode stratisMinerRemote = builder.CreateStratisPosNode(this.network);
+                CoreNode stratisMinerRemote = builder.CreateStratisPosNode(this.posNetwork);
 
                 builder.StartAll();
                 stratisMinerLocal.NotInIBD();
@@ -301,7 +303,7 @@ namespace Stratis.Bitcoin.IntegrationTests
 
             var sharedSteps = new SharedSteps();
             string testFolderPath = Path.Combine(this.GetType().Name, nameof(MiningNodeWithOneConnectionAlwaysSynced));
-            using (var builder = new NodeGroupBuilder(testFolderPath, KnownNetworks.RegTest))
+            using (var builder = new NodeGroupBuilder(testFolderPath, this.powNetwork))
             {
                 var nodes = builder.StratisPowNode(miner).Start().NotInIBD().WithWallet(walletName, walletPassword)
                     .StratisPowNode(connector).Start().NotInIBD().WithWallet(walletName, walletPassword)

--- a/src/Stratis.Bitcoin.IntegrationTests/NodeSyncTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/NodeSyncTests.cs
@@ -18,6 +18,13 @@ namespace Stratis.Bitcoin.IntegrationTests
 {
     public class NodeSyncTests
     {
+        private Network network;
+
+        public NodeSyncTests()
+        {
+            this.network = KnownNetworks.StratisRegTest;
+        }
+
         [Fact]
         public void NodesCanConnectToEachOthers()
         {
@@ -143,9 +150,9 @@ namespace Stratis.Bitcoin.IntegrationTests
         {
             using (NodeBuilder builder = NodeBuilder.Create(this))
             {
-                CoreNode stratisMiner = builder.CreateStratisPosNode();
-                CoreNode stratisSyncer = builder.CreateStratisPosNode();
-                CoreNode stratisReorg = builder.CreateStratisPosNode();
+                CoreNode stratisMiner = builder.CreateStratisPosNode(this.network);
+                CoreNode stratisSyncer = builder.CreateStratisPosNode(this.network);
+                CoreNode stratisReorg = builder.CreateStratisPosNode(this.network);
 
                 builder.StartAll();
                 stratisMiner.NotInIBD();
@@ -228,10 +235,10 @@ namespace Stratis.Bitcoin.IntegrationTests
             using (NodeBuilder builder = NodeBuilder.Create(this))
             {
                 // This represents local node.
-                CoreNode stratisMinerLocal = builder.CreateStratisPosNode();
+                CoreNode stratisMinerLocal = builder.CreateStratisPosNode(this.network);
 
                 // This represents remote, which blocks are received by local node using its puller.
-                CoreNode stratisMinerRemote = builder.CreateStratisPosNode();
+                CoreNode stratisMinerRemote = builder.CreateStratisPosNode(this.network);
 
                 builder.StartAll();
                 stratisMinerLocal.NotInIBD();

--- a/src/Stratis.Bitcoin.IntegrationTests/NodeSyncTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/NodeSyncTests.cs
@@ -10,6 +10,7 @@ using Stratis.Bitcoin.Features.RPC;
 using Stratis.Bitcoin.IntegrationTests.Common;
 using Stratis.Bitcoin.IntegrationTests.Common.Builders;
 using Stratis.Bitcoin.IntegrationTests.Common.EnvironmentMockUpHelpers;
+using Stratis.Bitcoin.Tests.Common;
 using Stratis.Bitcoin.Utilities.Extensions;
 using Xunit;
 
@@ -293,7 +294,7 @@ namespace Stratis.Bitcoin.IntegrationTests
 
             var sharedSteps = new SharedSteps();
             string testFolderPath = Path.Combine(this.GetType().Name, nameof(MiningNodeWithOneConnectionAlwaysSynced));
-            using (var builder = new NodeGroupBuilder(testFolderPath))
+            using (var builder = new NodeGroupBuilder(testFolderPath, KnownNetworks.RegTest))
             {
                 var nodes = builder.StratisPowNode(miner).Start().NotInIBD().WithWallet(walletName, walletPassword)
                     .StratisPowNode(connector).Start().NotInIBD().WithWallet(walletName, walletPassword)

--- a/src/Stratis.Bitcoin.IntegrationTests/ProofOfStakeSteps.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/ProofOfStakeSteps.cs
@@ -7,6 +7,7 @@ using Stratis.Bitcoin.Features.Miner.Staking;
 using Stratis.Bitcoin.IntegrationTests.Common;
 using Stratis.Bitcoin.IntegrationTests.Common.Builders;
 using Stratis.Bitcoin.IntegrationTests.Common.EnvironmentMockUpHelpers;
+using Stratis.Bitcoin.Tests.Common;
 
 namespace Stratis.Bitcoin.IntegrationTests
 {
@@ -24,7 +25,7 @@ namespace Stratis.Bitcoin.IntegrationTests
         public ProofOfStakeSteps(string displayName)
         {
             this.sharedSteps = new SharedSteps();
-            this.NodeGroupBuilder = new NodeGroupBuilder(Path.Combine(this.GetType().Name, displayName));
+            this.NodeGroupBuilder = new NodeGroupBuilder(Path.Combine(this.GetType().Name, displayName), KnownNetworks.StratisRegTest);
         }
 
         public void GenerateCoins()

--- a/src/Stratis.Bitcoin.IntegrationTests/RPC/RPCTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/RPC/RPCTests.cs
@@ -20,7 +20,7 @@ namespace Stratis.Bitcoin.IntegrationTests.RPC
         protected override void InitializeFixture()
         {
             this.Builder = NodeBuilder.Create(this);
-            this.Node = this.Builder.CreateStratisPowNode();
+            this.Node = this.Builder.CreateStratisPowNode(KnownNetworks.RegTest);
             this.Builder.StartAll();
             this.RpcClient = this.Node.CreateRPCClient();
             this.NetworkPeerClient = this.Node.CreateNetworkPeerClient();

--- a/src/Stratis.Bitcoin.IntegrationTests/SegWitTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/SegWitTests.cs
@@ -24,7 +24,7 @@ namespace Stratis.Bitcoin.IntegrationTests
                 coreNode.ConfigParameters.AddOrReplace("printtoconsole", "0");
                 coreNode.Start();
 
-                CoreNode stratisNode = builder.CreateStratisPowNode(start: true);
+                CoreNode stratisNode = builder.CreateStratisPowNode(KnownNetworks.RegTest, start: true);
 
                 RPCClient stratisNodeRpc = stratisNode.CreateRPCClient();
                 RPCClient coreRpc = coreNode.CreateRPCClient();

--- a/src/Stratis.Bitcoin.IntegrationTests/Transactions/TransactionWithNullDataSteps.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/Transactions/TransactionWithNullDataSteps.cs
@@ -10,6 +10,7 @@ using Stratis.Bitcoin.Features.Wallet.Controllers;
 using Stratis.Bitcoin.Features.Wallet.Models;
 using Stratis.Bitcoin.IntegrationTests.Common;
 using Stratis.Bitcoin.IntegrationTests.Common.EnvironmentMockUpHelpers;
+using Stratis.Bitcoin.Tests.Common;
 using Stratis.Bitcoin.Tests.Common.TestFramework;
 using Xunit.Abstractions;
 
@@ -48,8 +49,8 @@ namespace Stratis.Bitcoin.IntegrationTests.Transactions
 
         private void two_proof_of_work_nodes()
         {
-            this.senderNode = this.builder.CreateStratisPowNode();
-            this.receiverNode = this.builder.CreateStratisPowNode();
+            this.senderNode = this.builder.CreateStratisPowNode(KnownNetworks.RegTest);
+            this.receiverNode = this.builder.CreateStratisPowNode(KnownNetworks.RegTest);
             this.builder.StartAll();
             this.senderNode.NotInIBD();
             this.receiverNode.NotInIBD();

--- a/src/Stratis.Bitcoin.IntegrationTests/Wallet/SendingToAndFromManyAddressesSpecification_Steps.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/Wallet/SendingToAndFromManyAddressesSpecification_Steps.cs
@@ -9,6 +9,7 @@ using Stratis.Bitcoin.Features.Wallet.Models;
 using Stratis.Bitcoin.IntegrationTests.Common;
 using Stratis.Bitcoin.IntegrationTests.Common.Builders;
 using Stratis.Bitcoin.IntegrationTests.Common.EnvironmentMockUpHelpers;
+using Stratis.Bitcoin.Tests.Common;
 using Stratis.Bitcoin.Tests.Common.TestFramework;
 using Xunit.Abstractions;
 
@@ -38,7 +39,7 @@ namespace Stratis.Bitcoin.IntegrationTests.Wallet
         protected override void BeforeTest()
         {
             this.sharedSteps = new SharedSteps();
-            this.nodeGroupBuilder = new NodeGroupBuilder(Path.Combine(this.GetType().Name, this.CurrentTest.DisplayName));
+            this.nodeGroupBuilder = new NodeGroupBuilder(Path.Combine(this.GetType().Name, this.CurrentTest.DisplayName), KnownNetworks.RegTest);
         }
 
         protected override void AfterTest()

--- a/src/Stratis.Bitcoin.IntegrationTests/Wallet/SendingTransactionOverPolicyByteLimitSpecification_Steps.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/Wallet/SendingTransactionOverPolicyByteLimitSpecification_Steps.cs
@@ -9,6 +9,7 @@ using Stratis.Bitcoin.Features.Wallet.Models;
 using Stratis.Bitcoin.IntegrationTests.Common;
 using Stratis.Bitcoin.IntegrationTests.Common.Builders;
 using Stratis.Bitcoin.IntegrationTests.Common.EnvironmentMockUpHelpers;
+using Stratis.Bitcoin.Tests.Common;
 using Stratis.Bitcoin.Tests.Common.TestFramework;
 using Xunit.Abstractions;
 
@@ -37,7 +38,7 @@ namespace Stratis.Bitcoin.IntegrationTests.Wallet
         protected override void BeforeTest()
         {
             this.sharedSteps = new SharedSteps();
-            this.nodeGroupBuilder = new NodeGroupBuilder(this.CurrentTest.DisplayName);
+            this.nodeGroupBuilder = new NodeGroupBuilder(this.CurrentTest.DisplayName, KnownNetworks.RegTest);
         }
 
         protected override void AfterTest()

--- a/src/Stratis.Bitcoin.IntegrationTests/Wallet/SendingTxWithDoubleSpendSpecification_Steps.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/Wallet/SendingTxWithDoubleSpendSpecification_Steps.cs
@@ -8,6 +8,7 @@ using Stratis.Bitcoin.Features.Wallet.Controllers;
 using Stratis.Bitcoin.Features.Wallet.Models;
 using Stratis.Bitcoin.IntegrationTests.Common;
 using Stratis.Bitcoin.IntegrationTests.Common.EnvironmentMockUpHelpers;
+using Stratis.Bitcoin.Tests.Common;
 using Stratis.Bitcoin.Tests.Common.TestFramework;
 using Xunit.Abstractions;
 
@@ -27,8 +28,8 @@ namespace Stratis.Bitcoin.IntegrationTests.Wallet
         protected override void BeforeTest()
         {
             this.builder = NodeBuilder.Create(this);
-            this.stratisSender = this.builder.CreateStratisPowNode();
-            this.stratisReceiver = this.builder.CreateStratisPowNode();
+            this.stratisSender = this.builder.CreateStratisPowNode(KnownNetworks.RegTest);
+            this.stratisReceiver = this.builder.CreateStratisPowNode(KnownNetworks.RegTest);
             this.mempoolValidationState = new MempoolValidationState(true);
 
             this.builder.StartAll();

--- a/src/Stratis.Bitcoin.IntegrationTests/Wallet/WalletAddressGenerationAndFundsVisibility_Steps.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/Wallet/WalletAddressGenerationAndFundsVisibility_Steps.cs
@@ -34,7 +34,7 @@ namespace Stratis.Bitcoin.IntegrationTests.Wallet
 
         protected override void BeforeTest()
         {
-            this.nodeGroupBuilder = new NodeGroupBuilder(Path.Combine(this.GetType().Name, this.CurrentTest.DisplayName));
+            this.nodeGroupBuilder = new NodeGroupBuilder(Path.Combine(this.GetType().Name, this.CurrentTest.DisplayName), KnownNetworks.RegTest);
             this.sharedSteps = new SharedSteps();
         }
 

--- a/src/Stratis.Bitcoin.IntegrationTests/Wallet/WalletTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/Wallet/WalletTests.cs
@@ -10,6 +10,7 @@ using Stratis.Bitcoin.Features.Wallet.Interfaces;
 using Stratis.Bitcoin.Features.Wallet.Models;
 using Stratis.Bitcoin.IntegrationTests.Common;
 using Stratis.Bitcoin.IntegrationTests.Common.EnvironmentMockUpHelpers;
+using Stratis.Bitcoin.Tests.Common;
 using Xunit;
 
 namespace Stratis.Bitcoin.IntegrationTests.Wallet
@@ -21,8 +22,8 @@ namespace Stratis.Bitcoin.IntegrationTests.Wallet
         {
             using (NodeBuilder builder = NodeBuilder.Create(this))
             {
-                CoreNode stratisSender = builder.CreateStratisPowNode();
-                CoreNode stratisReceiver = builder.CreateStratisPowNode();
+                CoreNode stratisSender = builder.CreateStratisPowNode(KnownNetworks.RegTest);
+                CoreNode stratisReceiver = builder.CreateStratisPowNode(KnownNetworks.RegTest);
 
                 builder.StartAll();
                 stratisSender.NotInIBD();
@@ -85,7 +86,7 @@ namespace Stratis.Bitcoin.IntegrationTests.Wallet
         {
             using (NodeBuilder builder = NodeBuilder.Create(this))
             {
-                CoreNode stratisNodeSync = builder.CreateStratisPowNode();
+                CoreNode stratisNodeSync = builder.CreateStratisPowNode(KnownNetworks.RegTest);
                 builder.StartAll();
 
                 // Move a wallet file to the right folder and restart the wallet manager to take it into account.
@@ -114,9 +115,9 @@ namespace Stratis.Bitcoin.IntegrationTests.Wallet
 
             using (NodeBuilder builder = NodeBuilder.Create(this))
             {
-                CoreNode stratisSender = builder.CreateStratisPowNode();
-                CoreNode stratisReceiver = builder.CreateStratisPowNode();
-                CoreNode stratisReorg = builder.CreateStratisPowNode();
+                CoreNode stratisSender = builder.CreateStratisPowNode(KnownNetworks.RegTest);
+                CoreNode stratisReceiver = builder.CreateStratisPowNode(KnownNetworks.RegTest);
+                CoreNode stratisReorg = builder.CreateStratisPowNode(KnownNetworks.RegTest);
 
                 builder.StartAll();
                 stratisSender.NotInIBD();
@@ -267,9 +268,9 @@ namespace Stratis.Bitcoin.IntegrationTests.Wallet
         {
             using (NodeBuilder builder = NodeBuilder.Create(this))
             {
-                CoreNode stratisSender = builder.CreateStratisPowNode();
-                CoreNode stratisReceiver = builder.CreateStratisPowNode();
-                CoreNode stratisReorg = builder.CreateStratisPowNode();
+                CoreNode stratisSender = builder.CreateStratisPowNode(KnownNetworks.RegTest);
+                CoreNode stratisReceiver = builder.CreateStratisPowNode(KnownNetworks.RegTest);
+                CoreNode stratisReorg = builder.CreateStratisPowNode(KnownNetworks.RegTest);
 
                 builder.StartAll();
                 stratisSender.NotInIBD();
@@ -329,9 +330,9 @@ namespace Stratis.Bitcoin.IntegrationTests.Wallet
         {
             using (NodeBuilder builder = NodeBuilder.Create(this))
             {
-                CoreNode stratisSender = builder.CreateStratisPowNode();
-                CoreNode stratisReceiver = builder.CreateStratisPowNode();
-                CoreNode stratisReorg = builder.CreateStratisPowNode();
+                CoreNode stratisSender = builder.CreateStratisPowNode(KnownNetworks.RegTest);
+                CoreNode stratisReceiver = builder.CreateStratisPowNode(KnownNetworks.RegTest);
+                CoreNode stratisReorg = builder.CreateStratisPowNode(KnownNetworks.RegTest);
 
                 builder.StartAll();
                 stratisSender.NotInIBD();
@@ -389,7 +390,7 @@ namespace Stratis.Bitcoin.IntegrationTests.Wallet
         {
             using (NodeBuilder builder = NodeBuilder.Create(this))
             {
-                CoreNode stratisminer = builder.CreateStratisPowNode();
+                CoreNode stratisminer = builder.CreateStratisPowNode(KnownNetworks.RegTest);
 
                 builder.StartAll();
                 stratisminer.NotInIBD();
@@ -420,7 +421,7 @@ namespace Stratis.Bitcoin.IntegrationTests.Wallet
         {
             using (NodeBuilder builder = NodeBuilder.Create(this))
             {
-                CoreNode stratisNodeSync = builder.CreateStratisPowNode();
+                CoreNode stratisNodeSync = builder.CreateStratisPowNode(KnownNetworks.RegTest);
                 builder.StartAll();
                 stratisNodeSync.NotInIBD();
 

--- a/src/Stratis.Bitcoin.IntegrationTests/Wallet/WalletTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/Wallet/WalletTests.cs
@@ -17,13 +17,20 @@ namespace Stratis.Bitcoin.IntegrationTests.Wallet
 {
     public class WalletTests
     {
+        private readonly Network network;
+
+        public WalletTests()
+        {
+            this.network = KnownNetworks.RegTest;
+        }
+
         [Fact]
         public void WalletCanReceiveAndSendCorrectly()
         {
             using (NodeBuilder builder = NodeBuilder.Create(this))
             {
-                CoreNode stratisSender = builder.CreateStratisPowNode(KnownNetworks.RegTest);
-                CoreNode stratisReceiver = builder.CreateStratisPowNode(KnownNetworks.RegTest);
+                CoreNode stratisSender = builder.CreateStratisPowNode(this.network);
+                CoreNode stratisReceiver = builder.CreateStratisPowNode(this.network);
 
                 builder.StartAll();
                 stratisSender.NotInIBD();
@@ -86,7 +93,7 @@ namespace Stratis.Bitcoin.IntegrationTests.Wallet
         {
             using (NodeBuilder builder = NodeBuilder.Create(this))
             {
-                CoreNode stratisNodeSync = builder.CreateStratisPowNode(KnownNetworks.RegTest);
+                CoreNode stratisNodeSync = builder.CreateStratisPowNode(this.network);
                 builder.StartAll();
 
                 // Move a wallet file to the right folder and restart the wallet manager to take it into account.
@@ -115,9 +122,9 @@ namespace Stratis.Bitcoin.IntegrationTests.Wallet
 
             using (NodeBuilder builder = NodeBuilder.Create(this))
             {
-                CoreNode stratisSender = builder.CreateStratisPowNode(KnownNetworks.RegTest);
-                CoreNode stratisReceiver = builder.CreateStratisPowNode(KnownNetworks.RegTest);
-                CoreNode stratisReorg = builder.CreateStratisPowNode(KnownNetworks.RegTest);
+                CoreNode stratisSender = builder.CreateStratisPowNode(this.network);
+                CoreNode stratisReceiver = builder.CreateStratisPowNode(this.network);
+                CoreNode stratisReorg = builder.CreateStratisPowNode(this.network);
 
                 builder.StartAll();
                 stratisSender.NotInIBD();
@@ -268,9 +275,9 @@ namespace Stratis.Bitcoin.IntegrationTests.Wallet
         {
             using (NodeBuilder builder = NodeBuilder.Create(this))
             {
-                CoreNode stratisSender = builder.CreateStratisPowNode(KnownNetworks.RegTest);
-                CoreNode stratisReceiver = builder.CreateStratisPowNode(KnownNetworks.RegTest);
-                CoreNode stratisReorg = builder.CreateStratisPowNode(KnownNetworks.RegTest);
+                CoreNode stratisSender = builder.CreateStratisPowNode(this.network);
+                CoreNode stratisReceiver = builder.CreateStratisPowNode(this.network);
+                CoreNode stratisReorg = builder.CreateStratisPowNode(this.network);
 
                 builder.StartAll();
                 stratisSender.NotInIBD();
@@ -330,9 +337,9 @@ namespace Stratis.Bitcoin.IntegrationTests.Wallet
         {
             using (NodeBuilder builder = NodeBuilder.Create(this))
             {
-                CoreNode stratisSender = builder.CreateStratisPowNode(KnownNetworks.RegTest);
-                CoreNode stratisReceiver = builder.CreateStratisPowNode(KnownNetworks.RegTest);
-                CoreNode stratisReorg = builder.CreateStratisPowNode(KnownNetworks.RegTest);
+                CoreNode stratisSender = builder.CreateStratisPowNode(this.network);
+                CoreNode stratisReceiver = builder.CreateStratisPowNode(this.network);
+                CoreNode stratisReorg = builder.CreateStratisPowNode(this.network);
 
                 builder.StartAll();
                 stratisSender.NotInIBD();
@@ -390,7 +397,7 @@ namespace Stratis.Bitcoin.IntegrationTests.Wallet
         {
             using (NodeBuilder builder = NodeBuilder.Create(this))
             {
-                CoreNode stratisminer = builder.CreateStratisPowNode(KnownNetworks.RegTest);
+                CoreNode stratisminer = builder.CreateStratisPowNode(this.network);
 
                 builder.StartAll();
                 stratisminer.NotInIBD();
@@ -421,7 +428,7 @@ namespace Stratis.Bitcoin.IntegrationTests.Wallet
         {
             using (NodeBuilder builder = NodeBuilder.Create(this))
             {
-                CoreNode stratisNodeSync = builder.CreateStratisPowNode(KnownNetworks.RegTest);
+                CoreNode stratisNodeSync = builder.CreateStratisPowNode(this.network);
                 builder.StartAll();
                 stratisNodeSync.NotInIBD();
 


### PR DESCRIPTION
`NodeGroupBuilder` builds a group of nodes to presumably be used together, so it makes sense to use the same network for all the nodes it builds.