### PR TITLE
[Activation] Mark block invalid and don't create chained header for block that was already marked invalid

### DIFF
--- a/src/Stratis.Bitcoin.Features.BlockStore.Tests/BlockStoreTests.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore.Tests/BlockStoreTests.cs
@@ -81,7 +81,7 @@ namespace Stratis.Bitcoin.Features.BlockStore.Tests
                 return this.repositoryTipHashAndHeight;
             });
 
-            this.chainState = new ChainState(new InvalidBlockHashStore(new DateTimeProvider()));
+            this.chainState = new ChainState();
 
             this.blockStoreQueue = new BlockStoreQueue(this.chain, this.chainState, new StoreSettings(),
                 this.nodeLifetime, this.blockRepositoryMock.Object, new LoggerFactory());

--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/InitialBlockDownloadTest.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/InitialBlockDownloadTest.cs
@@ -21,7 +21,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests
             this.network = KnownNetworks.Main;
             this.consensusSettings = new ConsensusSettings(new NodeSettings(this.network));
             this.checkpoints = new Checkpoints(this.network, this.consensusSettings);
-            this.chainState = new ChainState(new InvalidBlockHashStore(DateTimeProvider.Default));
+            this.chainState = new ChainState();
         }
 
         [Fact]

--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/CommonRules/PowCoinViewRuleTests.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/CommonRules/PowCoinViewRuleTests.cs
@@ -93,7 +93,8 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
                     new Mock<IDateTimeProvider>().Object,
                     new ConcurrentChain(this.network),
                     new NodeDeployments(KnownNetworks.RegTest, new ConcurrentChain(this.network)),
-                    new ConsensusSettings(), new Mock<ICheckpoints>().Object, new Mock<ICoinView>().Object, new Mock<IChainState>().Object);
+                    new ConsensusSettings(), new Mock<ICheckpoints>().Object, new Mock<ICoinView>().Object, new Mock<IChainState>().Object,
+                    new InvalidBlockHashStore(new DateTimeProvider()));
 
                 rule.Initialize();
 

--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/ConsensusRuleUnitTestBase.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/ConsensusRuleUnitTestBase.cs
@@ -102,7 +102,9 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules
             return new T()
             {
                 Logger = this.logger.Object,
-                Parent = new TestPosConsensusRules(this.network, this.loggerFactory.Object, this.dateTimeProvider.Object, this.concurrentChain, this.nodeDeployments, this.consensusSettings, this.checkpoints.Object, this.coinView.Object, this.stakeChain.Object, this.stakeValidator.Object, this.chainState.Object)
+                Parent = new TestPosConsensusRules(this.network, this.loggerFactory.Object, this.dateTimeProvider.Object, this.concurrentChain, this.nodeDeployments,
+                    this.consensusSettings, this.checkpoints.Object, this.coinView.Object, this.stakeChain.Object, this.stakeValidator.Object, this.chainState.Object,
+                    new InvalidBlockHashStore(new DateTimeProvider()))
             };
         }
     }
@@ -194,7 +196,8 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules
 
         public override TestConsensusRules InitializeConsensusRules()
         {
-            return new TestConsensusRules(this.network, this.loggerFactory.Object, this.dateTimeProvider.Object, this.concurrentChain, this.nodeDeployments, this.consensusSettings, this.checkpoints.Object, this.chainState.Object);
+            return new TestConsensusRules(this.network, this.loggerFactory.Object, this.dateTimeProvider.Object, this.concurrentChain, this.nodeDeployments,
+                this.consensusSettings, this.checkpoints.Object, this.chainState.Object, new InvalidBlockHashStore(new DateTimeProvider()));
         }
     }
 
@@ -216,7 +219,9 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules
 
         public override TestPosConsensusRules InitializeConsensusRules()
         {
-            return new TestPosConsensusRules(this.network, this.loggerFactory.Object, this.dateTimeProvider.Object, this.concurrentChain, this.nodeDeployments, this.consensusSettings, this.checkpoints.Object, this.coinView.Object, this.stakeChain.Object, this.stakeValidator.Object, this.chainState.Object);
+            return new TestPosConsensusRules(this.network, this.loggerFactory.Object, this.dateTimeProvider.Object, this.concurrentChain,
+                this.nodeDeployments, this.consensusSettings, this.checkpoints.Object, this.coinView.Object, this.stakeChain.Object,
+                this.stakeValidator.Object, this.chainState.Object, new InvalidBlockHashStore(new DateTimeProvider()));
         }
     }
 }

--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/TestRulesContext.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/TestRulesContext.cs
@@ -155,7 +155,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules
             var consensusSettings = new ConsensusSettings(testRulesContext.NodeSettings);
             testRulesContext.Checkpoints = new Checkpoints();
             testRulesContext.Chain = new ConcurrentChain(network);
-            testRulesContext.ChainState = new ChainState(new InvalidBlockHashStore(testRulesContext.DateTimeProvider));
+            testRulesContext.ChainState = new ChainState();
 
             var deployments = new NodeDeployments(testRulesContext.Network, testRulesContext.Chain);
             testRulesContext.ConsensusRuleEngine = new PowConsensusRuleEngine(testRulesContext.Network, testRulesContext.LoggerFactory, testRulesContext.DateTimeProvider, testRulesContext.Chain, deployments, consensusSettings, testRulesContext.Checkpoints, new InMemoryCoinView(new uint256()), testRulesContext.ChainState).Register();

--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/TestRulesContext.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/TestRulesContext.cs
@@ -83,8 +83,9 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules
 
         private RuleRegistrationHelper ruleRegistrationHelper;
 
-        public TestConsensusRules(Network network, ILoggerFactory loggerFactory, IDateTimeProvider dateTimeProvider, ConcurrentChain chain, NodeDeployments nodeDeployments, ConsensusSettings consensusSettings, ICheckpoints checkpoints, IChainState chainState)
-            : base(network, loggerFactory, dateTimeProvider, chain, nodeDeployments, consensusSettings, checkpoints, chainState)
+        public TestConsensusRules(Network network, ILoggerFactory loggerFactory, IDateTimeProvider dateTimeProvider, ConcurrentChain chain, NodeDeployments nodeDeployments,
+            ConsensusSettings consensusSettings, ICheckpoints checkpoints, IChainState chainState, IInvalidBlockHashStore invalidBlockHashStore)
+            : base(network, loggerFactory, dateTimeProvider, chain, nodeDeployments, consensusSettings, checkpoints, chainState, invalidBlockHashStore)
         {
             this.ruleRegistrationHelper = new RuleRegistrationHelper();
         }
@@ -117,8 +118,10 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules
     {
         private RuleRegistrationHelper ruleRegistrationHelper;
 
-        public TestPosConsensusRules(Network network, ILoggerFactory loggerFactory, IDateTimeProvider dateTimeProvider, ConcurrentChain chain, NodeDeployments nodeDeployments, ConsensusSettings consensusSettings, ICheckpoints checkpoints, ICoinView uxtoSet, IStakeChain stakeChain, IStakeValidator stakeValidator, IChainState chainState)
-            : base(network, loggerFactory, dateTimeProvider, chain, nodeDeployments, consensusSettings, checkpoints, uxtoSet, stakeChain, stakeValidator, chainState)
+        public TestPosConsensusRules(Network network, ILoggerFactory loggerFactory, IDateTimeProvider dateTimeProvider, ConcurrentChain chain,
+            NodeDeployments nodeDeployments, ConsensusSettings consensusSettings, ICheckpoints checkpoints, ICoinView uxtoSet, IStakeChain stakeChain,
+            IStakeValidator stakeValidator, IChainState chainState, IInvalidBlockHashStore invalidBlockHashStore)
+            : base(network, loggerFactory, dateTimeProvider, chain, nodeDeployments, consensusSettings, checkpoints, uxtoSet, stakeChain, stakeValidator, chainState, invalidBlockHashStore)
         {
             this.ruleRegistrationHelper = new RuleRegistrationHelper();
         }
@@ -158,7 +161,9 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules
             testRulesContext.ChainState = new ChainState();
 
             var deployments = new NodeDeployments(testRulesContext.Network, testRulesContext.Chain);
-            testRulesContext.ConsensusRuleEngine = new PowConsensusRuleEngine(testRulesContext.Network, testRulesContext.LoggerFactory, testRulesContext.DateTimeProvider, testRulesContext.Chain, deployments, consensusSettings, testRulesContext.Checkpoints, new InMemoryCoinView(new uint256()), testRulesContext.ChainState).Register();
+            testRulesContext.ConsensusRuleEngine = new PowConsensusRuleEngine(testRulesContext.Network, testRulesContext.LoggerFactory, testRulesContext.DateTimeProvider,
+                testRulesContext.Chain, deployments, consensusSettings, testRulesContext.Checkpoints, new InMemoryCoinView(new uint256()), testRulesContext.ChainState,
+                new InvalidBlockHashStore(new DateTimeProvider())).Register();
 
             return testRulesContext;
         }

