### PR TITLE
[SC] State transition error improvements

### DIFF
--- a/src/Stratis.Bitcoin.Features.SmartContracts.Tests/ExecutorSpecification.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts.Tests/ExecutorSpecification.cs
@@ -54,11 +54,10 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Tests
                     mempoolFee,
                     context.Sender,
                     It.IsAny<Gas>(),
-                    vmExecutionResult.ExecutionException))
+                    false))
                 .Returns(refundResult);
 
-            var stateTransitionResult =
-                new StateTransitionResult(gasConsumed, newContractAddress, true, vmExecutionResult);
+            var stateTransitionResult = StateTransitionResult.Ok(gasConsumed, newContractAddress, vmExecutionResult.Result);
 
             var internalTransfers = new List<TransferInfo>().AsReadOnly();
             var stateMock = new Mock<IState>();
@@ -115,7 +114,7 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Tests
                         mempoolFee,
                         context.Sender,
                         It.IsAny<Gas>(),
-                        vmExecutionResult.ExecutionException),
+                        false),
                 Times.Once);
         }
     }

--- a/src/Stratis.Bitcoin.Features.SmartContracts.Tests/SmartContractExecutorTests.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts.Tests/SmartContractExecutorTests.cs
@@ -128,7 +128,7 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Tests
                 this.stateFactory);
 
             ISmartContractExecutionResult result = executor.Execute(transactionContext);
-            Assert.NotNull(result.Exception);
+            Assert.True(result.Revert);
         }
 
         [Fact]

--- a/src/Stratis.Bitcoin.Features.SmartContracts.Tests/SmartContractExecutorTests.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts.Tests/SmartContractExecutorTests.cs
@@ -128,7 +128,7 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Tests
                 this.stateFactory);
 
             ISmartContractExecutionResult result = executor.Execute(transactionContext);
-            Assert.IsType<SmartContractDoesNotExistException>(result.Exception);
+            Assert.NotNull(result.Exception);
         }
 
         [Fact]

--- a/src/Stratis.Bitcoin.Features.SmartContracts.Tests/SmartContractResultRefundProcessorTests.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts.Tests/SmartContractResultRefundProcessorTests.cs
@@ -31,7 +31,7 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Tests
             var carrier = SmartContractCarrier.CallContract(1, contractAddress, "ThrowException", 1, (Gas)5000);
             carrier.Sender = new uint160(2);
 
-            (Money fee, TxOut refund) = this.refundProcessor.Process(carrier.ContractTxData, new Money(10500), carrier.Sender, (Gas)950, null);
+            (Money fee, TxOut refund) = this.refundProcessor.Process(carrier.ContractTxData, new Money(10500), carrier.Sender, (Gas)950, false);
 
             Assert.Equal(6450, fee);
             Assert.Equal(carrier.Sender.ToBytes(), refund.ScriptPubKey.GetDestination(this.network).ToBytes());
@@ -46,7 +46,7 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Tests
             var carrier = SmartContractCarrier.CallContract(1, contractAddress, "ThrowException", 1, (Gas)5000);
             carrier.Sender = new uint160(2);
 
-            (Money fee, TxOut refund) = this.refundProcessor.Process(carrier.ContractTxData, new Money(10500), carrier.Sender, (Gas)5000, null);
+            (Money fee, TxOut refund) = this.refundProcessor.Process(carrier.ContractTxData, new Money(10500), carrier.Sender, (Gas)5000, false);
 
             Assert.Equal(10500, fee);
             Assert.Null(refund);
@@ -60,7 +60,7 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Tests
             var carrier = SmartContractCarrier.CallContract(1, contractAddress, "ThrowException", 1, (Gas)5000);
             carrier.Sender = new uint160(2);
 
-            (Money fee, TxOut refund) = this.refundProcessor.Process(carrier.ContractTxData, new Money(10500), carrier.Sender, (Gas)5000, new OutOfGasException());
+            (Money fee, TxOut refund) = this.refundProcessor.Process(carrier.ContractTxData, new Money(10500), carrier.Sender, (Gas)5000, true);
 
             Assert.Equal(10500, fee);
             Assert.Null(refund);

