### PR TITLE
[Activation] Remove block mined from context

### DIFF
--- a/src/Stratis.Bitcoin.Features.BlockStore.Tests/BlockStoreTests.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore.Tests/BlockStoreTests.cs
@@ -365,7 +365,6 @@ namespace Stratis.Bitcoin.Features.BlockStore.Tests
             await WaitUntilQueueIsEmptyAsync().ConfigureAwait(false);
 
             // Make sure chain is saved.
-            Assert.Equal(2, this.repositorySavesCount);
             Assert.Equal(this.chain.Tip.Height + alternativeBlocks.Count, this.repositoryTotalBlocksSaved);
             Assert.Equal(alternativeBlocks.Count, this.repositoryTotalBlocksDeleted);
 

--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/CommonRules/CalculateStakeRuleTest.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/CommonRules/CalculateStakeRuleTest.cs
@@ -51,41 +51,6 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
         }
 
         [Fact]
-        public async Task RunAsync_ProofOfWorkBlock_DoNotCheckPow_SetsStake_SetsNextWorkRequiredAsync()
-        {
-            Block block = this.network.CreateBlock();
-            Transaction transaction = this.network.CreateTransaction();
-            block.AddTransaction(transaction);
-
-            this.ruleContext.ValidationContext = new ValidationContext()
-            {
-                BlockToValidate = block,
-                ChainedHeaderToValidate = this.concurrentChain.GetBlock(4)
-            };
-
-            var target = new Target(0x1f111115);
-            this.ruleContext.ValidationContext.BlockToValidate.Header.Bits = target;
-
-            this.stakeValidator.Setup(s => s.GetNextTargetRequired(
-                this.stakeChain.Object,
-                this.concurrentChain.GetBlock(3),
-                this.network.Consensus,
-                false))
-                .Returns(target)
-                .Verifiable();
-
-            await this.consensusRules.RegisterRule<CheckDifficultykHybridRule>().RunAsync(this.ruleContext);
-
-            this.stakeValidator.Verify();
-            Assert.NotNull(this.ruleContext as PosRuleContext);
-            Assert.Equal(0, (int)(this.ruleContext as PosRuleContext).BlockStake.Flags);
-            Assert.Equal(uint256.Zero, (this.ruleContext as PosRuleContext).BlockStake.StakeModifierV2);
-            Assert.Equal(uint256.Zero, (this.ruleContext as PosRuleContext).BlockStake.HashProof);
-            Assert.Equal((uint)0, (this.ruleContext as PosRuleContext).BlockStake.StakeTime);
-            Assert.Null((this.ruleContext as PosRuleContext).BlockStake.PrevoutStake);
-        }
-
-        [Fact]
         public async Task RunAsync_ProofOfWorkBlock_CheckPow_ValidPow_SetsStake_SetsNextWorkRequiredAsync()
         {
             this.network = KnownNetworks.RegTest;

--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/CommonRules/CalculateStakeRuleTest.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/CommonRules/CalculateStakeRuleTest.cs
@@ -62,7 +62,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
                 BlockToValidate = block,
                 ChainedHeaderToValidate = this.concurrentChain.GetBlock(4)
             };
-            this.ruleContext.MinedBlock = true;
+
             var target = new Target(0x1f111115);
             this.ruleContext.ValidationContext.BlockToValidate.Header.Bits = target;
 
@@ -97,7 +97,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
                 BlockToValidate = TestRulesContextFactory.MineBlock(this.network, this.concurrentChain),
                 ChainedHeaderToValidate = this.concurrentChain.Tip
             };
