### PR TITLE
Shortened name of AddNodeWithValidNodeThenExecutesSuccessfully 

### DIFF
--- a/src/Stratis.Bitcoin.IntegrationTests/RPC/RpcBitcoinMutableTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/RPC/RpcBitcoinMutableTests.cs
@@ -57,7 +57,7 @@ namespace Stratis.Bitcoin.IntegrationTests.RPC
         /// <seealso cref="https://github.com/MetacoSA/NBitcoin/blob/master/NBitcoin.Tests/RPCClientTests.cs">NBitcoin test CanAddNodes</seealso>
         /// </summary>
         [Fact]
-        public void AddNodeWithValidNodeThenExecutesSuccessfully()
+        public void CanAddRemoveNode()
         {
             using (NodeBuilder builder = NodeBuilder.Create(this))
             {


### PR DESCRIPTION
This is to fix this integration test as it was failing to complete due to the folder path being too long.