--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/TestChainFactory.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/TestChainFactory.cs
@@ -109,9 +109,9 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests
             var cachedCoinView = new CachedCoinView(inMemoryCoinView, DateTimeProvider.Default, testChainContext.LoggerFactory);
 
             var dataFolder = new DataFolder(TestBase.AssureEmptyDir(dataDir));
-            testChainContext.PeerAddressManager = 
-                mockPeerAddressManager == null ? 
-                    new PeerAddressManager(DateTimeProvider.Default, dataFolder, testChainContext.LoggerFactory, new SelfEndpointTracker(testChainContext.LoggerFactory)) 
+            testChainContext.PeerAddressManager =
+                mockPeerAddressManager == null ?
+                    new PeerAddressManager(DateTimeProvider.Default, dataFolder, testChainContext.LoggerFactory, new SelfEndpointTracker(testChainContext.LoggerFactory))
                     : mockPeerAddressManager.Object;
 
             testChainContext.MockConnectionManager = new Mock<IConnectionManager>();
@@ -134,7 +134,8 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests
 
             testChainContext.Consensus = new ConsensusManager(network, testChainContext.LoggerFactory, testChainContext.ChainState, testChainContext.HeaderValidator, testChainContext.IntegrityValidator,
                 testChainContext.PartialValidator, testChainContext.Checkpoints, consensusSettings, testChainContext.ConsensusRules, testChainContext.FinalizedBlockInfo, new Signals.Signals(),
-                testChainContext.PeerBanning, testChainContext.InitialBlockDownloadState, testChainContext.Chain, new Mock<IBlockPuller>().Object, new Mock<IBlockStore>().Object);
+                testChainContext.PeerBanning, testChainContext.InitialBlockDownloadState, testChainContext.Chain, new Mock<IBlockPuller>().Object, new Mock<IBlockStore>().Object,
+                new InvalidBlockHashStore(new DateTimeProvider()));
 
             await testChainContext.Consensus.InitializeAsync(testChainContext.Chain.Tip);
 

--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/TestChainFactory.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/TestChainFactory.cs
@@ -125,7 +125,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests
             testChainContext.PeerBanning = new PeerBanning(testChainContext.ConnectionManager, testChainContext.LoggerFactory, testChainContext.DateTimeProvider, testChainContext.PeerAddressManager);
             var deployments = new NodeDeployments(testChainContext.Network, testChainContext.Chain);
             testChainContext.ConsensusRules = new PowConsensusRuleEngine(testChainContext.Network, testChainContext.LoggerFactory, testChainContext.DateTimeProvider,
-                testChainContext.Chain, deployments, consensusSettings, testChainContext.Checkpoints, cachedCoinView, testChainContext.ChainState)
+                testChainContext.Chain, deployments, consensusSettings, testChainContext.Checkpoints, cachedCoinView, testChainContext.ChainState, new InvalidBlockHashStore(new DateTimeProvider()))
                 .Register();
 
             testChainContext.HeaderValidator = new HeaderValidator(testChainContext.ConsensusRules, testChainContext.LoggerFactory);

--- a/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/BitcoinActivationRule.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/BitcoinActivationRule.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Extensions.Logging;
 using NBitcoin;
+using Stratis.Bitcoin.Consensus;
 using Stratis.Bitcoin.Consensus.Rules;
 using Stratis.Bitcoin.Networks;
 

--- a/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/BlockMerkleRootRule.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/BlockMerkleRootRule.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using Microsoft.Extensions.Logging;
 using NBitcoin;
 using NBitcoin.Crypto;
+using Stratis.Bitcoin.Consensus;
 using Stratis.Bitcoin.Consensus.Rules;
 
 namespace Stratis.Bitcoin.Features.Consensus.Rules.CommonRules

--- a/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/BlockSizeRule.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/BlockSizeRule.cs
@@ -2,6 +2,7 @@ using System.IO;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using NBitcoin;
+using Stratis.Bitcoin.Consensus;
 using Stratis.Bitcoin.Consensus.Rules;
 
 namespace Stratis.Bitcoin.Features.Consensus.Rules.CommonRules

--- a/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/CheckDifficultyPosRule.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/CheckDifficultyPosRule.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Extensions.Logging;
 using NBitcoin;
+using Stratis.Bitcoin.Consensus;
 using Stratis.Bitcoin.Consensus.Rules;
 using Stratis.Bitcoin.Utilities;
 

--- a/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/CheckDifficultyPowRule.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/CheckDifficultyPowRule.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Extensions.Logging;
 using NBitcoin;
+using Stratis.Bitcoin.Consensus;
 using Stratis.Bitcoin.Consensus.Rules;
 
 namespace Stratis.Bitcoin.Features.Consensus.Rules.CommonRules

--- a/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/CheckDifficultykHybridRule.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/CheckDifficultykHybridRule.cs
@@ -1,6 +1,7 @@
 ﻿using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using NBitcoin;
+using Stratis.Bitcoin.Consensus;
 using Stratis.Bitcoin.Consensus.Rules;
 using Stratis.Bitcoin.Utilities;
 

--- a/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/CheckPosTransactionRule.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/CheckPosTransactionRule.cs
@@ -1,6 +1,7 @@
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using NBitcoin;
+using Stratis.Bitcoin.Consensus;
 using Stratis.Bitcoin.Consensus.Rules;
 
 namespace Stratis.Bitcoin.Features.Consensus.Rules.CommonRules

--- a/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/CheckPowTransactionRule.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/CheckPowTransactionRule.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using NBitcoin;
+using Stratis.Bitcoin.Consensus;
 using Stratis.Bitcoin.Consensus.Rules;
 
 namespace Stratis.Bitcoin.Features.Consensus.Rules.CommonRules

--- a/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/CheckSigOpsRule.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/CheckSigOpsRule.cs
@@ -1,6 +1,7 @@
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using NBitcoin;
+using Stratis.Bitcoin.Consensus;
 using Stratis.Bitcoin.Consensus.Rules;
 
 namespace Stratis.Bitcoin.Features.Consensus.Rules.CommonRules

--- a/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/CoinbaseHeightRule.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/CoinbaseHeightRule.cs
@@ -2,6 +2,7 @@
 using Microsoft.Extensions.Logging;
 using NBitcoin;
 using Stratis.Bitcoin.Base.Deployments;
+using Stratis.Bitcoin.Consensus;
 using Stratis.Bitcoin.Consensus.Rules;
 
 namespace Stratis.Bitcoin.Features.Consensus.Rules.CommonRules

--- a/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/CoinviewRule.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/CoinviewRule.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using NBitcoin;
 using Stratis.Bitcoin.Base.Deployments;
+using Stratis.Bitcoin.Consensus;
 using Stratis.Bitcoin.Consensus.Rules;
 using Stratis.Bitcoin.Utilities;
 

--- a/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/EnsureCoinbaseRule.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/EnsureCoinbaseRule.cs
@@ -1,6 +1,7 @@
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using NBitcoin;
+using Stratis.Bitcoin.Consensus;
 using Stratis.Bitcoin.Consensus.Rules;
 
 namespace Stratis.Bitcoin.Features.Consensus.Rules.CommonRules

