### PR TITLE
little reorg of the consensus manager file

### DIFF
--- a/src/Stratis.Bitcoin/Consensus/BlockDownloadRequest.cs
+++ b/src/Stratis.Bitcoin/Consensus/BlockDownloadRequest.cs
@@ -4,9 +4,9 @@ using NBitcoin;
 namespace Stratis.Bitcoin.Consensus
 {
     /// <summary>
-    /// A request that holds information of blocks to download.
+    /// A request to the block puller that holds the chained headers of the blocks that are requested for download
     /// </summary>
-    public class BlockDownloadRequest
+    internal class BlockDownloadRequest
     {
         /// <summary>The list of block headers to download.</summary>
         public List<ChainedHeader> BlocksToDownload { get; set; }

--- a/src/Stratis.Bitcoin/Consensus/BlockDownloadRequest.cs
+++ b/src/Stratis.Bitcoin/Consensus/BlockDownloadRequest.cs
@@ -1,0 +1,14 @@
+﻿using System.Collections.Generic;
+using NBitcoin;
+
+namespace Stratis.Bitcoin.Consensus
+{
+    /// <summary>
+    /// A request that holds information of blocks to download.
+    /// </summary>
+    public class BlockDownloadRequest
+    {
+        /// <summary>The list of block headers to download.</summary>
+        public List<ChainedHeader> BlocksToDownload { get; set; }
+    }
+}

--- a/src/Stratis.Bitcoin/Consensus/BlockDownloadRequest.cs
+++ b/src/Stratis.Bitcoin/Consensus/BlockDownloadRequest.cs
@@ -4,7 +4,7 @@ using NBitcoin;
 namespace Stratis.Bitcoin.Consensus
 {
     /// <summary>
-    /// A request to the block puller that holds the chained headers of the blocks that are requested for download
+    /// A request to the block puller that holds the chained headers of the blocks that are requested for download.
     /// </summary>
     internal class BlockDownloadRequest
     {

--- a/src/Stratis.Bitcoin/Consensus/ConsensusManager.cs
+++ b/src/Stratis.Bitcoin/Consensus/ConsensusManager.cs
@@ -190,7 +190,7 @@ namespace Stratis.Bitcoin.Consensus
             }
 
             if (triggerDownload && (connectNewHeadersResult.DownloadTo != null))
-                this.DownloadBlocks(connectNewHeadersResult.ToArray(), this.OnBlockDownloaded);
+                this.DownloadBlocks(connectNewHeadersResult.ToArray(), this.ProcessDownloadedBlock);
 
             this.logger.LogTrace("(-):'{0}'", connectNewHeadersResult);
             return connectNewHeadersResult;
@@ -237,7 +237,7 @@ namespace Stratis.Bitcoin.Consensus
         /// <summary>
         /// A callback that is triggered when a block that <see cref="ConsensusManager"/> requested was downloaded.
         /// </summary>
-        private void OnBlockDownloaded(ChainedHeaderBlock chainedHeaderBlock)
+        private void ProcessDownloadedBlock(ChainedHeaderBlock chainedHeaderBlock)
         {
             this.logger.LogTrace("({0}:'{1}')", nameof(chainedHeaderBlock), chainedHeaderBlock);
 
@@ -394,7 +394,7 @@ namespace Stratis.Bitcoin.Consensus
             }
 
             foreach (ConnectNewHeadersResult newHeaders in blocksToDownload)
-                this.DownloadBlocks(newHeaders.ToArray(), this.OnBlockDownloaded);
+                this.DownloadBlocks(newHeaders.ToArray(), this.ProcessDownloadedBlock);
 
             this.logger.LogTrace("(-)");
         }
@@ -955,7 +955,7 @@ namespace Stratis.Bitcoin.Consensus
             if (blocksToDownload.Count != 0)
             {
                 this.logger.LogTrace("Asking block puller for {0} blocks.", blocksToDownload.Count);
-                this.DownloadBlocks(blocksToDownload.ToArray(), this.OnBlockDownloaded);
+                this.DownloadBlocks(blocksToDownload.ToArray(), this.ProcessDownloadedBlock);
             }
 
             this.logger.LogTrace("(-)");

--- a/src/Stratis.Bitcoin/Consensus/IConsensusManager.cs
+++ b/src/Stratis.Bitcoin/Consensus/IConsensusManager.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Threading.Tasks;
 using NBitcoin;
 using Stratis.Bitcoin.P2P.Peer;
@@ -56,7 +55,7 @@ namespace Stratis.Bitcoin.Consensus
     }
 
     /// <summary>
-    /// A delegate that is used to send callbacks when a bock is downloaded from the of queued requests to downloading blocks.
+    /// A delegate that is used to send callbacks when a block is downloaded from the of queued requests to downloading blocks.
     /// </summary>
     /// <param name="chainedHeaderBlock">The pair of the block and its chained header.</param>
     public delegate void OnBlockDownloadedCallback(ChainedHeaderBlock chainedHeaderBlock);

--- a/src/Stratis.Bitcoin/Consensus/IConsensusManager.cs
+++ b/src/Stratis.Bitcoin/Consensus/IConsensusManager.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using NBitcoin;
+using Stratis.Bitcoin.P2P.Peer;
+using Stratis.Bitcoin.Primitives;
+
+namespace Stratis.Bitcoin.Consensus
+{
+    /// <summary>
+    /// TODO add a big nice comment.
+    /// </summary>
+    public interface IConsensusManager
+    {
+        /// <summary>The current tip of the chain that has been validated.</summary>
+        ChainedHeader Tip { get; }
+
+        /// <summary>
+        /// Set the tip of <see cref="ConsensusManager"/>, if the given <paramref name="chainTip"/> is not equal to <see cref="Tip"/>
+        /// then rewind consensus until a common header is found.
+        /// </summary>
+        /// <param name="chainTip">Last common header between chain repository and block store if it's available,
+        /// if the store is not available it is the chain repository tip.</param>
+        Task InitializeAsync(ChainedHeader chainTip);
+
+        /// <summary>
+        /// A list of headers are presented from a given peer,
+        /// we'll attempt to connect the headers to the tree and if new headers are found they will be queued for download.
+        /// </summary>
+        /// <param name="peer">The peer that providing the headers.</param>
+        /// <param name="headers">The list of new headers.</param>
+        /// <param name="triggerDownload">Specifies if the download should be scheduled for interesting blocks.</param>
+        /// <returns>Information about consumed headers.</returns>
+        /// <exception cref="ConnectHeaderException">Thrown when first presented header can't be connected to any known chain in the tree.</exception>
+        /// <exception cref="CheckpointMismatchException">Thrown if checkpointed header doesn't match the checkpoint hash.</exception>
+        ConnectNewHeadersResult HeadersPresented(INetworkPeer peer, List<BlockHeader> headers, bool triggerDownload = true);
+
+        /// <summary>
+        /// Called after a peer was disconnected.
+        /// Informs underlying components about the even.
+        /// Processes any remaining blocks to download.
+        /// </summary>
+        /// <param name="peerId">The peer that was disconnected.</param>
+        void OnPeerDisconnected(int peerId);
+
+        /// <summary>
+        /// Provides block data for the given block hashes.
+        /// </summary>
+        /// <remarks>
+        /// First we check if the block exists in chained header tree, then it check the block store and if it wasn't found there the block will be scheduled for download.
+        /// Given callback is called when the block is obtained. If obtaining the block fails the callback will be called with <c>null</c>.
+        /// </remarks>
+        /// <param name="blockHashes">The block hashes to download.</param>
+        /// <param name="onBlockDownloadedCallback">The callback that will be called for each downloaded block.</param>
+        Task GetOrDownloadBlocksAsync(List<uint256> blockHashes, Action<ChainedHeaderBlock> onBlockDownloadedCallback);
+    }
+}

--- a/src/Stratis.Bitcoin/Consensus/IConsensusManager.cs
+++ b/src/Stratis.Bitcoin/Consensus/IConsensusManager.cs
@@ -41,7 +41,7 @@ namespace Stratis.Bitcoin.Consensus
         /// Processes any remaining blocks to download.
         /// </summary>
         /// <param name="peerId">The peer that was disconnected.</param>
-        void OnPeerDisconnected(int peerId);
+        void PeerDisconnected(int peerId);
 
         /// <summary>
         /// Provides block data for the given block hashes.
@@ -52,6 +52,12 @@ namespace Stratis.Bitcoin.Consensus
         /// </remarks>
         /// <param name="blockHashes">The block hashes to download.</param>
         /// <param name="onBlockDownloadedCallback">The callback that will be called for each downloaded block.</param>
-        Task GetOrDownloadBlocksAsync(List<uint256> blockHashes, Action<ChainedHeaderBlock> onBlockDownloadedCallback);
+        Task GetOrDownloadBlocksAsync(List<uint256> blockHashes, OnBlockDownloadedCallback onBlockDownloadedCallback);
     }
