### PR TITLE
Periodic log, small CHT and CM edits

### DIFF
--- a/src/NBitcoin/BouncyCastle/math/BigInteger.cs
+++ b/src/NBitcoin/BouncyCastle/math/BigInteger.cs
@@ -2101,7 +2101,7 @@ namespace NBitcoin.BouncyCastle.Math
         {
             // Note: this method allows w to be only (2 * x.Length - 1) words if result will fit
             //            if (w.Length != 2 * x.Length)
-            //                throw new ArgumentException("no I don't think so...");
+            //                throw new ArgumentException("no I don't think so.");
 
             ulong c;
 

--- a/src/Stratis.Bitcoin.Cli/Program.cs
+++ b/src/Stratis.Bitcoin.Cli/Program.cs
@@ -138,13 +138,13 @@ namespace Stratis.Bitcoin.Cli
                         rpcSettings.RpcUser = options.GetValueOf("-rpcuser") ?? rpcSettings.RpcUser;
                         rpcSettings.RpcPassword = options.GetValueOf("-rpcpassword") ?? rpcSettings.RpcPassword;
 
-                        Console.WriteLine($"Connecting to the following RPC node: http://{rpcSettings.RpcUser}:{rpcSettings.RpcPassword}@{rpcUri.Authority}...");
+                        Console.WriteLine($"Connecting to the following RPC node: http://{rpcSettings.RpcUser}:{rpcSettings.RpcPassword}@{rpcUri.Authority}.");
 
                         // Initialize the RPC client with the configured or passed userid, password and endpoint.
                         var rpcClient = new RPCClient($"{rpcSettings.RpcUser}:{rpcSettings.RpcPassword}", rpcUri, network);
 
                         // Execute the RPC command
-                        Console.WriteLine($"Sending RPC command '{command} {string.Join(" ", commandArgList)}' to '{rpcUri}'...");
+                        Console.WriteLine($"Sending RPC command '{command} {string.Join(" ", commandArgList)}' to '{rpcUri}'.");
                         RPCResponse response = rpcClient.SendCommand(command, commandArgList.ToArray());
 
                         // Return the result as a string to the console.
@@ -167,7 +167,7 @@ namespace Stratis.Bitcoin.Cli
                         try
                         {
                             // Get the response.
-                            Console.WriteLine($"Sending API command to {url}...");
+                            Console.WriteLine($"Sending API command to {url}.");
                             string response = client.GetStringAsync(url).GetAwaiter().GetResult();
 
                             // Format and return the result as a string to the console.

--- a/src/Stratis.Bitcoin.Features.Apps/AppsFeature.cs
+++ b/src/Stratis.Bitcoin.Features.Apps/AppsFeature.cs
@@ -30,7 +30,7 @@ namespace Stratis.Bitcoin.Features.Apps
 
         public override void Initialize()
         {
-            this.logger.LogInformation("Initializing {0}", nameof(AppsFeature));
+            this.logger.LogInformation("Initializing {0}.", nameof(AppsFeature));
 
             Directory.CreateDirectory(this.dataFolder.ApplicationsPath);
 
@@ -41,7 +41,7 @@ namespace Stratis.Bitcoin.Features.Apps
         {
             if (this.disposed)
                 return;
-            this.logger.LogInformation("Disposing {0}", nameof(AppsFeature));
+            this.logger.LogInformation("Disposing {0}.", nameof(AppsFeature));
 
             this.appsHost.Close();
 
@@ -62,7 +62,7 @@ namespace Stratis.Bitcoin.Features.Apps
                     .AddFeature<AppsFeature>()
                     .FeatureServices(services =>
                     {
-                        services.AddSingleton<IAppsStore, AppsStore>();                        
+                        services.AddSingleton<IAppsStore, AppsStore>();
                         services.AddSingleton<IAppsHost, AppsHost>();
                         services.AddSingleton<AppsController>();
                     });

--- a/src/Stratis.Bitcoin.Features.Apps/AppsStore.cs
+++ b/src/Stratis.Bitcoin.Features.Apps/AppsStore.cs
@@ -24,13 +24,13 @@ namespace Stratis.Bitcoin.Features.Apps
         public AppsStore(ILoggerFactory loggerFactory, DataFolder dataFolder)
         {
             this.dataFolder = dataFolder;
-            this.logger = loggerFactory.CreateLogger(this.GetType().FullName);            
+            this.logger = loggerFactory.CreateLogger(this.GetType().FullName);
         }
 
         public IEnumerable<IStratisApp> Applications
         {
             get
-            {                
+            {
                 this.Load();
 
                 return this.applications;
@@ -55,7 +55,7 @@ namespace Stratis.Bitcoin.Features.Apps
                 this.applications.AddRange(apps.Where(x => x != null));
 
                 if (this.applications.IsEmpty())
-                    this.logger.LogWarning("No Stratis applications found at or below {0}", this.dataFolder.ApplicationsPath);
+                    this.logger.LogWarning("No Stratis applications found at or below '{0}'", this.dataFolder.ApplicationsPath);
             }
             catch (Exception e)
             {

--- a/src/Stratis.Bitcoin.Features.Apps/AppsStore.cs
+++ b/src/Stratis.Bitcoin.Features.Apps/AppsStore.cs
@@ -55,7 +55,7 @@ namespace Stratis.Bitcoin.Features.Apps
                 this.applications.AddRange(apps.Where(x => x != null));
 
                 if (this.applications.IsEmpty())
-                    this.logger.LogWarning("No Stratis applications found at or below '{0}'", this.dataFolder.ApplicationsPath);
+                    this.logger.LogWarning("No Stratis applications found at or below '{0}'.", this.dataFolder.ApplicationsPath);
             }
             catch (Exception e)
             {

--- a/src/Stratis.Bitcoin.Features.BlockStore/BlockStoreFeature.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/BlockStoreFeature.cs
@@ -94,7 +94,7 @@ namespace Stratis.Bitcoin.Features.BlockStore
         /// <inheritdoc />
         public override void Dispose()
         {
-            this.logger.LogInformation("Stopping BlockStore...");
+            this.logger.LogInformation("Stopping BlockStore.");
 
             this.blockStoreSignaled.Dispose();
         }

--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/TestChainFactory.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/TestChainFactory.cs
@@ -145,7 +145,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests
             testChainContext.Consensus = new ConsensusManager(network, testChainContext.LoggerFactory, testChainContext.ChainState, testChainContext.HeaderValidator, testChainContext.IntegrityValidator,
                 testChainContext.PartialValidator, testChainContext.FullValidator, testChainContext.Checkpoints, consensusSettings, testChainContext.ConsensusRules, testChainContext.FinalizedBlockInfo, new Signals.Signals(),
                 testChainContext.PeerBanning, testChainContext.InitialBlockDownloadState, testChainContext.Chain, new Mock<IBlockPuller>().Object, blockStore,
-                new InvalidBlockHashStore(new DateTimeProvider()), new Mock<IConnectionManager>().Object);
+                new InvalidBlockHashStore(new DateTimeProvider()), new Mock<IConnectionManager>().Object, new Mock<INodeStats>().Object);
 
             await testChainContext.Consensus.InitializeAsync(testChainContext.Chain.Tip);
 

--- a/src/Stratis.Bitcoin.Features.Consensus/CoinViews/CachedCoinView.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/CoinViews/CachedCoinView.cs
@@ -244,7 +244,7 @@ namespace Stratis.Bitcoin.Features.Consensus.CoinViews
             int cacheEntryCount = this.CacheEntryCount;
             if (cacheEntryCount > this.MaxItems)
             {
-                this.logger.LogTrace("Cache is full now with {0} entries, evicting ...", cacheEntryCount);
+                this.logger.LogTrace("Cache is full now with {0} entries, evicting.", cacheEntryCount);
                 await this.EvictAsync().ConfigureAwait(false);
             }
 

--- a/src/Stratis.Bitcoin.Features.Consensus/ConsensusFeature.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/ConsensusFeature.cs
@@ -47,8 +47,7 @@ namespace Stratis.Bitcoin.Features.Consensus
             Signals.Signals signals,
             IConsensusManager consensusManager,
             NodeDeployments nodeDeployments,
-            ConsensusStats consensusStats,
-            INodeStats nodeStats)
+            ConsensusStats consensusStats)
         {
             this.chainState = chainState;
             this.connectionManager = connectionManager;
@@ -58,20 +57,6 @@ namespace Stratis.Bitcoin.Features.Consensus
             this.consensusStats = consensusStats;
 
             this.chainState.MaxReorgLength = network.Consensus.MaxReorgLength;
-
-            nodeStats.RegisterStats(this.AddInlineStats, StatsType.Inline, 1000);
-        }
-
-        private void AddInlineStats(StringBuilder benchLogs)
-        {
-            if (this.chainState?.ConsensusTip != null)
-            {
-                string log = "Consensus.Height: ".PadRight(LoggingConfiguration.ColumnLength + 1) +
-                    this.chainState.ConsensusTip.Height.ToString().PadRight(8) + " Consensus.Hash: ".PadRight(LoggingConfiguration.ColumnLength - 1) +
-                    this.chainState.ConsensusTip.HashBlock;
-
-                benchLogs.AppendLine(log);
-            }
         }
 
         /// <inheritdoc />

--- a/src/Stratis.Bitcoin.Features.Consensus/Rules/PowConsensusRuleEngine.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/Rules/PowConsensusRuleEngine.cs
@@ -62,7 +62,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Rules
             var cache = this.UtxoSet as CachedCoinView;
             if (cache != null)
             {
-                this.logger.LogInformation("Flushing Cache CoinView...");
+                this.logger.LogInformation("Flushing Cache CoinView.");
                 cache.FlushAsync().GetAwaiter().GetResult();
                 cache.Dispose();
             }

--- a/src/Stratis.Bitcoin.Features.MemoryPool.Tests/TestChainFactory.cs
+++ b/src/Stratis.Bitcoin.Features.MemoryPool.Tests/TestChainFactory.cs
@@ -110,7 +110,7 @@ namespace Stratis.Bitcoin.Features.MemoryPool.Tests
             var consensus = new ConsensusManager(network, loggerFactory, chainState, new HeaderValidator(consensusRules, loggerFactory),
                 new IntegrityValidator(consensusRules, loggerFactory), new PartialValidator(consensusRules, loggerFactory), new FullValidator(consensusRules, loggerFactory), new Checkpoints(), consensusSettings, consensusRules,
                 new Mock<IFinalizedBlockInfo>().Object, new Signals.Signals(), peerBanning, new Mock<IInitialBlockDownloadState>().Object, chain, new Mock<IBlockPuller>().Object,
-                new Mock<IBlockStore>().Object, new InvalidBlockHashStore(new DateTimeProvider()), new Mock<IConnectionManager>().Object);
+                new Mock<IBlockStore>().Object, new InvalidBlockHashStore(new DateTimeProvider()), new Mock<IConnectionManager>().Object, new Mock<INodeStats>().Object);
 
             var genesis = new ChainedHeader(network.GetGenesis().Header, network.GenesisHash, 0);
             chainState.BlockStoreTip = genesis;

--- a/src/Stratis.Bitcoin.Features.MemoryPool/MempoolFeature.cs
+++ b/src/Stratis.Bitcoin.Features.MemoryPool/MempoolFeature.cs
@@ -132,16 +132,16 @@ namespace Stratis.Bitcoin.Features.MemoryPool
         /// <inheritdoc />
         public override void Dispose()
         {
-            this.mempoolLogger.LogInformation("Saving Memory Pool...");
+            this.mempoolLogger.LogInformation("Saving Memory Pool.");
 
             MemPoolSaveResult result = this.mempoolManager.SavePool();
             if (result.Succeeded)
             {
-                this.mempoolLogger.LogInformation($"...Memory Pool Saved {result.TrxSaved} transactions");
+                this.mempoolLogger.LogInformation($"Memory Pool Saved {result.TrxSaved} transactions");
             }
             else
             {
-                this.mempoolLogger.LogWarning("...Memory Pool Not Saved!");
+                this.mempoolLogger.LogWarning("Memory Pool Not Saved!");
             }
 
             this.mempoolSignaled.Stop();

--- a/src/Stratis.Bitcoin.Features.MemoryPool/MempoolManager.cs
+++ b/src/Stratis.Bitcoin.Features.MemoryPool/MempoolManager.cs
@@ -129,13 +129,13 @@ namespace Stratis.Bitcoin.Features.MemoryPool
             this.logger.LogTrace("({0}:'{1}')", nameof(fileName), fileName);
             if (this.mempoolPersistence != null && this.memPool?.MapTx != null && this.Validator != null)
             {
-                this.logger.LogInformation("Loading Memory Pool...");
+                this.logger.LogInformation("Loading Memory Pool.");
                 IEnumerable<MempoolPersistenceEntry> entries = this.mempoolPersistence.Load(this.network, fileName);
                 await this.AddMempoolEntriesToMempoolAsync(entries);
             }
             else
             {
-                this.logger.LogInformation("...Unable to load memory pool cache from '{0}'.", fileName);
+                this.logger.LogInformation("Unable to load memory pool cache from '{0}'.", fileName);
             }
             this.logger.LogTrace("(-)");
         }
@@ -260,7 +260,7 @@ namespace Stratis.Bitcoin.Features.MemoryPool
                 // tx timeout in seconds
                 long expiryTimeout = this.mempoolSettings.MempoolExpiry * 60 * 60;
 
-                this.logger.LogInformation("...loaded {0} cached entries.", entries.Count());
+                this.logger.LogInformation("Loaded {0} cached entries.", entries.Count());
                 foreach (MempoolPersistenceEntry entry in entries)
                 {
                     Transaction trx = entry.Tx;
@@ -269,28 +269,28 @@ namespace Stratis.Bitcoin.Features.MemoryPool
 
                     if ((entry.Time + expiryTimeout) <= currentTime)
                     {
-                        this.logger.LogDebug("...transaction ID '{0}' not accepted to mempool due to age of {1:0.##} days.", trxHash, TimeSpan.FromSeconds(this.DateTimeProvider.GetTime() - entry.Time).TotalDays);
+                        this.logger.LogDebug("Transaction ID '{0}' not accepted to mempool due to age of {1:0.##} days.", trxHash, TimeSpan.FromSeconds(this.DateTimeProvider.GetTime() - entry.Time).TotalDays);
                         continue;
                     }
 
                     if (this.memPool.Exists(trxHash))
                     {
-                        this.logger.LogDebug("...transaction ID '{0}' not accepted to mempool because it already exists.", trxHash);
+                        this.logger.LogDebug("Transaction ID '{0}' not accepted to mempool because it already exists.", trxHash);
                         continue;
                     }
                     var state = new MempoolValidationState(false) { AcceptTime = entry.Time, OverrideMempoolLimit = true };
                     if (await this.Validator.AcceptToMemoryPoolWithTime(state, trx) && this.memPool.MapTx.ContainsKey(trxHash))
                     {
-                        this.logger.LogDebug("...transaction ID '{0}' accepted to mempool.", trxHash);
+                        this.logger.LogDebug("Transaction ID '{0}' accepted to mempool.", trxHash);
                         i++;
                         this.memPool.MapTx[trxHash].UpdateFeeDelta(entry.FeeDelta);
                     }
                     else
                     {
-                        this.logger.LogDebug("...transaction ID '{0}' not accepted to mempool because its invalid.", trxHash);
+                        this.logger.LogDebug("Transaction ID '{0}' not accepted to mempool because its invalid.", trxHash);
                     }
                 }
-                this.logger.LogInformation("...{0} entries accepted.", i);
+                this.logger.LogInformation("{0} entries accepted.", i);
             }
 
             this.logger.LogTrace("(-)");

--- a/src/Stratis.Bitcoin.Features.MemoryPool/MempoolPersistence.cs
+++ b/src/Stratis.Bitcoin.Features.MemoryPool/MempoolPersistence.cs
@@ -298,14 +298,14 @@ namespace Stratis.Bitcoin.Features.MemoryPool
                 bitcoinReader.ReadWrite(ref version);
                 if (version != MempoolDumpVersion)
                 {
-                    this.mempoolLogger.LogWarning($"Memorypool data is wrong version ({version}) aborting...");
+                    this.mempoolLogger.LogWarning($"Memorypool data is wrong version ({version}) aborting.");
                     return null;
                 }
                 bitcoinReader.ReadWrite(ref numEntries);
             }
             catch
             {
-                this.mempoolLogger.LogWarning($"Memorypool data is corrupt at header, aborting...");
+                this.mempoolLogger.LogWarning($"Memorypool data is corrupt at header, aborting.");
                 return null;
             }
 
@@ -318,7 +318,7 @@ namespace Stratis.Bitcoin.Features.MemoryPool
                 }
                 catch
                 {
-                    this.mempoolLogger.LogWarning($"Memorypool data is corrupt at item {i + 1}, aborting...");
+                    this.mempoolLogger.LogWarning($"Memorypool data is corrupt at item {i + 1}, aborting.");
                     return null;
                 }
 