--- a/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/HeaderTimeChecksPosRule.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/HeaderTimeChecksPosRule.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Extensions.Logging;
 using NBitcoin;
+using Stratis.Bitcoin.Consensus;
 using Stratis.Bitcoin.Consensus.Rules;
 
 namespace Stratis.Bitcoin.Features.Consensus.Rules.CommonRules

--- a/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/HeaderTimeChecksRule.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/HeaderTimeChecksRule.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Microsoft.Extensions.Logging;
 using NBitcoin;
+using Stratis.Bitcoin.Consensus;
 using Stratis.Bitcoin.Consensus.Rules;
 
 namespace Stratis.Bitcoin.Features.Consensus.Rules.CommonRules

--- a/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/LoadCoinviewRule.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/LoadCoinviewRule.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using NBitcoin;
 using Stratis.Bitcoin.Base.Deployments;
+using Stratis.Bitcoin.Consensus;
 using Stratis.Bitcoin.Consensus.Rules;
 using Stratis.Bitcoin.Features.Consensus.CoinViews;
 using Stratis.Bitcoin.Utilities;

--- a/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/PosBlockSignatureRule.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/PosBlockSignatureRule.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using Microsoft.Extensions.Logging;
 using NBitcoin;
 using NBitcoin.Crypto;
+using Stratis.Bitcoin.Consensus;
 using Stratis.Bitcoin.Consensus.Rules;
 
 namespace Stratis.Bitcoin.Features.Consensus.Rules.CommonRules

--- a/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/PosCoinstakeRule.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/PosCoinstakeRule.cs
@@ -2,6 +2,7 @@
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using NBitcoin;
+using Stratis.Bitcoin.Consensus;
 using Stratis.Bitcoin.Consensus.Rules;
 using Stratis.Bitcoin.Utilities;
 

--- a/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/PosCoinviewRule.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/PosCoinviewRule.cs
@@ -1,6 +1,7 @@
 ﻿using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using NBitcoin;
+using Stratis.Bitcoin.Consensus;
 using Stratis.Bitcoin.Consensus.Rules;
 using Stratis.Bitcoin.Features.Consensus.Interfaces;
 using Stratis.Bitcoin.Utilities;

--- a/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/PosFutureDriftRule.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/PosFutureDriftRule.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Extensions.Logging;
 using NBitcoin;
+using Stratis.Bitcoin.Consensus;
 using Stratis.Bitcoin.Consensus.Rules;
 using Stratis.Bitcoin.Networks;
 using Stratis.Bitcoin.Utilities;

--- a/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/PosTimeMaskRule.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/PosTimeMaskRule.cs
@@ -1,6 +1,7 @@
 ﻿using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using NBitcoin;
+using Stratis.Bitcoin.Consensus;
 using Stratis.Bitcoin.Consensus.Rules;
 
 namespace Stratis.Bitcoin.Features.Consensus.Rules.CommonRules

--- a/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/PowCoinviewRule.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/PowCoinviewRule.cs
@@ -1,6 +1,7 @@
 ﻿using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using NBitcoin;
+using Stratis.Bitcoin.Consensus;
 using Stratis.Bitcoin.Consensus.Rules;
 using Stratis.Bitcoin.Utilities;
 

--- a/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/StratisHeaderVersionRule.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/StratisHeaderVersionRule.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Extensions.Logging;
 using NBitcoin;
 using Stratis.Bitcoin.Base.Deployments;
+using Stratis.Bitcoin.Consensus;
 using Stratis.Bitcoin.Consensus.Rules;
 using Stratis.Bitcoin.Networks;
 using Stratis.Bitcoin.Utilities;

--- a/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/TransactionDuplicationActivationRule.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/TransactionDuplicationActivationRule.cs
@@ -2,6 +2,7 @@
 using Microsoft.Extensions.Logging;
 using NBitcoin;
 using Stratis.Bitcoin.Base.Deployments;
+using Stratis.Bitcoin.Consensus;
 using Stratis.Bitcoin.Consensus.Rules;
 using Stratis.Bitcoin.Utilities;
 

--- a/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/TransactionLocktimeActivationRule.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/TransactionLocktimeActivationRule.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using NBitcoin;
 using Stratis.Bitcoin.Base.Deployments;
+using Stratis.Bitcoin.Consensus;
 using Stratis.Bitcoin.Consensus.Rules;
 
 namespace Stratis.Bitcoin.Features.Consensus.Rules.CommonRules

--- a/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/WitnessCommitmentsRule.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/WitnessCommitmentsRule.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.Logging;
 using NBitcoin;
 using NBitcoin.Crypto;
 using Stratis.Bitcoin.Base.Deployments;
+using Stratis.Bitcoin.Consensus;
 using Stratis.Bitcoin.Consensus.Rules;
 
 namespace Stratis.Bitcoin.Features.Consensus.Rules.CommonRules

--- a/src/Stratis.Bitcoin.Features.Consensus/Rules/PosConsensusRuleEngine.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/Rules/PosConsensusRuleEngine.cs
@@ -29,8 +29,10 @@ namespace Stratis.Bitcoin.Features.Consensus.Rules
         /// <summary>
         /// Initializes an instance of the object.
         /// </summary>
