### PR TITLE
[SC] Remove ThrownException from ITransferResult and ICreateResult

### DIFF
--- a/src/Stratis.SmartContracts/ICreateResult.cs
+++ b/src/Stratis.SmartContracts/ICreateResult.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace Stratis.SmartContracts
+﻿namespace Stratis.SmartContracts
 {
     public interface ICreateResult
     {
@@ -8,11 +6,6 @@ namespace Stratis.SmartContracts
         /// Address of the contract just created.
         /// </summary>
         Address NewContractAddress { get; }
-
-        /// <summary>
-        /// The exception thrown by execution, if there was one.
-        /// </summary>
-        Exception ThrownException { get; }
 
         /// <summary>
         /// Whether the constructor code ran successfully and thus whether the contract was successfully deployed.

--- a/src/Stratis.SmartContracts/ITransferResult.cs
+++ b/src/Stratis.SmartContracts/ITransferResult.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace Stratis.SmartContracts
+﻿namespace Stratis.SmartContracts
 {
     /// <summary>
     /// Defines what gets returned should a contract execute a transfer.
@@ -11,11 +9,6 @@ namespace Stratis.SmartContracts
         /// The return value of the method called.
         /// </summary>
         object ReturnValue { get; }
-
-        /// <summary>
-        /// If there was an error during execution of the selected method it will be stored here.
-        /// </summary>
-        Exception ThrownException { get; }
 
         /// <summary>
         /// Whether execution of the contract method was successful.


### PR DESCRIPTION
Trivial change - everything still builds and tests pass. 

Important so that smart contract developers can't access StackTrace inside their contracts (and save it to state hence determinism issue)