### PR TITLE
Clean up TransactionBuilderContext to be easier for a user to use.

### DIFF
--- a/src/Stratis.Bitcoin.Features.SmartContracts.Wallet/SmartContractWalletTransactionHandler.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts.Wallet/SmartContractWalletTransactionHandler.cs
@@ -25,7 +25,7 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Wallet
         /// The initialization of the builder is overridden as smart contracts calls allow dust and does not group
         /// inputs by ScriptPubKey.
         /// </summary>
-        public override void InitializeTransactionBuilder(TransactionBuildContext context)
+        protected override void InitializeTransactionBuilder(TransactionBuildContext context)
         {
             Guard.NotNull(context, nameof(context));
             Guard.NotNull(context.Recipients, nameof(context.Recipients));

--- a/src/Stratis.Bitcoin.Features.SmartContracts/ReflectionExecutor/Controllers/SmartContractsController.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts/ReflectionExecutor/Controllers/SmartContractsController.cs
@@ -268,12 +268,15 @@ namespace Stratis.Bitcoin.Features.SmartContracts.ReflectionExecutor.Controllers
             ulong totalFee = (gasPrice * gasLimit) + Money.Parse(request.FeeAmount);
             var walletAccountReference = new WalletAccountReference(request.WalletName, request.AccountName);
             var recipient = new Recipient { Amount = request.Amount ?? "0", ScriptPubKey = new Script(carrier.Serialize()) };
-            var context = new TransactionBuildContext(this.network, walletAccountReference, new[] { recipient }.ToList(), request.Password)
+            var context = new TransactionBuildContext(this.network)
             {
+                AccountReference = walletAccountReference,
                 TransactionFee = totalFee,
                 ChangeAddress = senderAddress,
                 SelectedInputs = selectedInputs,
                 MinConfirmations = MinConfirmationsAllChecks,
+                WalletPassword = request.Password,
+                Recipients = new[] { recipient }.ToList()
             };
 
             try
@@ -317,15 +320,15 @@ namespace Stratis.Bitcoin.Features.SmartContracts.ReflectionExecutor.Controllers
             }
 
             ulong totalFee = (gasPrice * gasLimit) + Money.Parse(request.FeeAmount);
-            var context = new TransactionBuildContext(this.network,
-                new WalletAccountReference(request.WalletName, request.AccountName),
-                new[] { new Recipient { Amount = request.Amount, ScriptPubKey = new Script(carrier.Serialize()) } }.ToList(),
-                request.Password)
+            var context = new TransactionBuildContext(this.network)
             {
+                AccountReference = new WalletAccountReference(request.WalletName, request.AccountName),
                 TransactionFee = totalFee,
                 ChangeAddress = senderAddress,
                 SelectedInputs = selectedInputs,
                 MinConfirmations = MinConfirmationsAllChecks,
+                WalletPassword = request.Password,
+                Recipients = new[] { new Recipient { Amount = request.Amount, ScriptPubKey = new Script(carrier.Serialize()) } }.ToList()
             };
 
             try

--- a/src/Stratis.Bitcoin.Features.Wallet.Tests/WalletTransactionHandlerTest.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet.Tests/WalletTransactionHandlerTest.cs
@@ -292,17 +292,18 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
             };
 
             // create a trx with 3 outputs 50 + 50 + 49 = 149 BTC
-            var context = new TransactionBuildContext(this.Network, walletReference,
-                new[]
+            var context = new TransactionBuildContext(this.Network)
+            {
+                AccountReference = walletReference,
+                MinConfirmations = 0,
+                FeeType = FeeType.Low,
+                WalletPassword = "password",
+                Recipients = new[]
                 {
                     new Recipient { Amount = new Money(50, MoneyUnit.BTC), ScriptPubKey = destinationKeys1.PubKey.ScriptPubKey },
                     new Recipient { Amount = new Money(50, MoneyUnit.BTC), ScriptPubKey = destinationKeys2.PubKey.ScriptPubKey },
                     new Recipient { Amount = new Money(49, MoneyUnit.BTC), ScriptPubKey = destinationKeys3.PubKey.ScriptPubKey }
-                }
-                .ToList(), "password")
-            {
-                MinConfirmations = 0,
-                FeeType = FeeType.Low
+                }.ToList()
             };
 
             Transaction fundTransaction = walletTransactionHandler.BuildTransaction(context);
@@ -318,10 +319,13 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
             Assert.Single(fundTransaction.Inputs); // 4 inputs
 
             Transaction fundTransactionClone = this.Network.CreateTransaction(fundTransaction.ToBytes());
