### PR TITLE
Include extra LogInformation around application shutdown.

### DIFF
--- a/src/Stratis.Bitcoin.IntegrationTests/BlockStore/ReorgToLongestChainSteps.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/BlockStore/ReorgToLongestChainSteps.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using System.IO;
+﻿using System.IO;
 using System.Linq;
 using FluentAssertions;
 using NBitcoin;
@@ -28,7 +27,7 @@ namespace Stratis.Bitcoin.IntegrationTests.BlockStore
         private const string WalletZero = "wallet 0";
         private const string WalletPassword = "123456";
         private const string WalletPassphrase = "phrase";
-       
+
         public ReorgToLongestChainSpecification(ITestOutputHelper output) : base(output)
         {
         }
@@ -140,7 +139,7 @@ namespace Stratis.Bitcoin.IntegrationTests.BlockStore
         private void jings_connection_comes_back()
         {
             this.jingNode.CreateRPCClient().AddNode(this.bobNode.Endpoint);
-            this.sharedSteps.WaitForNodeToSync(this.jingNode, this.bobNode, this.charlieNode, this.daveNode);
+            this.sharedSteps.WaitForNodeToSyncIgnoreMempool(this.jingNode, this.bobNode, this.charlieNode, this.daveNode);
         }
 
         private void bob_charlie_and_dave_reorg_to_jings_longest_chain()

--- a/src/Stratis.Bitcoin/Base/BaseFeature.cs
+++ b/src/Stratis.Bitcoin/Base/BaseFeature.cs
@@ -278,25 +278,37 @@ namespace Stratis.Bitcoin.Base
             this.logger.LogInformation("Flushing peers...");
             this.flushAddressManagerLoop.Dispose();
 
+            this.logger.LogInformation("peerAddressManager...");
             this.peerAddressManager.Dispose();
 
+            this.logger.LogInformation("partialValidator...");
             this.partialValidator.Dispose();
 
-            this.logger.LogInformation("Flushing headers chain...");
-            this.flushChainLoop?.Dispose();
+            if (this.flushChainLoop != null)
+            {
+                this.logger.LogInformation("Flushing headers chain...");
+                this.flushChainLoop.Dispose();
+            }
 
+            this.logger.LogInformation("Saving chainRepository...");
             this.chainRepository.SaveAsync(this.chain).GetAwaiter().GetResult();
 
             foreach (IDisposable disposable in this.disposableResources)
             {
+                this.logger.LogInformation($"{disposable.GetType().Name}...");
                 disposable.Dispose();
             }
 
+            this.logger.LogInformation("blockPuller...");
             this.blockPuller.Dispose();
 
+            this.logger.LogInformation("consensusManager...");
             this.consensusManager.Dispose();
+
+            this.logger.LogInformation("consensusRules...");
             this.consensusRules.Dispose();
 
+            this.logger.LogInformation("blockStore...");
             this.blockStore.Dispose();
         }
     }

--- a/src/Stratis.Bitcoin/Builder/FullNodeFeatureExecutor.cs
+++ b/src/Stratis.Bitcoin/Builder/FullNodeFeatureExecutor.cs
@@ -68,7 +68,11 @@ namespace Stratis.Bitcoin.Builder
         {
             try
             {
-                this.Execute(feature => feature.Dispose(), true);
+                this.Execute(feature =>
+                {
+                    this.logger.LogInformation($"{feature.GetType().Name}...");
+                    feature.Dispose();
+                }, true);
             }
             catch (Exception ex)
             {

--- a/src/Stratis.Bitcoin/FullNode.cs
+++ b/src/Stratis.Bitcoin/FullNode.cs
@@ -264,17 +264,24 @@ namespace Stratis.Bitcoin
             // Fire INodeLifetime.Stopping.
             this.nodeLifetime.StopApplication();
 
+            this.logger.LogInformation("ConnectionManager...");
             this.ConnectionManager.Dispose();
 
             foreach (IDisposable disposable in this.Resources)
+            {
+                this.logger.LogInformation($"{disposable.GetType().Name}...");
                 disposable.Dispose();
+            }
 
             // Fire the NodeFeatureExecutor.Stop.
+            this.logger.LogInformation("fullNodeFeatureExecutor...");
             this.fullNodeFeatureExecutor.Dispose();
 
+            this.logger.LogInformation("Settings...");
             this.Settings.Dispose();
 
             // Fire INodeLifetime.Stopped.
+            this.logger.LogInformation("Signals ApplicationStopped...");
             this.nodeLifetime.NotifyStopped();
 
             this.State = FullNodeState.Disposed;

--- a/src/Stratis.StratisD/Properties/launchSettings.json
+++ b/src/Stratis.StratisD/Properties/launchSettings.json
@@ -5,7 +5,7 @@
     },
     "Stratis.StratisD Test": {
       "commandName": "Project",
-      "commandLineArgs": "-testnet"
+      "commandLineArgs": "-testnet -datadir=D:\\\\Stratis\\\\ShutDownCore -agentprefix=ferdeen"
     },
     "Stratis.StratisD Test with RPC": {
       "commandName": "Project",

--- a/src/Stratis.StratisD/Properties/launchSettings.json
+++ b/src/Stratis.StratisD/Properties/launchSettings.json
@@ -5,7 +5,7 @@
     },
     "Stratis.StratisD Test": {
       "commandName": "Project",
-      "commandLineArgs": "-testnet -datadir=D:\\\\Stratis\\\\ShutDownCore -agentprefix=ferdeen"
+      "commandLineArgs": "-testnet"
     },
     "Stratis.StratisD Test with RPC": {
       "commandName": "Project",


### PR DESCRIPTION
I've included `LogInformation` when objects are being disposed at shutdown.  I looked at making this trace level logging, but it was difficult to see which objects were shutdown, with other trace level logging going on.

Also noticed there were times where Consensus stats were shown during shutdown, which looked messy.  I've stopped this happening.