--- a/src/Stratis.Bitcoin.Features.Miner/Staking/PosMinting.cs
+++ b/src/Stratis.Bitcoin.Features.Miner/Staking/PosMinting.cs
@@ -388,7 +388,7 @@ namespace Stratis.Bitcoin.Features.Miner.Staking
                 if (this.initialBlockDownloadState.IsInitialBlockDownload() ||
                     this.consensusManager.Tip != this.chain.Tip)
                 {
-                    this.logger.LogTrace("Waiting for synchronization before mining can be started...");
+                    this.logger.LogTrace("Waiting for synchronization before mining can be started.");
 
                     await Task.Delay(TimeSpan.FromMilliseconds(this.minerSleep), cancellationToken).ConfigureAwait(false);
                     continue;
@@ -441,7 +441,7 @@ namespace Stratis.Bitcoin.Features.Miner.Staking
                 }
                 else
                 {
-                    this.logger.LogTrace("{0} failed to create POS block, waiting {1} ms for next round...", nameof(this.StakeAndSignBlockAsync), this.minerSleep);
+                    this.logger.LogTrace("{0} failed to create POS block, waiting {1} ms for next round.", nameof(this.StakeAndSignBlockAsync), this.minerSleep);
                     await Task.Delay(TimeSpan.FromMilliseconds(this.minerSleep), cancellationToken).ConfigureAwait(false);
                 }
             }
