### PR TITLE
Block to chainedheaderblock

### DIFF
--- a/src/Stratis.Bitcoin.Features.MemoryPool.Tests/BlocksDisconnectedSignaledTest.cs
+++ b/src/Stratis.Bitcoin.Features.MemoryPool.Tests/BlocksDisconnectedSignaledTest.cs
@@ -20,12 +20,12 @@ namespace Stratis.Bitcoin.Features.MemoryPool.Tests
             var subject = new BlocksDisconnectedSignaled(mempoolValidatorMock.Object, new MempoolSchedulerLock(), loggerFactoryMock.Object);
 
             var block = new Block();
-            var chb = new ChainedHeaderBlock(block, ChainedHeadersHelper.CreateGenesisChainedHeader());
+            var genesisChainedHeaderBlock = new ChainedHeaderBlock(block, ChainedHeadersHelper.CreateGenesisChainedHeader());
             var transaction1 = new Transaction();
             var transaction2 = new Transaction();
             block.Transactions = new List<Transaction> { transaction1, transaction2 };
 
-            subject.OnNext(chb);
+            subject.OnNext(genesisChainedHeaderBlock);
 
             mempoolValidatorMock.Verify(x => x.AcceptToMemoryPool(It.IsAny<MempoolValidationState>(), transaction1));
             mempoolValidatorMock.Verify(x => x.AcceptToMemoryPool(It.IsAny<MempoolValidationState>(), transaction2));

--- a/src/Stratis.Bitcoin.Features.MemoryPool.Tests/BlocksDisconnectedSignaledTest.cs
+++ b/src/Stratis.Bitcoin.Features.MemoryPool.Tests/BlocksDisconnectedSignaledTest.cs
@@ -2,6 +2,7 @@
 using Microsoft.Extensions.Logging;
 using Moq;
 using NBitcoin;
+using Stratis.Bitcoin.Primitives;
 using Stratis.Bitcoin.Tests.Common;
 using Xunit;
 
@@ -19,11 +20,12 @@ namespace Stratis.Bitcoin.Features.MemoryPool.Tests
             var subject = new BlocksDisconnectedSignaled(mempoolValidatorMock.Object, new MempoolSchedulerLock(), loggerFactoryMock.Object);
 
             var block = new Block();
+            var chb = new ChainedHeaderBlock(block, ChainedHeadersHelper.CreateGenesisChainedHeader());
             var transaction1 = new Transaction();
             var transaction2 = new Transaction();
             block.Transactions = new List<Transaction> { transaction1, transaction2 };
 
-            subject.OnNext(block);
+            subject.OnNext(chb);
 
             mempoolValidatorMock.Verify(x => x.AcceptToMemoryPool(It.IsAny<MempoolValidationState>(), transaction1));
             mempoolValidatorMock.Verify(x => x.AcceptToMemoryPool(It.IsAny<MempoolValidationState>(), transaction2));

--- a/src/Stratis.Bitcoin.Features.MemoryPool/BlocksDisconnectedSignaled.cs
+++ b/src/Stratis.Bitcoin.Features.MemoryPool/BlocksDisconnectedSignaled.cs
@@ -1,6 +1,7 @@
 ﻿using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using NBitcoin;
+using Stratis.Bitcoin.Primitives;
 using Stratis.Bitcoin.Signals;
 
 namespace Stratis.Bitcoin.Features.MemoryPool
@@ -8,7 +9,7 @@ namespace Stratis.Bitcoin.Features.MemoryPool
     /// <summary>
     /// Mempool observer on disconnected block notifications.
     /// </summary>
-    public class BlocksDisconnectedSignaled : SignalObserver<Block>
+    public class BlocksDisconnectedSignaled : SignalObserver<ChainedHeaderBlock>
     {
         private readonly IMempoolValidator mempoolValidator;
         private readonly MempoolSchedulerLock mempoolLock;
@@ -22,11 +23,11 @@ namespace Stratis.Bitcoin.Features.MemoryPool
             this.logger = loggerFactory.CreateLogger(this.GetType().FullName);
         }
 