-        public PosConsensusRuleEngine(Network network, ILoggerFactory loggerFactory, IDateTimeProvider dateTimeProvider, ConcurrentChain chain, NodeDeployments nodeDeployments, ConsensusSettings consensusSettings, ICheckpoints checkpoints, ICoinView utxoSet, IStakeChain stakeChain, IStakeValidator stakeValidator, IChainState chainState)
-            : base(network, loggerFactory, dateTimeProvider, chain, nodeDeployments, consensusSettings, checkpoints, utxoSet, chainState)
+        public PosConsensusRuleEngine(Network network, ILoggerFactory loggerFactory, IDateTimeProvider dateTimeProvider, ConcurrentChain chain, NodeDeployments nodeDeployments,
+            ConsensusSettings consensusSettings, ICheckpoints checkpoints, ICoinView utxoSet, IStakeChain stakeChain, IStakeValidator stakeValidator, IChainState chainState,
+            IInvalidBlockHashStore invalidBlockHashStore)
+            : base(network, loggerFactory, dateTimeProvider, chain, nodeDeployments, consensusSettings, checkpoints, utxoSet, chainState, invalidBlockHashStore)
         {
             this.StakeChain = stakeChain;
             this.StakeValidator = stakeValidator;

--- a/src/Stratis.Bitcoin.Features.Consensus/Rules/PowConsensusRuleEngine.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/Rules/PowConsensusRuleEngine.cs
@@ -22,8 +22,10 @@ namespace Stratis.Bitcoin.Features.Consensus.Rules
         /// <summary>
         /// Initializes an instance of the object.
         /// </summary>
-        public PowConsensusRuleEngine(Network network, ILoggerFactory loggerFactory, IDateTimeProvider dateTimeProvider, ConcurrentChain chain, NodeDeployments nodeDeployments, ConsensusSettings consensusSettings, ICheckpoints checkpoints, ICoinView utxoSet, IChainState chainState)
-            : base(network, loggerFactory, dateTimeProvider, chain, nodeDeployments, consensusSettings, checkpoints, chainState)
+        public PowConsensusRuleEngine(Network network, ILoggerFactory loggerFactory, IDateTimeProvider dateTimeProvider, ConcurrentChain chain,
+            NodeDeployments nodeDeployments, ConsensusSettings consensusSettings, ICheckpoints checkpoints, ICoinView utxoSet, IChainState chainState,
+            IInvalidBlockHashStore invalidBlockHashStore)
+            : base(network, loggerFactory, dateTimeProvider, chain, nodeDeployments, consensusSettings, checkpoints, chainState, invalidBlockHashStore)
         {
             this.UtxoSet = utxoSet;
         }

--- a/src/Stratis.Bitcoin.Features.Consensus/StakeValidator.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/StakeValidator.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.Logging;
 using NBitcoin;
 using NBitcoin.BouncyCastle.Math;
 using NBitcoin.Crypto;
+using Stratis.Bitcoin.Consensus;
 using Stratis.Bitcoin.Features.Consensus.CoinViews;
 using Stratis.Bitcoin.Features.Consensus.Interfaces;
 using Stratis.Bitcoin.Utilities;

--- a/src/Stratis.Bitcoin.Features.MemoryPool.Tests/MempoolPersistenceTest.cs
+++ b/src/Stratis.Bitcoin.Features.MemoryPool.Tests/MempoolPersistenceTest.cs
@@ -285,7 +285,7 @@ namespace Stratis.Bitcoin.Features.MemoryPool.Tests
             var mempoolLock = new MempoolSchedulerLock();
             var coins = new InMemoryCoinView(settings.Network.GenesisHash);
             var chain = new ConcurrentChain(KnownNetworks.Main);
-            var chainState = new ChainState(new InvalidBlockHashStore(dateTimeProvider));
+            var chainState = new ChainState();
             var mempoolPersistence = new MempoolPersistence(settings, loggerFactory);
             this.network.Consensus.Options = new PosConsensusOptions();
             new FullNodeBuilderConsensusExtension.PowConsensusRulesRegistration().RegisterRules(this.network.Consensus);

--- a/src/Stratis.Bitcoin.Features.MemoryPool.Tests/MempoolPersistenceTest.cs
+++ b/src/Stratis.Bitcoin.Features.MemoryPool.Tests/MempoolPersistenceTest.cs
@@ -289,7 +289,8 @@ namespace Stratis.Bitcoin.Features.MemoryPool.Tests
             var mempoolPersistence = new MempoolPersistence(settings, loggerFactory);
             this.network.Consensus.Options = new PosConsensusOptions();
             new FullNodeBuilderConsensusExtension.PowConsensusRulesRegistration().RegisterRules(this.network.Consensus);
-            ConsensusRuleEngine consensusRules = new PowConsensusRuleEngine(this.network, loggerFactory, dateTimeProvider, chain, new NodeDeployments(this.network, chain), consensusSettings, new Checkpoints(), coins, chainState).Register();
+            ConsensusRuleEngine consensusRules = new PowConsensusRuleEngine(this.network, loggerFactory, dateTimeProvider, chain,
+                new NodeDeployments(this.network, chain), consensusSettings, new Checkpoints(), coins, chainState, new InvalidBlockHashStore(dateTimeProvider)).Register();
             var mempoolValidator = new MempoolValidator(txMemPool, mempoolLock, dateTimeProvider, mempoolSettings, chain, coins, loggerFactory, settings, consensusRules);
             return new MempoolManager(mempoolLock, txMemPool, mempoolValidator, dateTimeProvider, mempoolSettings, mempoolPersistence, coins, loggerFactory, settings.Network);
         }

--- a/src/Stratis.Bitcoin.Features.MemoryPool.Tests/TestChainFactory.cs
+++ b/src/Stratis.Bitcoin.Features.MemoryPool.Tests/TestChainFactory.cs
@@ -89,7 +89,7 @@ namespace Stratis.Bitcoin.Features.MemoryPool.Tests
             var connectionSettings = new ConnectionManagerSettings(nodeSettings);
             var selfEndpointTracker = new SelfEndpointTracker(loggerFactory);
             var connectionManager = new ConnectionManager(dateTimeProvider, loggerFactory, network, networkPeerFactory, nodeSettings, new NodeLifetime(), new NetworkPeerConnectionParameters(), peerAddressManager, new IPeerConnector[] { }, peerDiscovery, selfEndpointTracker, connectionSettings, new VersionProvider());
-            var chainState = new ChainState(new InvalidBlockHashStore(dateTimeProvider));
+            var chainState = new ChainState();
             var peerBanning = new PeerBanning(connectionManager, loggerFactory, dateTimeProvider, peerAddressManager);
             var deployments = new NodeDeployments(network, chain);
             ConsensusRuleEngine consensusRules = new PowConsensusRuleEngine(network, loggerFactory, dateTimeProvider, chain, deployments, consensusSettings, new Checkpoints(), inMemoryCoinView, chainState).Register();

--- a/src/Stratis.Bitcoin.Features.MemoryPool.Tests/TestChainFactory.cs
+++ b/src/Stratis.Bitcoin.Features.MemoryPool.Tests/TestChainFactory.cs
@@ -96,7 +96,8 @@ namespace Stratis.Bitcoin.Features.MemoryPool.Tests
 
             var consensus = new ConsensusManager(network, loggerFactory, chainState, new HeaderValidator(consensusRules, loggerFactory),
                 new IntegrityValidator(consensusRules, loggerFactory), new PartialValidator(consensusRules, loggerFactory),new Checkpoints(), consensusSettings, consensusRules,
-                new Mock<IFinalizedBlockInfo>().Object, new Signals.Signals(), peerBanning, new Mock<IInitialBlockDownloadState>().Object, chain, new Mock<IBlockPuller>().Object, new Mock<IBlockStore>().Object);
+                new Mock<IFinalizedBlockInfo>().Object, new Signals.Signals(), peerBanning, new Mock<IInitialBlockDownloadState>().Object, chain, new Mock<IBlockPuller>().Object,
+                new Mock<IBlockStore>().Object, new InvalidBlockHashStore(new DateTimeProvider()));
 
             var blockPolicyEstimator = new BlockPolicyEstimator(new MempoolSettings(nodeSettings), loggerFactory, nodeSettings);
             var mempool = new TxMempool(dateTimeProvider, blockPolicyEstimator, loggerFactory, nodeSettings);

--- a/src/Stratis.Bitcoin.Features.MemoryPool.Tests/TestChainFactory.cs
+++ b/src/Stratis.Bitcoin.Features.MemoryPool.Tests/TestChainFactory.cs
@@ -92,7 +92,8 @@ namespace Stratis.Bitcoin.Features.MemoryPool.Tests
             var chainState = new ChainState();
             var peerBanning = new PeerBanning(connectionManager, loggerFactory, dateTimeProvider, peerAddressManager);
             var deployments = new NodeDeployments(network, chain);
-            ConsensusRuleEngine consensusRules = new PowConsensusRuleEngine(network, loggerFactory, dateTimeProvider, chain, deployments, consensusSettings, new Checkpoints(), inMemoryCoinView, chainState).Register();
+            ConsensusRuleEngine consensusRules = new PowConsensusRuleEngine(network, loggerFactory, dateTimeProvider, chain, deployments, consensusSettings, new Checkpoints(),
+                inMemoryCoinView, chainState, new InvalidBlockHashStore(new DateTimeProvider())).Register();
 
             var consensus = new ConsensusManager(network, loggerFactory, chainState, new HeaderValidator(consensusRules, loggerFactory),
                 new IntegrityValidator(consensusRules, loggerFactory), new PartialValidator(consensusRules, loggerFactory),new Checkpoints(), consensusSettings, consensusRules,

--- a/src/Stratis.Bitcoin.Features.Miner.Tests/PosBlockAssemblerTest.cs
+++ b/src/Stratis.Bitcoin.Features.Miner.Tests/PosBlockAssemblerTest.cs
@@ -439,7 +439,8 @@ namespace Stratis.Bitcoin.Features.Miner.Tests
                 new Mock<ICoinView>().Object,
                 new Mock<IStakeChain>().Object,
                 new Mock<IStakeValidator>().Object,
-                new Mock<IChainState>().Object);
+                new Mock<IChainState>().Object,
+                new InvalidBlockHashStore(new DateTimeProvider()));
 
             posConsensusRules.Register();
 

