### PR TITLE
[SC] Byte conversion of uint ulong int long

### DIFF
--- a/src/Stratis.Bitcoin.Features.SmartContracts.Tests/ByteArrayConversionTests.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts.Tests/ByteArrayConversionTests.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using Xunit;
+
+namespace Stratis.Bitcoin.Features.SmartContracts.Tests
+{
+    public class ByteArrayConversionTests
+    {
+        // The smart contract being tested contains a bunch of static methods related to the conversion of bytes to smart contract primitives.
+        // It's also validated inside DeterminismValidationTests so we know it is deterministic too.
+        // Serves as a good example for future documentation.
+
+        [Fact]
+        public void UIntConversion()
+        {
+            // TODO: Test more values.
+            byte[] max = new byte[] { 255, 255, 255, 255 };
+            uint expected = BitConverter.ToUInt32(max);
+            uint actual = ByteArrayConversion.BytesToUInt(max);
+            Assert.Equal(expected, actual);
+
+            byte[] expectedBytes = BitConverter.GetBytes(uint.MaxValue);
+            byte[] actualBytes = ByteArrayConversion.UIntToBytes(uint.MaxValue);
+            Assert.Equal(expectedBytes, actualBytes);
+        }
+
+        [Fact]
+        public void IntConversion()
+        {
+            // TODO: Test more values.
+            byte[] max = new byte[] { 255, 255, 255, 255 };
+            int expected = BitConverter.ToInt32(max);
+            int actual = ByteArrayConversion.BytesToInt(max);
+            Assert.Equal(expected, actual);
+
+            byte[] expectedBytes = BitConverter.GetBytes(int.MaxValue);
+            byte[] actualBytes = ByteArrayConversion.IntToBytes(int.MaxValue);
+            Assert.Equal(expectedBytes, actualBytes);
+        }
+
+
+    }
+}

--- a/src/Stratis.Bitcoin.Features.SmartContracts.Tests/ByteArrayConversionTests.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts.Tests/ByteArrayConversionTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Text;
 using Xunit;
 
 namespace Stratis.Bitcoin.Features.SmartContracts.Tests
@@ -37,6 +38,34 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Tests
             Assert.Equal(expectedBytes, actualBytes);
         }
 
+        [Fact]
+        public void ULongConversion()
+        {
+            // TODO: Test more values.
+            byte[] max = new byte[] { 255, 255, 255, 255, 255, 255, 255, 255 };
+            ulong expected = BitConverter.ToUInt64(max);
+            ulong actual = ByteArrayConversion.BytesToULong(max);
+            Assert.Equal(expected, actual);
 
+            byte[] expectedBytes = BitConverter.GetBytes(ulong.MaxValue);
+            byte[] actualBytes = ByteArrayConversion.ULongToBytes(ulong.MaxValue);
+            Assert.Equal(expectedBytes, actualBytes);
+        }
+
+        [Fact]
+        public void LongConversion()
+        {
+            // TODO: Test more values.
+            byte[] max = new byte[] { 255, 255, 255, 255, 255, 255, 255, 255 };
+            long expected = BitConverter.ToInt64(max);
+            long actual = ByteArrayConversion.BytesToLong(max);
+            Assert.Equal(expected, actual);
+
+            byte[] expectedBytes = BitConverter.GetBytes(long.MaxValue);
+            byte[] actualBytes = ByteArrayConversion.LongToBytes(long.MaxValue);
+            Assert.Equal(expectedBytes, actualBytes);
+        }
+
+        
     }
 }

--- a/src/Stratis.Bitcoin.Features.SmartContracts.Tests/DeterminismValidationTests.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts.Tests/DeterminismValidationTests.cs
@@ -1,8 +1,4 @@
-using System;
-using System.Collections.Generic;
 using System.Linq;
-using Mono.Cecil;
-using Stratis.ModuleValidation.Net;
 using Stratis.ModuleValidation.Net.Determinism;
 using Stratis.SmartContracts.Core.Validation;
 using Stratis.SmartContracts.Core.Validation.Validators;
@@ -811,6 +807,18 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Tests
                   }").Replace(ReplaceReferencesString, "");
 
             SmartContractCompilationResult compilationResult = SmartContractCompiler.Compile(adjustedSource);
+            Assert.True(compilationResult.Success);
+
+            byte[] assemblyBytes = compilationResult.Compilation;
+            SmartContractDecompilation decomp = SmartContractDecompiler.GetModuleDefinition(assemblyBytes);
+            SmartContractValidationResult result = this.validator.Validate(decomp);
+            Assert.True(result.IsValid);
+        }
+
+        [Fact]
+        public void Validate_ByteArray_Conversion()
+        {
+            SmartContractCompilationResult compilationResult = SmartContractCompiler.CompileFile("SmartContracts/ByteArrayConversion.cs");
             Assert.True(compilationResult.Success);
 
             byte[] assemblyBytes = compilationResult.Compilation;

--- a/src/Stratis.Bitcoin.Features.SmartContracts.Tests/SmartContracts/ByteArrayConversion.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts.Tests/SmartContracts/ByteArrayConversion.cs
@@ -16,6 +16,40 @@ public class ByteArrayConversion : SmartContract
         return (uint) value[0] | (uint) (value[1] << 8) | (uint) (value[2] << 16) | (uint) (value[3] << 24);
     }
 
