### PR TITLE
Make fee estimate conditional on whether blocks are full

### DIFF
--- a/src/Stratis.Bitcoin.Features.Wallet.Tests/WalletFeePolicyTest.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet.Tests/WalletFeePolicyTest.cs
@@ -1,0 +1,92 @@
+﻿using System;
+using Moq;
+using NBitcoin;
+using Stratis.Bitcoin.Configuration;
+using Stratis.Bitcoin.Features.BlockStore;
+using Stratis.Bitcoin.Tests.Common;
+using Stratis.Bitcoin.Tests.Common.Logging;
+using Xunit;
+
+namespace Stratis.Bitcoin.Features.Wallet.Tests
+{
+    public class WalletFeePolicyTest : LogsTestBase
+    {
+        private const int blocksInChainCount = 3;
+        private const int notEmptyTxCount = 10;
+
+        /// <summary>
+        /// Tests GetFeeRate return min relay fee rate if blocks are empty.
+        /// Mock out to return block with only 1 tx.
+        /// </summary>
+        [Fact]
+        public void GetFeeRateWithEmptyBlocksReturnsMinRelayFee()
+        {
+            DataFolder dataFolder = CreateDataFolder(this);
+            var nodeSettings = NodeSettings.Default();
+
+            var chain = this.GetMockChain();
+
+            var blockRepoMock = new Mock<IBlockRepository>();
+            var block = this.Network.CreateBlock(); 
+            block.AddTransaction(new Transaction());
+            block.UpdateMerkleRoot();
+            block.Header.HashPrevBlock = chain.Genesis.HashBlock;
+            block.Header.Nonce = RandomUtils.GetUInt32();
+            block.Header.BlockTime = DateTimeOffset.Now;
+            blockRepoMock.Setup(m => m.GetAsync(It.IsAny<uint256>()))
+                .ReturnsAsync(block);
+
+            WalletFeePolicy walletFeePolicy = new WalletFeePolicy(nodeSettings, chain, blockRepoMock.Object, this.LoggerFactory.Object);
+            Assert.Equal(nodeSettings.MinRelayTxFeeRate, walletFeePolicy.GetFeeRate(20));
+        }
+
+        /// <summary>
+        /// Tests GetFeeRate return fallback fee rate if blocks are not empty.
+        /// Mock out to return block with 10 tx.
+        /// </summary>
+        [Fact]
+        public void GetFeeRateWithNotEmptyBlocksReturnsFallbackFee()
+        {
+            DataFolder dataFolder = CreateDataFolder(this);
+            var nodeSettings = NodeSettings.Default();
+
+            var chain = this.GetMockChain();
+
+            var blockRepoMock = new Mock<IBlockRepository>();
+            var block = this.Network.CreateBlock();
+            for (int i = 0; i < notEmptyTxCount; i++)
+            {
+                block.AddTransaction(new Transaction());
+            }
+            block.UpdateMerkleRoot();
+            block.Header.HashPrevBlock = chain.Genesis.HashBlock;
+            block.Header.Nonce = RandomUtils.GetUInt32();
+            block.Header.BlockTime = DateTimeOffset.Now;
+            blockRepoMock.Setup(m => m.GetAsync(It.IsAny<uint256>()))
+                .ReturnsAsync(block);        
+
+            WalletFeePolicy walletFeePolicy = new WalletFeePolicy(nodeSettings, chain, blockRepoMock.Object, this.LoggerFactory.Object);
+            Assert.Equal(nodeSettings.FallbackTxFeeRate, walletFeePolicy.GetFeeRate(20));
+        }
+
+        private ConcurrentChain GetMockChain()
+        {
+            var chain = new ConcurrentChain(KnownNetworks.StratisMain);
+
+            uint256 prevBlockHash = chain.Genesis.HashBlock;
+            for (int i = 0; i < blocksInChainCount; i++)
+            {
+                var block = this.Network.CreateBlock();
+                block.AddTransaction(new Transaction());
+                block.UpdateMerkleRoot();
+                block.Header.HashPrevBlock = prevBlockHash;
+                block.Header.Nonce = RandomUtils.GetUInt32();
+                block.Header.BlockTime = DateTimeOffset.Now;
+                chain.SetTip(block.Header);
+                prevBlockHash = block.GetHash();
+            }
+
+            return chain;
+        }
+    }
+}

--- a/src/Stratis.Bitcoin.Features.Wallet/WalletFeePolicy.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/WalletFeePolicy.cs
@@ -1,6 +1,9 @@
 ﻿using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using NBitcoin;
 using Stratis.Bitcoin.Configuration;
+using Stratis.Bitcoin.Features.BlockStore;
 using Stratis.Bitcoin.Features.Wallet.Interfaces;
 
 namespace Stratis.Bitcoin.Features.Wallet
@@ -33,17 +36,35 @@ namespace Stratis.Bitcoin.Features.Wallet
         /// </summary>
         private readonly FeeRate minRelayTxFee;
 