--- a/src/Stratis.Bitcoin.Features.Miner.Tests/PowBlockAssemblerTest.cs
+++ b/src/Stratis.Bitcoin.Features.Miner.Tests/PowBlockAssemblerTest.cs
@@ -414,7 +414,7 @@ namespace Stratis.Bitcoin.Features.Miner.Tests
             var powConsensusRules = new PowConsensusRuleEngine(this.testNet,
                     this.LoggerFactory.Object, this.dateTimeProvider.Object, chain,
                     new NodeDeployments(this.testNet, chain), new ConsensusSettings(new NodeSettings(this.testNet)), new Checkpoints(),
-                    new Mock<ICoinView>().Object, new Mock<IChainState>().Object);
+                    new Mock<ICoinView>().Object, new Mock<IChainState>().Object, new InvalidBlockHashStore(new DateTimeProvider()));
 
             powConsensusRules.Register();
             this.consensusManager.SetupGet(x => x.ConsensusRules).Returns(powConsensusRules);

--- a/src/Stratis.Bitcoin.Features.SmartContracts.Tests/Consensus/ReflectionRuleRegistrationTests.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts.Tests/Consensus/ReflectionRuleRegistrationTests.cs
@@ -35,7 +35,8 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Tests.Consensus
                 new Base.Deployments.NodeDeployments(network, chain), contractState,
                 new Mock<IReceiptRepository>().Object,
                 new Mock<ICoinView>().Object,
-                new Mock<IChainState>().Object);
+                new Mock<IChainState>().Object,
+                new InvalidBlockHashStore(new DateTimeProvider()));
 
             var feature = new ReflectionVirtualMachineFeature(loggerFactory, network);
             feature.Initialize();

--- a/src/Stratis.Bitcoin.Features.SmartContracts.Tests/Consensus/Rules/TestRulesContext.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts.Tests/Consensus/Rules/TestRulesContext.cs
@@ -81,7 +81,8 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Tests.Consensus.Rules
             testRulesContext.ChainState = new ChainState();
 
             NodeDeployments deployments = new NodeDeployments(testRulesContext.Network, testRulesContext.Chain);
-            testRulesContext.Consensus = new PowConsensusRuleEngine(testRulesContext.Network, testRulesContext.LoggerFactory, testRulesContext.DateTimeProvider, testRulesContext.Chain, deployments, consensusSettings, testRulesContext.Checkpoints, null, testRulesContext.ChainState).Register();
+            testRulesContext.Consensus = new PowConsensusRuleEngine(testRulesContext.Network, testRulesContext.LoggerFactory, testRulesContext.DateTimeProvider,
+                testRulesContext.Chain, deployments, consensusSettings, testRulesContext.Checkpoints, null, testRulesContext.ChainState, new InvalidBlockHashStore(new DateTimeProvider())).Register();
 
             return testRulesContext;
         }

--- a/src/Stratis.Bitcoin.Features.SmartContracts.Tests/Consensus/Rules/TestRulesContext.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts.Tests/Consensus/Rules/TestRulesContext.cs
@@ -78,7 +78,7 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Tests.Consensus.Rules
             ConsensusSettings consensusSettings = new ConsensusSettings(testRulesContext.NodeSettings);
             testRulesContext.Checkpoints = new Checkpoints();
             testRulesContext.Chain = new ConcurrentChain(network);
-            testRulesContext.ChainState = new ChainState(new InvalidBlockHashStore(testRulesContext.DateTimeProvider));
+            testRulesContext.ChainState = new ChainState();
 
             NodeDeployments deployments = new NodeDeployments(testRulesContext.Network, testRulesContext.Chain);
             testRulesContext.Consensus = new PowConsensusRuleEngine(testRulesContext.Network, testRulesContext.LoggerFactory, testRulesContext.DateTimeProvider, testRulesContext.Chain, deployments, consensusSettings, testRulesContext.Checkpoints, null, testRulesContext.ChainState).Register();

--- a/src/Stratis.Bitcoin.Features.SmartContracts/Consensus/Rules/SmartContractLoadCoinviewRule.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts/Consensus/Rules/SmartContractLoadCoinviewRule.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using NBitcoin;
+using Stratis.Bitcoin.Consensus;
 using Stratis.Bitcoin.Consensus.Rules;
 using Stratis.Bitcoin.Features.Consensus;
 using Stratis.Bitcoin.Features.Consensus.CoinViews;

--- a/src/Stratis.Bitcoin.Features.SmartContracts/Consensus/Rules/SmartContractPosBlockSignatureRule.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts/Consensus/Rules/SmartContractPosBlockSignatureRule.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using Microsoft.Extensions.Logging;
 using NBitcoin;
 using NBitcoin.Crypto;
+using Stratis.Bitcoin.Consensus;
 using Stratis.Bitcoin.Consensus.Rules;
 using Stratis.Bitcoin.Features.Consensus;
 

--- a/src/Stratis.Bitcoin.Features.SmartContracts/Consensus/Rules/SmartContractPosCoinviewRule.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts/Consensus/Rules/SmartContractPosCoinviewRule.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using NBitcoin;
+using Stratis.Bitcoin.Consensus;
 using Stratis.Bitcoin.Consensus.Rules;
 using Stratis.Bitcoin.Features.Consensus;
 using Stratis.Bitcoin.Features.Consensus.Interfaces;

--- a/src/Stratis.Bitcoin.Features.SmartContracts/Consensus/SmartContractPosConsensusRuleEngine.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts/Consensus/SmartContractPosConsensusRuleEngine.cs
@@ -39,8 +39,9 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Consensus
             IStakeChain stakeChain,
             IStakeValidator stakeValidator,
             ICoinView utxoSet,
-            IChainState chainState)
-            : base(network, loggerFactory, dateTimeProvider, chain, nodeDeployments, consensusSettings, checkpoints, utxoSet, stakeChain, stakeValidator, chainState)
+            IChainState chainState,
+            IInvalidBlockHashStore invalidBlockHashStore)
+            : base(network, loggerFactory, dateTimeProvider, chain, nodeDeployments, consensusSettings, checkpoints, utxoSet, stakeChain, stakeValidator, chainState, invalidBlockHashStore)
         {
             this.ExecutorFactory = executorFactory;
             this.OriginalStateRoot = originalStateRoot;

--- a/src/Stratis.Bitcoin.Features.SmartContracts/Consensus/SmartContractPowConsensusRuleEngine.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts/Consensus/SmartContractPowConsensusRuleEngine.cs
@@ -36,8 +36,9 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Consensus
             ContractStateRepositoryRoot originalStateRoot,
             IReceiptRepository receiptRepository,
             ICoinView utxoSet,
-            IChainState chainState)
-            : base(network, loggerFactory, dateTimeProvider, chain, nodeDeployments, consensusSettings, checkpoints, utxoSet, chainState)
+            IChainState chainState,
+            IInvalidBlockHashStore invalidBlockHashStore)
+            : base(network, loggerFactory, dateTimeProvider, chain, nodeDeployments, consensusSettings, checkpoints, utxoSet, chainState, invalidBlockHashStore)
         {
             this.ExecutorFactory = executorFactory;
             this.OriginalStateRoot = originalStateRoot;

--- a/src/Stratis.Bitcoin.IntegrationTests/MinerTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/MinerTests.cs
@@ -152,7 +152,7 @@ namespace Stratis.Bitcoin.IntegrationTests
                 var connectionSettings = new ConnectionManagerSettings(nodeSettings);
                 var selfEndpointTracker = new SelfEndpointTracker(loggerFactory);
                 var connectionManager = new ConnectionManager(dateTimeProvider, loggerFactory, this.network, networkPeerFactory, nodeSettings, new NodeLifetime(), new NetworkPeerConnectionParameters(), peerAddressManager, new IPeerConnector[] { }, peerDiscovery, selfEndpointTracker, connectionSettings, new VersionProvider());
-                var chainState = new ChainState(new InvalidBlockHashStore(dateTimeProvider));
+                var chainState = new ChainState();
 
                 var peerBanning = new PeerBanning(connectionManager, loggerFactory, dateTimeProvider, peerAddressManager);
                 var deployments = new NodeDeployments(this.network, this.chain);

--- a/src/Stratis.Bitcoin.IntegrationTests/MinerTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/MinerTests.cs
@@ -160,7 +160,8 @@ namespace Stratis.Bitcoin.IntegrationTests
 
                 this.consensus = new ConsensusManager(this.network, loggerFactory, chainState, new HeaderValidator(this.ConsensusRules, loggerFactory),
                     new IntegrityValidator(this.ConsensusRules, loggerFactory), new PartialValidator(this.ConsensusRules, loggerFactory), new Checkpoints(), consensusSettings, this.ConsensusRules,
-                    new Mock<IFinalizedBlockInfo>().Object, new Signals.Signals(), peerBanning, new Mock<IInitialBlockDownloadState>().Object, this.chain, new Mock<IBlockPuller>().Object, new Mock<IBlockStore>().Object);
+                    new Mock<IFinalizedBlockInfo>().Object, new Signals.Signals(), peerBanning, new Mock<IInitialBlockDownloadState>().Object, this.chain, new Mock<IBlockPuller>().Object,
+                    new Mock<IBlockStore>().Object, new InvalidBlockHashStore(new DateTimeProvider()));
 
                 this.entry.Fee(11);
                 this.entry.Height(11);