-            var fundContext = new TransactionBuildContext(this.Network, walletReference, new List<Recipient>(), "password")
+            var fundContext = new TransactionBuildContext(this.Network)
             {
+                AccountReference = walletReference,
                 MinConfirmations = 0,
-                FeeType = FeeType.Low
+                FeeType = FeeType.Low,
+                WalletPassword = "password",
+                Recipients = new List<Recipient>()
             };
 
             fundContext.OverrideFeeRate = overrideFeeRate;
@@ -588,10 +592,14 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
         public static TransactionBuildContext CreateContext(Network network, WalletAccountReference accountReference, string password,
             Script destinationScript, Money amount, FeeType feeType, int minConfirmations, string opReturnData = null)
         {
-            return new TransactionBuildContext(network, accountReference, new[] { new Recipient { Amount = amount, ScriptPubKey = destinationScript } }.ToList(), password, opReturnData)
+            return new TransactionBuildContext(network)
             {
+                AccountReference = accountReference,
                 MinConfirmations = minConfirmations,
-                FeeType = feeType
+                FeeType = feeType,
+                OpReturnData = opReturnData,
+                WalletPassword = password,
+                Recipients = new[] { new Recipient { Amount = amount, ScriptPubKey = destinationScript } }.ToList()
             };
         }
 

--- a/src/Stratis.Bitcoin.Features.Wallet/Controllers/WalletController.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Controllers/WalletController.cs
@@ -666,13 +666,12 @@ namespace Stratis.Bitcoin.Features.Wallet.Controllers
             try
             {
                 Script destination = BitcoinAddress.Create(request.DestinationAddress, this.network).ScriptPubKey;
-                var context = new TransactionBuildContext(
-                    this.network,
-                    new WalletAccountReference(request.WalletName, request.AccountName),
-                    new[] { new Recipient { Amount = request.Amount, ScriptPubKey = destination } }.ToList())
+                var context = new TransactionBuildContext(this.network)
                 {
+                    AccountReference = new WalletAccountReference(request.WalletName, request.AccountName),
                     FeeType = FeeParser.Parse(request.FeeType),
                     MinConfirmations = request.AllowUnconfirmed ? 0 : 1,
+                    Recipients = new[] { new Recipient { Amount = request.Amount, ScriptPubKey = destination } }.ToList()
                 };
 
                 return this.Json(this.walletTransactionHandler.EstimateFee(context));
@@ -704,15 +703,15 @@ namespace Stratis.Bitcoin.Features.Wallet.Controllers
             try
             {
                 Script destination = BitcoinAddress.Create(request.DestinationAddress, this.network).ScriptPubKey;
-                var context = new TransactionBuildContext(
-                    this.network,
-                    new WalletAccountReference(request.WalletName, request.AccountName),
-                    new[] { new Recipient { Amount = request.Amount, ScriptPubKey = destination } }.ToList(),
-                    request.Password, request.OpReturnData)
+                var context = new TransactionBuildContext(this.network)
                 {
+                    AccountReference = new WalletAccountReference(request.WalletName, request.AccountName),
                     TransactionFee = string.IsNullOrEmpty(request.FeeAmount) ? null : Money.Parse(request.FeeAmount),
                     MinConfirmations = request.AllowUnconfirmed ? 0 : 1,
-                    Shuffle = request.ShuffleOutputs ?? true // We shuffle transaction outputs by default as it's better for anonymity.
+                    Shuffle = request.ShuffleOutputs ?? true, // We shuffle transaction outputs by default as it's better for anonymity.
+                    OpReturnData = request.OpReturnData,
+                    WalletPassword = request.Password,
+                    Recipients = new[] { new Recipient { Amount = request.Amount, ScriptPubKey = destination } }.ToList()
                 };
 
                 if (!string.IsNullOrEmpty(request.FeeType))

--- a/src/Stratis.Bitcoin.Features.Wallet/Interfaces/IWalletTransactionHandler.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Interfaces/IWalletTransactionHandler.cs
@@ -20,7 +20,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Interfaces
         /// This will not modify existing inputs, and will add at most one change output to the outputs.
         /// No existing outputs will be modified unless <see cref="Recipient.SubtractFeeFromAmount"/> is specified.
         /// Note that inputs which were signed may need to be resigned after completion since in/outputs have been added.
-        /// The inputs added may be signed depending on <see cref="TransactionBuildContext.Sign"/>, use signrawtransaction for that.
+        /// The inputs added may be signed depending on whether a <see cref="TransactionBuildContext.WalletPassword"/> is passed.
         /// Note that all existing inputs must have their previous output transaction be in the wallet.
         /// </remarks>
         void FundTransaction(TransactionBuildContext context, Transaction transaction);

--- a/src/Stratis.Bitcoin.Features.Wallet/Recipient.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Recipient.cs
@@ -1,0 +1,25 @@
+﻿using NBitcoin;
+
+namespace Stratis.Bitcoin.Features.Wallet
+{
+    /// <summary>
+    /// Represents recipients of a payment, used in <see cref="WalletTransactionHandler.BuildTransaction"/>.
+    /// </summary>
+    public class Recipient
+    {
+        /// <summary>
+        /// The destination script.
+        /// </summary>
+        public Script ScriptPubKey { get; set; }
+
+        /// <summary>
+        /// The amount that will be sent.
+        /// </summary>
+        public Money Amount { get; set; }
+
+        /// <summary>
+        /// An indicator if the fee is subtracted from the current recipient.
+        /// </summary>
+        public bool SubtractFeeFromAmount { get; set; }
+    }
+}

--- a/src/Stratis.Bitcoin.Features.Wallet/WalletTransactionHandler.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/WalletTransactionHandler.cs
@@ -31,8 +31,6 @@ namespace Stratis.Bitcoin.Features.Wallet
         /// </remarks>
         private const int SendCountThresholdLimit = 500;
 
-        private readonly CoinType coinType;
-
         private readonly ILogger logger;
 
         public Network Network { get; }
@@ -55,7 +53,6 @@ namespace Stratis.Bitcoin.Features.Wallet
             this.Network = network;
             this.walletManager = walletManager;
             this.walletFeePolicy = walletFeePolicy;
-            this.coinType = (CoinType)network.Consensus.CoinType;
             this.logger = loggerFactory.CreateLogger(this.GetType().FullName);
             this.privateKeyCache = new MemoryCache(new MemoryCacheOptions() { ExpirationScanFrequency = new TimeSpan(0, 1, 0) });
             this.TransactionPolicy = transactionPolicy;
@@ -500,26 +497,5 @@ namespace Stratis.Bitcoin.Features.Wallet
         /// Optional data to be added as an extra OP_RETURN transaction output with Money.Zero value.
         /// </summary>
         public string OpReturnData { get; set; }
-    }
-
-    /// <summary>
-    /// Represents recipients of a payment, used in <see cref="WalletTransactionHandler.BuildTransaction"/>.
-    /// </summary>
-    public class Recipient
-    {
-        /// <summary>
-        /// The destination script.
-        /// </summary>
-        public Script ScriptPubKey { get; set; }
-
-        /// <summary>
-        /// The amount that will be sent.
-        /// </summary>
-        public Money Amount { get; set; }
-
-        /// <summary>
-        /// An indicator if the fee is subtracted from the current recipient.
-        /// </summary>
-        public bool SubtractFeeFromAmount { get; set; }
     }
 }

