### PR TITLE
Fixes #1847 NodeSettings is initalized 3 times

### DIFF
--- a/src/Stratis.Bitcoin/Configuration/NodeSettings.cs
+++ b/src/Stratis.Bitcoin/Configuration/NodeSettings.cs
@@ -360,8 +360,6 @@ namespace Stratis.Bitcoin.Configuration
         /// <param name="network">The network to base the defaults off.</param>
         public static void BuildDefaultConfigurationFile(StringBuilder builder, Network network)
         {
-            NodeSettings defaults = Default(network: network);
-
             builder.AppendLine("####Node Settings####");
             builder.AppendLine($"#Test network. Defaults to 0.");
             builder.AppendLine($"testnet={((network.IsTest() && !network.IsRegTest()) ? 1 : 0)}");

--- a/src/Stratis.Bitcoin/Configuration/Settings/ConnectionManagerSettings.cs
+++ b/src/Stratis.Bitcoin/Configuration/Settings/ConnectionManagerSettings.cs
@@ -141,7 +141,6 @@ namespace Stratis.Bitcoin.Configuration.Settings
         /// <param name="network">The network to base the defaults off.</param>
         public static void BuildDefaultConfigurationFile(StringBuilder builder, Network network)
         {
-            var defaults = NodeSettings.Default(network: network);
             builder.AppendLine("####ConnectionManager Settings####");
             builder.AppendLine($"#The default network port to connect to. Default { network.DefaultPort }.");
             builder.AppendLine($"#port={network.DefaultPort}");


### PR DESCRIPTION
Looks like two unused variables were introduced that load NodeSettings defaults.

Fix #1847