### PR TITLE
Register Network if passed in to NodeSettings

### DIFF
--- a/src/Stratis.Bitcoin/Configuration/NodeSettings.cs
+++ b/src/Stratis.Bitcoin/Configuration/NodeSettings.cs
@@ -157,6 +157,10 @@ namespace Stratis.Bitcoin.Configuration
 
                 this.Logger.LogDebug("Network set to '{0}'.", this.Network.Name);
             }
+            else
+            {
+                NetworkRegistration.Register(network);
+            }
 
             // Set the full data directory path.
             if (this.DataDir == null)

--- a/src/Stratis.Bitcoin/Configuration/NodeSettings.cs
+++ b/src/Stratis.Bitcoin/Configuration/NodeSettings.cs
@@ -158,8 +158,8 @@ namespace Stratis.Bitcoin.Configuration
                 this.Logger.LogDebug("Network set to '{0}'.", this.Network.Name);
             }
 
-            // Ensure the network being used is registered.
-            NetworkRegistration.Register(this.Network);
+            // Ensure the network being used is registered and we have the correct Network object reference.
+            this.Network = NetworkRegistration.Register(this.Network);
 
             // Set the full data directory path.
             if (this.DataDir == null)

--- a/src/Stratis.Bitcoin/Configuration/NodeSettings.cs
+++ b/src/Stratis.Bitcoin/Configuration/NodeSettings.cs
@@ -151,16 +151,15 @@ namespace Stratis.Bitcoin.Configuration
                     throw new ConfigurationException("Invalid combination of regtest and testnet.");
 
                 if (protocolVersion == ProtocolVersion.ALT_PROTOCOL_VERSION)
-                    this.Network = testNet ? NetworkRegistration.Register(new StratisTest()) : regTest ? NetworkRegistration.Register(new StratisRegTest()) : NetworkRegistration.Register(new StratisMain());
+                    this.Network = testNet ? new StratisTest() : regTest ? new StratisRegTest() : new StratisMain();
                 else
-                    this.Network = testNet ? NetworkRegistration.Register(new BitcoinTest()) : regTest ? NetworkRegistration.Register(new BitcoinRegTest()) : NetworkRegistration.Register(new BitcoinMain());
+                    this.Network = testNet ? new BitcoinTest() : regTest ? new BitcoinRegTest() : new BitcoinMain();
 
                 this.Logger.LogDebug("Network set to '{0}'.", this.Network.Name);
             }
-            else
-            {
-                NetworkRegistration.Register(network);
-            }
+
+            // Ensure the network being used is registered.
+            NetworkRegistration.Register(this.Network);
 
             // Set the full data directory path.
             if (this.DataDir == null)

--- a/src/Stratis.StratisSmartContractsD/Program.cs
+++ b/src/Stratis.StratisSmartContractsD/Program.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 using System.Threading.Tasks;
-using NBitcoin;
-using NBitcoin.Networks;
 using NBitcoin.Protocol;
 using Stratis.Bitcoin.Builder;
 using Stratis.Bitcoin.Configuration;
@@ -27,8 +25,7 @@ namespace Stratis.StratisSmartContractsD
         {
             try
             {
-                Network network = NetworkRegistration.Register(new SmartContractPosTest());
-                NodeSettings nodeSettings = new NodeSettings(network, ProtocolVersion.ALT_PROTOCOL_VERSION, "StratisSC", args: args);
+                NodeSettings nodeSettings = new NodeSettings(new SmartContractPosTest(), ProtocolVersion.ALT_PROTOCOL_VERSION, "StratisSC", args: args);
 
                 Bitcoin.IFullNode node = new FullNodeBuilder()
                     .UseNodeSettings(nodeSettings)


### PR DESCRIPTION
If a network is passed into the `NodeSettings` to be used by the node, it also needs to be registered in our list of networks so that we can create a wallet, as the `Network.Parse` method relies on `GetCandidates` using registered networks. Insanely gross, we should fix that eventually, but for now at least we can patch it here.

It's otherwise misleading for anyone else consuming our API trying to run a new network.