### PR TITLE
Make Consensus/IConsensus an object that can be merged

### DIFF
--- a/src/NBitcoin/Consensus.cs
+++ b/src/NBitcoin/Consensus.cs
@@ -11,76 +11,76 @@ namespace NBitcoin
         public long CoinbaseMaturity { get; set; }
 
         /// <inheritdoc />
-        public Money PremineReward { get; }
+        public Money PremineReward { get; private set; }
 
         /// <inheritdoc />
-        public long PremineHeight { get; }
+        public long PremineHeight { get; private set; }
 
         /// <inheritdoc />
-        public Money ProofOfWorkReward { get; }
+        public Money ProofOfWorkReward { get; private set; }
 
         /// <inheritdoc />
-        public Money ProofOfStakeReward { get; }
+        public Money ProofOfStakeReward { get; private set; }
 
         /// <inheritdoc />
-        public uint MaxReorgLength { get; }
+        public uint MaxReorgLength { get; private set; }
 
         /// <inheritdoc />
-        public long MaxMoney { get; }
+        public long MaxMoney { get; private set; }
 
         public ConsensusOptions Options { get; set; }
 
-        public BuriedDeploymentsArray BuriedDeployments { get; }
+        public BuriedDeploymentsArray BuriedDeployments { get; private set; }
 
-        public BIP9DeploymentsArray BIP9Deployments { get; }
+        public BIP9DeploymentsArray BIP9Deployments { get; private set; }
 
-        public int SubsidyHalvingInterval { get; }
+        public int SubsidyHalvingInterval { get; private set; }
 
-        public int MajorityEnforceBlockUpgrade { get; }
+        public int MajorityEnforceBlockUpgrade { get; private set; }
 
-        public int MajorityRejectBlockOutdated { get; }
+        public int MajorityRejectBlockOutdated { get; private set; }
 
-        public int MajorityWindow { get; }
+        public int MajorityWindow { get; private set; }
 
-        public uint256 BIP34Hash { get; }
+        public uint256 BIP34Hash { get; private set; }
 
-        public Target PowLimit { get; }
+        public Target PowLimit { get; private set; }
 
-        public TimeSpan PowTargetTimespan { get; }
+        public TimeSpan PowTargetTimespan { get; private set; }
 
-        public TimeSpan PowTargetSpacing { get; }
+        public TimeSpan PowTargetSpacing { get; private set; }
 
-        public bool PowAllowMinDifficultyBlocks { get; }
+        public bool PowAllowMinDifficultyBlocks { get; private set; }
 
-        public bool PowNoRetargeting { get; }
+        public bool PowNoRetargeting { get; private set; }
 
-        public uint256 HashGenesisBlock { get; }
+        public uint256 HashGenesisBlock { get; private set; }
 
         /// <inheritdoc />
-        public uint256 MinimumChainWork { get; }
+        public uint256 MinimumChainWork { get; private set; }
 
         public int MinerConfirmationWindow { get; set; }
 
         public int RuleChangeActivationThreshold { get; set; }
 
         /// <inheritdoc />
-        public int CoinType { get; }
+        public int CoinType { get; private set; }
 
-        public BigInteger ProofOfStakeLimit { get; }
+        public BigInteger ProofOfStakeLimit { get; private set; }
 
-        public BigInteger ProofOfStakeLimitV2 { get; }
+        public BigInteger ProofOfStakeLimitV2 { get; private set; }
 
         /// <inheritdoc />
         public int LastPOWBlock { get; set; }
 
         /// <inheritdoc />
-        public bool IsProofOfStake { get; }
+        public bool IsProofOfStake { get; private set; }
 
         /// <inheritdoc />
-        public uint256 DefaultAssumeValid { get; }
+        public uint256 DefaultAssumeValid { get; private set; }
 
         /// <inheritdoc />
-        public ConsensusFactory ConsensusFactory { get; }
+        public ConsensusFactory ConsensusFactory { get; private set; }
 
         /// <inheritdoc />
         public List<IIntegrityValidationConsensusRule> IntegrityValidationRules { get; set; }
@@ -162,6 +162,115 @@ namespace NBitcoin
             this.IsProofOfStake = isProofOfStake;
             this.DefaultAssumeValid = defaultAssumeValid;
             this.ConsensusFactory = consensusFactory;
