### PR TITLE
Validate Block Based On Public Key Extracted From CoinStake Output

### DIFF
--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/CommonRules/PosBlockSignatureRuleTest.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/CommonRules/PosBlockSignatureRuleTest.cs
@@ -281,7 +281,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
         }
 
         /// <summary>
-        /// This helper creates a cold coin staking block containing a cold coin staking transaction built according to
+        /// This helper creates a coin staking block containing a coin staking transaction built according to
         /// the parameters and with valid first input and output. The block signature is created correctly with the
         /// private key corresponding to the public key.
         /// </summary>
@@ -290,7 +290,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
         /// <param name="includeSecondPush">Determines whether the second transaction output will include a small integer
         /// after the public key.</param>
         /// <param name="expectFailure">Determines whether we expect failure (versus success).</param>
-        private void ProofOfStakeBlock_ColdStakeTestHelper(bool useCompressedKey, bool includeSecondPush, bool expectFailure)
+        private void ProofOfStakeBlock_CoinStakeTestHelper(bool useCompressedKey, bool includeSecondPush, bool expectFailure)
         {
             Block block = KnownNetworks.StratisMain.Consensus.ConsensusFactory.CreateBlock();
 
@@ -345,9 +345,9 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
         /// with the block signature correctly created with the corresponding private key expect success.
         /// </summary>
         [Fact]
-        public async Task ProofOfStakeBlock_ValidColdStakeBlockDoesNotThrowExceptionAsync()
+        public async Task ProofOfStakeBlock_ValidCoinStakeBlockDoesNotThrowExceptionAsync()
         {
-            ProofOfStakeBlock_ColdStakeTestHelper(useCompressedKey: true, includeSecondPush: false, expectFailure: false);
+            ProofOfStakeBlock_CoinStakeTestHelper(useCompressedKey: true, includeSecondPush: false, expectFailure: false);
         }
 
         /// <summary>
@@ -355,9 +355,9 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
         /// with the block signature correctly created with the corresponding private key expect failure.
         /// </summary>
         [Fact]
-        public async Task ProofOfStakeBlock_ValidColdStakeBlockExceptUncompressedKeyThrowsExceptionAsync()
+        public async Task ProofOfStakeBlock_ValidCoinStakeBlockExceptUncompressedKeyThrowsExceptionAsync()
         {
-            ProofOfStakeBlock_ColdStakeTestHelper(useCompressedKey: false, includeSecondPush: false, expectFailure: true);
+            ProofOfStakeBlock_CoinStakeTestHelper(useCompressedKey: false, includeSecondPush: false, expectFailure: true);
         }
 
         /// <summary>
@@ -366,9 +366,9 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
         /// expect failure.
         /// </summary>
         [Fact]
-        public async Task ProofOfStakeBlock_ValidColdStakeBlockExceptExtraPushThrowsExceptionAsync()
+        public async Task ProofOfStakeBlock_ValidCoinStakeBlockExceptExtraPushThrowsExceptionAsync()
         {
-            ProofOfStakeBlock_ColdStakeTestHelper(useCompressedKey: true, includeSecondPush: true, expectFailure: true);
+            ProofOfStakeBlock_CoinStakeTestHelper(useCompressedKey: true, includeSecondPush: true, expectFailure: true);
         }
     }
 }

--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/CommonRules/PosBlockSignatureRuleTest.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/CommonRules/PosBlockSignatureRuleTest.cs
@@ -230,34 +230,6 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
         }
 
         [Fact]