+    public static ulong BytesToULong(byte[] value)
+    {
+        return (ulong) value[0] 
+            | (ulong)(value[1] << 8) 
+            | (ulong)(value[2] << 16) 
+            | (ulong)(value[3] << 24) 
+            | (ulong)(value[4] << 32)
+            | (ulong)(value[5] << 40)
+            | (ulong)(value[6] << 48)
+            | (ulong)(value[7] << 56);
+    }
+
+    public static long BytesToLong(byte[] value)
+    {
+        return (long)value[0]
+            | (long)(value[1] << 8)
+            | (long)(value[2] << 16)
+            | (long)(value[3] << 24)
+            | (long)(value[4] << 32)
+            | (long)(value[5] << 40)
+            | (long)(value[6] << 48)
+            | (long)(value[7] << 56);
+    }
+
+    public static string BytesToString(byte[] value)
+    {
+        string ret = "";
+        for(int i = 0; i < value.Length; i++)
+        {
+            ret += value[i]; 
+        }
+        return ret;
+    }
+
     public static byte[] IntToBytes(int value)
     {
         unchecked
@@ -40,5 +74,49 @@ public class ByteArrayConversion : SmartContract
             bytes[3] = (byte)(value >> 24);
             return bytes;
         }
+    }
+
+    public static byte[] ULongToBytes(ulong value)
+    {
+        unchecked
+        {
+            byte[] bytes = new byte[8];
+            bytes[0] = (byte)value;
+            bytes[1] = (byte)(value >> 8);
+            bytes[2] = (byte)(value >> 16);
+            bytes[3] = (byte)(value >> 24);
+            bytes[4] = (byte)(value >> 32);
+            bytes[5] = (byte)(value >> 40);
+            bytes[6] = (byte)(value >> 48);
+            bytes[7] = (byte)(value >> 56);
+            return bytes;
+        }
+    }
+
+    public static byte[] LongToBytes(long value)
+    {
+        unchecked
+        {
+            byte[] bytes = new byte[8];
+            bytes[0] = (byte)value;
+            bytes[1] = (byte)(value >> 8);
+            bytes[2] = (byte)(value >> 16);
+            bytes[3] = (byte)(value >> 24);
+            bytes[4] = (byte)(value >> 32);
+            bytes[5] = (byte)(value >> 40);
+            bytes[6] = (byte)(value >> 48);
+            bytes[7] = (byte)(value >> 56);
+            return bytes;
+        }
+    }
+
+    public static byte[] StringToBytes(string value)
+    {
+        byte[] ret = new byte[value.Length];
+        for(int i=0; i< value.Length; i++)
+        {
+            ret[i] = (byte) value[i];
+        }
+        return ret;
     }
 }

--- a/src/Stratis.Bitcoin.Features.SmartContracts.Tests/SmartContracts/ByteArrayConversion.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts.Tests/SmartContracts/ByteArrayConversion.cs
@@ -1,0 +1,44 @@
+﻿using Stratis.SmartContracts;
+
+public class ByteArrayConversion : SmartContract
+{
+    public ByteArrayConversion(ISmartContractState smartContractState) : base(smartContractState)
+    {
+    }
+
+    public static int BytesToInt(byte[] value)
+    {
+        return value[0] | (value[1] << 8) | (value[2] << 16) | (value[3] << 24);
+    }
+
+    public static uint BytesToUInt(byte[] value)
+    {
+        return (uint) value[0] | (uint) (value[1] << 8) | (uint) (value[2] << 16) | (uint) (value[3] << 24);
+    }
+
+    public static byte[] IntToBytes(int value)
+    {
+        unchecked
+        {
+            byte[] bytes = new byte[4];
+            bytes[0] = (byte)value;
+            bytes[1] = (byte)(value >> 8);
+            bytes[2] = (byte)(value >> 16);
+            bytes[3] = (byte)(value >> 24);
+            return bytes;
+        }
+    }
+
+    public static byte[] UIntToBytes(uint value)
+    {
+        unchecked
+        {
+            byte[] bytes = new byte[4];
+            bytes[0] = (byte)value;
+            bytes[1] = (byte)(value >> 8);
+            bytes[2] = (byte)(value >> 16);
+            bytes[3] = (byte)(value >> 24);
+            return bytes;
+        }
+    }
+}

--- a/src/Stratis.Bitcoin.Features.SmartContracts.Tests/Stratis.Bitcoin.Features.SmartContracts.Tests.csproj
+++ b/src/Stratis.Bitcoin.Features.SmartContracts.Tests/Stratis.Bitcoin.Features.SmartContracts.Tests.csproj
@@ -45,6 +45,9 @@
     <Compile Update="SmartContracts\AsyncTask.cs">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Compile>
+    <Compile Update="SmartContracts\ByteArrayConversion.cs">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Compile>
     <Compile Update="SmartContracts\CallInfiniteLoopContract.cs">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Compile>


### PR DESCRIPTION
Example smart contract showing conversion from little-endian byte arrays to integer primitives and back. 

Tests can be expanded but this prevents us needing to expose BitConverter and could be useful for 