--- a/src/Stratis.Bitcoin.IntegrationTests/MinerTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/MinerTests.cs
@@ -156,7 +156,8 @@ namespace Stratis.Bitcoin.IntegrationTests
 
                 var peerBanning = new PeerBanning(connectionManager, loggerFactory, dateTimeProvider, peerAddressManager);
                 var deployments = new NodeDeployments(this.network, this.chain);
-                this.ConsensusRules = new PowConsensusRuleEngine(this.network, loggerFactory, dateTimeProvider, this.chain, deployments, consensusSettings, new Checkpoints(), this.cachedCoinView, chainState).Register();
+                this.ConsensusRules = new PowConsensusRuleEngine(this.network, loggerFactory, dateTimeProvider, this.chain, deployments, consensusSettings,
+                    new Checkpoints(), this.cachedCoinView, chainState, new InvalidBlockHashStore(dateTimeProvider)).Register();
 
                 this.consensus = new ConsensusManager(this.network, loggerFactory, chainState, new HeaderValidator(this.ConsensusRules, loggerFactory),
                     new IntegrityValidator(this.ConsensusRules, loggerFactory), new PartialValidator(this.ConsensusRules, loggerFactory), new Checkpoints(), consensusSettings, this.ConsensusRules,

--- a/src/Stratis.Bitcoin.IntegrationTests/SmartContracts/SmartContractMinerTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/SmartContracts/SmartContractMinerTests.cs
@@ -232,7 +232,8 @@ namespace Stratis.Bitcoin.IntegrationTests.SmartContracts
 
                 this.consensusManager = new ConsensusManager(this.network, loggerFactory, chainState, new HeaderValidator(consensusRules, loggerFactory),
                     new IntegrityValidator(consensusRules, loggerFactory), new PartialValidator(consensusRules, loggerFactory), new Checkpoints(), consensusSettings, consensusRules,
-                    new Mock<IFinalizedBlockInfo>().Object, new Signals.Signals(), peerBanning, new Mock<IInitialBlockDownloadState>().Object, this.chain, new Mock<IBlockPuller>().Object, new Mock<IBlockStore>().Object);
+                    new Mock<IFinalizedBlockInfo>().Object, new Signals.Signals(), peerBanning, new Mock<IInitialBlockDownloadState>().Object, this.chain, new Mock<IBlockPuller>().Object,
+                    new Mock<IBlockStore>().Object, new InvalidBlockHashStore(new DateTimeProvider()));
 
                 await this.consensusManager.InitializeAsync(new ChainedHeader(this.newBlock.Block.Header, this.newBlock.Block.GetHash(), 0));
 

--- a/src/Stratis.Bitcoin.IntegrationTests/SmartContracts/SmartContractMinerTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/SmartContracts/SmartContractMinerTests.cs
@@ -227,7 +227,9 @@ namespace Stratis.Bitcoin.IntegrationTests.SmartContracts
                 var nodeDeployments = new NodeDeployments(this.network, this.chain);
 
                 var chainState = new ChainState();
-                var consensusRules = new SmartContractPowConsensusRuleEngine(this.chain, new Checkpoints(), consensusSettings, dateTimeProvider, this.executorFactory, loggerFactory, this.network, nodeDeployments, this.stateRoot, new ReceiptRepository(), this.cachedCoinView, chainState).Register();
+                var consensusRules = new SmartContractPowConsensusRuleEngine(this.chain, new Checkpoints(), consensusSettings,
+                    dateTimeProvider, this.executorFactory, loggerFactory, this.network, nodeDeployments, this.stateRoot, new ReceiptRepository(),
+                    this.cachedCoinView, chainState, new InvalidBlockHashStore(new DateTimeProvider())).Register();
                 this.newBlock = AssemblerForTest(this).Build(this.chain.Tip, this.scriptPubKey);
 
                 this.consensusManager = new ConsensusManager(this.network, loggerFactory, chainState, new HeaderValidator(consensusRules, loggerFactory),

--- a/src/Stratis.Bitcoin.IntegrationTests/SmartContracts/SmartContractMinerTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/SmartContracts/SmartContractMinerTests.cs
@@ -226,7 +226,7 @@ namespace Stratis.Bitcoin.IntegrationTests.SmartContracts
                 var peerBanning = new PeerBanning(connectionManager, loggerFactory, dateTimeProvider, peerAddressManager);
                 var nodeDeployments = new NodeDeployments(this.network, this.chain);
 
-                var chainState = new ChainState(new InvalidBlockHashStore(DateTimeProvider.Default));
+                var chainState = new ChainState();
                 var consensusRules = new SmartContractPowConsensusRuleEngine(this.chain, new Checkpoints(), consensusSettings, dateTimeProvider, this.executorFactory, loggerFactory, this.network, nodeDeployments, this.stateRoot, new ReceiptRepository(), this.cachedCoinView, chainState).Register();
                 this.newBlock = AssemblerForTest(this).Build(this.chain.Tip, this.scriptPubKey);
 

--- a/src/Stratis.Bitcoin.Tests/Base/ChainStateTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Base/ChainStateTest.cs
@@ -30,7 +30,7 @@ namespace Stratis.Bitcoin.Tests.Base
             fullNode.Setup(f => f.NodeService<IDateTimeProvider>(true))
                 .Returns(DateTimeProvider.Default);
 
-            var chainState = new ChainState(new InvalidBlockHashStore(DateTimeProvider.Default));
+            var store = new InvalidBlockHashStore(DateTimeProvider.Default);
 
             // Create some hashes that will be banned forever.
             var hashesBannedPermanently = new uint256[]
@@ -42,7 +42,7 @@ namespace Stratis.Bitcoin.Tests.Base
             };
 
             foreach (uint256 hash in hashesBannedPermanently)
-                chainState.MarkBlockInvalid(hash);
+                store.MarkInvalid(hash);
 
             // Create some hashes that will be banned now, but not in 5 seconds.
             var hashesBannedTemporarily1 = new uint256[]
@@ -54,7 +54,7 @@ namespace Stratis.Bitcoin.Tests.Base
             };
 
             foreach (uint256 hash in hashesBannedTemporarily1)
-                chainState.MarkBlockInvalid(hash, DateTime.UtcNow.AddMilliseconds(rng.Next(2000, 5000)));
+                store.MarkInvalid(hash, DateTime.UtcNow.AddMilliseconds(rng.Next(2000, 5000)));
 
             // Create some hashes that will be banned now and also after 5 seconds.
             var hashesBannedTemporarily2 = new uint256[]
@@ -66,7 +66,7 @@ namespace Stratis.Bitcoin.Tests.Base
             };
 
             foreach (uint256 hash in hashesBannedTemporarily2)
