### PR TITLE
[PH] - New payloads for Proven headers

### DIFF
--- a/src/NBitcoin/ProvenBlockHeader.cs
+++ b/src/NBitcoin/ProvenBlockHeader.cs
@@ -63,6 +63,10 @@ namespace NBitcoin
         /// </summary>
         public BlockSignature Signature => this.signature;
 
+        public ProvenBlockHeader()
+        {
+        }
+
         public ProvenBlockHeader(PosBlock block)
         {
             if (block == null) throw new ArgumentNullException(nameof(block));

--- a/src/Stratis.Bitcoin/P2P/Protocol/Payloads/GetHeadersPayload.cs
+++ b/src/Stratis.Bitcoin/P2P/Protocol/Payloads/GetHeadersPayload.cs
@@ -9,7 +9,7 @@ namespace Stratis.Bitcoin.P2P.Protocol.Payloads
     [Payload("getheaders")]
     public class GetHeadersPayload : Payload
     {
-        private uint version = (uint)ProtocolVersion.PROTOCOL_VERSION; // TODO: Update once new protocol version is merge in
+        private uint version = (uint)ProtocolVersion.PROTOCOL_VERSION;
 
         public ProtocolVersion Version
         {

--- a/src/Stratis.Bitcoin/P2P/Protocol/Payloads/GetHeadersPayload.cs
+++ b/src/Stratis.Bitcoin/P2P/Protocol/Payloads/GetHeadersPayload.cs
@@ -9,7 +9,7 @@ namespace Stratis.Bitcoin.P2P.Protocol.Payloads
     [Payload("getheaders")]
     public class GetHeadersPayload : Payload
     {
-        private uint version = (uint)ProtocolVersion.PROTOCOL_VERSION;
+        private uint version = (uint)ProtocolVersion.PROTOCOL_VERSION; // TODO: Update once new protocol version is merge in
 
         public ProtocolVersion Version
         {

--- a/src/Stratis.Bitcoin/P2P/Protocol/Payloads/GetProvenHeadersPayload.cs
+++ b/src/Stratis.Bitcoin/P2P/Protocol/Payloads/GetProvenHeadersPayload.cs
@@ -28,7 +28,7 @@ namespace Stratis.Bitcoin.P2P.Protocol.Payloads
         /// <summary>
         /// <see cref="HashStop"/>
         /// </summary>
-        private uint256 hashStop = uint256.Zero;
+        private uint256 hashStop;
 
         /// <summary>
         /// Gets a hash after which no new headers should be sent withing the same message.
@@ -45,11 +45,13 @@ namespace Stratis.Bitcoin.P2P.Protocol.Payloads
 
         public GetProvenHeadersPayload()
         {
+            this.HashStop = uint256.Zero;
         }
 
         public GetProvenHeadersPayload(BlockLocator locator)
         {
             this.BlockLocator = locator;
+            this.HashStop = uint256.Zero;
         }
 
         /// <inheritdoc />

--- a/src/Stratis.Bitcoin/P2P/Protocol/Payloads/GetProvenHeadersPayload.cs
+++ b/src/Stratis.Bitcoin/P2P/Protocol/Payloads/GetProvenHeadersPayload.cs
@@ -1,22 +1,13 @@
 ﻿using NBitcoin;
-using NBitcoin.Protocol;
 
 namespace Stratis.Bitcoin.P2P.Protocol.Payloads
 {
     /// <summary>
-    /// Ask for proven block headers that happened since BlockLocator.
+    /// Ask for proven block headers that happened since <see cref="BlockLocator"/>.
     /// </summary>
     [Payload("getprovhdr")]
     public class GetProvenHeadersPayload : Payload
     {
-        private uint version = (uint)ProtocolVersion.PROTOCOL_VERSION;
-
-        public ProtocolVersion Version
-        {
-            get => (ProtocolVersion)this.version;
-            set => this.version = (uint)value;
-        }
-
         private BlockLocator blockLocator;
 
         public BlockLocator BlockLocator
@@ -44,7 +35,6 @@ namespace Stratis.Bitcoin.P2P.Protocol.Payloads
 
         public override void ReadWriteCore(BitcoinStream stream)
         {
-            stream.ReadWrite(ref this.version);
             stream.ReadWrite(ref this.blockLocator);
             stream.ReadWrite(ref this.hashStop);
         }

--- a/src/Stratis.Bitcoin/P2P/Protocol/Payloads/GetProvenHeadersPayload.cs
+++ b/src/Stratis.Bitcoin/P2P/Protocol/Payloads/GetProvenHeadersPayload.cs
@@ -3,21 +3,37 @@
 namespace Stratis.Bitcoin.P2P.Protocol.Payloads
 {
     /// <summary>
-    /// Ask for proven block headers that happened since <see cref="BlockLocator"/>.
+    /// Get proven headers payload which requests proven headers using a similar mechanism as
+    /// the getheaders protocol message.
     /// </summary>
+    /// <seealso cref="Stratis.Bitcoin.P2P.Protocol.Payloads.Payload" />
     [Payload("getprovhdr")]
     public class GetProvenHeadersPayload : Payload
     {
+        /// <summary>
+        /// A block locator which represents a compact structure of one's chain position which can be used to find
+        /// forks with another chain.
+        /// </summary>
         private BlockLocator blockLocator;
 
+        /// <summary>
+        /// Gets a block locator which represents a compact structure of one's chain position which can be used to find
+        /// forks with another chain.
+        /// </summary>
         public BlockLocator BlockLocator
         {
             get => this.blockLocator;
             set => this.blockLocator = value;
         }
 
+        /// <summary>
+        /// Hash of the block after which constructing proven headers payload should stop.
+        /// </summary>
         private uint256 hashStop = uint256.Zero;
 
+        /// <summary>
+        /// Gets a hash of the block after which constructing proven headers payload should stop.
+        /// </summary>
         public uint256 HashStop
         {
             get => this.hashStop;
@@ -33,6 +49,7 @@ namespace Stratis.Bitcoin.P2P.Protocol.Payloads
             this.BlockLocator = locator;
         }
 
+        /// <inheritdoc />
         public override void ReadWriteCore(BitcoinStream stream)
         {
             stream.ReadWrite(ref this.blockLocator);

--- a/src/Stratis.Bitcoin/P2P/Protocol/Payloads/GetProvenHeadersPayload.cs
+++ b/src/Stratis.Bitcoin/P2P/Protocol/Payloads/GetProvenHeadersPayload.cs
@@ -11,8 +11,7 @@ namespace Stratis.Bitcoin.P2P.Protocol.Payloads
     public class GetProvenHeadersPayload : Payload
     {
         /// <summary>
-        /// A block locator which represents a compact structure of one's chain position which can be used to find
-        /// forks with another chain.
+        /// <see cref="BlockLocator"/>
         /// </summary>
         private BlockLocator blockLocator;
 
@@ -27,13 +26,17 @@ namespace Stratis.Bitcoin.P2P.Protocol.Payloads
         }
 
         /// <summary>
-        /// Hash of the block after which constructing proven headers payload should stop.
+        /// <see cref="HashStop"/>
         /// </summary>
         private uint256 hashStop = uint256.Zero;
 
         /// <summary>
-        /// Gets a hash of the block after which constructing proven headers payload should stop.
+        /// Gets a hash after which no new headers should be sent withing the same message.
         /// </summary>
+        /// <remarks>
+        /// As an example, in case we are asked to send headers from block 1000 but hashStop is at block
+        /// 1200 the answer should contain 200 headers.
+        /// </remarks>
         public uint256 HashStop
         {
             get => this.hashStop;

--- a/src/Stratis.Bitcoin/P2P/Protocol/Payloads/GetProvenHeadersPayload.cs
+++ b/src/Stratis.Bitcoin/P2P/Protocol/Payloads/GetProvenHeadersPayload.cs
@@ -1,0 +1,52 @@
+﻿using NBitcoin;
+using NBitcoin.Protocol;
+
+namespace Stratis.Bitcoin.P2P.Protocol.Payloads
+{
+    /// <summary>
+    /// Ask for proven block headers that happened since BlockLocator.
+    /// </summary>
+    [Payload("getprovhdr")]
+    public class GetProvenHeadersPayload : Payload
+    {
+        private uint version = (uint)ProtocolVersion.PROTOCOL_VERSION;
+
+        public ProtocolVersion Version
+        {
+            get => (ProtocolVersion)this.version;
+            set => this.version = (uint)value;
+        }
+
+        private BlockLocator blockLocator;
+
+        public BlockLocator BlockLocator
+        {
+            get => this.blockLocator;
+            set => this.blockLocator = value;
+        }
+
+        private uint256 hashStop = uint256.Zero;
+
+        public uint256 HashStop
+        {
+            get => this.hashStop;
+            set => this.hashStop = value;
+        }
+
+        public GetProvenHeadersPayload()
+        {
+        }
+
+        public GetProvenHeadersPayload(BlockLocator locator)
+        {
+            this.BlockLocator = locator;
+        }
+
+        public override void ReadWriteCore(BitcoinStream stream)
+        {
+            stream.ReadWrite(ref this.version);
+            stream.ReadWrite(ref this.blockLocator);
+            stream.ReadWrite(ref this.hashStop);
+        }
+    }
+}

--- a/src/Stratis.Bitcoin/P2P/Protocol/Payloads/HeadersPayload.cs
+++ b/src/Stratis.Bitcoin/P2P/Protocol/Payloads/HeadersPayload.cs
@@ -53,8 +53,8 @@ namespace Stratis.Bitcoin.P2P.Protocol.Payloads
         {
             if (stream.Serializing)
             {
-                List<BlockHeaderWithTxCount> heardersOff = this.headers.Select(h => new BlockHeaderWithTxCount(h)).ToList();
-                stream.ReadWrite(ref heardersOff);
+                List<BlockHeaderWithTxCount> headersOff = this.headers.Select(h => new BlockHeaderWithTxCount(h)).ToList();
+                stream.ReadWrite(ref headersOff);
             }
             else
             {

--- a/src/Stratis.Bitcoin/P2P/Protocol/Payloads/ProvenHeadersPayload.cs
+++ b/src/Stratis.Bitcoin/P2P/Protocol/Payloads/ProvenHeadersPayload.cs
@@ -6,7 +6,7 @@ using NBitcoin.Protocol;
 namespace Stratis.Bitcoin.P2P.Protocol.Payloads
 {
     /// <summary>
-    /// Proven block headers received after a getheaders messages.
+    /// Proven block headers received after a getheaders message.
     /// </summary>
     [Payload("provhdr")]
     public class ProvenHeadersPayload : Payload
@@ -53,8 +53,8 @@ namespace Stratis.Bitcoin.P2P.Protocol.Payloads
         {
             if (stream.Serializing)
             {
-                List<ProvenBlockHeaderWithTxCount> heardersOff = this.Headers.Select(h => new ProvenBlockHeaderWithTxCount(h)).ToList();
-                stream.ReadWrite(ref heardersOff);
+                List<ProvenBlockHeaderWithTxCount> headersOff = this.Headers.Select(h => new ProvenBlockHeaderWithTxCount(h)).ToList();
+                stream.ReadWrite(ref headersOff);
             }
             else
             {

--- a/src/Stratis.Bitcoin/P2P/Protocol/Payloads/ProvenHeadersPayload.cs
+++ b/src/Stratis.Bitcoin/P2P/Protocol/Payloads/ProvenHeadersPayload.cs
@@ -1,0 +1,68 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using NBitcoin;
+using NBitcoin.Protocol;
+
+namespace Stratis.Bitcoin.P2P.Protocol.Payloads
+{
+    /// <summary>
+    /// Proven block headers received after a getheaders messages.
+    /// </summary>
+    [Payload("provhdr")]
+    public class ProvenHeadersPayload : Payload
+    {
+        private class ProvenBlockHeaderWithTxCount : IBitcoinSerializable
+        {
+            internal ProvenBlockHeader Header;
+
+            public ProvenBlockHeaderWithTxCount()
+            {
+            }
+
+            public ProvenBlockHeaderWithTxCount(ProvenBlockHeader header)
+            {
+                this.Header = header;
+            }
+
+            public void ReadWrite(BitcoinStream stream)
+            {
+                stream.ReadWrite(ref this.Header);
+                var txCount = new VarInt(0);
+                stream.ReadWrite(ref txCount);
+
+                // Stratis adds an additional byte to the end of a header need to investigate why.
+                if (stream.ConsensusFactory is PosConsensusFactory)
+                {
+                    stream.ReadWrite(ref txCount);
+                }
+            }
+        }
+
+        public List<ProvenBlockHeader> Headers { get; } = new List<ProvenBlockHeader>();
+
+        public ProvenHeadersPayload()
+        {
+        }
+
+        public ProvenHeadersPayload(params ProvenBlockHeader[] headers)
+        {
+            this.Headers.AddRange(headers);
+        }
+
+        public override void ReadWriteCore(BitcoinStream stream)
+        {
+            if (stream.Serializing)
+            {
+                List<ProvenBlockHeaderWithTxCount> heardersOff = this.Headers.Select(h => new ProvenBlockHeaderWithTxCount(h)).ToList();
+                stream.ReadWrite(ref heardersOff);
+            }
+            else
+            {
+                this.Headers.Clear();
+                var headersOff = new List<ProvenBlockHeaderWithTxCount>();
+                stream.ReadWrite(ref headersOff);
+                this.Headers.AddRange(headersOff.Select(h => h.Header));
+            }
+        }
+    }
+}

--- a/src/Stratis.Bitcoin/P2P/Protocol/Payloads/ProvenHeadersPayload.cs
+++ b/src/Stratis.Bitcoin/P2P/Protocol/Payloads/ProvenHeadersPayload.cs
@@ -1,7 +1,5 @@
 ﻿using System.Collections.Generic;
-using System.Linq;
 using NBitcoin;
-using NBitcoin.Protocol;
 
 namespace Stratis.Bitcoin.P2P.Protocol.Payloads
 {
@@ -11,34 +9,9 @@ namespace Stratis.Bitcoin.P2P.Protocol.Payloads
     [Payload("provhdr")]
     public class ProvenHeadersPayload : Payload
     {
-        private class ProvenBlockHeaderWithTxCount : IBitcoinSerializable
-        {
-            internal ProvenBlockHeader Header;
+        private List<BlockHeader> headers = new List<BlockHeader>();
 
-            public ProvenBlockHeaderWithTxCount()
-            {
-            }
-
-            public ProvenBlockHeaderWithTxCount(ProvenBlockHeader header)
-            {
-                this.Header = header;
-            }
-
-            public void ReadWrite(BitcoinStream stream)
-            {
-                stream.ReadWrite(ref this.Header);
-                var txCount = new VarInt(0);
-                stream.ReadWrite(ref txCount);
-
-                // Stratis adds an additional byte to the end of a header need to investigate why.
-                if (stream.ConsensusFactory is PosConsensusFactory)
-                {
-                    stream.ReadWrite(ref txCount);
-                }
-            }
-        }
-
-        public List<ProvenBlockHeader> Headers { get; } = new List<ProvenBlockHeader>();
+        public List<BlockHeader> Headers => this.headers;
 
         public ProvenHeadersPayload()
         {
@@ -51,18 +24,7 @@ namespace Stratis.Bitcoin.P2P.Protocol.Payloads
 
         public override void ReadWriteCore(BitcoinStream stream)
         {
-            if (stream.Serializing)
-            {
-                List<ProvenBlockHeaderWithTxCount> headersOff = this.Headers.Select(h => new ProvenBlockHeaderWithTxCount(h)).ToList();
-                stream.ReadWrite(ref headersOff);
-            }
-            else
-            {
-                this.Headers.Clear();
-                var headersOff = new List<ProvenBlockHeaderWithTxCount>();
-                stream.ReadWrite(ref headersOff);
-                this.Headers.AddRange(headersOff.Select(h => h.Header));
-            }
+            stream.ReadWrite(ref this.headers);
         }
     }
 }

--- a/src/Stratis.Bitcoin/P2P/Protocol/Payloads/ProvenHeadersPayload.cs
+++ b/src/Stratis.Bitcoin/P2P/Protocol/Payloads/ProvenHeadersPayload.cs
@@ -4,13 +4,20 @@ using NBitcoin;
 namespace Stratis.Bitcoin.P2P.Protocol.Payloads
 {
     /// <summary>
-    /// Proven block headers received after a getheaders message.
+    /// Proven headers payload which contains list of up to 2000 proven headers.
     /// </summary>
+    /// <seealso cref="Stratis.Bitcoin.P2P.Protocol.Payloads.Payload" />
     [Payload("provhdr")]
     public class ProvenHeadersPayload : Payload
     {
+        /// <summary>
+        /// A list of up to 2,000 proven headers.
+        /// </summary>
         private List<BlockHeader> headers = new List<BlockHeader>();
 
+        /// <summary>
+        /// Gets a list of up to 2,000 proven headers.
+        /// </summary>
         public List<BlockHeader> Headers => this.headers;
 
         public ProvenHeadersPayload()
@@ -22,6 +29,7 @@ namespace Stratis.Bitcoin.P2P.Protocol.Payloads
             this.Headers.AddRange(headers);
         }
 
+        /// <inheritdoc />
         public override void ReadWriteCore(BitcoinStream stream)
         {
             stream.ReadWrite(ref this.headers);

--- a/src/Stratis.Bitcoin/P2P/Protocol/Payloads/ProvenHeadersPayload.cs
+++ b/src/Stratis.Bitcoin/P2P/Protocol/Payloads/ProvenHeadersPayload.cs
@@ -11,14 +11,14 @@ namespace Stratis.Bitcoin.P2P.Protocol.Payloads
     public class ProvenHeadersPayload : Payload
     {
         /// <summary>
-        /// A list of up to 2,000 proven headers.
+        /// <see cref="Headers"/>
         /// </summary>
-        private List<BlockHeader> headers = new List<BlockHeader>();
+        private List<ProvenBlockHeader> headers = new List<ProvenBlockHeader>();
 
         /// <summary>
         /// Gets a list of up to 2,000 proven headers.
         /// </summary>
-        public List<BlockHeader> Headers => this.headers;
+        public List<ProvenBlockHeader> Headers => this.headers;
 
         public ProvenHeadersPayload()
         {

--- a/src/Stratis.Bitcoin/P2P/Protocol/Payloads/SendProvenHeadersPayload.cs
+++ b/src/Stratis.Bitcoin/P2P/Protocol/Payloads/SendProvenHeadersPayload.cs
@@ -1,7 +1,29 @@
-﻿namespace Stratis.Bitcoin.P2P.Protocol.Payloads
+﻿using NBitcoin;
+
+namespace Stratis.Bitcoin.P2P.Protocol.Payloads
 {
+    /// <summary>
+    /// Send proven headers payload which informs the peer that we are only willing to sync using the proven
+    /// headers and not the old type of headers.
+    /// </summary>
+    /// <seealso cref="Stratis.Bitcoin.P2P.Protocol.Payloads.Payload" />
     [Payload("sendprovhdr")]
     public class SendProvenHeadersPayload : Payload
     {
+        /// <summary>
+        /// A height from which proven headers should be received.
+        /// </summary>
+        private int height;
+
+        /// <summary>
+        /// Gets a height from which proven headers should be received.
+        /// </summary>
+        public int FromHeight => this.height;
+
+        /// <inheritdoc />
+        public override void ReadWriteCore(BitcoinStream stream)
+        {
+            stream.ReadWrite(ref this.height);
+        }
     }
 }

--- a/src/Stratis.Bitcoin/P2P/Protocol/Payloads/SendProvenHeadersPayload.cs
+++ b/src/Stratis.Bitcoin/P2P/Protocol/Payloads/SendProvenHeadersPayload.cs
@@ -11,19 +11,21 @@ namespace Stratis.Bitcoin.P2P.Protocol.Payloads
     public class SendProvenHeadersPayload : Payload
     {
         /// <summary>
-        /// A height from which proven headers should be received.
+        /// <see cref="RequireFromHeight"/>
         /// </summary>
-        private int height;
+        private int requireFromHeight;
 
         /// <summary>
-        /// Gets a height from which proven headers should be received.
+        /// Gets a height from which proven headers must be sent over the normal header.
+        /// Before that height sending normal headers is acceptable because they are checkpointed and therefore
+        /// don't require a proof of validity which proven headers supply.
         /// </summary>
-        public int FromHeight => this.height;
+        public int RequireFromHeight => this.requireFromHeight;
 
         /// <inheritdoc />
         public override void ReadWriteCore(BitcoinStream stream)
         {
-            stream.ReadWrite(ref this.height);
+            stream.ReadWrite(ref this.requireFromHeight);
         }
     }
 }

--- a/src/Stratis.Bitcoin/P2P/Protocol/Payloads/SendProvenHeadersPayload.cs
+++ b/src/Stratis.Bitcoin/P2P/Protocol/Payloads/SendProvenHeadersPayload.cs
@@ -1,0 +1,7 @@
+﻿namespace Stratis.Bitcoin.P2P.Protocol.Payloads
+{
+    [Payload("sendprovhdr")]
+    public class SendProvenHeadersPayload : Payload
+    {
+    }
+}


### PR DESCRIPTION
New set of payloads to be used for `ProvenBlockHeaders` as per #1787 

Payloads are based on equivalent `BlockHeader` payloads