@@ -797,7 +797,7 @@ namespace Stratis.Bitcoin.Features.Miner.Staking
             bool stopWork = false;
             foreach (UtxoStakeDescription utxoStakeInfo in orderedUtxoStakeDescriptions)
             {
-                context.Logger.LogTrace("Trying UTXO from address '{0}', output amount {1}...", utxoStakeInfo.Address.Address, utxoStakeInfo.TxOut.Value);
+                context.Logger.LogTrace("Trying UTXO from address '{0}', output amount {1}.", utxoStakeInfo.Address.Address, utxoStakeInfo.TxOut.Value);
 
                 // Script of the first coinstake input.
                 Script scriptPubKeyKernel = utxoStakeInfo.TxOut.ScriptPubKey;
@@ -841,7 +841,7 @@ namespace Stratis.Bitcoin.Features.Miner.Staking
                     if ((txTime & PosTimeMaskRule.StakeTimestampMask) != 0)
                         continue;
 
-                    context.Logger.LogTrace("Trying with transaction time {0}...", txTime);
+                    context.Logger.LogTrace("Trying with transaction time {0}.", txTime);
 
                     try
                     {

--- a/src/Stratis.Bitcoin.Features.Notifications.Tests/NotificationsControllerTest.cs
+++ b/src/Stratis.Bitcoin.Features.Notifications.Tests/NotificationsControllerTest.cs
@@ -54,7 +54,7 @@ namespace Stratis.Bitcoin.Features.Notifications.Tests
             ConsensusManager consensusManager = new ConsensusManager(this.network, this.LoggerFactory.Object, chainState, new HeaderValidator(emptyConsensusRules, this.LoggerFactory.Object),
                 new IntegrityValidator(emptyConsensusRules, this.LoggerFactory.Object), new PartialValidator(emptyConsensusRules, this.LoggerFactory.Object), new FullValidator(emptyConsensusRules, this.LoggerFactory.Object), new Checkpoints(), consensusSettings, emptyConsensusRules,
                 new Mock<IFinalizedBlockInfo>().Object, new Signals.Signals(), peerBanning, new Mock<IInitialBlockDownloadState>().Object, chain, new Mock<IBlockPuller>().Object, new Mock<IBlockStore>().Object,
-                new Mock<IInvalidBlockHashStore>().Object, new Mock<IConnectionManager>().Object);
+                new Mock<IInvalidBlockHashStore>().Object, new Mock<IConnectionManager>().Object, new Mock<INodeStats>().Object);
 
             return consensusManager;
         }