--- a/src/Stratis.SmartContracts.Executor.Reflection/Executor.cs
+++ b/src/Stratis.SmartContracts.Executor.Reflection/Executor.cs
@@ -113,7 +113,7 @@ namespace Stratis.SmartContracts.Executor.Reflection
             {
                 To = !callData.IsCreateContract ? callData.ContractAddress : null,
                 NewContractAddress = !revert && creation ? result.Success?.ContractAddress : null,
-                Exception = result.IsFailure ? new Exception() : null, // TODO remove the Exception field
+                Exception = result.Error?.VmException,
                 GasConsumed = gasConsumed,
                 Return = result.Success?.ExecutionResult,
                 InternalTransaction = internalTransaction,

--- a/src/Stratis.SmartContracts.Executor.Reflection/Executor.cs
+++ b/src/Stratis.SmartContracts.Executor.Reflection/Executor.cs
@@ -89,10 +89,6 @@ namespace Stratis.SmartContracts.Executor.Reflection
 
             bool revert = !result.IsSuccess;
 
-            Gas gasConsumed = result.IsSuccess 
-                ? result.Success.GasConsumed 
-                : result.Error.GasConsumed;
-
             Transaction internalTransaction = this.transferProcessor.Process(
                 this.stateRoot,
                 result.Success?.ContractAddress,
@@ -106,7 +102,7 @@ namespace Stratis.SmartContracts.Executor.Reflection
                 callData,
                 transactionContext.MempoolFee,
                 transactionContext.Sender,
-                gasConsumed,
+                result.GasConsumed,
                 outOfGas);
 
             var executionResult = new SmartContractExecutionResult
@@ -114,7 +110,7 @@ namespace Stratis.SmartContracts.Executor.Reflection
                 To = !callData.IsCreateContract ? callData.ContractAddress : null,
                 NewContractAddress = !revert && creation ? result.Success?.ContractAddress : null,
                 Exception = result.Error?.VmException,
-                GasConsumed = gasConsumed,
+                GasConsumed = result.GasConsumed,
                 Return = result.Success?.ExecutionResult,
                 InternalTransaction = internalTransaction,
                 Fee = fee,

--- a/src/Stratis.SmartContracts.Executor.Reflection/Executor.cs
+++ b/src/Stratis.SmartContracts.Executor.Reflection/Executor.cs
@@ -110,6 +110,7 @@ namespace Stratis.SmartContracts.Executor.Reflection
                 To = !callData.IsCreateContract ? callData.ContractAddress : null,
                 NewContractAddress = !revert && creation ? result.Success?.ContractAddress : null,
                 Exception = result.Error?.VmException,
+                Revert = revert,
                 GasConsumed = result.GasConsumed,
                 Return = result.Success?.ExecutionResult,
                 InternalTransaction = internalTransaction,

--- a/src/Stratis.SmartContracts.Executor.Reflection/ISmartContractResultRefundProcessor.cs
+++ b/src/Stratis.SmartContracts.Executor.Reflection/ISmartContractResultRefundProcessor.cs
@@ -14,6 +14,6 @@ namespace Stratis.SmartContracts.Executor.Reflection
         (Money, TxOut) Process(ContractTxData contractTxData,
             ulong mempoolFee, uint160 sender,
             Gas gasConsumed,
-            Exception exception);
+            bool outOfGas);
     }
 }

--- a/src/Stratis.SmartContracts.Executor.Reflection/InternalTransactionExecutor.cs
+++ b/src/Stratis.SmartContracts.Executor.Reflection/InternalTransactionExecutor.cs
@@ -70,7 +70,7 @@ namespace Stratis.SmartContracts.Executor.Reflection
 
             return result.Success
                 ? TransferResult.Transferred(result.VmExecutionResult.Result)
-                : TransferResult.Failed(result.VmExecutionResult.ExecutionException);
+                : TransferResult.Failed();
         }
 
         ///<inheritdoc />
@@ -91,7 +91,7 @@ namespace Stratis.SmartContracts.Executor.Reflection
 
             return result.Success 
                 ? TransferResult.Empty() 
-                : TransferResult.Failed(result.VmExecutionResult?.ExecutionException);
+                : TransferResult.Failed();
         }
     }
 }

--- a/src/Stratis.SmartContracts.Executor.Reflection/InternalTransactionExecutor.cs
+++ b/src/Stratis.SmartContracts.Executor.Reflection/InternalTransactionExecutor.cs
@@ -41,8 +41,8 @@ namespace Stratis.SmartContracts.Executor.Reflection
 
             var result = this.state.Apply(message);
 