-                chainState.MarkBlockInvalid(hash, DateTime.UtcNow.AddMilliseconds(rng.Next(20000, 50000)));
+                store.MarkInvalid(hash, DateTime.UtcNow.AddMilliseconds(rng.Next(20000, 50000)));
 
             // Check that all hashes we have generated are banned now.
             var allHashes = new List<uint256>(hashesBannedPermanently);
@@ -74,7 +74,7 @@ namespace Stratis.Bitcoin.Tests.Base
             allHashes.AddRange(hashesBannedTemporarily2);
 
             foreach (uint256 hash in allHashes)
-                Assert.True(chainState.IsMarkedInvalid(hash));
+                Assert.True(store.IsInvalid(hash));
 
             // Wait 5 seconds and then check if hashes from first temporary group are no longer banned and all others still are.
             Thread.Sleep(5000);
@@ -83,7 +83,7 @@ namespace Stratis.Bitcoin.Tests.Base
             {
                 uint num = hash.GetLow32();
                 bool isSecondGroup = (0x10 <= num) && (num < 0x20);
-                Assert.Equal(!isSecondGroup, chainState.IsMarkedInvalid(hash));
+                Assert.Equal(!isSecondGroup, store.IsInvalid(hash));
             }
         }
     }

--- a/src/Stratis.Bitcoin.Tests/BlockPulling/BlockPullerTestsHelper.cs
+++ b/src/Stratis.Bitcoin.Tests/BlockPulling/BlockPullerTestsHelper.cs
@@ -45,7 +45,7 @@ namespace Stratis.Bitcoin.Tests.BlockPulling
             this.loggerFactory.AddConsoleWithFilters();
 
             this.CallbacksCalled = new Dictionary<uint256, Block>();
-            this.ChainState = new ChainState(new InvalidBlockHashStore(new DateTimeProvider())) {ConsensusTip = ChainedHeadersHelper.CreateGenesisChainedHeader()};
+            this.ChainState = new ChainState(){ ConsensusTip = ChainedHeadersHelper.CreateGenesisChainedHeader()};
 
             this.Puller = new ExtendedBlockPuller(this.ChainState, new NodeSettings(new StratisMain()), new DateTimeProvider(), this.loggerFactory);
         }

--- a/src/Stratis.Bitcoin.Tests/BlockPulling/BlockPullerTestsHelper.cs
+++ b/src/Stratis.Bitcoin.Tests/BlockPulling/BlockPullerTestsHelper.cs
@@ -45,7 +45,7 @@ namespace Stratis.Bitcoin.Tests.BlockPulling
             this.loggerFactory.AddConsoleWithFilters();
 
             this.CallbacksCalled = new Dictionary<uint256, Block>();
-            this.ChainState = new ChainState(){ ConsensusTip = ChainedHeadersHelper.CreateGenesisChainedHeader()};
+            this.ChainState = new ChainState() {ConsensusTip = ChainedHeadersHelper.CreateGenesisChainedHeader()};
 
             this.Puller = new ExtendedBlockPuller(this.ChainState, new NodeSettings(new StratisMain()), new DateTimeProvider(), this.loggerFactory);
         }

--- a/src/Stratis.Bitcoin.Tests/Consensus/ConsensusTestContext.cs
+++ b/src/Stratis.Bitcoin.Tests/Consensus/ConsensusTestContext.cs
@@ -37,7 +37,7 @@ namespace Stratis.Bitcoin.Tests.Consensus
         public IConsensusManager ConsensusManager;
         public readonly Mock<IConsensusRuleEngine> ConsensusRulesEngine = new Mock<IConsensusRuleEngine>();
         public Mock<IFinalizedBlockInfo> FinalizedBlockMock = new Mock<IFinalizedBlockInfo>();
-        
+
         public readonly Mock<IInitialBlockDownloadState> ibdState = new Mock<IInitialBlockDownloadState>();
         internal ChainedHeader InitialChainTip;
         public Mock<IIntegrityValidator> IntegrityValidator = new Mock<IIntegrityValidator>();
@@ -65,7 +65,8 @@ namespace Stratis.Bitcoin.Tests.Consensus
                 this.Checkpoints.Object,
                 this.ChainState.Object,
                 this.FinalizedBlockMock.Object,
-                this.ConsensusSettings);
+                this.ConsensusSettings,
+                new InvalidBlockHashStore(new DateTimeProvider()));
 
             this.ConsensusManager = CreateConsensusManager();
         }
@@ -102,7 +103,8 @@ namespace Stratis.Bitcoin.Tests.Consensus
                 this.ibdState.Object,
                 new ConcurrentChain(this.Network),
                 new Mock<IBlockPuller>().Object,
-                null);
+                null,
+                new InvalidBlockHashStore(new DateTimeProvider()));
 
             return this.ConsensusManager;
         }

--- a/src/Stratis.Bitcoin.Tests/Consensus/ConsensusTestContext.cs
+++ b/src/Stratis.Bitcoin.Tests/Consensus/ConsensusTestContext.cs
@@ -51,7 +51,8 @@ namespace Stratis.Bitcoin.Tests.Consensus
         {
             var chain = new ConcurrentChain(this.Network);
             var extendedLoggerFactory = new ExtendedLoggerFactory();
-            var powConsensusRulesEngine = new PowConsensusRuleEngine(this.Network, extendedLoggerFactory, DateTimeProvider.Default, chain, new NodeDeployments(this.Network, chain), this.ConsensusSettings, this.Checkpoints.Object, new Mock<ICoinView>().Object, this.ChainState.Object);
+            var powConsensusRulesEngine = new PowConsensusRuleEngine(this.Network, extendedLoggerFactory, DateTimeProvider.Default, chain,
+                new NodeDeployments(this.Network, chain), this.ConsensusSettings, this.Checkpoints.Object, new Mock<ICoinView>().Object, this.ChainState.Object, new InvalidBlockHashStore(new DateTimeProvider()));
 
             this.PartialValidation = new PartialValidator(powConsensusRulesEngine, extendedLoggerFactory);
             this.HeaderValidator = new Mock<IHeaderValidator>();

--- a/src/Stratis.Bitcoin/Base/ChainState.cs
+++ b/src/Stratis.Bitcoin/Base/ChainState.cs
@@ -20,20 +20,6 @@ namespace Stratis.Bitcoin.Base
         /// <summary>Maximal length of reorganization that the node is willing to accept, or 0 to disable long reorganization protection.</summary>
         /// <remarks>TODO: This should be removed once consensus options are part of network.</remarks>
         uint MaxReorgLength { get; set; }
-
-        /// <summary>
-        /// Check if a block is marked as invalid.
-        /// </summary>
-        /// <param name="hashBlock">The block hash to check.</param>
-        /// <returns><c>true</c> if the block is marked as invalid.</returns>
-        bool IsMarkedInvalid(uint256 hashBlock);
-
-        /// <summary>
-        /// Marks a block as invalid. This is used to prevent DOS attacks as the next time the block is seen, it is not processed again.
-        /// </summary>
-        /// <param name="hashBlock">The block hash to mark as invalid.</param>
-        /// <param name="rejectedUntil">Time in UTC after which the block is no longer considered as invalid, or <c>null</c> if the block is to be considered invalid forever.</param>
-        void MarkBlockInvalid(uint256 hashBlock, DateTime? rejectedUntil = null);
     }
 
     /// <summary>
@@ -41,11 +27,9 @@ namespace Stratis.Bitcoin.Base
     /// The data are provided by different components and the chaine state is a mechanism that allows
     /// these components to share that data without creating extra dependencies.
     /// </summary>