-            this.ruleContext.MinedBlock = false;
+
             var target = this.ruleContext.ValidationContext.BlockToValidate.Header.Bits;
 
             this.stakeValidator.Setup(s => s.GetNextTargetRequired(
@@ -131,7 +131,6 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
                 BlockToValidate = block,
                 ChainedHeaderToValidate = this.concurrentChain.GetBlock(4)
             };
-            this.ruleContext.MinedBlock = false;
 
             ConsensusErrorException exception = await Assert.ThrowsAsync<ConsensusErrorException>(() => this.consensusRules.RegisterRule<CheckDifficultykHybridRule>().RunAsync(this.ruleContext));
 

--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/CommonRules/CalculateWorkRuleTest.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/CommonRules/CalculateWorkRuleTest.cs
@@ -32,14 +32,13 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
         [Fact]
         public void Run_ProofOfWorkBlock_CheckPow_InValidPow_ThrowsBadDiffBitsConsensusErrorException()
         {
-            Block block = this.network.CreateBlock();
+            Block block = TestRulesContextFactory.MineBlock(KnownNetworks.RegTest, this.concurrentChain);
 
             this.ruleContext.ValidationContext = new ValidationContext()
             {
                 BlockToValidate = block,
                 ChainedHeaderToValidate = new ChainedHeader(block.Header, block.Header.GetHash(), this.concurrentChain.GetBlock(block.Header.HashPrevBlock))
             };
-            block.Header.Bits = this.ruleContext.ValidationContext.ChainedHeaderToValidate.GetWorkRequired(this.network.Consensus) + 1;
 
             var exception = Assert.Throws<ConsensusErrorException>(() =>
                 this.consensusRules.RegisterRule<CheckDifficultyPowRule>().Run(this.ruleContext));

--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/CommonRules/CalculateWorkRuleTest.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/CommonRules/CalculateWorkRuleTest.cs
@@ -22,7 +22,6 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
                 BlockToValidate = block,
                 ChainedHeaderToValidate = this.concurrentChain.GetBlock(4)
             };
-            this.ruleContext.MinedBlock = false;
 
             var exception = Assert.Throws<ConsensusErrorException>(() =>
                 this.consensusRules.RegisterRule<CheckDifficultyPowRule>().Run(this.ruleContext));
@@ -41,8 +40,6 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
                 ChainedHeaderToValidate = new ChainedHeader(block.Header, block.Header.GetHash(), this.concurrentChain.GetBlock(block.Header.HashPrevBlock))
             };
             block.Header.Bits = this.ruleContext.ValidationContext.ChainedHeaderToValidate.GetWorkRequired(this.network.Consensus) + 1;
-
-            this.ruleContext.MinedBlock = true;
 
             var exception = Assert.Throws<ConsensusErrorException>(() =>
                 this.consensusRules.RegisterRule<CheckDifficultyPowRule>().Run(this.ruleContext));

--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/TestChainFactory.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/TestChainFactory.cs
@@ -144,7 +144,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests
             testChainContext.Consensus = new ConsensusManager(network, testChainContext.LoggerFactory, testChainContext.ChainState, testChainContext.HeaderValidator, testChainContext.IntegrityValidator,
                 testChainContext.PartialValidator, testChainContext.FullValidator, testChainContext.Checkpoints, consensusSettings, testChainContext.ConsensusRules, testChainContext.FinalizedBlockInfo, new Signals.Signals(),
                 testChainContext.PeerBanning, testChainContext.InitialBlockDownloadState, testChainContext.Chain, new Mock<IBlockPuller>().Object, blockStore,
-                new InvalidBlockHashStore(new DateTimeProvider()), new Mock<ConnectionManager>().Object);
+                new InvalidBlockHashStore(new DateTimeProvider()), new Mock<IConnectionManager>().Object);
 
             await testChainContext.Consensus.InitializeAsync(testChainContext.Chain.Tip);
 

