### PR TITLE
Virtuals for testing

### DIFF
--- a/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/CoinviewRule.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/CoinviewRule.cs
@@ -400,7 +400,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Rules.CommonRules
         /// <param name="block">Block that we get weight of.</param>
         /// <returns>Block weight.</returns>
         /// TODO: this is a duplicate of the same method in BlockSizeRule <see cref="BlockSizeRule.GetBlockWeight"/>
-        public long GetBlockWeight(Block block)
+        public virtual long GetBlockWeight(Block block)
         {
             return this.GetSize(block, TransactionOptions.None)
                    * (this.ConsensusOptions.WitnessScaleFactor - 1)

--- a/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/HeaderVersionRule.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/HeaderVersionRule.cs
@@ -1,13 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
-using System.Threading.Tasks;
-using Microsoft.Extensions.Logging;
 using NBitcoin;
 using Stratis.Bitcoin.Base.Deployments;
 using Stratis.Bitcoin.Consensus.Rules;
-using Stratis.Bitcoin.Utilities;
 
 namespace Stratis.Bitcoin.Features.Consensus.Rules.CommonRules
 {
@@ -22,7 +18,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Rules.CommonRules
         /// <remarks>This method is currently used during block creation only. Different nodes may not implement
         /// BIP9, or may disagree about what the current valid set of deployments are. It is therefore not strictly
         /// possible to validate a block version number in anything more than general terms.</remarks>
-        public int ComputeBlockVersion(ChainedHeader prevChainedHeader)
+        public virtual int ComputeBlockVersion(ChainedHeader prevChainedHeader)
         {
             uint version = ThresholdConditionCache.VersionbitsTopBits;
             var thresholdConditionCache = new ThresholdConditionCache(this.Parent.Network.Consensus);

--- a/src/Stratis.Bitcoin.Features.Miner/MinerSettings.cs
+++ b/src/Stratis.Bitcoin.Features.Miner/MinerSettings.cs
@@ -64,7 +64,7 @@ namespace Stratis.Bitcoin.Features.Miner
         /// <summary>
         /// Settings for <see cref="BlockDefinition"/>.
         /// </summary>
-        public virtual BlockDefinitionOptions BlockDefinitionOptions { get; }
+        public BlockDefinitionOptions BlockDefinitionOptions { get; }
 
         /// <summary>
         /// Initializes an instance of the object from the default configuration.

--- a/src/Stratis.Bitcoin.Features.Miner/MinerSettings.cs
+++ b/src/Stratis.Bitcoin.Features.Miner/MinerSettings.cs
@@ -64,7 +64,7 @@ namespace Stratis.Bitcoin.Features.Miner
         /// <summary>
         /// Settings for <see cref="BlockDefinition"/>.
         /// </summary>
-        public BlockDefinitionOptions BlockDefinitionOptions { get; }
+        public virtual BlockDefinitionOptions BlockDefinitionOptions { get; }
 
         /// <summary>
         /// Initializes an instance of the object from the default configuration.


### PR DESCRIPTION
Hey guys, the retrieval of concrete classes in the BlockDefinition isn't really conducive to testing, but we can get around it if we mark the given methods virtual. 

Hopefully this is okay!