--- a/src/Stratis.Bitcoin.Features.Wallet/WalletTransactionHandler.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/WalletTransactionHandler.cs
@@ -152,10 +152,12 @@ namespace Stratis.Bitcoin.Features.Wallet
                 // Here we try to create a transaction that contains all the spendable coins, leaving no room for the fee.
                 // When the transaction builder throws an exception informing us that we have insufficient funds,
                 // we use the amount we're missing as the fee.
-                var context = new TransactionBuildContext(this.network, accountReference, recipients, null)
+                var context = new TransactionBuildContext(this.network)
                 {
                     FeeType = feeType,
-                    MinConfirmations = allowUnconfirmed ? 0 : 1
+                    MinConfirmations = allowUnconfirmed ? 0 : 1,
+                    Recipients = recipients,
+                    AccountReference = accountReference
                 };
 
                 this.AddRecipients(context);
@@ -384,24 +386,15 @@ namespace Stratis.Bitcoin.Features.Wallet
         /// Initialize a new instance of a <see cref="TransactionBuildContext"/>
         /// </summary>
         /// <param name="network">The network for which this transaction will be built.</param>
-        /// <param name="accountReference">The wallet and account from which to build this transaction</param>
-        /// <param name="recipients">The target recipients to send coins to.</param>
-        /// <param name="walletPassword">The password that protects the wallet in <see cref="accountReference"/></param>
-        /// <param name="opReturnData">Optional transaction data <see cref="OpReturnData"/></param>
-        public TransactionBuildContext(Network network, WalletAccountReference accountReference, List<Recipient> recipients, string walletPassword = "", string opReturnData = null)
+        public TransactionBuildContext(Network network)
         {
-            Guard.NotNull(recipients, nameof(recipients));
-
             this.TransactionBuilder = new TransactionBuilder(network);
-            this.AccountReference = accountReference;
-            this.Recipients = recipients;
-            this.WalletPassword = walletPassword;
+            this.Recipients = new List<Recipient>();
+            this.WalletPassword = string.Empty;
             this.FeeType = FeeType.Medium;
             this.MinConfirmations = 1;
             this.SelectedInputs = new List<OutPoint>();
             this.AllowOtherInputs = false;
-            this.Sign = !string.IsNullOrEmpty(walletPassword);
-            this.OpReturnData = opReturnData;
         }
 
         /// <summary>