--- a/src/Stratis.Bitcoin.Features.RPC/RPCFeature.cs
+++ b/src/Stratis.Bitcoin.Features.RPC/RPCFeature.cs
@@ -101,7 +101,7 @@ namespace Stratis.Bitcoin.Features.RPC
             }
             else
             {
-                this.logger.LogDebug("RPC Server is off based on configuration.");
+                this.logger.LogInformation("RPC Server is off based on configuration.");
             }
         }
     }

--- a/src/Stratis.Bitcoin.Features.RPC/RPCFeature.cs
+++ b/src/Stratis.Bitcoin.Features.RPC/RPCFeature.cs
@@ -101,7 +101,7 @@ namespace Stratis.Bitcoin.Features.RPC
             }
             else
             {
-                this.logger.LogWarning("RPC Server is off based on configuration.");
+                this.logger.LogDebug("RPC Server is off based on configuration.");
             }
         }
     }

--- a/src/Stratis.Bitcoin.Features.Wallet/WalletManager.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/WalletManager.cs
@@ -180,7 +180,7 @@ namespace Stratis.Bitcoin.Features.Wallet
             this.WalletTipHash = this.LastReceivedBlockHash();
 
             // Save the wallets file every 5 minutes to help against crashes.
-            this.asyncLoop = this.asyncLoopFactory.Run("wallet persist job", token =>
+            this.asyncLoop = this.asyncLoopFactory.Run("Wallet persist job", token =>
             {
                 this.logger.LogTrace("()");
 

--- a/src/Stratis.Bitcoin.IntegrationTests/MinerTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/MinerTests.cs
@@ -176,7 +176,7 @@ namespace Stratis.Bitcoin.IntegrationTests
                 this.consensus = new ConsensusManager(this.network, loggerFactory, chainState, new HeaderValidator(this.ConsensusRules, loggerFactory),
                     new IntegrityValidator(this.ConsensusRules, loggerFactory), new PartialValidator(this.ConsensusRules, loggerFactory), new FullValidator(this.ConsensusRules, loggerFactory), new Checkpoints(),
                     consensusSettings, this.ConsensusRules, new Mock<IFinalizedBlockInfo>().Object, new Signals.Signals(), peerBanning,
-                    new Mock<IInitialBlockDownloadState>().Object, this.chain, new Mock<IBlockPuller>().Object, null, new InvalidBlockHashStore(dateTimeProvider), new Mock<IConnectionManager>().Object);
+                    new Mock<IInitialBlockDownloadState>().Object, this.chain, new Mock<IBlockPuller>().Object, null, new InvalidBlockHashStore(dateTimeProvider), new Mock<IConnectionManager>().Object, new Mock<INodeStats>().Object);
 
                 await this.consensus.InitializeAsync(chainState.BlockStoreTip);
 

--- a/src/Stratis.Bitcoin.IntegrationTests/SmartContracts/SmartContractMinerTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/SmartContracts/SmartContractMinerTests.cs
@@ -254,7 +254,8 @@ namespace Stratis.Bitcoin.IntegrationTests.SmartContracts
                     new Mock<IBlockPuller>().Object,
                     null,
                     new InvalidBlockHashStore(DateTimeProvider.Default),
-                    connectionManager);
+                    connectionManager,
+                    new Mock<INodeStats>().Object);
 
                 await this.consensusManager.InitializeAsync(chainState.BlockStoreTip);
 

