### PR TITLE
Added timeoffset option to adjust node time

### DIFF
--- a/src/Stratis.Bitcoin.Tests.Common/TestFramework/BddSpecification.cs
+++ b/src/Stratis.Bitcoin.Tests.Common/TestFramework/BddSpecification.cs
@@ -4,6 +4,7 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
+using NBitcoin;
 using Xunit.Abstractions;
 
 namespace Stratis.Bitcoin.Tests.Common.TestFramework

--- a/src/Stratis.Bitcoin.Tests/Utilities/DateTimeProviderTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Utilities/DateTimeProviderTest.cs
@@ -10,9 +10,11 @@ namespace Stratis.Bitcoin.Tests.Utilities
         [Fact]
         public void GetUtcNowReturnsCurrentUtcDateTime()
         {
+            int timeOffset = -96;
+            DateTimeProvider.Default.SetSystemTimeOffset(timeOffset);
             DateTime result = DateTimeProvider.Default.GetUtcNow();
 
-            Assert.Equal(DateTime.UtcNow.ToString("yyyyMMddhhmmss"), result.ToString("yyyyMMddhhmmss"));
+            Assert.Equal(DateTime.UtcNow.AddSeconds(timeOffset).ToString("yyyyMMddhhmmss"), result.ToString("yyyyMMddhhmmss"));
         }
 
         [Fact]

--- a/src/Stratis.Bitcoin/Configuration/NodeSettings.cs
+++ b/src/Stratis.Bitcoin/Configuration/NodeSettings.cs
@@ -76,6 +76,9 @@ namespace Stratis.Bitcoin.Configuration
         /// <summary>Minimum relay transaction fee for network.</summary>
         public FeeRate MinRelayTxFeeRate { get; private set; }
 
+        /// <summary>Node's time offset in relation to system time expresed as either positive or negative number of seconds.</summary>
+        public int TimeOffset { get; set; }
+
         /// <summary>
         /// Initializes a new instance of the object.
         /// </summary>
@@ -266,7 +269,12 @@ namespace Stratis.Bitcoin.Configuration
             this.MinTxFeeRate = new FeeRate(config.GetOrDefault("mintxfee", this.Network.MinTxFee, this.Logger));
             this.FallbackTxFeeRate = new FeeRate(config.GetOrDefault("fallbackfee", this.Network.FallbackFee, this.Logger));
             this.MinRelayTxFeeRate = new FeeRate(config.GetOrDefault("minrelaytxfee", this.Network.MinRelayTxFee, this.Logger));
+
+            // Node time adjustment
+            this.TimeOffset = this.ConfigReader.GetOrDefault<int>("timeoffset", 0, this.Logger);
+            DateTimeProvider.Default.SetSystemTimeOffset(TimeOffset);
         }
+
 
         /// <summary>
         /// Creates default data directories respecting different operating system specifics.

--- a/src/Stratis.Bitcoin/Utilities/DateTimeProvider.cs
+++ b/src/Stratis.Bitcoin/Utilities/DateTimeProvider.cs
@@ -40,11 +40,19 @@ namespace Stratis.Bitcoin.Utilities
         /// </summary>
         /// <param name="adjustedTimeOffset">Offset to adjust time with.</param>
         void SetAdjustedTimeOffset(TimeSpan adjustedTimeOffset);
+
+        /// <summary>
+        /// Sets node time difference in relation to the system clock
+        /// </summary>
+        /// <param name="timeOffset"></param>
+        void SetSystemTimeOffset(int timeOffset);
     }
 
     /// <inheritdoc />
     public class DateTimeProvider : IDateTimeProvider
     {
+        private int systemTimeOffset = 0;
+
         /// <summary>Static instance of the object to prevent the need of creating new instance.</summary>
         public static IDateTimeProvider Default { get; }
 
@@ -76,7 +84,7 @@ namespace Stratis.Bitcoin.Utilities
         /// <inheritdoc />
         public virtual DateTime GetUtcNow()
         {
-            return DateTime.UtcNow;
+            return DateTime.UtcNow.AddSeconds(this.systemTimeOffset);
         }
 
         /// <inheritdoc />
@@ -101,6 +109,12 @@ namespace Stratis.Bitcoin.Utilities
         public void SetAdjustedTimeOffset(TimeSpan adjustedTimeOffset)
         {
             this.adjustedTimeOffset = adjustedTimeOffset;
+        }
+
+        /// <inheritdoc />
+        public void SetSystemTimeOffset(int timeOffset)
+        {
+            this.systemTimeOffset = timeOffset;
         }
     }
 }


### PR DESCRIPTION
The timeoffset option will allow to run a node with a different time to the current system time. This is required in order to set up end to end testing where nodes are required to run few seconds in the future (using positive value for the setting) or in the past (by using negative value for the setting).

As we are planning to setup test network on Docker we need to have ability to adjust time on each of the nodes. Running each node in a different Docker container is great in terms of isolating the FullNode process, assigning unique IP address "to the node", controlling resource utilisation, etc. Because all Docker containers are using the same linux kernel it is impossible to have two containers with a different system time.
I have experimented with faking Linux calls for the date time with https://github.com/wolfcw/libfaketime (doesn't work probably due to how dotNet is loading libraries) 
And replacing method implementation by changing method's pointers at the IL level https://www.codeproject.com/Articles/37549/CLR-Injection-Runtime-Method-Replacer (gave up after about half a day; I suspect that for this to work you need to clear the compiled versions of the CLR libraries)
There is also an option to run each node on a different machine but this is too resource consuming and would limit how many nodes could run per machine.

The alternative to the above approach is to have the ability to adjust time within the node. This is one of the 2 PR to achieve this.

**PR 1992: Replaced all references to DateTime.Now and DateTime.UtcNow with DateTimeProvider**
I have replaced all references to the DateTime properties Now, UtcNow and Today (last one not used anywhere) with calls to DateTimeProvider.GetUtcNow(). As a result the current time could be changed. The limitation is that any external classes (e.g. NLog) which still use DateTime.Now property will return system time. This however should not be a problem as we are only changing the time for all activities related to the blockchain.

**PR 1995: Added timeoffset option to adjust node time**
This is to add ability to configure time offset from the command line and config file. With the above PR 1992 we have ensured that all calls to get current time are made through DateTimeProvider class so that the time offset have to be set in only one place.