### PR TITLE
CM bugfix

### DIFF
--- a/src/Stratis.Bitcoin/Consensus/ConsensusManager.cs
+++ b/src/Stratis.Bitcoin/Consensus/ConsensusManager.cs
@@ -623,7 +623,7 @@ namespace Stratis.Bitcoin.Consensus
 
                     if (block == null)
                     {
-                        // Sanity check.
+                        // Sanity check. Block being disconnected should always be in the block store before we rewind.
                         this.logger.LogTrace("(-)[BLOCK_NOT_FOUND]");
                         throw new Exception("Block that is about to be rewinded wasn't found in cache or database!");
                     }

--- a/src/Stratis.Bitcoin/Consensus/ConsensusManager.cs
+++ b/src/Stratis.Bitcoin/Consensus/ConsensusManager.cs
@@ -590,7 +590,7 @@ namespace Stratis.Bitcoin.Consensus
         /// <returns>List of blocks that were disconnected.</returns>
         private async Task<List<ChainedHeaderBlock>> RewindToForkPointAsync(ChainedHeader fork, ChainedHeader oldTip)
         {
-            this.logger.LogTrace("({0}:'{1}',{2}:'{3}'", nameof(fork), fork, nameof(oldTip), oldTip);
+            this.logger.LogTrace("({0}:'{1}',{2}:'{3}')", nameof(fork), fork, nameof(oldTip), oldTip);
 
             // This is sanity check and should never happen.
             if (fork.Height > oldTip.Height)


### PR DESCRIPTION
Bug found by @dangershony 

Bug setup: we start the node at height 100 and advance 1-2 blocks to height 102. After that we find a better chain with fork at 80 and length of 120. We rewind but we don't have blocks that are being rewinded in memory and therefore `disconnectedBlocks` list will contain nulls for blocks that are missing. 
Then we find out that that better chain is invalid and we try to reconnect old blocks. But we can't- we have nulls in the list. 

Fixed by loading from DB in case it's not found in cache. 