### PR TITLE
Integration Test - Only Sync if a Wallet exists.

### DIFF
--- a/src/Stratis.Bitcoin.IntegrationTests.Common/TestHelper.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests.Common/TestHelper.cs
@@ -47,7 +47,10 @@ namespace Stratis.Bitcoin.IntegrationTests.Common
         {
             if (node.FullNode.Chain.Tip.HashBlock != node.FullNode.ChainBehaviorState.ConsensusTip.HashBlock) return false;
             if (node.FullNode.Chain.Tip.HashBlock != node.FullNode.GetBlockStoreTip().HashBlock) return false;
-            if (node.FullNode.Chain.Tip.HashBlock != node.FullNode.WalletManager().WalletTipHash) return false;
+
+            if (!node.FullNode.WalletManager().Wallets.IsEmpty)
+                if (node.FullNode.Chain.Tip.HashBlock != node.FullNode.WalletManager().WalletTipHash) return false;
+
             return true;
         }
 


### PR DESCRIPTION
@bokobza identified an issue in  `MempoolSyncTransactions`.  

It stays syncing forever in  `TestHelper.WaitLoop(() => TestHelper.IsNodeSynced(stratisNodeSync));` and it's stuck waiting for the wallet tip to be at a certain height.