-            return result.Success
-                ? CreateResult.Succeeded(result.ContractAddress.ToAddress(this.network))
+            return result.IsSuccess
+                ? CreateResult.Succeeded(result.Success.ContractAddress.ToAddress(this.network))
                 : CreateResult.Failed();
         }
 
@@ -68,8 +68,8 @@ namespace Stratis.SmartContracts.Executor.Reflection
 
             var result = this.state.Apply(message);
 
-            return result.Success
-                ? TransferResult.Transferred(result.VmExecutionResult.Result)
+            return result.IsSuccess
+                ? TransferResult.Transferred(result.Success.ExecutionResult)
                 : TransferResult.Failed();
         }
 
@@ -89,7 +89,7 @@ namespace Stratis.SmartContracts.Executor.Reflection
             
             var result = this.state.Apply(message);
 
-            return result.Success 
+            return result.IsSuccess 
                 ? TransferResult.Empty() 
                 : TransferResult.Failed();
         }

--- a/src/Stratis.SmartContracts.Executor.Reflection/SmartContractExecutionResult.cs
+++ b/src/Stratis.SmartContracts.Executor.Reflection/SmartContractExecutionResult.cs
@@ -23,10 +23,7 @@ namespace Stratis.SmartContracts.Executor.Reflection
         public Exception Exception { get; set; }
 
         /// <inheritdoc/>
-        public bool Revert
-        {
-            get { return this.Exception != null; }
-        }
+        public bool Revert { get; set; }
 
         /// <inheritdoc/>
         public ulong FutureRefund { get; set; }

--- a/src/Stratis.SmartContracts.Executor.Reflection/SmartContractResultRefundProcessor.cs
+++ b/src/Stratis.SmartContracts.Executor.Reflection/SmartContractResultRefundProcessor.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using Microsoft.Extensions.Logging;
 using NBitcoin;
-using Stratis.SmartContracts.Executor.Reflection.Exceptions;
 
 namespace Stratis.SmartContracts.Executor.Reflection
 {
@@ -21,13 +20,13 @@ namespace Stratis.SmartContracts.Executor.Reflection
         public (Money, TxOut) Process(ContractTxData contractTxData,
             ulong mempoolFee, uint160 sender,
             Gas gasConsumed,
-            Exception exception)
+            bool outOfGas)
         {
             this.logger.LogTrace("(){0}:{1}", nameof(mempoolFee), mempoolFee);
 
             Money fee = mempoolFee;
 
-            if (exception is OutOfGasException)
+            if (outOfGas)
             {
                 this.logger.LogTrace("(-)[OUTOFGAS_EXCEPTION]");
                 return (fee, null);

--- a/src/Stratis.SmartContracts.Executor.Reflection/State.cs
+++ b/src/Stratis.SmartContracts.Executor.Reflection/State.cs
@@ -192,8 +192,8 @@ namespace Stratis.SmartContracts.Executor.Reflection
 
                 return StateTransitionResult.Fail(
                     gasMeter.GasConsumed,
-                    errorKind
-                );
+                    errorKind,
+                    result.ExecutionException);
             }
             else
             {
@@ -282,8 +282,8 @@ namespace Stratis.SmartContracts.Executor.Reflection
 
                 return StateTransitionResult.Fail(
                     gasMeter.GasConsumed,
-                    errorKind
-                );
+                    errorKind,
+                    result.ExecutionException);
             }
             else
             {

--- a/src/Stratis.SmartContracts.Executor.Reflection/State.cs
+++ b/src/Stratis.SmartContracts.Executor.Reflection/State.cs
@@ -190,10 +190,8 @@ namespace Stratis.SmartContracts.Executor.Reflection
                     gasMeter.GasConsumed,
                     result.ExecutionException);
             }
-            else
-            {
-                state.Commit();
-            }
+
+            state.Commit();
 
             return StateTransitionResult.Ok(
                 gasMeter.GasConsumed,
@@ -275,11 +273,9 @@ namespace Stratis.SmartContracts.Executor.Reflection
                     gasMeter.GasConsumed,
                     result.ExecutionException);
             }
