### PR TITLE
handle unexpected error in rules engine

### DIFF
--- a/src/Stratis.Bitcoin/Consensus/ConsensusRuleEngine.cs
+++ b/src/Stratis.Bitcoin/Consensus/ConsensusRuleEngine.cs
@@ -236,7 +236,7 @@ namespace Stratis.Bitcoin.Consensus
             }
             catch (Exception exception)
             {
-                this.logger.LogCritical("Not handled error in the rules engine, exception: {0}.", exception.ToString());
+                this.logger.LogCritical("Unhandled exception in consensus rules engine: {0}.", exception.ToString());
                 throw;
             }
         }
@@ -280,7 +280,7 @@ namespace Stratis.Bitcoin.Consensus
             }
             catch (Exception exception)
             {
-                this.logger.LogCritical("Not handled error in the rules engine, exception: {0}.", exception.ToString());
+                this.logger.LogCritical("Unhandled exception in consensus rules engine: {0}.", exception.ToString());
                 throw;
             }
         }

--- a/src/Stratis.Bitcoin/Consensus/ConsensusRuleEngine.cs
+++ b/src/Stratis.Bitcoin/Consensus/ConsensusRuleEngine.cs
@@ -234,6 +234,11 @@ namespace Stratis.Bitcoin.Consensus
             {
                 ruleContext.ValidationContext.Error = ex.ConsensusError;
             }
+            catch (Exception exception)
+            {
+                this.logger.LogCritical("Not handled error in the rules engine, exception: {0}.", exception.ToString());
+                throw;
+            }
         }
 
         /// <summary>Adds block hash to a list of failed header unless specific consensus error was used that doesn't require block banning.</summary>
@@ -272,6 +277,11 @@ namespace Stratis.Bitcoin.Consensus
             catch (ConsensusErrorException ex)
             {
                 ruleContext.ValidationContext.Error = ex.ConsensusError;
+            }
+            catch (Exception exception)
+            {
+                this.logger.LogCritical("Not handled error in the rules engine, exception: {0}.", exception.ToString());
+                throw;
             }
         }
 


### PR DESCRIPTION
This will at least log out unexpected errors, but the greater question is what to do when that happens, we could for example inject the lifetime token and just shutdown the node for such errors.