### PR TITLE
ISelfEndpointTracker.MyExternalAddress was null when running CanCall_AddNode()

### DIFF
--- a/src/Stratis.Bitcoin.IntegrationTests/RPC/AddNodeActionTest.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/RPC/AddNodeActionTest.cs
@@ -14,6 +14,8 @@ namespace Stratis.Bitcoin.IntegrationTests.RPC
             string testDirectory = CreateTestDir(this);
 
             IFullNode fullNode = this.BuildServicedNode(testDirectory);
+            fullNode.Start();
+
             var controller = fullNode.Services.ServiceProvider.GetService<ConnectionManagerController>();
 
             Assert.ThrowsAny<System.Net.Sockets.SocketException>(() => { controller.AddNodeRPC("0.0.0.0", "onetry"); });


### PR DESCRIPTION
Need to call FullNode.Start() to make sure ConnectionManager.Initialize() is called, then logic to set up ISelfEndpointTracker.MyExternalAddress is invoked.