-            else
-            {
-                state.Commit();
-                this.GasRemaining -= gasMeter.GasConsumed;
-            }
+
+            state.Commit();
+            this.GasRemaining -= gasMeter.GasConsumed;            
 
             return StateTransitionResult.Ok(
                 gasMeter.GasConsumed,

--- a/src/Stratis.SmartContracts.Executor.Reflection/State.cs
+++ b/src/Stratis.SmartContracts.Executor.Reflection/State.cs
@@ -186,13 +186,8 @@ namespace Stratis.SmartContracts.Executor.Reflection
             {
                 this.Rollback(stateSnapshot);
 
-                StateTransitionErrorKind errorKind = result.ExecutionException is OutOfGasException
-                    ? StateTransitionErrorKind.OutOfGas
-                    : StateTransitionErrorKind.VmError;
-
                 return StateTransitionResult.Fail(
                     gasMeter.GasConsumed,
-                    errorKind,
                     result.ExecutionException);
             }
             else
@@ -276,13 +271,8 @@ namespace Stratis.SmartContracts.Executor.Reflection
             {
                 this.Rollback(stateSnapshot);
 
-                StateTransitionErrorKind errorKind = result.ExecutionException is OutOfGasException
-                    ? StateTransitionErrorKind.OutOfGas
-                    : StateTransitionErrorKind.VmError;
-
                 return StateTransitionResult.Fail(
                     gasMeter.GasConsumed,
-                    errorKind,
                     result.ExecutionException);
             }
             else

--- a/src/Stratis.SmartContracts.Executor.Reflection/StateTransitionResult.cs
+++ b/src/Stratis.SmartContracts.Executor.Reflection/StateTransitionResult.cs
@@ -86,7 +86,7 @@ namespace Stratis.SmartContracts.Executor.Reflection
 
         /// <summary>
         /// An exception thrown by the VM. This value is null unless <see cref="Kind"/>
-        /// equals <see cref="StateTransitionErrorKind.VmError"/>.
+        /// equals <see cref="StateTransitionErrorKind.VmError"/> or <see cref="StateTransitionErrorKind.OutOfGas"/>.
         /// </summary>
         public Exception VmException { get; }
 

--- a/src/Stratis.SmartContracts.Executor.Reflection/StateTransitionResult.cs
+++ b/src/Stratis.SmartContracts.Executor.Reflection/StateTransitionResult.cs
@@ -79,6 +79,8 @@ namespace Stratis.SmartContracts.Executor.Reflection
             this.Success = success;
         }
 
+        public Gas GasConsumed => this.IsSuccess ? this.Success.GasConsumed : this.Error.GasConsumed;
+
         public bool IsSuccess { get; }
 
         public bool IsFailure => !this.IsSuccess;