-        protected override void OnNextCore(Block block)
+        protected override void OnNextCore(ChainedHeaderBlock block)
         {
-            this.logger.LogTrace("({0}:'{1}')", nameof(block), block.GetHash());
+            this.logger.LogTrace("({0}:'{1}')", nameof(block), block.Block.GetHash());
 
-            this.AddBackToMempoolAsync(block).ConfigureAwait(false).GetAwaiter().GetResult();
+            this.AddBackToMempoolAsync(block.Block).ConfigureAwait(false).GetAwaiter().GetResult();
 
             this.logger.LogTrace("(-)");
         }

--- a/src/Stratis.Bitcoin.IntegrationTests/API/ApiSteps.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/API/ApiSteps.cs
@@ -55,7 +55,7 @@ namespace Stratis.Bitcoin.IntegrationTests.API
         // Consensus
         private const string GetBestBlockHashUri = "api/consensus/getbestblockhash";
         private const string GetBlockHashUri = "api/consensus/getblockhash";
-        DateTime.Now.AddHours(-2)
+
         // Mempool
         private const string GetRawMempoolUri = "api/mempool/getrawmempool";
 

--- a/src/Stratis.Bitcoin.IntegrationTests/API/ApiSteps.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/API/ApiSteps.cs
@@ -55,7 +55,7 @@ namespace Stratis.Bitcoin.IntegrationTests.API
         // Consensus
         private const string GetBestBlockHashUri = "api/consensus/getbestblockhash";
         private const string GetBlockHashUri = "api/consensus/getblockhash";
-
+        DateTime.Now.AddHours(-2)
         // Mempool
         private const string GetRawMempoolUri = "api/mempool/getrawmempool";
 

--- a/src/Stratis.Bitcoin.Tests/Signals/SignalsTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Signals/SignalsTest.cs
@@ -1,5 +1,6 @@
 ﻿using Moq;
 using NBitcoin;
+using Stratis.Bitcoin.Primitives;
 using Stratis.Bitcoin.Signals;
 using Stratis.Bitcoin.Tests.Common;
 using Xunit;