--- a/src/Stratis.Bitcoin.Tests/Consensus/ConsensusTestContext.cs
+++ b/src/Stratis.Bitcoin.Tests/Consensus/ConsensusTestContext.cs
@@ -108,7 +108,8 @@ namespace Stratis.Bitcoin.Tests.Consensus
                 new Mock<IBlockPuller>().Object,
                 null,
                 new InvalidBlockHashStore(new DateTimeProvider()),
-                new Mock<IConnectionManager>().Object);
+                new Mock<IConnectionManager>().Object,
+                new Mock<INodeStats>().Object);
 
             return this.ConsensusManager;
         }

--- a/src/Stratis.Bitcoin/Base/BaseFeature.cs
+++ b/src/Stratis.Bitcoin/Base/BaseFeature.cs
@@ -260,7 +260,6 @@ namespace Stratis.Bitcoin.Base
                 this.peerAddressManager.LoadPeers();
             }
 
-            this.logger.LogInformation("Starting periodic peer flushing loop");
             this.flushAddressManagerLoop = this.asyncLoopFactory.Run("Periodic peer flush", token =>
             {
                 this.peerAddressManager.SavePeers();

--- a/src/Stratis.Bitcoin/Base/BaseFeature.cs
+++ b/src/Stratis.Bitcoin/Base/BaseFeature.cs
@@ -222,18 +222,18 @@ namespace Stratis.Bitcoin.Base
         {
             if (!Directory.Exists(this.dataFolder.ChainPath))
             {
-                this.logger.LogInformation("Creating " + this.dataFolder.ChainPath);
+                this.logger.LogInformation("Creating {0}.", this.dataFolder.ChainPath);
                 Directory.CreateDirectory(this.dataFolder.ChainPath);
             }
 
-            this.logger.LogInformation("Loading finalized block height");
+            this.logger.LogInformation("Loading finalized block height.");
             await this.finalizedBlockInfo.LoadFinalizedBlockInfoAsync(this.network).ConfigureAwait(false);
 
-            this.logger.LogInformation("Loading chain");
+            this.logger.LogInformation("Loading chain.");
             ChainedHeader chainTip = await this.chainRepository.LoadAsync(this.chain.Genesis).ConfigureAwait(false);
             this.chain.SetTip(chainTip);
 
-            this.logger.LogInformation("Chain loaded at height {0}", this.chain.Height);
+            this.logger.LogInformation("Chain loaded at height {0}.", this.chain.Height);
 
             this.flushChainLoop = this.asyncLoopFactory.Run("FlushChain", async token =>
             {
@@ -256,7 +256,7 @@ namespace Stratis.Bitcoin.Base
 
             if (File.Exists(Path.Combine(this.dataFolder.AddressManagerFilePath, PeerAddressManager.PeerFileName)))
             {
-                this.logger.LogInformation($"Loading peers from : {this.dataFolder.AddressManagerFilePath}...");
+                this.logger.LogInformation($"Loading peers from : {this.dataFolder.AddressManagerFilePath}.");
                 this.peerAddressManager.LoadPeers();
             }
 
@@ -273,19 +273,19 @@ namespace Stratis.Bitcoin.Base
         /// <inheritdoc />
         public override void Dispose()
         {
-            this.logger.LogInformation("Flushing peers...");
+            this.logger.LogInformation("Flushing peers.");
             this.flushAddressManagerLoop.Dispose();
 
-            this.logger.LogInformation("Disposing peer address manager...");
+            this.logger.LogInformation("Disposing peer address manager.");
             this.peerAddressManager.Dispose();
 
             if (this.flushChainLoop != null)
             {
-                this.logger.LogInformation("Flushing headers chain...");
+                this.logger.LogInformation("Flushing headers chain.");
                 this.flushChainLoop.Dispose();
             }
 
-            this.logger.LogInformation("Saving chain repository...");
+            this.logger.LogInformation("Saving chain repository.");
             this.chainRepository.SaveAsync(this.chain).GetAwaiter().GetResult();
 
             foreach (IDisposable disposable in this.disposableResources)
@@ -294,16 +294,16 @@ namespace Stratis.Bitcoin.Base
                 disposable.Dispose();
             }
 
-            this.logger.LogInformation("Disposing block puller...");
+            this.logger.LogInformation("Disposing block puller.");
             this.blockPuller.Dispose();
 
-            this.logger.LogInformation("Disposing consensus manager...");
+            this.logger.LogInformation("Disposing consensus manager.");
             this.consensusManager.Dispose();
 
-            this.logger.LogInformation("Disposing consensus rules...");
+            this.logger.LogInformation("Disposing consensus rules.");
             this.consensusRules.Dispose();
 
-            this.logger.LogInformation("Disposing block store...");
+            this.logger.LogInformation("Disposing block store.");
             this.blockStore.Dispose();
         }
     }

--- a/src/Stratis.Bitcoin/Base/BaseFeature.cs
+++ b/src/Stratis.Bitcoin/Base/BaseFeature.cs
@@ -233,7 +233,7 @@ namespace Stratis.Bitcoin.Base
             ChainedHeader chainTip = await this.chainRepository.LoadAsync(this.chain.Genesis).ConfigureAwait(false);
             this.chain.SetTip(chainTip);
 
-            this.logger.LogInformation("Chain loaded at height " + this.chain.Height);
+            this.logger.LogInformation("Chain loaded at height {0}", this.chain.Height);
 
             this.flushChainLoop = this.asyncLoopFactory.Run("FlushChain", async token =>
             {
@@ -260,7 +260,8 @@ namespace Stratis.Bitcoin.Base
                 this.peerAddressManager.LoadPeers();
             }
 
-            this.flushAddressManagerLoop = this.asyncLoopFactory.Run("Periodic peer flush...", token =>
+            this.logger.LogInformation("Starting periodic peer flushing loop");
+            this.flushAddressManagerLoop = this.asyncLoopFactory.Run("Periodic peer flush", token =>
             {
                 this.peerAddressManager.SavePeers();
                 return Task.CompletedTask;

--- a/src/Stratis.Bitcoin/Base/BaseFeature.cs
+++ b/src/Stratis.Bitcoin/Base/BaseFeature.cs
@@ -290,7 +290,7 @@ namespace Stratis.Bitcoin.Base
 
             foreach (IDisposable disposable in this.disposableResources)
             {
-                this.logger.LogInformation($"{disposable.GetType().Name}...");
+                this.logger.LogInformation($"{disposable.GetType().Name}.");
                 disposable.Dispose();
             }
 

--- a/src/Stratis.Bitcoin/Connection/ConnectionManager.cs
+++ b/src/Stratis.Bitcoin/Connection/ConnectionManager.cs
@@ -261,7 +261,7 @@ namespace Stratis.Bitcoin.Connection
         {
             this.logger.LogTrace("()");
 
-            this.logger.LogInformation("Stopping peer discovery...");
+            this.logger.LogInformation("Stopping peer discovery.");
             this.peerDiscovery?.Dispose();
 
             foreach (IPeerConnector peerConnector in this.PeerConnectors)

--- a/src/Stratis.Bitcoin/Consensus/ConsensusManager.cs
+++ b/src/Stratis.Bitcoin/Consensus/ConsensusManager.cs
@@ -1203,7 +1203,7 @@ namespace Stratis.Bitcoin.Consensus
             {
                 ChainedHeader bestTip = this.chainedHeaderTree.GetBestPeerTip();
 
-                if (bestTip == null || bestTip.Height < this.Tip.Height)
+                if ((bestTip == null) || (bestTip.Height < this.Tip.Height))
                     bestTip = this.Tip;
 
                 string headersLog = "Headers.Height: ".PadRight(LoggingConfiguration.ColumnLength + 1) + bestTip.Height.ToString().PadRight(8) +

--- a/src/Stratis.Bitcoin/FullNode.cs
+++ b/src/Stratis.Bitcoin/FullNode.cs
@@ -180,7 +180,7 @@ namespace Stratis.Bitcoin
             this.AsyncLoopFactory = this.Services.ServiceProvider.GetService<IAsyncLoopFactory>();
 
             this.logger.LogInformation(Properties.Resources.AsciiLogo);
-            this.logger.LogInformation($"Full node initialized on {this.Network.Name}");
+            this.logger.LogInformation("Full node initialized on {0}.", this.Network.Name);
 
             this.State = FullNodeState.Initialized;
             this.StartTime = this.DateTimeProvider.GetUtcNow();
@@ -208,7 +208,7 @@ namespace Stratis.Bitcoin
             if (this.fullNodeFeatureExecutor == null)
                 throw new InvalidOperationException($"{nameof(FullNodeFeatureExecutor)} must be set.");
 
-            this.logger.LogInformation("Starting node...");
+            this.logger.LogInformation("Starting node.");
 
             // Initialize all registered features.
             this.fullNodeFeatureExecutor.Initialize();
@@ -259,29 +259,29 @@ namespace Stratis.Bitcoin
 
             this.State = FullNodeState.Disposing;
 
-            this.logger.LogInformation("Closing node pending...");
+            this.logger.LogInformation("Closing node pending.");
 
             // Fire INodeLifetime.Stopping.
             this.nodeLifetime.StopApplication();
 
-            this.logger.LogInformation("Disposing connection manager...");
+            this.logger.LogInformation("Disposing connection manager.");
             this.ConnectionManager.Dispose();
 
             foreach (IDisposable disposable in this.Resources)
             {
-                this.logger.LogInformation($"{disposable.GetType().Name}...");
+                this.logger.LogInformation($"{disposable.GetType().Name}.");
                 disposable.Dispose();
             }
 
             // Fire the NodeFeatureExecutor.Stop.
-            this.logger.LogInformation("Disposing the full node feature executor...");
+            this.logger.LogInformation("Disposing the full node feature executor.");
             this.fullNodeFeatureExecutor.Dispose();
 
-            this.logger.LogInformation("Disposing settings...");
+            this.logger.LogInformation("Disposing settings.");
             this.Settings.Dispose();
 
             // Fire INodeLifetime.Stopped.
-            this.logger.LogInformation("Notify application has stopped...");
+            this.logger.LogInformation("Notify application has stopped.");
             this.nodeLifetime.NotifyStopped();
 
             this.State = FullNodeState.Disposed;

--- a/src/Stratis.Bitcoin/P2P/PeerConnectorDiscovery.cs
+++ b/src/Stratis.Bitcoin/P2P/PeerConnectorDiscovery.cs
@@ -126,7 +126,7 @@ namespace Stratis.Bitcoin.P2P
             // effectively override the connector's burst mode.
             if (peer == null)
             {
-                this.logger.LogTrace("Peer selection failed, executing selection delay...");
+                this.logger.LogTrace("Peer selection failed, executing selection delay.");
                 await Task.Delay(2000, this.nodeLifetime.ApplicationStopping).ConfigureAwait(false);
             }
             else

--- a/src/Stratis.Bitcoin/Utilities/AsyncLoop.cs
+++ b/src/Stratis.Bitcoin/Utilities/AsyncLoop.cs
@@ -115,7 +115,7 @@ namespace Stratis.Bitcoin.Utilities
             return Task.Run(async () =>
             {
                 Exception uncaughtException = null;
-                this.logger.LogInformation(this.Name + " starting");
+                this.logger.LogInformation(this.Name + " starting.");
                 try
                 {
                     if (delayStart != null)
@@ -149,7 +149,7 @@ namespace Stratis.Bitcoin.Utilities
                 }
                 finally
                 {
-                    this.logger.LogInformation(this.Name + " stopping");
+                    this.logger.LogInformation(this.Name + " stopping.");
                 }
 
                 if (uncaughtException != null)

--- a/src/Stratis.Bitcoin/Utilities/FullNodeExtensions.cs
+++ b/src/Stratis.Bitcoin/Utilities/FullNodeExtensions.cs
@@ -24,7 +24,7 @@ namespace Stratis.Bitcoin.Utilities
                 {
                     if (!cts.IsCancellationRequested)
                     {
-                        Console.WriteLine("Application is shutting down...");
+                        Console.WriteLine("Application is shutting down.");
                         try
                         {
                             cts.Cancel();

--- a/src/Stratis.Bitcoin/Utilities/PeriodicTask.cs
+++ b/src/Stratis.Bitcoin/Utilities/PeriodicTask.cs
@@ -65,7 +65,7 @@ namespace Stratis.Bitcoin.Utilities
             var t = new Thread(() =>
             {
                 Exception uncatchException = null;
-                this.logger.LogInformation(this.name + " starting");
+                this.logger.LogInformation(this.name + " starting.");
                 try
                 {
                     if (delayStart)
@@ -88,7 +88,7 @@ namespace Stratis.Bitcoin.Utilities
                 }
                 finally
                 {
-                    this.logger.LogInformation(this.Name + " stopping");
+                    this.logger.LogInformation(this.Name + " stopping.");
                 }
 
                 if (uncatchException != null)


### PR DESCRIPTION
Fixed bug in `IsConsensusConsideredToBeSyncedLocked` - it was considering our own tip and would return `true` in case we are not connected to anyone or connected to peers who are less synced than we are. 

Minor initialization logging fixes

Added logging for headers to periodic log as we had them before activation:

![log](https://user-images.githubusercontent.com/10259355/45449455-ea50ed80-b6dd-11e8-8dff-d73aa875b350.png)