@@ -481,7 +474,7 @@ namespace Stratis.Bitcoin.Features.Wallet
         /// <summary>
         /// Specify whether to sign the transaction.
         /// </summary>
-        public bool Sign { get; set; }
+        public bool Sign => !string.IsNullOrEmpty(this.WalletPassword);
 
         /// <summary>
         /// Allows the context to specify a <see cref="FeeRate"/> when building a transaction.

--- a/src/Stratis.Bitcoin.Features.Wallet/WalletTransactionHandler.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/WalletTransactionHandler.cs
@@ -33,7 +33,7 @@ namespace Stratis.Bitcoin.Features.Wallet
 
         private readonly ILogger logger;
 
-        public Network Network { get; }
+        private readonly Network network;
 
         private readonly MemoryCache privateKeyCache;
 
@@ -50,7 +50,7 @@ namespace Stratis.Bitcoin.Features.Wallet
             Network network,
             StandardTransactionPolicy transactionPolicy)
         {
-            this.Network = network;
+            this.network = network;
             this.walletManager = walletManager;
             this.walletFeePolicy = walletFeePolicy;
             this.logger = loggerFactory.CreateLogger(this.GetType().FullName);
@@ -152,7 +152,7 @@ namespace Stratis.Bitcoin.Features.Wallet
                 // Here we try to create a transaction that contains all the spendable coins, leaving no room for the fee.
                 // When the transaction builder throws an exception informing us that we have insufficient funds,
                 // we use the amount we're missing as the fee.
-                var context = new TransactionBuildContext(this.Network, accountReference, recipients, null)
+                var context = new TransactionBuildContext(this.network, accountReference, recipients, null)
                 {
                     FeeType = feeType,
                     MinConfirmations = allowUnconfirmed ? 0 : 1
@@ -376,7 +376,6 @@ namespace Stratis.Bitcoin.Features.Wallet
             Script opReturnScript = TxNullDataTemplate.Instance.GenerateScriptPubKey(bytes);
             context.TransactionBuilder.Send(opReturnScript, Money.Zero);
         }
-
     }
 
     public class TransactionBuildContext
@@ -384,6 +383,7 @@ namespace Stratis.Bitcoin.Features.Wallet
         /// <summary>
         /// Initialize a new instance of a <see cref="TransactionBuildContext"/>
         /// </summary>
+        /// <param name="network">The network for which this transaction will be built.</param>
         /// <param name="accountReference">The wallet and account from which to build this transaction</param>
         /// <param name="recipients">The target recipients to send coins to.</param>
         /// <param name="walletPassword">The password that protects the wallet in <see cref="accountReference"/></param>

--- a/src/Stratis.Bitcoin.Features.Wallet/WalletTransactionHandler.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/WalletTransactionHandler.cs
@@ -187,7 +187,7 @@ namespace Stratis.Bitcoin.Features.Wallet
         /// Initializes the context transaction builder from information in <see cref="TransactionBuildContext"/>.
         /// </summary>
         /// <param name="context">Transaction build context.</param>