@@ -9,14 +10,14 @@ namespace Stratis.Bitcoin.Tests.Signals
     public class SignalsTest
     {
         private readonly Mock<ISignaler<Block>> blockConnectedSignaler;
-        private readonly Mock<ISignaler<Block>> blockDisconnectedSignaler;
+        private readonly Mock<ISignaler<ChainedHeaderBlock>> blockDisconnectedSignaler;
         private readonly Bitcoin.Signals.Signals signals;
         private readonly Mock<ISignaler<Transaction>> transactionSignaler;
 
         public SignalsTest()
         {
             this.blockConnectedSignaler = new Mock<ISignaler<Block>>();
-            this.blockDisconnectedSignaler = new Mock<ISignaler<Block>>();
+            this.blockDisconnectedSignaler = new Mock<ISignaler<ChainedHeaderBlock>>();
             this.transactionSignaler = new Mock<ISignaler<Transaction>>();
             this.signals = new Bitcoin.Signals.Signals(this.blockConnectedSignaler.Object, this.blockDisconnectedSignaler.Object, this.transactionSignaler.Object);
         }
@@ -35,10 +36,12 @@ namespace Stratis.Bitcoin.Tests.Signals
         public void SignalBlockDisconnectedToBlockSignaler()
         {
             Block block = KnownNetworks.StratisMain.CreateBlock();
+            ChainedHeader header = ChainedHeadersHelper.CreateGenesisChainedHeader();
+            var chainedHeaderBlock = new ChainedHeaderBlock(block, header);
 
-            this.signals.SignalBlockDisconnected(block);
+            this.signals.SignalBlockDisconnected(chainedHeaderBlock);
 
-            this.blockDisconnectedSignaler.Verify(b => b.Broadcast(block), Times.Exactly(1));
+            this.blockDisconnectedSignaler.Verify(b => b.Broadcast(chainedHeaderBlock), Times.Exactly(1));
         }
 
         [Fact]

--- a/src/Stratis.Bitcoin/Signals/Signals.cs
+++ b/src/Stratis.Bitcoin/Signals/Signals.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using NBitcoin;
+using Stratis.Bitcoin.Primitives;
 using Stratis.Bitcoin.Utilities;
 
 namespace Stratis.Bitcoin.Signals
@@ -19,7 +20,7 @@ namespace Stratis.Bitcoin.Signals
         /// Notify subscribers about a block being disconnected.
         /// </summary>
         /// <param name="block">Block that was disconnected.</param>
-        void SignalBlockDisconnected(Block block);
+        void SignalBlockDisconnected(ChainedHeaderBlock block);
 
         /// <summary>
         /// Notify subscribers about a new transaction being available.
@@ -39,7 +40,7 @@ namespace Stratis.Bitcoin.Signals
         /// </summary>
         /// <param name="observer">Observer to be subscribed to receive signaler's messages.</param>
         /// <returns>Disposable object to allow observer to unsubscribe from the signaler.</returns>
-        IDisposable SubscribeForBlocksDisconnected(IObserver<Block> observer);
+        IDisposable SubscribeForBlocksDisconnected(IObserver<ChainedHeaderBlock> observer);
 
         /// <summary>
         /// Subscribes to receive notifications when a new transaction is available.
@@ -55,7 +56,7 @@ namespace Stratis.Bitcoin.Signals
         /// <summary>
         /// Initializes the object with newly created instances of signalers.
         /// </summary>
-        public Signals() : this(new Signaler<Block>(), new Signaler<Block>(), new Signaler<Transaction>())
+        public Signals() : this(new Signaler<Block>(), new Signaler<ChainedHeaderBlock>(), new Signaler<Transaction>())
         {
         }
 
@@ -65,7 +66,7 @@ namespace Stratis.Bitcoin.Signals
         /// <param name="blockConnectedSignaler">Signaler providing notifications about newly available blocks to its subscribers.</param>
         /// <param name="blockDisonnectedSignaler">Signaler providing notifications about a block being disconnected to its subscribers.</param>
         /// <param name="transactionSignaler">Signaler providing notifications about newly available transactions to its subscribers.</param>
-        public Signals(ISignaler<Block> blockConnectedSignaler, ISignaler<Block> blockDisonnectedSignaler, ISignaler<Transaction> transactionSignaler)
+        public Signals(ISignaler<Block> blockConnectedSignaler, ISignaler<ChainedHeaderBlock> blockDisonnectedSignaler, ISignaler<Transaction> transactionSignaler)
         {
             Guard.NotNull(blockConnectedSignaler, nameof(blockConnectedSignaler));
             Guard.NotNull(blockDisonnectedSignaler, nameof(blockDisonnectedSignaler));
@@ -80,7 +81,7 @@ namespace Stratis.Bitcoin.Signals
         private ISignaler<Block> blocksConnected { get; }
 
         /// <summary>Signaler providing notifications about blocks being disconnected to its subscribers.</summary>
-        private ISignaler<Block> blocksDisconnected { get; }
+        private ISignaler<ChainedHeaderBlock> blocksDisconnected { get; }
 
         /// <summary>Signaler providing notifications about newly available transactions to its subscribers.</summary>
         private ISignaler<Transaction> transactions { get; }
@@ -94,7 +95,7 @@ namespace Stratis.Bitcoin.Signals
         }
 
         /// <inheritdoc />
-        public void SignalBlockDisconnected(Block block)
+        public void SignalBlockDisconnected(ChainedHeaderBlock block)
         {
             Guard.NotNull(block, nameof(block));
 
@@ -118,7 +119,7 @@ namespace Stratis.Bitcoin.Signals
         }
 
         /// <inheritdoc />
-        public IDisposable SubscribeForBlocksDisconnected(IObserver<Block> observer)
+        public IDisposable SubscribeForBlocksDisconnected(IObserver<ChainedHeaderBlock> observer)
         {
             Guard.NotNull(observer, nameof(observer));
 


### PR DESCRIPTION
fixes #1813 

A phenomenal amount of unit tests are breaking but cannot be related to this change so must be breaking in core-way-activation.

Obviously don't merge until that is resolved