+        }
+
+        /// <inheritdoc />
+        public void Merge(IConsensus consensus)
+        {
+            if (consensus.BIP34Hash != null && consensus.BIP34Hash != uint256.Zero)
+                this.BIP34Hash = consensus.BIP34Hash;
+
+            if (consensus.BIP9Deployments != null)
+                this.BIP9Deployments = consensus.BIP9Deployments;
+
+            if (consensus.BuriedDeployments != null)
+                this.BuriedDeployments = consensus.BuriedDeployments;
+
+            if (consensus.CoinbaseMaturity != 0)
+                this.CoinbaseMaturity = consensus.CoinbaseMaturity;
+
+            if (consensus.CoinType != 0)
+                this.CoinType = consensus.CoinType;
+
+            if (consensus.ConsensusFactory != null)
+                this.ConsensusFactory = consensus.ConsensusFactory;
+
+            if (consensus.DefaultAssumeValid != null && consensus.DefaultAssumeValid != uint256.Zero)
+                this.DefaultAssumeValid = consensus.DefaultAssumeValid;
+
+            if (consensus.FullValidationRules != null)
+                this.FullValidationRules = consensus.FullValidationRules;
+
+            if (consensus.HashGenesisBlock != null && consensus.HashGenesisBlock != uint256.Zero)
+                this.HashGenesisBlock = consensus.HashGenesisBlock;
+
+            if (consensus.HeaderValidationRules != null)
+                this.HeaderValidationRules = consensus.HeaderValidationRules;
+
+            if (consensus.IntegrityValidationRules != null)
+                this.IntegrityValidationRules = consensus.IntegrityValidationRules;
+
+            if (consensus.IsProofOfStake)
+                this.IsProofOfStake = consensus.IsProofOfStake;
+
+            if (consensus.LastPOWBlock != 0)
+                this.LastPOWBlock = consensus.LastPOWBlock;
+
+            if (consensus.MajorityEnforceBlockUpgrade != 0)
+                this.MajorityEnforceBlockUpgrade = consensus.MajorityEnforceBlockUpgrade;
+
+            if (consensus.MajorityRejectBlockOutdated != 0)
+                this.MajorityRejectBlockOutdated = consensus.MajorityRejectBlockOutdated;
+
+            if (consensus.MajorityWindow != 0)
+                this.MajorityWindow = consensus.MajorityWindow;
+
+            if (consensus.MaxMoney != 0)
+                this.MaxMoney = consensus.MaxMoney;
+
+            if (consensus.MaxReorgLength != 0)
+                this.MaxReorgLength = consensus.MaxReorgLength;
+
+            if (consensus.MinerConfirmationWindow != 0)
+                this.MinerConfirmationWindow = consensus.MinerConfirmationWindow;
+
+            if (consensus.MinimumChainWork != null && consensus.MinimumChainWork != uint256.Zero)
+                this.MinimumChainWork = consensus.MinimumChainWork;
+
+            if (consensus.Options != null)
+                this.Options = consensus.Options;
+
+            if (consensus.PartialValidationRules != null)
+                this.PartialValidationRules = consensus.PartialValidationRules;
+
+            if (consensus.PowAllowMinDifficultyBlocks)
+                this.PowAllowMinDifficultyBlocks = consensus.PowAllowMinDifficultyBlocks;
+
+            if (consensus.PowLimit != null)
+                this.PowLimit = consensus.PowLimit;
+
+            if (consensus.PowNoRetargeting)
+                this.PowNoRetargeting = consensus.PowNoRetargeting;
+
+            if (consensus.PowTargetSpacing != null && consensus.PowTargetSpacing != TimeSpan.Zero)
+                this.PowTargetSpacing = consensus.PowTargetSpacing;
+
+            if (consensus.PowTargetTimespan != null && consensus.PowTargetTimespan != TimeSpan.Zero)
+                this.PowTargetTimespan = consensus.PowTargetTimespan;
+
+            if (consensus.PremineHeight != 0)
+                this.PremineHeight = consensus.PremineHeight;
+
+            if (consensus.PremineReward != null)
+                this.PremineReward = consensus.PremineReward;
+
+            if (consensus.ProofOfStakeLimit != null)
+                this.ProofOfStakeLimit = consensus.ProofOfStakeLimit;
+
+            if (consensus.ProofOfStakeLimitV2 != null)
+                this.ProofOfStakeLimitV2 = consensus.ProofOfStakeLimitV2;
+
+            if (consensus.ProofOfStakeReward != null)
+                this.ProofOfStakeReward = consensus.ProofOfStakeReward;
+
+            if (consensus.ProofOfWorkReward != null)
+                this.ProofOfWorkReward = consensus.ProofOfWorkReward;
+
+            if (consensus.RuleChangeActivationThreshold != 0)
+                this.RuleChangeActivationThreshold = consensus.RuleChangeActivationThreshold;
+
+            if (consensus.SubsidyHalvingInterval != 0)
+                this.SubsidyHalvingInterval = consensus.SubsidyHalvingInterval;
         }
     }
 }