--- a/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/BlockMerkleRootRule.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/BlockMerkleRootRule.cs
@@ -31,9 +31,6 @@ namespace Stratis.Bitcoin.Features.Consensus.Rules.CommonRules
         /// <exception cref="ConsensusErrors.BadTransactionDuplicate">One of the leaf nodes on the merkle tree has a duplicate hash within the subtree.</exception>
         public override void Run(RuleContext context)
         {
-            if (context.MinedBlock)
-                return;
-
             Block block = context.ValidationContext.BlockToValidate;
 
             uint256 hashMerkleRoot2 = BlockMerkleRoot(block, out bool mutated);

--- a/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/CheckDifficultyPowRule.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/CheckDifficultyPowRule.cs
@@ -12,7 +12,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Rules.CommonRules
         /// <exception cref="ConsensusErrors.HighHash"> Thrown if block doesn't have a valid PoS header.</exception>
         public override void Run(RuleContext context)
         {
-            if (!context.MinedBlock && !context.ValidationContext.ChainedHeaderToValidate.Header.CheckProofOfWork())
+            if (!context.ValidationContext.ChainedHeaderToValidate.Header.CheckProofOfWork())
                 ConsensusErrors.HighHash.Throw();
 
             Target nextWorkRequired = context.ValidationContext.ChainedHeaderToValidate.GetWorkRequired(this.Parent.Network.Consensus);

--- a/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/CheckDifficultykHybridRule.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/CheckDifficultykHybridRule.cs
@@ -35,14 +35,14 @@ namespace Stratis.Bitcoin.Features.Consensus.Rules.CommonRules
 
             if (posRuleContext.BlockStake.IsProofOfWork())
             {
-                if (!context.MinedBlock && !context.ValidationContext.BlockToValidate.Header.CheckProofOfWork())
+                if (!context.ValidationContext.BlockToValidate.Header.CheckProofOfWork())
                 {
                     this.Logger.LogTrace("(-)[HIGH_HASH]");
                     ConsensusErrors.HighHash.Throw();
                 }
             }
 
-            Target nextWorkRequired = this.PosParent.StakeValidator.GetNextTargetRequired(this.PosParent.StakeChain, 
+            Target nextWorkRequired = this.PosParent.StakeValidator.GetNextTargetRequired(this.PosParent.StakeChain,
                 context.ValidationContext.ChainedHeaderToValidate.Previous, this.Parent.Network.Consensus, posRuleContext.BlockStake.IsProofOfStake());
 
             BlockHeader header = context.ValidationContext.BlockToValidate.Header;

--- a/src/Stratis.Bitcoin.Features.MemoryPool.Tests/TestChainFactory.cs
+++ b/src/Stratis.Bitcoin.Features.MemoryPool.Tests/TestChainFactory.cs
@@ -82,11 +82,11 @@ namespace Stratis.Bitcoin.Features.MemoryPool.Tests
             InMemoryCoinView inMemoryCoinView = new InMemoryCoinView(chain.Tip.HashBlock);
 
             var cachedCoinView = new CachedCoinView(inMemoryCoinView, DateTimeProvider.Default, loggerFactory);
-            var networkPeerFactory = new NetworkPeerFactory(network, 
-                dateTimeProvider, 
-                loggerFactory, new PayloadProvider().DiscoverPayloads(), 
-                new SelfEndpointTracker(loggerFactory), 
-                new Mock<IInitialBlockDownloadState>().Object, 
+            var networkPeerFactory = new NetworkPeerFactory(network,
+                dateTimeProvider,
+                loggerFactory, new PayloadProvider().DiscoverPayloads(),
+                new SelfEndpointTracker(loggerFactory),
+                new Mock<IInitialBlockDownloadState>().Object,
                 new ConnectionManagerSettings());
 
             var peerAddressManager = new PeerAddressManager(DateTimeProvider.Default, nodeSettings.DataFolder, loggerFactory, new SelfEndpointTracker(loggerFactory));
@@ -104,6 +104,10 @@ namespace Stratis.Bitcoin.Features.MemoryPool.Tests
                 new IntegrityValidator(consensusRules, loggerFactory), new PartialValidator(consensusRules, loggerFactory), new FullValidator(consensusRules, loggerFactory), new Checkpoints(), consensusSettings, consensusRules,
                 new Mock<IFinalizedBlockInfo>().Object, new Signals.Signals(), peerBanning, new Mock<IInitialBlockDownloadState>().Object, chain, new Mock<IBlockPuller>().Object,
                 new Mock<IBlockStore>().Object, new InvalidBlockHashStore(new DateTimeProvider()), new Mock<IConnectionManager>().Object);
+
+            var genesis = new ChainedHeader(network.GetGenesis().Header, network.GenesisHash, 0);
+            chainState.BlockStoreTip = genesis;
+            await consensus.InitializeAsync(genesis).ConfigureAwait(false);
 
             var blockPolicyEstimator = new BlockPolicyEstimator(new MempoolSettings(nodeSettings), loggerFactory, nodeSettings);
             var mempool = new TxMempool(dateTimeProvider, blockPolicyEstimator, loggerFactory, nodeSettings);

--- a/src/Stratis.Bitcoin.Features.MemoryPool.Tests/TestChainFactory.cs
+++ b/src/Stratis.Bitcoin.Features.MemoryPool.Tests/TestChainFactory.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Moq;
 using NBitcoin;
+using NBitcoin.Rules;
 using Stratis.Bitcoin.Base;
 using Stratis.Bitcoin.Base.Deployments;
 using Stratis.Bitcoin.BlockPulling;
@@ -11,11 +12,11 @@ using Stratis.Bitcoin.Configuration;
 using Stratis.Bitcoin.Configuration.Settings;
 using Stratis.Bitcoin.Connection;
 using Stratis.Bitcoin.Consensus;
-using Stratis.Bitcoin.Consensus.Rules;
 using Stratis.Bitcoin.Consensus.Validators;
 using Stratis.Bitcoin.Features.Consensus;
 using Stratis.Bitcoin.Features.Consensus.CoinViews;
 using Stratis.Bitcoin.Features.Consensus.Rules;
+using Stratis.Bitcoin.Features.Consensus.Rules.CommonRules;
 using Stratis.Bitcoin.Features.MemoryPool.Fee;
 using Stratis.Bitcoin.Features.Miner;
 using Stratis.Bitcoin.Interfaces;
@@ -76,6 +77,10 @@ namespace Stratis.Bitcoin.Features.MemoryPool.Tests
 
             network.Consensus.Options = new ConsensusOptions();
             new FullNodeBuilderConsensusExtension.PowConsensusRulesRegistration().RegisterRules(network.Consensus);
+
+            // Dont check PoW of a header in this test.
+            IHeaderValidationConsensusRule checkDiffRule = network.Consensus.HeaderValidationRules.SingleOrDefault(x => x.GetType() == typeof(CheckDifficultyPowRule));
+            network.Consensus.HeaderValidationRules.Remove(checkDiffRule);
 
             var consensusSettings = new ConsensusSettings(nodeSettings);
             var chain = new ConcurrentChain(network);

--- a/src/Stratis.Bitcoin.Features.MemoryPool.Tests/TestChainFactory.cs
+++ b/src/Stratis.Bitcoin.Features.MemoryPool.Tests/TestChainFactory.cs
@@ -103,7 +103,7 @@ namespace Stratis.Bitcoin.Features.MemoryPool.Tests
             var consensus = new ConsensusManager(network, loggerFactory, chainState, new HeaderValidator(consensusRules, loggerFactory),
                 new IntegrityValidator(consensusRules, loggerFactory), new PartialValidator(consensusRules, loggerFactory), new FullValidator(consensusRules, loggerFactory), new Checkpoints(), consensusSettings, consensusRules,
                 new Mock<IFinalizedBlockInfo>().Object, new Signals.Signals(), peerBanning, new Mock<IInitialBlockDownloadState>().Object, chain, new Mock<IBlockPuller>().Object,
-                new Mock<IBlockStore>().Object, new InvalidBlockHashStore(new DateTimeProvider()), new Mock<ConnectionManager>().Object);
+                new Mock<IBlockStore>().Object, new InvalidBlockHashStore(new DateTimeProvider()), new Mock<IConnectionManager>().Object);
 
             var blockPolicyEstimator = new BlockPolicyEstimator(new MempoolSettings(nodeSettings), loggerFactory, nodeSettings);
             var mempool = new TxMempool(dateTimeProvider, blockPolicyEstimator, loggerFactory, nodeSettings);

--- a/src/Stratis.Bitcoin.Features.MemoryPool.Tests/TestChainFactory.cs
+++ b/src/Stratis.Bitcoin.Features.MemoryPool.Tests/TestChainFactory.cs
@@ -118,7 +118,6 @@ namespace Stratis.Bitcoin.Features.MemoryPool.Tests
             // Simple block creation, nothing special yet:
             PowBlockDefinition blockDefinition = new PowBlockDefinition(consensus, dateTimeProvider, loggerFactory, mempool, mempoolLock, minerSettings, network, consensusRules);
             BlockTemplate newBlock = blockDefinition.Build(chain.Tip, scriptPubKey);
-            chain.SetTip(newBlock.Block.Header);
 
             await consensus.BlockMinedAsync(newBlock.Block);
 

--- a/src/Stratis.Bitcoin.Features.MemoryPool.Tests/TestChainFactory.cs
+++ b/src/Stratis.Bitcoin.Features.MemoryPool.Tests/TestChainFactory.cs
@@ -79,8 +79,7 @@ namespace Stratis.Bitcoin.Features.MemoryPool.Tests
             new FullNodeBuilderConsensusExtension.PowConsensusRulesRegistration().RegisterRules(network.Consensus);
 
             // Dont check PoW of a header in this test.
-            IHeaderValidationConsensusRule checkDiffRule = network.Consensus.HeaderValidationRules.SingleOrDefault(x => x.GetType() == typeof(CheckDifficultyPowRule));
-            network.Consensus.HeaderValidationRules.Remove(checkDiffRule);
+            network.Consensus.HeaderValidationRules.RemoveAll(x => x.GetType() == typeof(CheckDifficultyPowRule));
 
             var consensusSettings = new ConsensusSettings(nodeSettings);
             var chain = new ConcurrentChain(network);

--- a/src/Stratis.Bitcoin.IntegrationTests/MinerTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/MinerTests.cs
@@ -174,7 +174,7 @@ namespace Stratis.Bitcoin.IntegrationTests
                 this.consensus = new ConsensusManager(this.network, loggerFactory, chainState, new HeaderValidator(this.ConsensusRules, loggerFactory),
                     new IntegrityValidator(this.ConsensusRules, loggerFactory), new PartialValidator(this.ConsensusRules, loggerFactory), new FullValidator(this.ConsensusRules, loggerFactory), new Checkpoints(),
                     consensusSettings, this.ConsensusRules, new Mock<IFinalizedBlockInfo>().Object, new Signals.Signals(), peerBanning,
-                    new Mock<IInitialBlockDownloadState>().Object, this.chain, new Mock<IBlockPuller>().Object, null, new InvalidBlockHashStore(dateTimeProvider), new Mock<ConnectionManager>().Object);
+                    new Mock<IInitialBlockDownloadState>().Object, this.chain, new Mock<IBlockPuller>().Object, null, new InvalidBlockHashStore(dateTimeProvider), new Mock<IConnectionManager>().Object);
 
                 await this.consensus.InitializeAsync(chainState.BlockStoreTip);
 

--- a/src/Stratis.Bitcoin.IntegrationTests/SmartContracts/SmartContractMinerTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/SmartContracts/SmartContractMinerTests.cs
@@ -239,7 +239,7 @@ namespace Stratis.Bitcoin.IntegrationTests.SmartContracts
                 this.consensusManager = new ConsensusManager(this.network, loggerFactory, chainState, new HeaderValidator(consensusRules, loggerFactory),
                     new IntegrityValidator(consensusRules, loggerFactory), new PartialValidator(consensusRules, loggerFactory), new FullValidator(consensusRules, loggerFactory), new Checkpoints(), consensusSettings, consensusRules,
                     new Mock<IFinalizedBlockInfo>().Object, new Signals.Signals(), peerBanning, new Mock<IInitialBlockDownloadState>().Object, this.chain, new Mock<IBlockPuller>().Object,
-                    new Mock<IBlockStore>().Object, new InvalidBlockHashStore(new DateTimeProvider()), new Mock<ConnectionManager>().Object);
+                    new Mock<IBlockStore>().Object, new InvalidBlockHashStore(new DateTimeProvider()), new Mock<IConnectionManager>().Object);
 
                 await this.consensusManager.InitializeAsync(new ChainedHeader(this.newBlock.Block.Header, this.newBlock.Block.GetHash(), 0));
 