+    /// TODO this class should be removed since consensus and block store are moved or about to be moved to base feature
     public class ChainState : IChainState
     {
-        /// <summary>Store of block header hashes that are to be considered invalid.</summary>
-        private readonly IInvalidBlockHashStore invalidBlockHashStore;
-
         /// <inheritdoc />
         public ChainedHeader ConsensusTip { get; set; }
 
@@ -58,26 +42,5 @@ namespace Stratis.Bitcoin.Base
         /// <summary>Maximal length of reorganization that the node is willing to accept, or 0 to disable long reorganization protection.</summary>
         /// <remarks>TODO: This should be removed once consensus options are part of network.</remarks>
         public uint MaxReorgLength { get; set; }
-
-        /// <summary>
-        /// Initialize instance of the object.
-        /// </summary>
-        /// <param name="invalidBlockHashStore">Store of block header hashes that are to be considered invalid.</param>
-        public ChainState(IInvalidBlockHashStore invalidBlockHashStore)
-        {
-            this.invalidBlockHashStore = invalidBlockHashStore;
-        }
-
-        /// <inheritdoc/>
-        public bool IsMarkedInvalid(uint256 hashBlock)
-        {
-            return this.invalidBlockHashStore.IsInvalid(hashBlock);
-        }
-
-        /// <inheritdoc/>
-        public void MarkBlockInvalid(uint256 hashBlock, DateTime? rejectedUntil = null)
-        {
-            this.invalidBlockHashStore.MarkInvalid(hashBlock, rejectedUntil);
-        }
     }
 }

--- a/src/Stratis.Bitcoin/Consensus/ConsensusErrors.cs
+++ b/src/Stratis.Bitcoin/Consensus/ConsensusErrors.cs
@@ -1,5 +1,4 @@
-﻿
-namespace Stratis.Bitcoin.Consensus
+﻿namespace Stratis.Bitcoin.Consensus
 {
     /// <summary>
     /// A class that holds consensus errors.

--- a/src/Stratis.Bitcoin/Consensus/ConsensusErrors.cs
+++ b/src/Stratis.Bitcoin/Consensus/ConsensusErrors.cs
@@ -1,6 +1,5 @@
-﻿using Stratis.Bitcoin.Consensus;
-
-namespace Stratis.Bitcoin.Features.Consensus
+﻿
+namespace Stratis.Bitcoin.Consensus
 {
     /// <summary>
     /// A class that holds consensus errors.
@@ -74,5 +73,7 @@ namespace Stratis.Bitcoin.Features.Consensus
         public static readonly ConsensusError ProofOfWorkTooHigh = new ConsensusError("proof-of-work-too-heigh", "proof of work too high");
 
         public static readonly ConsensusError CheckpointViolation = new ConsensusError("checkpoint-violation", "block header hash does not match the checkpointed value");
+
+        public static readonly ConsensusError BannedHash = new ConsensusError("banned-hash", "block header hash was previously marked invalid");
     }
 }

--- a/src/Stratis.Bitcoin/Consensus/ConsensusManager.cs
+++ b/src/Stratis.Bitcoin/Consensus/ConsensusManager.cs
@@ -97,7 +97,8 @@ namespace Stratis.Bitcoin.Consensus
             IInitialBlockDownloadState ibdState,
             ConcurrentChain chain,
             IBlockPuller blockPuller,
-            IBlockStore blockStore)
+            IBlockStore blockStore,
+            IInvalidBlockHashStore invalidHashesStore)
         {
             this.network = network;
             this.chainState = chainState;
@@ -110,7 +111,7 @@ namespace Stratis.Bitcoin.Consensus
             this.chain = chain;
             this.logger = loggerFactory.CreateLogger(this.GetType().FullName);
 
-            this.chainedHeaderTree = new ChainedHeaderTree(network, loggerFactory, headerValidator, integrityValidator, checkpoints, chainState, finalizedBlockInfo, consensusSettings);
+            this.chainedHeaderTree = new ChainedHeaderTree(network, loggerFactory, headerValidator, integrityValidator, checkpoints, chainState, finalizedBlockInfo, consensusSettings, invalidHashesStore);
 
             this.peerLock = new object();
             this.reorgLock = new AsyncLock();

--- a/src/Stratis.Bitcoin/Consensus/ConsensusManager.cs
+++ b/src/Stratis.Bitcoin/Consensus/ConsensusManager.cs
@@ -353,6 +353,15 @@ namespace Stratis.Bitcoin.Consensus
             {
                 var peersToBan = new List<INetworkPeer>();
 
+                // TODO ACTIVATION implement following (used to be in consensus loop)
+                //if (validationContext.Error == ConsensusErrors.BadWitnessNonceSize)
+                //{
+                //    this.logger.LogInformation("You probably need witness information, activating witness requirement for peers.");
+                //    this.connectionManager.AddDiscoveredNodesRequirement(NetworkPeerServices.NODE_WITNESS);
+                //    this.Puller.RequestOptions(TransactionOptions.Witness);
+                //    return;
+                //}
+
                 lock (this.peerLock)
                 {
                     List<int> peerIdsToBan = this.chainedHeaderTree.PartialOrFullValidationFailed(validationContext.ChainedHeaderToValidate);

--- a/src/Stratis.Bitcoin/Consensus/ConsensusRuleEngine.cs
+++ b/src/Stratis.Bitcoin/Consensus/ConsensusRuleEngine.cs
@@ -240,6 +240,8 @@ namespace Stratis.Bitcoin.Consensus
         {
             this.logger.LogTrace("()");
 
+            // This error will be handled in ConsensusManager.
+            // The block shouldn't be banned because it might be valid, it's just we need to redownload it including witness data.
             if (validationContext.Error == ConsensusErrors.BadWitnessNonceSize)
             {
                 this.logger.LogTrace("(-)[BAD_WITNESS_NONCE]");

--- a/src/Stratis.Bitcoin/Consensus/ConsensusRuleEngine.cs
+++ b/src/Stratis.Bitcoin/Consensus/ConsensusRuleEngine.cs
@@ -227,12 +227,15 @@ namespace Stratis.Bitcoin.Consensus
             {
                 ruleContext.ValidationContext.Error = ex.ConsensusError;
 
-                uint256 hashToBan = ruleContext.ValidationContext.ChainedHeaderToValidate.HashBlock;
+                if (ruleContext.ValidationContext.Error != ConsensusErrors.BadTransactionDuplicate)
+                {
+                    uint256 hashToBan = ruleContext.ValidationContext.ChainedHeaderToValidate.HashBlock;
 
-                if (ruleContext.ValidationContext.RejectUntil != null)
-                    this.invalidBlockHashStore.MarkInvalid(hashToBan, ruleContext.ValidationContext.RejectUntil);
-                else
-                    this.invalidBlockHashStore.MarkInvalid(hashToBan);
+                    if (ruleContext.ValidationContext.RejectUntil != null)
+                        this.invalidBlockHashStore.MarkInvalid(hashToBan, ruleContext.ValidationContext.RejectUntil);
+                    else
+                        this.invalidBlockHashStore.MarkInvalid(hashToBan);
+                }
             }
         }
 

--- a/src/Stratis.Bitcoin/Consensus/Validators/BlockValidator.cs
+++ b/src/Stratis.Bitcoin/Consensus/Validators/BlockValidator.cs
@@ -3,7 +3,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using NBitcoin;
-using Stratis.Bitcoin.Primitives;
 using Stratis.Bitcoin.Utilities;
 
 namespace Stratis.Bitcoin.Consensus.Validators
@@ -57,7 +56,6 @@ namespace Stratis.Bitcoin.Consensus.Validators
         /// <remarks>
         /// This validation represents minimal required validation for every block that we download.
         /// It should be performed even if the block is behind last checkpoint or part of assume valid chain.
-        /// TODO specify what exceptions are thrown (add throws xmldoc)
         /// </remarks>
         /// <param name="header">The chained header that is going to be validated.</param>
         /// <param name="block">The block that is going to be validated.</param>


### PR DESCRIPTION
Removed `IsMarkedInvalid` and `MarkBlockInvalid` from `ChainState` because now we can access `IInvalidBlockStore` from consensus validation code. 
Instead started using there an instance of `IInvalidBlockStore` directly

Moved `ConsensusErrors` to Stratis.Bitcoin.Consensus and added there one more error for cases when hash was already banned

In `CHT.CreateAndValidateNewChainedHeader` check hash against banned hashes before we create chained header. If it's there- throw.

In `ConsensusRuleEngine` add hash of invalid block to banned hashes

Fix: #2014