--- a/src/NBitcoin/IConsensus.cs
+++ b/src/NBitcoin/IConsensus.cs
@@ -115,5 +115,8 @@ namespace NBitcoin
 
         /// <summary>Group of rules that are used during full validation (connection of a new block) specific to the given network.</summary>
         List<IFullValidationConsensusRule> FullValidationRules { get; set; }
+
+        /// <summary>Merge an instance of <see cref="IConsensus"/> to the current.</summary>
+        void Merge(IConsensus consensus);
     }
 }

--- a/src/Stratis.Bitcoin.IntegrationTests/NodeSyncTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/NodeSyncTests.cs
@@ -1,17 +1,14 @@
-﻿using System;
-using System.IO;
+﻿using System.IO;
 using System.Linq;
 using System.Threading;
 using FluentAssertions;
+using Moq;
 using NBitcoin;
-using NBitcoin.BouncyCastle.Math;
-using NBitcoin.Networks;
 using Stratis.Bitcoin.Connection;
 using Stratis.Bitcoin.Features.RPC;
 using Stratis.Bitcoin.IntegrationTests.Common;
 using Stratis.Bitcoin.IntegrationTests.Common.Builders;
 using Stratis.Bitcoin.IntegrationTests.Common.EnvironmentMockUpHelpers;
-using Stratis.Bitcoin.Networks;
 using Stratis.Bitcoin.Tests.Common;
 using Stratis.Bitcoin.Utilities.Extensions;
 using Xunit;
@@ -25,48 +22,11 @@ namespace Stratis.Bitcoin.IntegrationTests
 
         public NodeSyncTests()
         {
-            this.posNetwork = NetworkRegistration.Register(new StratisRegTestMaxReorg());
+            this.posNetwork = KnownNetworks.StratisRegTest;
+            var maxReorgAdjusted = new Mock<IConsensus>();
+            maxReorgAdjusted.SetupGet(c => c.MaxReorgLength).Returns(10);
+            this.posNetwork.Consensus.Merge(maxReorgAdjusted.Object);
             this.powNetwork = KnownNetworks.RegTest;
-        }
-
-        private class StratisRegTestMaxReorg : StratisRegTest
-        {
-            public StratisRegTestMaxReorg()
-            {
-                this.Consensus = new NBitcoin.Consensus(
-                consensusFactory: base.Consensus.ConsensusFactory,
-                consensusOptions: base.Consensus.Options,
-                coinType: 105,
-                hashGenesisBlock: base.GenesisHash,
-                subsidyHalvingInterval: 210000,
-                majorityEnforceBlockUpgrade: 750,
-                majorityRejectBlockOutdated: 950,
-                majorityWindow: 1000,
-                buriedDeployments: base.Consensus.BuriedDeployments,
-                bip9Deployments: base.Consensus.BIP9Deployments,
-                bip34Hash: new uint256("0x000000000000024b89b42a942fe0d9fea3bb44ab7bd1b19115dd6a759c0808b8"),
-                ruleChangeActivationThreshold: 1916, // 95% of 2016
-                minerConfirmationWindow: 2016, // nPowTargetTimespan / nPowTargetSpacing
-                maxReorgLength: 10,
-                defaultAssumeValid: null, // turn off assumevalid for regtest.
-                maxMoney: long.MaxValue,
-                coinbaseMaturity: 10,
-                premineHeight: 2,
-                premineReward: Money.Coins(98000000),
-                proofOfWorkReward: Money.Coins(4),
-                powTargetTimespan: TimeSpan.FromSeconds(14 * 24 * 60 * 60), // two weeks
-                powTargetSpacing: TimeSpan.FromSeconds(10 * 60),
-                powAllowMinDifficultyBlocks: true,
-                powNoRetargeting: true,
-                powLimit: base.Consensus.PowLimit,
-                minimumChainWork: null,
-                isProofOfStake: true,
-                lastPowBlock: 12500,
-                proofOfStakeLimit: new BigInteger(uint256.Parse("00000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff").ToBytes(false)),
-                proofOfStakeLimitV2: new BigInteger(uint256.Parse("000000000000ffffffffffffffffffffffffffffffffffffffffffffffffffff").ToBytes(false)),
-                proofOfStakeReward: Money.COIN
-            );
-            }
         }
 
         [Fact]


### PR DESCRIPTION
Should be pretty self-explanatory but if not, this PR makes the Consensus object on Network merg-able so that a developer can merge an instance of Consensus to the current one. In other words provide the ability to makes changes to single properties, for example MaxReorgLength, to the current Consensus instance without affecting the immutability of it or having to construct a full new instance.