+
+    /// <summary>
+    /// A delegate that is used to send callbacks when a bock is downloaded from the of queued requests to downloading blocks.
+    /// </summary>
+    /// <param name="chainedHeaderBlock">The pair of the block and its chained header.</param>
+    public delegate void OnBlockDownloadedCallback(ChainedHeaderBlock chainedHeaderBlock);
 }

--- a/src/Stratis.Bitcoin/Consensus/ValidationResults/ConnectBlocksResult.cs
+++ b/src/Stratis.Bitcoin/Consensus/ValidationResults/ConnectBlocksResult.cs
@@ -1,0 +1,36 @@
+﻿using System.Collections.Generic;
+using NBitcoin;
+
+namespace Stratis.Bitcoin.Consensus.ValidationResults
+{
+    /// <summary>
+    /// Information related to the block full validation process.
+    /// </summary>
+    internal class ConnectBlocksResult : ValidationResult
+    {
+        public bool ConsensusTipChanged { get; private set; }
+
+        /// <summary>List of peer IDs to be banned and disconnected.</summary>
+        /// <remarks><c>null</c> in case <see cref="ValidationResult.Succeeded"/> is <c>false</c>.</remarks>
+        public List<int> PeersToBan { get; private set; }
+
+        public ChainedHeader LastValidatedBlockHeader { get; set; }
+
+        public ConnectBlocksResult(bool succeeded, bool consensusTipChanged = true, List<int> peersToBan = null, string banReason = null, int banDurationSeconds = 0)
+        {
+            this.ConsensusTipChanged = consensusTipChanged;
+            this.Succeeded = succeeded;
+            this.PeersToBan = peersToBan;
+            this.BanReason = banReason;
+            this.BanDurationSeconds = banDurationSeconds;
+        }
+
+        public override string ToString()
+        {
+            if (this.Succeeded)
+                return $"{nameof(this.Succeeded)}={this.Succeeded}";
+
+            return $"{nameof(this.Succeeded)}={this.Succeeded},{nameof(this.ConsensusTipChanged)}={this.ConsensusTipChanged},{nameof(this.PeersToBan)}.{nameof(this.PeersToBan.Count)}={this.PeersToBan.Count},{nameof(this.BanReason)}={this.BanReason},{nameof(this.BanDurationSeconds)}={this.BanDurationSeconds}";
+        }
+    }
+}

