### PR TITLE
[SC] Remove unused fields on TransactionContext

### DIFF
--- a/src/Stratis.Bitcoin.Features.SmartContracts.Tests/ExecutorSpecification.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts.Tests/ExecutorSpecification.cs
@@ -22,11 +22,10 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Tests
             var gasConsumed = (Gas) 100;
             var code = new byte[] {0xAA, 0xBB, 0xCC};
             var contractTxData = new ContractTxData(1, 1, (Gas) 1000, code);
-            var script = new Script(code);
             var refund = new Money(0);
             const ulong mempoolFee = 2UL; // MOQ doesn't like it when you use a type with implicit conversions (Money)
             ISmartContractTransactionContext context = Mock.Of<ISmartContractTransactionContext>(c => 
-                c.ScriptPubKey == script &&
+                c.Data == code &&
                 c.MempoolFee == mempoolFee &&
                 c.Sender == uint160.One);
 

--- a/src/Stratis.SmartContracts.Core/ISmartContractTransactionContext.cs
+++ b/src/Stratis.SmartContracts.Core/ISmartContractTransactionContext.cs
@@ -45,16 +45,6 @@ namespace Stratis.SmartContracts.Core
         ulong BlockHeight { get; }
 
         /// <summary>
-        /// Whether this transaction is creating a new contract.
-        /// </summary>
-        bool IsCreate { get; }
-
-        /// <summary>
-        /// Whether this transaction is calling a method on a contract.
-        /// </summary>
-        bool IsCall { get; }
-
-        /// <summary>
         /// Time as set on transaction.
         /// </summary>
         uint Time { get; }

--- a/src/Stratis.SmartContracts.Core/ISmartContractTransactionContext.cs
+++ b/src/Stratis.SmartContracts.Core/ISmartContractTransactionContext.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using NBitcoin;
+﻿using NBitcoin;
 
 namespace Stratis.SmartContracts.Core
 {
@@ -26,14 +25,9 @@ namespace Stratis.SmartContracts.Core
         uint Nvout { get; }
 
         /// <summary>
-        /// All of the bytes included in the script after the create or call opcode.
+        /// The raw data provided as part of the transaction.
         /// </summary>
-        IEnumerable<byte> ContractData { get; }
-
-        /// <summary>
-        /// The script pub key
-        /// </summary>
-        Script ScriptPubKey { get; }
+        byte[] Data { get; }
 
         /// <summary>
         /// Total fee for transaction.

--- a/src/Stratis.SmartContracts.Core/SmartContractTransactionContext.cs
+++ b/src/Stratis.SmartContracts.Core/SmartContractTransactionContext.cs
@@ -19,18 +19,6 @@ namespace Stratis.SmartContracts.Core
         private readonly Money mempoolFee;
 
         /// <inheritdoc />
-        public bool IsCreate
-        {
-            get { return this.contractTxOut.ScriptPubKey.IsSmartContractCreate(); }
-        }
-
-        /// <inheritdoc />
-        public bool IsCall
-        {
-            get { return this.contractTxOut.ScriptPubKey.IsSmartContractCall(); }
-        }
-
-        /// <inheritdoc />
         public uint256 TransactionHash
         {
             get { return this.transaction.GetHash(); }

--- a/src/Stratis.SmartContracts.Core/SmartContractTransactionContext.cs
+++ b/src/Stratis.SmartContracts.Core/SmartContractTransactionContext.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Linq;
+﻿using System.Linq;
 using NBitcoin;
 using Stratis.Bitcoin.Utilities;
 
@@ -56,12 +55,10 @@ namespace Stratis.SmartContracts.Core
         }
 
         /// <inheritdoc />
-        public IEnumerable<byte> ContractData
+        public byte[] Data
         {
-            get { return this.contractTxOut.ScriptPubKey.ToBytes().Skip(1); }
+            get { return this.contractTxOut.ScriptPubKey.ToBytes(); }
         }
-
-        public Script ScriptPubKey => this.contractTxOut.ScriptPubKey;
 
         /// <inheritdoc />
         public Money MempoolFee

--- a/src/Stratis.SmartContracts.Executor.Reflection/Executor.cs
+++ b/src/Stratis.SmartContracts.Executor.Reflection/Executor.cs
@@ -44,7 +44,7 @@ namespace Stratis.SmartContracts.Executor.Reflection
             this.logger.LogTrace("()");
 
             // Deserialization can't fail because this has already been through SmartContractFormatRule.
-            Result<ContractTxData> callDataDeserializationResult = this.serializer.Deserialize(transactionContext.ScriptPubKey.ToBytes());
+            Result<ContractTxData> callDataDeserializationResult = this.serializer.Deserialize(transactionContext.Data);
             ContractTxData callData = callDataDeserializationResult.Value;
 
             var gasMeter = new GasMeter(callData.GasLimit);


### PR DESCRIPTION
Removes some unused fields on TransactionContext. Changes the Type of the contract transaction data to be bytes rather than having to pull them from the Script.