+        /// <summary>Header chain.</summary>
+        private readonly ConcurrentChain chainState;
+
+        /// <summary>Repository containing blocks.</summary>
+        private readonly IBlockRepository blockRepository;
+
+        /// <summary>Instance logger.</summary>
+        private readonly ILogger logger;
+
         /// <summary>
         /// Constructs a wallet fee policy.
         /// </summary>
         /// <param name="nodeSettings">Settings for the the node.</param>
-        public WalletFeePolicy(NodeSettings nodeSettings)
+        /// <param name="chain">Header chain.</param>
+        /// <param name="blockRepository">Repository containing blocks.</param>
+        /// <param name="loggerFactory">Factory for creating instance logger.</param>
+        public WalletFeePolicy( NodeSettings nodeSettings,                                 
+                                ConcurrentChain chain,
+                                IBlockRepository blockRepository,
+                                ILoggerFactory loggerFactory)
         {
             this.minTxFee = nodeSettings.MinTxFeeRate;
             this.fallbackFee = nodeSettings.FallbackTxFeeRate;
             this.payTxFee = new FeeRate(0);
             this.maxTxFee = new Money(0.1M, MoneyUnit.BTC);
             this.minRelayTxFee = nodeSettings.MinRelayTxFeeRate;
+            this.logger = loggerFactory.CreateLogger(this.GetType().FullName);
+            this.chainState = chain;
+            this.blockRepository = blockRepository;
         }
 
         /// <inheritdoc />
@@ -74,6 +95,8 @@ namespace Stratis.Bitcoin.Features.Wallet
         /// <inheritdoc />
         public Money GetMinimumFee(int txBytes, int confirmTarget, Money targetFee)
         {
+            this.logger.LogTrace("({0}:{1},{2}:{3},{4}:{5})", nameof(txBytes), txBytes, nameof(confirmTarget), confirmTarget, nameof(targetFee), targetFee);
+
             Money nFeeNeeded = targetFee;
             // User didn't set: use -txconfirmtarget to estimate...
             if (nFeeNeeded == 0)
@@ -91,14 +114,64 @@ namespace Stratis.Bitcoin.Features.Wallet
             // But always obey the maximum
             if (nFeeNeeded > this.maxTxFee)
                 nFeeNeeded = this.maxTxFee;
+
+            this.logger.LogTrace("():{0}", nFeeNeeded);
             return nFeeNeeded;
         }
 
         /// <inheritdoc />
         public FeeRate GetFeeRate(int confirmTarget)
         {
+            this.logger.LogTrace("({0}:{1})", nameof(confirmTarget), confirmTarget);
+
+            // Maximum number of blocks to check empty state.
+            const int maxBlockCount = 3;
+
+            // Minimum number of transactions required in a block to consider it not empty.
+            const int minTxCount = 5;
+
             //this.blockPolicyEstimator.EstimateSmartFee(confirmTarget, this.mempool, out estimateFoundTarget).GetFee(txBytes);
-            return this.fallbackFee;
+            FeeRate feeRate = this.AreBlocksEmptyAsync(maxBlockCount, minTxCount).GetAwaiter().GetResult() ?  this.minRelayTxFee : this.fallbackFee;
+            this.logger.LogTrace("():{0}", feeRate);
+            return feeRate;
+        }
+
+        /// <summary>
+        /// Identifies whether the last <paramref name="maxBlockCount"/> blocks are empty
+        /// based on blocks transaction count being greater than <paramref name="minTxCount"/> 
+        /// to determine if they are empty are not.
+        /// </summary>
+        /// <param name="maxBlockCount">Number of blocks to check.</param>
+        /// <param name="minTxCount">Minimum number of transaction in a block to consider it not empty.</param>
+        /// <returns>Whether recent blocks are empty.</returns>
+        private async Task<bool> AreBlocksEmptyAsync(int maxBlockCount, int minTxCount)
+        {
+            this.logger.LogTrace("({0}:{1},{2}:{3})", nameof(maxBlockCount), maxBlockCount, nameof(minTxCount), minTxCount);
+            var headers = this.chainState.ToEnumerable(true);
+            
+            int blockCount = 0;
+
+            bool isBlockEmpty = true;
+            foreach (ChainedHeader header in headers)
+            {
+                if (blockCount >= maxBlockCount || !isBlockEmpty)
+                    break;
+
+                Block block = header.Block;
+                if (block == null)
+                    block = await this.blockRepository.GetAsync(header.HashBlock);
+
+                if (block != null)
+                {
+                    if (block.Transactions.Count >= minTxCount)
+                        isBlockEmpty = false;
+
+                    blockCount++;
+                }
+            }
+
+            this.logger.LogTrace("():{0}", isBlockEmpty);
+            return isBlockEmpty;
         }
     }
 }


### PR DESCRIPTION
Fixes #1283 

Will look at number of transaction in last 3 blocks to determine whether to use minRelayTxFee (0.0001) or fallbackTxFee *0.0006) rate for fee estimation on full node wallet.

Have tested with FullNodeUI wallet on testnet, with empty blocks.