--- a/src/Stratis.Bitcoin/Consensus/ValidationResults/PartialValidationResult.cs
+++ b/src/Stratis.Bitcoin/Consensus/ValidationResults/PartialValidationResult.cs
@@ -2,6 +2,9 @@
 
 namespace Stratis.Bitcoin.Consensus.ValidationResults
 {
+    /// <summary>
+    /// Feedback specific to a partial block validation.
+    /// </summary>
     public class PartialValidationResult : ValidationResult
     {
         public ChainedHeaderBlock ChainedHeaderBlock { get; set; }

--- a/src/Stratis.Bitcoin/Consensus/ValidationResults/PartialValidationResult.cs
+++ b/src/Stratis.Bitcoin/Consensus/ValidationResults/PartialValidationResult.cs
@@ -1,0 +1,18 @@
+﻿using Stratis.Bitcoin.Primitives;
+
+namespace Stratis.Bitcoin.Consensus.ValidationResults
+{
+    public class PartialValidationResult : ValidationResult
+    {
+        public ChainedHeaderBlock ChainedHeaderBlock { get; set; }
+
+        /// <inheritdoc/>
+        public override string ToString()
+        {
+            if (this.Succeeded)
+                return base.ToString();
+
+            return base.ToString() + $",{nameof(this.ChainedHeaderBlock)}={this.ChainedHeaderBlock}";
+        }
+    }
+}

--- a/src/Stratis.Bitcoin/Consensus/ValidationResults/ValidationResult.cs
+++ b/src/Stratis.Bitcoin/Consensus/ValidationResults/ValidationResult.cs
@@ -1,5 +1,8 @@
 ﻿namespace Stratis.Bitcoin.Consensus.ValidationResults
 {
+    /// <summary>
+    /// Feedback after a block was validated.
+    /// </summary>
     public class ValidationResult
     {
         public bool Succeeded { get; set; }

--- a/src/Stratis.Bitcoin/Consensus/ValidationResults/ValidationResult.cs
+++ b/src/Stratis.Bitcoin/Consensus/ValidationResults/ValidationResult.cs
@@ -1,0 +1,20 @@
+﻿namespace Stratis.Bitcoin.Consensus.ValidationResults
+{
+    public class ValidationResult
+    {
+        public bool Succeeded { get; set; }
+
+        public int BanDurationSeconds { get; set; }
+
+        public string BanReason { get; set; }
+
+        /// <inheritdoc/>
+        public override string ToString()
+        {
+            if (this.Succeeded)
+                return $"{nameof(this.Succeeded)}={this.Succeeded}";
+
+            return $"{nameof(this.Succeeded)}={this.Succeeded},{nameof(this.BanReason)}={this.BanReason},{nameof(this.BanDurationSeconds)}={this.BanDurationSeconds}";
+        }
+    }
+}

--- a/src/Stratis.Bitcoin/Consensus/Validators/BlockValidator.cs
+++ b/src/Stratis.Bitcoin/Consensus/Validators/BlockValidator.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using NBitcoin;
 using Stratis.Bitcoin.Consensus.Rules;
+using Stratis.Bitcoin.Consensus.ValidationResults;
 using Stratis.Bitcoin.Primitives;
 using Stratis.Bitcoin.Utilities;
 


### PR DESCRIPTION
split of the file
use Action<ChainedHeaderBlock> instead of OnBlockDownloaded callback (I asked in the room and everybody was finding that more readable)