### PR TITLE
Improvements toTestHelper.Wait loop, increased wait time on Segwit test

### DIFF
--- a/src/Stratis.Bitcoin.IntegrationTests.Common/TestHelper.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests.Common/TestHelper.cs
@@ -5,18 +5,28 @@ using System.Threading;
 using Stratis.Bitcoin.Base;
 using Stratis.Bitcoin.IntegrationTests.Common.EnvironmentMockUpHelpers;
 using Stratis.Bitcoin.P2P.Peer;
+using Xunit;
 
 namespace Stratis.Bitcoin.IntegrationTests.Common
 {
     public class TestHelper
     {
-        public static void WaitLoop(Func<bool> act)
+        public static void WaitLoop(Func<bool> act, string failureReason = "Unknown Reason", int millisecondsTimeout = 50, CancellationToken cancellationToken = default(CancellationToken))
         {
-            var cancel = new CancellationTokenSource(Debugger.IsAttached ? 15 * 60 * 1000 : 30 * 1000);
+            cancellationToken = cancellationToken == default(CancellationToken)
+                ? new CancellationTokenSource(Debugger.IsAttached ? 15 * 60 * 1000 : 30 * 1000).Token
+                : cancellationToken;
             while (!act())
             {
-                cancel.Token.ThrowIfCancellationRequested();
-                Thread.Sleep(50);
+                try
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    Thread.Sleep(millisecondsTimeout);
+                }
+                catch (OperationCanceledException e)
+                {
+                    Assert.False(true, $"{failureReason}{Environment.NewLine}{e.Message}");
+                }
             }
         }
 

--- a/src/Stratis.Bitcoin.IntegrationTests/SegWitTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/SegWitTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 using NBitcoin;
 using Stratis.Bitcoin.Base.Deployments;
 using Stratis.Bitcoin.Features.Consensus.Interfaces;
@@ -42,8 +43,8 @@ namespace Stratis.Bitcoin.IntegrationTests
                 {
                     // generate 450 blocks, block 431 will be segwit activated.
                     coreRpc.Generate(450);
-
-                    TestHelper.WaitLoop(() => stratisNode.CreateRPCClient().GetBestBlockHash() == coreNode.CreateRPCClient().GetBestBlockHash());
+                    var cancellationToken = new CancellationTokenSource(TimeSpan.FromMinutes(2)).Token;
+                    TestHelper.WaitLoop(() => stratisNode.CreateRPCClient().GetBestBlockHash() == coreNode.CreateRPCClient().GetBestBlockHash(), cancellationToken: cancellationToken);
 
                     // segwit activation on Bitcoin regtest.
                     // - On regtest deployment state changes every 144 block, the threshold for activating a rule is 108 blocks.


### PR DESCRIPTION
TestHelper.Wait loop is now accepting 3 additional arguments to control exceptions, sampling interval and cancellation token