### PR TITLE
Initial block weight depends on Network.

### DIFF
--- a/src/Stratis.Bitcoin.Features.Miner/BlockDefinition.cs
+++ b/src/Stratis.Bitcoin.Features.Miner/BlockDefinition.cs
@@ -170,7 +170,7 @@ namespace Stratis.Bitcoin.Features.Miner
             this.BlockSize = 1000;
             this.BlockTemplate = new BlockTemplate(this.Network);
             this.BlockTx = 0;
-            this.BlockWeight = 4000;
+            this.BlockWeight = 1000 * this.Network.Consensus.Options.WitnessScaleFactor;
             this.BlockSigOpsCost = 400;
             this.fees = 0;
             this.inBlock = new TxMempool.SetEntries();


### PR DESCRIPTION
Setting the initial block weight to 4000 in the BlockDefinition works for the Bitcoin network, but it does not make sense for any networks without weighting (i.e. WitnessScaleFactor=1) such as Stratis. 

The result without this change would just be that blocks mined via the C# node have a maximum of BlockSize - 3KB (4000 - 1000).

This change also makes it much easier for us to write certain test cases in SC :)