--- a/src/Stratis.Bitcoin.Tests/Consensus/ConsensusTestContext.cs
+++ b/src/Stratis.Bitcoin.Tests/Consensus/ConsensusTestContext.cs
@@ -108,7 +108,7 @@ namespace Stratis.Bitcoin.Tests.Consensus
                 new Mock<IBlockPuller>().Object,
                 null,
                 new InvalidBlockHashStore(new DateTimeProvider()),
-                new Mock<ConnectionManager>().Object);
+                new Mock<IConnectionManager>().Object);
 
             return this.ConsensusManager;
         }

--- a/src/Stratis.Bitcoin/Consensus/Rules/RuleContext.cs
+++ b/src/Stratis.Bitcoin/Consensus/Rules/RuleContext.cs
@@ -16,9 +16,6 @@ namespace Stratis.Bitcoin.Consensus.Rules
 
         public DeploymentFlags Flags { get; set; }
 
-        /// <summary>Indicate the block was created by our node.</summary>
-        public bool MinedBlock { get; set; }
-
         /// <summary>Whether to skip block validation for this block due to either a checkpoint or assumevalid hash set.</summary>
         public bool SkipValidation { get; set; }
 
@@ -32,7 +29,6 @@ namespace Stratis.Bitcoin.Consensus.Rules
 
             this.ValidationContext = validationContext;
             this.Time = time;
-            this.MinedBlock = false;
         }
     }
 }


### PR DESCRIPTION
This PR removes .BlockMined property from the context and fixes mempool tests + mocking that fails CHT tests + improves stability of BS tests