--- a/src/Stratis.SmartContracts.Executor.Reflection/StateTransitionResult.cs
+++ b/src/Stratis.SmartContracts.Executor.Reflection/StateTransitionResult.cs
@@ -4,16 +4,45 @@ using Stratis.SmartContracts.Executor.Reflection.Exceptions;
 
 namespace Stratis.SmartContracts.Executor.Reflection
 {
+    /// <summary>
+    /// Represents the kinds of error that can occur during a state transition.
+    /// </summary>
     public enum StateTransitionErrorKind
     {
+        /// <summary>
+        /// The execution ran out of gas.
+        /// </summary>
         OutOfGas,
+
+        /// <summary>
+        /// The sender did not have enough funds.
+        /// </summary>
         InsufficientBalance,
+
+        /// <summary>
+        /// The sender did not supply enough gas.
+        /// </summary>
         InsufficientGas,
+
+        /// <summary>
+        /// The supplied method name was null.
+        /// </summary>
         NoMethodName,
+
+        /// <summary>
+        /// No contract code was present.
+        /// </summary>
         NoCode,
+
+        /// <summary>
+        /// An exception was thrown during VM execution.
+        /// </summary>
         VmError
     }
 
+    /// <summary>
+    /// Represents the result of a successful state transition.
+    /// </summary>
     public class StateTransitionSuccess
     {
         public StateTransitionSuccess(
@@ -43,6 +72,9 @@ namespace Stratis.SmartContracts.Executor.Reflection
 
     }
 
+    /// <summary>
+    /// Represents the result of a failed state transition.
+    /// </summary>
     public class StateTransitionError
     {
         public StateTransitionError(Gas gasConsumed, StateTransitionErrorKind kind, Exception vmException)
@@ -52,19 +84,25 @@ namespace Stratis.SmartContracts.Executor.Reflection
             this.VmException = vmException;
         }
 
+        /// <summary>
+        /// An exception thrown by the VM. This value is null unless <see cref="Kind"/>
+        /// equals <see cref="StateTransitionErrorKind.VmError"/>.
+        /// </summary>
         public Exception VmException { get; }
 
+        /// <summary>
+        /// The kind of error that occurred during the state transition.
+        /// </summary>
         public StateTransitionErrorKind Kind { get; }
 
+        /// <summary>
+        /// The gas consumed during execution.
+        /// </summary>
         public Gas GasConsumed { get; }
     }
 
     /// <summary>
-    /// The result of a state transition operation. A successful or failed operation can still have gas consumed.
-    ///
-    /// A successful operation will have the contract's address.
-    ///
-    /// A failed operation will have the error. Even if an error is produced, the operation is still included in a block.
+    /// The result of a state transition operation.
     /// </summary>
     public class StateTransitionResult
     {
@@ -80,16 +118,30 @@ namespace Stratis.SmartContracts.Executor.Reflection
             this.Success = success;
         }
 
+        /// <summary>
+        /// The gas consumed during the state transition.
+        /// </summary>
         public Gas GasConsumed => this.IsSuccess ? this.Success.GasConsumed : this.Error.GasConsumed;
 
         public bool IsSuccess { get; }
 
         public bool IsFailure => !this.IsSuccess;
 
+        /// <summary>
+        /// The successful result of the state transition. This value is null unless
+        /// <see cref="IsSuccess"/> equals true.
+        /// </summary>
         public StateTransitionSuccess Success { get; }
 
+        /// <summary>
+        /// The error result of the state transition. This value is null unless
+        /// <see cref="IsFailure"/> equals true.
+        /// </summary>
         public StateTransitionError Error { get; }
 
+        /// <summary>
+        /// Creates a new result for a successful state transition.
+        /// </summary>
         public static StateTransitionResult Ok(Gas gasConsumed,
             uint160 contractAddress,
             object result = null)
@@ -98,6 +150,9 @@ namespace Stratis.SmartContracts.Executor.Reflection
                 new StateTransitionSuccess(gasConsumed, contractAddress, result));
         }
 
+        /// <summary>
+        /// Creates a new result for a failed state transition due to a VM exception.
+        /// </summary>
         public static StateTransitionResult Fail(Gas gasConsumed, Exception vmException)
         {
             StateTransitionErrorKind errorKind = vmException is OutOfGasException
@@ -107,6 +162,9 @@ namespace Stratis.SmartContracts.Executor.Reflection
             return new StateTransitionResult(new StateTransitionError(gasConsumed, errorKind, vmException));
         }
 
+        /// <summary>
+        /// Creates a new result for a failed state transition.
+        /// </summary>
         public static StateTransitionResult Fail(Gas gasConsumed, StateTransitionErrorKind kind)
         {
             return new StateTransitionResult(new StateTransitionError(gasConsumed, kind, null));

--- a/src/Stratis.SmartContracts.Executor.Reflection/StateTransitionResult.cs
+++ b/src/Stratis.SmartContracts.Executor.Reflection/StateTransitionResult.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using NBitcoin;
+using Stratis.SmartContracts.Executor.Reflection.Exceptions;
 
 namespace Stratis.SmartContracts.Executor.Reflection
 {
@@ -97,9 +98,13 @@ namespace Stratis.SmartContracts.Executor.Reflection
                 new StateTransitionSuccess(gasConsumed, contractAddress, result));
         }
 
-        public static StateTransitionResult Fail(Gas gasConsumed, StateTransitionErrorKind kind, Exception vmException)
+        public static StateTransitionResult Fail(Gas gasConsumed, Exception vmException)
         {
-            return new StateTransitionResult(new StateTransitionError(gasConsumed, kind, vmException));
+            StateTransitionErrorKind errorKind = vmException is OutOfGasException
+                ? StateTransitionErrorKind.OutOfGas
+                : StateTransitionErrorKind.VmError;
+
+            return new StateTransitionResult(new StateTransitionError(gasConsumed, errorKind, vmException));
         }
 
         public static StateTransitionResult Fail(Gas gasConsumed, StateTransitionErrorKind kind)

