### PR TITLE
Fix failing test CallWithDependencies on activation #1936

### DIFF
--- a/src/Stratis.Bitcoin.Features.Consensus/ConsensusFeature.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/ConsensusFeature.cs
@@ -105,6 +105,7 @@ namespace Stratis.Bitcoin.Features.Consensus
                     services.AddSingleton<ConsensusOptions, ConsensusOptions>();
                     services.AddSingleton<DBreezeCoinView>();
                     services.AddSingleton<ICoinView, CachedCoinView>();
+                    services.AddSingleton<ConsensusController>();
                     services.AddSingleton<ConsensusStats>();
                     services.AddSingleton<IConsensusRuleEngine, PowConsensusRuleEngine>();
                     services.AddSingleton<IChainState, ChainState>();
@@ -133,6 +134,7 @@ namespace Stratis.Bitcoin.Features.Consensus
                         services.AddSingleton<ICoinView, CachedCoinView>();
                         services.AddSingleton<StakeChainStore>().AddSingleton<IStakeChain, StakeChainStore>(provider => provider.GetService<StakeChainStore>());
                         services.AddSingleton<IStakeValidator, StakeValidator>();
+                        services.AddSingleton<ConsensusController>();
                         services.AddSingleton<ConsensusStats>();
                         services.AddSingleton<IConsensusRuleEngine, PosConsensusRuleEngine>();
                         services.AddSingleton<IChainState, ChainState>();

--- a/src/Stratis.Bitcoin.Features.Consensus/ConsensusFeature.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/ConsensusFeature.cs
@@ -111,7 +111,7 @@ namespace Stratis.Bitcoin.Features.Consensus
                     services.AddSingleton<IChainState, ChainState>();
                     services.AddSingleton<ConsensusQuery>()
                         .AddSingleton<INetworkDifficulty, ConsensusQuery>(provider => provider.GetService<ConsensusQuery>())
-                        .AddSingleton<IGetUnspentTransaction, ConsensusQuery>();
+                        .AddSingleton<IGetUnspentTransaction, ConsensusQuery>(provider => provider.GetService<ConsensusQuery>());
                     new PowConsensusRulesRegistration().RegisterRules(fullNodeBuilder.Network.Consensus);
                 });
             });
@@ -140,7 +140,7 @@ namespace Stratis.Bitcoin.Features.Consensus
                         services.AddSingleton<IChainState, ChainState>();
                         services.AddSingleton<ConsensusQuery>()
                             .AddSingleton<INetworkDifficulty, ConsensusQuery>(provider => provider.GetService<ConsensusQuery>())
-                            .AddSingleton<IGetUnspentTransaction, ConsensusQuery>();
+                            .AddSingleton<IGetUnspentTransaction, ConsensusQuery>(provider => provider.GetService<ConsensusQuery>());
                         new PosConsensusRulesRegistration().RegisterRules(fullNodeBuilder.Network.Consensus);
                     });
             });

--- a/src/Stratis.Bitcoin.Features.Consensus/ConsensusFeature.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/ConsensusFeature.cs
@@ -105,11 +105,12 @@ namespace Stratis.Bitcoin.Features.Consensus
                     services.AddSingleton<ConsensusOptions, ConsensusOptions>();
                     services.AddSingleton<DBreezeCoinView>();
                     services.AddSingleton<ICoinView, CachedCoinView>();
-                    services.AddSingleton<ConsensusController>();
                     services.AddSingleton<ConsensusStats>();
                     services.AddSingleton<IConsensusRuleEngine, PowConsensusRuleEngine>();
-                    services.AddSingleton<IGetUnspentTransaction, ConsensusQuery>();
-
+                    services.AddSingleton<IChainState, ChainState>();
+                    services.AddSingleton<ConsensusQuery>()
+                        .AddSingleton<INetworkDifficulty, ConsensusQuery>(provider => provider.GetService<ConsensusQuery>())
+                        .AddSingleton<IGetUnspentTransaction, ConsensusQuery>();
                     new PowConsensusRulesRegistration().RegisterRules(fullNodeBuilder.Network.Consensus);
                 });
             });
@@ -132,11 +133,12 @@ namespace Stratis.Bitcoin.Features.Consensus
                         services.AddSingleton<ICoinView, CachedCoinView>();
                         services.AddSingleton<StakeChainStore>().AddSingleton<IStakeChain, StakeChainStore>(provider => provider.GetService<StakeChainStore>());
                         services.AddSingleton<IStakeValidator, StakeValidator>();
-                        services.AddSingleton<ConsensusController>();
                         services.AddSingleton<ConsensusStats>();
                         services.AddSingleton<IConsensusRuleEngine, PosConsensusRuleEngine>();
-                        services.AddSingleton<IGetUnspentTransaction, ConsensusQuery>();
-
+                        services.AddSingleton<IChainState, ChainState>();
+                        services.AddSingleton<ConsensusQuery>()
+                            .AddSingleton<INetworkDifficulty, ConsensusQuery>(provider => provider.GetService<ConsensusQuery>())
+                            .AddSingleton<IGetUnspentTransaction, ConsensusQuery>();
                         new PosConsensusRulesRegistration().RegisterRules(fullNodeBuilder.Network.Consensus);
                     });
             });

--- a/src/Stratis.Bitcoin.Features.Consensus/ConsensusQuery.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/ConsensusQuery.cs
@@ -2,6 +2,7 @@
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using NBitcoin;
+using Stratis.Bitcoin.Base;
 using Stratis.Bitcoin.Features.Consensus.CoinViews;
 using Stratis.Bitcoin.Interfaces;
 using Stratis.Bitcoin.Utilities;
@@ -11,16 +12,22 @@ namespace Stratis.Bitcoin.Features.Consensus
     /// <summary>
     /// A class that provides the ability to query consensus elements.
     /// </summary>
-    public class ConsensusQuery : IGetUnspentTransaction
+    public class ConsensusQuery : IGetUnspentTransaction, INetworkDifficulty
     {
         private readonly ICoinView coinView;
         private readonly ILogger logger;
-        
+        private readonly IChainState chainState;
+        private readonly Network network;
+
         public ConsensusQuery(
             ICoinView coinView,
+            IChainState chainState,
+            Network network,
             ILoggerFactory loggerFactory)
         {
             this.coinView = coinView;
+            this.chainState = chainState;
+            this.network = network;
             this.logger = loggerFactory.CreateLogger(this.GetType().FullName);
         }
 
@@ -35,6 +42,12 @@ namespace Stratis.Bitcoin.Features.Consensus
 
             this.logger.LogTrace("(-):{0}", unspentOutputs);
             return unspentOutputs;
+        }
+
+        /// <inheritdoc/>
+        public Target GetNetworkDifficulty()
+        {
+            return this.chainState.ConsensusTip?.GetWorkRequired(this.network.Consensus);
         }
     }
 }


### PR DESCRIPTION
**Fix failing test CallWithDependencies on activation #1936**

_Fix provides INetworkDifficulty from ConsensusQuery following deprecation of ConsensusLoop._

![image](https://user-images.githubusercontent.com/30984080/45046408-f8639600-b06d-11e8-8e96-573f060e927a.png)

Preferred: @fassadlr @dangershony 