-        public virtual void InitializeTransactionBuilder(TransactionBuildContext context)
+        protected virtual void InitializeTransactionBuilder(TransactionBuildContext context)
         {
             Guard.NotNull(context, nameof(context));
             Guard.NotNull(context.Recipients, nameof(context.Recipients));

--- a/src/Stratis.Bitcoin.Features.Wallet/WalletTransactionHandler.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/WalletTransactionHandler.cs
@@ -66,7 +66,8 @@ namespace Stratis.Bitcoin.Features.Wallet
             if (context.Shuffle)
                 context.TransactionBuilder.Shuffle();
 
-            Transaction transaction = context.TransactionBuilder.BuildTransaction(context.Sign);
+            bool sign = !string.IsNullOrEmpty(context.WalletPassword);
+            Transaction transaction = context.TransactionBuilder.BuildTransaction(sign);
 
             if (context.TransactionBuilder.Verify(transaction, out TransactionPolicyError[] errors))
                 return transaction;
@@ -207,7 +208,7 @@ namespace Stratis.Bitcoin.Features.Wallet
         /// <param name="context">The context associated with the current transaction being built.</param>
         protected void AddSecrets(TransactionBuildContext context)
         {
-            if (!context.Sign)
+            if (string.IsNullOrEmpty(context.WalletPassword))
                 return;
 
             Wallet wallet = this.walletManager.GetWalletByName(context.AccountReference.WalletName);
@@ -465,11 +466,6 @@ namespace Stratis.Bitcoin.Features.Wallet
         /// If false, allows unselected inputs, but requires all selected inputs be used.
         /// </summary>
         public bool AllowOtherInputs { get; set; }
-
-        /// <summary>
-        /// Specify whether to sign the transaction.
-        /// </summary>
-        public bool Sign => !string.IsNullOrEmpty(this.WalletPassword);
 
         /// <summary>
         /// Allows the context to specify a <see cref="FeeRate"/> when building a transaction.

--- a/src/Stratis.Bitcoin.Features.Wallet/WalletTransactionHandler.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/WalletTransactionHandler.cs
@@ -66,10 +66,10 @@ namespace Stratis.Bitcoin.Features.Wallet
             if (context.Shuffle)
                 context.TransactionBuilder.Shuffle();
 
-            context.Transaction = context.TransactionBuilder.BuildTransaction(context.Sign);
+            Transaction transaction = context.TransactionBuilder.BuildTransaction(context.Sign);
 
-            if (context.TransactionBuilder.Verify(context.Transaction, out TransactionPolicyError[] errors))
-                return context.Transaction;
+            if (context.TransactionBuilder.Verify(transaction, out TransactionPolicyError[] errors))
+                return transaction;
 
             string errorsMessage = string.Join(" - ", errors.Select(s => s.ToString()));
             this.logger.LogError($"Build transaction failed: {errorsMessage}");
@@ -443,11 +443,6 @@ namespace Stratis.Bitcoin.Features.Wallet
         /// The total fee on the transaction.
         /// </summary>
         public Money TransactionFee { get; set; }
-
-        /// <summary>
-        /// The final transaction.
-        /// </summary>
-        public Transaction Transaction { get; set; }
 
         /// <summary>
         /// The password that protects the wallet in <see cref="WalletAccountReference"/>.

--- a/src/Stratis.Bitcoin.IntegrationTests.Common/SharedSteps.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests.Common/SharedSteps.cs
@@ -18,10 +18,13 @@ namespace Stratis.Bitcoin.IntegrationTests.Common
             FeeType feeType,
             int minConfirmations)
         {
-            return new TransactionBuildContext(network, new WalletAccountReference(sendingWalletName, sendingAccountName), recipients.ToList(), sendingPassword)
+            return new TransactionBuildContext(network)
             {
+                AccountReference = new WalletAccountReference(sendingWalletName, sendingAccountName),
                 MinConfirmations = minConfirmations,
-                FeeType = feeType
+                FeeType = feeType,
+                WalletPassword = sendingPassword,
+                Recipients = recipients.ToList()
             };
         }
 

--- a/src/Stratis.Bitcoin.IntegrationTests/BlockStore/RetrieveFromBlockStoreSteps.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/BlockStore/RetrieveFromBlockStoreSteps.cs
@@ -122,12 +122,14 @@ namespace Stratis.Bitcoin.IntegrationTests.BlockStore
 
         private void a_real_transaction()
         {
-            var transactionBuildContext = new TransactionBuildContext(
-                    this.node.FullNode.Network,
-                    this.miningWalletAccountReference,
-                    new List<Recipient>() { new Recipient() { Amount = this.transferAmount, ScriptPubKey = this.receiverAddress.ScriptPubKey } },
-                    this.password)
-            { MinConfirmations = this.maturity };
+            var transactionBuildContext = new TransactionBuildContext(this.node.FullNode.Network)
+            {
+                AccountReference = this.miningWalletAccountReference,
+                MinConfirmations = this.maturity,
+                WalletPassword = this.password,
+                Recipients = new List<Recipient>() { new Recipient() { Amount = this.transferAmount, ScriptPubKey = this.receiverAddress.ScriptPubKey } }
+            };
+
             this.transaction = this.node.FullNode.WalletTransactionHandler().BuildTransaction(transactionBuildContext);
 
             this.node.FullNode.NodeService<WalletController>()

--- a/src/Stratis.Bitcoin.IntegrationTests/SmartContracts/SmartContractWalletOnPosNetworkTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/SmartContracts/SmartContractWalletOnPosNetworkTests.cs
@@ -61,11 +61,14 @@ namespace Stratis.Bitcoin.IntegrationTests.SmartContracts
                 var contractCarrier = SmartContractCarrier.CreateContract(vmVersion, compilationResult.Compilation, gasPrice, gasLimit);
 
                 var contractCreateScript = new Script(contractCarrier.Serialize());
-                var txBuildContext = new TransactionBuildContext(scSender.FullNode.Network, new WalletAccountReference(WalletName, AccountName), new[] { new Recipient { Amount = 0, ScriptPubKey = contractCreateScript } }.ToList(), Password)
+                var txBuildContext = new TransactionBuildContext(scSender.FullNode.Network)
                 {
+                    AccountReference = new WalletAccountReference(WalletName, AccountName),
                     ChangeAddress = senderAddress,
                     MinConfirmations = maturity,
-                    FeeType = FeeType.High
+                    FeeType = FeeType.High,
+                    WalletPassword = Password,
+                    Recipients = new[] { new Recipient { Amount = 0, ScriptPubKey = contractCreateScript } }.ToList()
                 };
 
                 // Build the transfer contract transaction
@@ -98,11 +101,14 @@ namespace Stratis.Bitcoin.IntegrationTests.SmartContracts
                 Assert.True(compilationResult.Success);
                 contractCarrier = SmartContractCarrier.CreateContract(vmVersion, compilationResult.Compilation, gasPrice, gasLimit);
                 contractCreateScript = new Script(contractCarrier.Serialize());
-                txBuildContext = new TransactionBuildContext(scSender.FullNode.Network, new WalletAccountReference(WalletName, AccountName), new[] { new Recipient { Amount = 0, ScriptPubKey = contractCreateScript } }.ToList(), Password)
+                txBuildContext = new TransactionBuildContext(scSender.FullNode.Network)
                 {
+                    AccountReference = new WalletAccountReference(WalletName, AccountName),
                     ChangeAddress = senderAddress,
                     MinConfirmations = maturity,
-                    FeeType = FeeType.High
+                    FeeType = FeeType.High,
+                    WalletPassword = Password,
+                    Recipients = new[] { new Recipient { Amount = 0, ScriptPubKey = contractCreateScript } }.ToList()
                 };
 
                 // Build the transfer contract transaction
@@ -132,11 +138,14 @@ namespace Stratis.Bitcoin.IntegrationTests.SmartContracts
                 // Create a call contract transaction which will transfer funds
                 contractCarrier = SmartContractCarrier.CallContract(1, tokenContractAddress, "Test", gasPrice, gasLimit);
                 Script contractCallScript = new Script(contractCarrier.Serialize());
-                txBuildContext = new TransactionBuildContext(scSender.FullNode.Network, new WalletAccountReference(WalletName, AccountName), new[] { new Recipient { Amount = 1000, ScriptPubKey = contractCallScript } }.ToList(), Password)
+                txBuildContext = new TransactionBuildContext(scSender.FullNode.Network)
                 {
+                    AccountReference = new WalletAccountReference(WalletName, AccountName),
                     ChangeAddress = senderAddress,
                     MinConfirmations = maturity,
-                    FeeType = FeeType.High
+                    FeeType = FeeType.High,
+                    WalletPassword = Password,
+                    Recipients = new[] { new Recipient { Amount = 1000, ScriptPubKey = contractCallScript } }.ToList()
                 };
 
                 // Build the transfer contract transaction

--- a/src/Stratis.Bitcoin.IntegrationTests/SmartContracts/SmartContractWalletTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/SmartContracts/SmartContractWalletTests.cs
@@ -66,10 +66,13 @@ namespace Stratis.Bitcoin.IntegrationTests.SmartContracts
 
                 // send coins to the receiver
                 HdAddress sendto = scReceiver.FullNode.WalletManager().GetUnusedAddress(new WalletAccountReference(WalletName, AccountName));
-                var txBuildContext = new TransactionBuildContext(scSender.FullNode.Network, new WalletAccountReference(WalletName, AccountName), new[] { new Recipient { Amount = Money.COIN * 100, ScriptPubKey = sendto.ScriptPubKey } }.ToList(), Password)
+                var txBuildContext = new TransactionBuildContext(scSender.FullNode.Network)
                 {
+                    AccountReference = new WalletAccountReference(WalletName, AccountName),
                     MinConfirmations = maturity,
-                    FeeType = FeeType.Medium
+                    FeeType = FeeType.Medium,
+                    WalletPassword = Password,
+                    Recipients = new[] { new Recipient { Amount = Money.COIN * 100, ScriptPubKey = sendto.ScriptPubKey } }.ToList()
                 };
 
                 Transaction trx = (scSender.FullNode.NodeService<IWalletTransactionHandler>() as SmartContractWalletTransactionHandler).BuildTransaction(txBuildContext);
@@ -137,10 +140,13 @@ namespace Stratis.Bitcoin.IntegrationTests.SmartContracts
                 var contractCarrier = SmartContractCarrier.CreateContract(vmVersion, compilationResult.Compilation, gasPrice, gasLimit);
 
                 var contractCreateScript = new Script(contractCarrier.Serialize());
-                var txBuildContext = new TransactionBuildContext(scSender.FullNode.Network, new WalletAccountReference(WalletName, AccountName), new[] { new Recipient { Amount = 0, ScriptPubKey = contractCreateScript } }.ToList(), Password)
+                var txBuildContext = new TransactionBuildContext(scSender.FullNode.Network)
                 {
+                    AccountReference = new WalletAccountReference(WalletName, AccountName),
                     MinConfirmations = maturity,
-                    FeeType = FeeType.High
+                    FeeType = FeeType.High,
+                    WalletPassword = Password,
+                    Recipients = new[] { new Recipient { Amount = 0, ScriptPubKey = contractCreateScript } }.ToList()
                 };
 
                 Transaction transferContractTransaction = (scSender.FullNode.NodeService<IWalletTransactionHandler>() as SmartContractWalletTransactionHandler).BuildTransaction(txBuildContext);
@@ -172,10 +178,13 @@ namespace Stratis.Bitcoin.IntegrationTests.SmartContracts
                 Assert.True(compilationResult.Success);
                 contractCarrier = SmartContractCarrier.CreateContract(vmVersion, compilationResult.Compilation, gasPrice, gasLimit);
                 contractCreateScript = new Script(contractCarrier.Serialize());
-                txBuildContext = new TransactionBuildContext(scSender.FullNode.Network, new WalletAccountReference(WalletName, AccountName), new[] { new Recipient { Amount = 0, ScriptPubKey = contractCreateScript } }.ToList(), Password)
+                txBuildContext = new TransactionBuildContext(scSender.FullNode.Network)
                 {
+                    AccountReference = new WalletAccountReference(WalletName, AccountName),
                     MinConfirmations = maturity,
-                    FeeType = FeeType.High
+                    FeeType = FeeType.High,
+                    WalletPassword = Password,
+                    Recipients = new[] { new Recipient { Amount = 0, ScriptPubKey = contractCreateScript } }.ToList()
                 };
 
                 // Broadcast the token transaction to the network
@@ -203,10 +212,13 @@ namespace Stratis.Bitcoin.IntegrationTests.SmartContracts
                 // Create a call contract transaction which will transfer funds
                 contractCarrier = SmartContractCarrier.CallContract(1, tokenContractAddress, "Test", gasPrice, gasLimit);
                 Script contractCallScript = new Script(contractCarrier.Serialize());
-                txBuildContext = new TransactionBuildContext(scSender.FullNode.Network, new WalletAccountReference(WalletName, AccountName), new[] { new Recipient { Amount = 1000, ScriptPubKey = contractCallScript } }.ToList(), Password)
+                txBuildContext = new TransactionBuildContext(scSender.FullNode.Network)
                 {
+                    AccountReference = new WalletAccountReference(WalletName, AccountName),
                     MinConfirmations = maturity,
-                    FeeType = FeeType.High
+                    FeeType = FeeType.High,
+                    WalletPassword = Password,
+                    Recipients = new[] { new Recipient { Amount = 1000, ScriptPubKey = contractCallScript } }.ToList()
                 };
 
                 // Broadcast the token transaction to the network

--- a/src/Stratis.Bitcoin.IntegrationTests/Transactions/TransactionWithNullDataSteps.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/Transactions/TransactionWithNullDataSteps.cs
@@ -95,12 +95,15 @@ namespace Stratis.Bitcoin.IntegrationTests.Transactions
         private void a_nulldata_transaction()
         {
             var maturity = (int)this.senderNode.FullNode.Network.Consensus.CoinbaseMaturity;
-            var transactionBuildContext = new TransactionBuildContext(
-                this.senderNode.FullNode.Network,
-                this.sendingWalletAccountReference,
-                new List<Recipient>() { new Recipient() { Amount = this.transferAmount, ScriptPubKey = this.receiverAddress.ScriptPubKey } },
-                this.password, this.opReturnContent)
-            { MinConfirmations = maturity };
+            var transactionBuildContext = new TransactionBuildContext(this.senderNode.FullNode.Network)
+            {
+                AccountReference = this.sendingWalletAccountReference,
+                MinConfirmations = maturity,
+                OpReturnData = this.opReturnContent,
+                WalletPassword = this.password,
+                Recipients = new List<Recipient>() { new Recipient() { Amount = this.transferAmount, ScriptPubKey = this.receiverAddress.ScriptPubKey } }
+            };
+
             this.transaction = this.senderNode.FullNode.WalletTransactionHandler().BuildTransaction(transactionBuildContext);
 
             this.transaction.Outputs.Single(t => t.ScriptPubKey.IsUnspendable).Value.Should().Be(Money.Zero);

--- a/src/Stratis.Bitcoin.IntegrationTests/Wallet/SendingToAndFromManyAddressesSpecification_Steps.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/Wallet/SendingToAndFromManyAddressesSpecification_Steps.cs
@@ -109,18 +109,12 @@ namespace Stratis.Bitcoin.IntegrationTests.Wallet
         {
             HdAddress sendToNodeOne = this.nodes[NodeOne].FullNode.WalletManager().GetUnusedAddress(new WalletAccountReference(WalletName, WalletAccountName));
 
-            this.transactionBuildContext = new TransactionBuildContext(
-                this.nodes[NodeOne].FullNode.Network,
-                new WalletAccountReference(WalletName, WalletAccountName),
-                new[]
-                {
-                    new Recipient
-                    {
-                        Amount = this.nodeTwoBalance - Money.COIN,
-                        ScriptPubKey = sendToNodeOne.ScriptPubKey
-                    }
-                }.ToList(),
-                WalletPassword);
+            this.transactionBuildContext = new TransactionBuildContext(this.nodes[NodeOne].FullNode.Network)
+            {
+                AccountReference = new WalletAccountReference(WalletName, WalletAccountName),
+                WalletPassword = WalletPassword,
+                Recipients = new[] { new Recipient { Amount = this.nodeTwoBalance - Money.COIN, ScriptPubKey = sendToNodeOne.ScriptPubKey } }.ToList()
+            };
 
             Transaction transaction = this.nodes[NodeTwo].FullNode.WalletTransactionHandler().BuildTransaction(this.transactionBuildContext);
 

--- a/src/Stratis.Bitcoin.IntegrationTests/Wallet/WalletTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/Wallet/WalletTests.cs
@@ -454,13 +454,13 @@ namespace Stratis.Bitcoin.IntegrationTests.Wallet
         public static TransactionBuildContext CreateContext(Network network, WalletAccountReference accountReference, string password,
             Script destinationScript, Money amount, FeeType feeType, int minConfirmations)
         {
-            return new TransactionBuildContext(
-                network,
-                accountReference,
-                new[] { new Recipient { Amount = amount, ScriptPubKey = destinationScript } }.ToList(), password)
+            return new TransactionBuildContext(network)
             {
+                AccountReference = accountReference,
                 MinConfirmations = minConfirmations,
-                FeeType = feeType
+                FeeType = feeType,
+                WalletPassword = password,
+                Recipients = new[] { new Recipient { Amount = amount, ScriptPubKey = destinationScript } }.ToList()
             };
         }
 

--- a/src/Stratis.Bitcoin.Tests.Wallet.Common/WalletTestsHelpers.cs
+++ b/src/Stratis.Bitcoin.Tests.Wallet.Common/WalletTestsHelpers.cs
@@ -116,13 +116,13 @@ namespace Stratis.Bitcoin.Tests.Wallet.Common
         public static TransactionBuildContext CreateContext(Network network, WalletAccountReference accountReference, string password,
             Script destinationScript, Money amount, FeeType feeType, int minConfirmations)
         {
-            return new TransactionBuildContext(
-                network,
-                accountReference,
-                new[] { new Recipient { Amount = amount, ScriptPubKey = destinationScript } }.ToList(), password)
+            return new TransactionBuildContext(network)
             {
+                AccountReference = accountReference,
                 MinConfirmations = minConfirmations,
-                FeeType = feeType
+                FeeType = feeType,
+                WalletPassword = password,
+                Recipients = new[] { new Recipient { Amount = amount, ScriptPubKey = destinationScript } }.ToList()
             };
         }
 


### PR DESCRIPTION
This PR was geared up to be something a bit different, in line with https://github.com/stratisproject/StratisBitcoinFullNode/pull/1773 but in the end we opted for a less disruptive change.

* `Transaction Transaction` and `bool Sign` were removed from the TransactionBuilderContext object because the user shouldn't set them.
* The object originally passed to TransactionBuilderContext's ctor are now initialized via properties. This has the advantage to allow more flexibility as to where the inputs are taken from, and it also shows to the user that all the properties are settable and effectively on the same level.

Closes https://github.com/stratisproject/StratisBitcoinFullNode/pull/1773
Related to https://github.com/stratisproject/StratisBitcoinFullNode/issues/1689

@codingupastorm if you need changes with the changeAddress stuff, please do it as part of a SC issue.

🍒 All unit test + integration tests passing (all bar one).
🍒 Nodes are syncing.

![image](https://user-images.githubusercontent.com/1867877/43897689-c103a1d0-9bd4-11e8-8d0e-c2c08f93c76e.png)