-        public async Task RunAsync_ProofOfStakeBlock_ScriptKeyPassesBlockSignatureValidation_DoesNotThrowExceptionAsync()
-        {
-            Block block = KnownNetworks.StratisMain.Consensus.ConsensusFactory.CreateBlock();
-            block.Transactions.Add(KnownNetworks.StratisMain.CreateTransaction());
-
-            Transaction transaction = KnownNetworks.StratisMain.CreateTransaction();
-            transaction.Inputs.Add(new TxIn()
-            {
-                PrevOut = new OutPoint(new uint256(15), 1),
-                ScriptSig = new Script()
-            });
-
-            transaction.Outputs.Add(new TxOut(Money.Zero, (IDestination)null));
-            // push op_return to note external dependancy in front of pay to pubkey script so it does not match pay to pubkey template.
-            var scriptPubKeyOut = new Script(OpcodeType.OP_RETURN, Op.GetPushOp(this.key.PubKey.ToBytes(true)), OpcodeType.OP_CHECKSIG);
-            transaction.Outputs.Add(new TxOut(Money.Zero, scriptPubKeyOut));
-            block.Transactions.Add(transaction);
-
-            ECDSASignature signature = this.key.Sign(block.GetHash());
-            (block as PosBlock).BlockSignature = new BlockSignature { Signature = signature.ToDER() };
-
-            this.ruleContext.ValidationContext.Block = block;
-            Assert.True(BlockStake.IsProofOfStake(this.ruleContext.ValidationContext.Block));
-
-            await this.consensusRules.RegisterRule<PosBlockSignatureRule>().RunAsync(this.ruleContext);
-        }
-
-        [Fact]
         public async Task RunAsync_ProofOfStakeBlock_PayToPubKeyScriptPassesBlockSignatureValidation_DoesNotThrowExceptionAsync()
         {
             Block block = KnownNetworks.StratisMain.Consensus.ConsensusFactory.CreateBlock();

--- a/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/PosBlockSignatureRule.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/PosBlockSignatureRule.cs
@@ -91,7 +91,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Rules.CommonRules
 
             if (ops.Count != 2)
             {
-                this.Logger.LogTrace("(-)[NO_SECOND_OP]:false");
+                this.Logger.LogTrace("(-)[INVALID_OP_COUNT]:false");
                 return false;
             }
 

--- a/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/PosBlockSignatureRule.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/PosBlockSignatureRule.cs
@@ -16,6 +16,9 @@ namespace Stratis.Bitcoin.Features.Consensus.Rules.CommonRules
     [IntegrityValidationRule]
     public class PosBlockSignatureRule : StakeStoreConsensusRule
     {
+        /// <summary>When checking the POS block signature this determines the maximum push data (public key) size following the OP_RETURN in the nonspendable output.</summary>
+        private const int MaxPushDataSize = 40;
+
         /// <inheritdoc />
         /// <exception cref="ConsensusErrors.BadBlockSignature">The block signature is invalid.</exception>
         public override Task RunAsync(RuleContext context)
@@ -86,13 +89,20 @@ namespace Stratis.Bitcoin.Features.Consensus.Rules.CommonRules
                 return false;
             }
 
-            if (ops.Count < 2) // script.GetOp(pc, opcode, vchPushValue)
+            if (ops.Count != 2)
             {
                 this.Logger.LogTrace("(-)[NO_SECOND_OP]:false");
                 return false;
             }
 
             byte[] data = ops.ElementAt(1).PushData;
+
+            if (data.Length > MaxPushDataSize)
+            {
+                this.Logger.LogTrace("(-)[PUSH_DATA_TOO_LARGE]:false");
+                return false;
+            }
+
             if (!ScriptEvaluationContext.IsCompressedOrUncompressedPubKey(data))
             {
                 this.Logger.LogTrace("(-)[NO_PUSH_DATA]:false");

--- a/src/Stratis.Bitcoin.Features.SmartContracts/Consensus/Rules/SmartContractPosBlockSignatureRule.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts/Consensus/Rules/SmartContractPosBlockSignatureRule.cs
@@ -42,6 +42,7 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Consensus.Rules
 
         /// <summary>
         /// Checks if block signature is valid.
+        /// TODO: Update this code to reflect changes made to the corresponding method in <see cref="Features.Consensus.Rules.CommonRules.PosBlockSignatureRule"/>.
         /// </summary>
         /// <param name="block">The block.</param>
         /// <returns><c>true</c> if the signature is valid, <c>false</c> otherwise.</returns>


### PR DESCRIPTION
Verify the exact number of opcodes and the maximum size of the data following an OP_RETURN in the (optional) special second output of coin stake transactions.