--- a/src/Stratis.SmartContracts.Executor.Reflection/StateTransitionResult.cs
+++ b/src/Stratis.SmartContracts.Executor.Reflection/StateTransitionResult.cs
@@ -44,13 +44,17 @@ namespace Stratis.SmartContracts.Executor.Reflection
 
     public class StateTransitionError
     {
-        public StateTransitionError(Gas gasConsumed, StateTransitionErrorKind kind)
+        public StateTransitionError(Gas gasConsumed, StateTransitionErrorKind kind, Exception vmException)
         {
             this.Kind = kind;
             this.GasConsumed = gasConsumed;
+            this.VmException = vmException;
         }
 
+        public Exception VmException { get; }
+
         public StateTransitionErrorKind Kind { get; }
+
         public Gas GasConsumed { get; }
     }
 
@@ -91,9 +95,14 @@ namespace Stratis.SmartContracts.Executor.Reflection
                 new StateTransitionSuccess(gasConsumed, contractAddress, result));
         }
 
+        public static StateTransitionResult Fail(Gas gasConsumed, StateTransitionErrorKind kind, Exception vmException)
+        {
+            return new StateTransitionResult(new StateTransitionError(gasConsumed, kind, vmException));
+        }
+
         public static StateTransitionResult Fail(Gas gasConsumed, StateTransitionErrorKind kind)
         {
-            return new StateTransitionResult(new StateTransitionError(gasConsumed, kind));
+            return new StateTransitionResult(new StateTransitionError(gasConsumed, kind, null));
         }
     }
 }

--- a/src/Stratis.SmartContracts.Executor.Reflection/TransferResult.cs
+++ b/src/Stratis.SmartContracts.Executor.Reflection/TransferResult.cs
@@ -10,38 +10,28 @@ namespace Stratis.SmartContracts.Executor.Reflection
         /// <summary>The return value of the method called.</summary>
         public object ReturnValue { get; private set; }
 
-        /// <summary>
-        /// If there was an error during execution of the selected method it will be stored here.
-        /// </summary>
-        public Exception ThrownException { get; private set; }
-
         /// <summary>Whether execution of the contract method was successful.</summary>
-        public bool Success
-        {
-            get { return this.ThrownException == null; }
-        }
+        public bool Success { get; }
 
-        private TransferResult() { }
+        private TransferResult(bool success)
+        {
+            this.Success = success;
+        }
 
         /// <summary>
         /// Constructs a an empty result i.e. a transfer from a contract was not defined/executed.
         /// </summary>
         public static TransferResult Empty()
         {
-            return new TransferResult();
+            return new TransferResult(true);
         }
 
         /// <summary>
         /// Constructs a result when a transfer from a contract failed.
         /// </summary>
-        /// <param name="thrownException">The exception that was thrown by the executor.</param>
-        public static TransferResult Failed(Exception thrownException)
+        public static TransferResult Failed()
         {
-            var result = new TransferResult
-            {
-                ThrownException = thrownException
-            };
-            return result;
+            return new TransferResult(false);
         }
 
         /// <summary>
@@ -50,10 +40,11 @@ namespace Stratis.SmartContracts.Executor.Reflection
         /// <param name="returnValue">The object that was returned from the executor.</param>
         public static TransferResult Transferred(object returnValue)
         {
-            var result = new TransferResult
+            var result = new TransferResult(true)
             {
                 ReturnValue = returnValue
             };
+
             return result;
         }
     }

--- a/src/Stratis.SmartContracts.Executor.Reflection/TransferResult.cs
+++ b/src/Stratis.SmartContracts.Executor.Reflection/TransferResult.cs
@@ -19,7 +19,7 @@ namespace Stratis.SmartContracts.Executor.Reflection
         }
 
         /// <summary>
-        /// Constructs a an empty result i.e. a transfer from a contract was not defined/executed.
+        /// Constructs a result when the transfer is a funds transfer only and no return value is expected.
         /// </summary>
         public static TransferResult Empty()
         {
@@ -35,7 +35,7 @@ namespace Stratis.SmartContracts.Executor.Reflection
         }
 
         /// <summary>
-        /// Constructs a result when a transfer from a contract succeeded.
+        /// Constructs a result when a transfer from a contract succeeded and a return value is expected.
         /// </summary>
         /// <param name="returnValue">The object that was returned from the executor.</param>
         public static TransferResult Transferred(object returnValue)


### PR DESCRIPTION
Closes #2121.
* Adds success and error result types which are returned on `StateTransitionResult`.
* Returns an error type for all expected state transition errors.
* Returns any exceptions generated within the VM execution.
* Pushes the handling of internally generated transaction errors back to the ITE.

For review only. Do not merge until we establish what's going on with core-way-activation.