### PR TITLE
Fix unhandled exceptions in ConsensusRuleEngine

### DIFF
--- a/src/Stratis.Bitcoin.Features.Consensus/StakeChainStore.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/StakeChainStore.cs
@@ -88,7 +88,7 @@ namespace Stratis.Bitcoin.Features.Consensus
             if (stakeItem.BlockStake != null) this.logger.LogTrace("(-):*.{0}='{1}'", nameof(stakeItem.BlockStake.HashProof), stakeItem.BlockStake.HashProof);
             else this.logger.LogTrace("(-):null");
 
-            Guard.Assert(stakeItem.BlockStake != null); // if we ask for it then we expect its in store
+            Guard.Assert(stakeItem.BlockStake != null, string.Format("{0}:{1} does not exist in the stake store.", nameof(blockid), blockid));
             return stakeItem.BlockStake;
         }
 

--- a/src/Stratis.Bitcoin/Consensus/ConsensusRuleEngine.cs
+++ b/src/Stratis.Bitcoin/Consensus/ConsensusRuleEngine.cs
@@ -8,7 +8,6 @@ using Stratis.Bitcoin.Base;
 using Stratis.Bitcoin.Base.Deployments;
 using Stratis.Bitcoin.Configuration.Settings;
 using Stratis.Bitcoin.Consensus.Rules;
-using Stratis.Bitcoin.Primitives;
 using Stratis.Bitcoin.Utilities;
 
 namespace Stratis.Bitcoin.Consensus
@@ -233,6 +232,10 @@ namespace Stratis.Bitcoin.Consensus
             catch (ConsensusErrorException ex)
             {
                 ruleContext.ValidationContext.Error = ex.ConsensusError;
+            }
+            catch (Exception ex)
+            {
+                ruleContext.ValidationContext.Error = new ConsensusError("unhandled-exception", ex.Message);
             }
         }
 

--- a/src/Stratis.Bitcoin/Consensus/ConsensusRuleEngine.cs
+++ b/src/Stratis.Bitcoin/Consensus/ConsensusRuleEngine.cs
@@ -235,7 +235,7 @@ namespace Stratis.Bitcoin.Consensus
             }
             catch (Exception ex)
             {
-                ruleContext.ValidationContext.Error = new ConsensusError("unhandled-exception", ex.Message);
+                ruleContext.ValidationContext.Error = new ConsensusError("unhandled-exception", ex.Message.ToString());
             }
         }
 

--- a/src/Stratis.Bitcoin/Utilities/Guard.cs
+++ b/src/Stratis.Bitcoin/Utilities/Guard.cs
@@ -21,6 +21,12 @@ namespace Stratis.Bitcoin.Utilities
                 throw new Exception("Assertion failed");
         }
 
+        public static void Assert(bool condition, string message)
+        {
+            if (!condition)
+                throw new Exception(message);
+        }
+
         /// <summary>
         /// Checks an object is not null.
         /// </summary>


### PR DESCRIPTION
Currently if we encounter an unhandled exception in the `ConsensusRuleEngine`, it is not handled and as such ConsensusManager does not know what to do with the peer it received the invalid block from.

An example is being connected to a Stratis-X node that was upgraded and after the upgrade activation point we receive a block which is now not valid anymore and we cant load it from the stake store, an exception is thrown which is not handled. This causes the peer to still be connected and as such the node fails to advance.

I am not sure whether we should do this as now ALL unhandled exceptions in the `ConsensusRuleEngine` will now cause the peer it got the block from, to be banned and disconnected?