### PR TITLE
Fix partial validation sequence when a fork occurs

### DIFF
--- a/src/NBitcoin/Consensus.cs
+++ b/src/NBitcoin/Consensus.cs
@@ -23,7 +23,7 @@ namespace NBitcoin
         public Money ProofOfStakeReward { get; }
 
         /// <inheritdoc />
-        public uint MaxReorgLength { get; }
+        public uint MaxReorgLength { get; private set; }
 
         /// <inheritdoc />
         public long MaxMoney { get; }

--- a/src/Stratis.Bitcoin.IntegrationTests.Common/TestHelper.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests.Common/TestHelper.cs
@@ -110,7 +110,7 @@ namespace Stratis.Bitcoin.IntegrationTests.Common
             if (numberOfBlocks == 0) throw new ArgumentOutOfRangeException(nameof(numberOfBlocks), "Number of blocks must be greater than zero.");
 
             HdAddress address = node.FullNode.WalletManager().GetUnusedAddress(new WalletAccountReference(walletName, accountName));
-            
+
             Wallet wallet = node.FullNode.WalletManager().GetWalletByName(walletName);
             Key extendedPrivateKey = wallet.GetExtendedPrivateKeyForAddress(walletPassword, address).PrivateKey;
 
@@ -201,6 +201,11 @@ namespace Stratis.Bitcoin.IntegrationTests.Common
             return result;
         }
 
+        public static void Disconnect(CoreNode from, CoreNode to)
+        {
+            from.CreateRPCClient().RemoveNode(to.Endpoint);
+        }
+
         private class TransactionNode
         {
             public uint256 Hash = null;
@@ -242,6 +247,11 @@ namespace Stratis.Bitcoin.IntegrationTests.Common
         {
             Connect(from, to);
             WaitLoop(() => AreNodesSynced(from, to));
+        }
+
+        public static bool IsNodeConnectedTo(CoreNode thisNode, CoreNode isConnectedToNode)
+        {
+            return thisNode.FullNode.ConnectionManager.ConnectedPeers.Any(p => p.PeerEndPoint == isConnectedToNode.Endpoint);
         }
     }
 }

--- a/src/Stratis.Bitcoin.IntegrationTests/ConsensusManagerTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/ConsensusManagerTests.cs
@@ -1,0 +1,93 @@
+﻿using System;
+using NBitcoin;
+using Stratis.Bitcoin.IntegrationTests.Common;
+using Stratis.Bitcoin.IntegrationTests.Common.EnvironmentMockUpHelpers;
+using Stratis.Bitcoin.Networks;
+using Xunit;
+
+namespace Stratis.Bitcoin.IntegrationTests
+{
+    public class ConsensusManagerTests
+    {
+        private readonly Network network;
+
+        private const string walletAccount = "account 0";
+        private const string walletName = "mywallet";
+        private const string walletPassword = "123456";
+
+        public ConsensusManagerTests()
+        {
+            this.network = new StratisRegTest();
+            this.network.Consensus.Options = new ConsensusOptionsTest();
+
+            Type consensusType = typeof(NBitcoin.Consensus);
+            consensusType.GetProperty("MaxReorgLength").SetValue(this.network.Consensus, (uint)20);
+        }
+
+        private class ConsensusOptionsTest : PosConsensusOptions
+        {
+            public override int GetStakeMinConfirmations(int height, Network network)
+            {
+                return height < 10 ? 5 : 10;
+            }
+        }
+
+        [Fact]
+        public void ConsensusManager_Fork_Occurs_Node_Gets_Disconnected_Due_To_MaxReorgViolation()
+        {
+            using (NodeBuilder builder = NodeBuilder.Create(this))
+            {
+                var minerA = builder.CreateStratisPosNode(this.network);
+                var minerB = builder.CreateStratisPosNode(this.network);
+                var syncer = builder.CreateStratisPosNode(this.network);
+
+                builder.StartAll();
+
+                minerA.NotInIBD().WithWallet();
+                minerB.NotInIBD().WithWallet();
+                syncer.NotInIBD();
+
+                // MinerA mines to height 10.
+                TestHelper.MineBlocks(minerA, walletName, walletPassword, walletAccount, 10);
+
+                // Sync the network to height 10.
+                TestHelper.Connect(syncer, minerA);
+                TestHelper.Connect(syncer, minerB);
+                TestHelper.WaitLoop(() => TestHelper.AreNodesSynced(syncer, minerA));
+                TestHelper.WaitLoop(() => TestHelper.AreNodesSynced(syncer, minerB));
+
+                // Disconnect Miner A and B.
+                TestHelper.Disconnect(syncer, minerA);
+                TestHelper.Disconnect(syncer, minerB);
+
+                // Ensure syncer does not have any connections.
+                TestHelper.WaitLoop(() => !TestHelper.IsNodeConnected(syncer));
+
+                // Miner A continues to mine to height 20 whilst disconnected.
+                TestHelper.MineBlocks(minerA, walletName, walletPassword, walletAccount, 10);
+
+                // Miner B continues to mine to height 14 whilst disconnected.
+                TestHelper.MineBlocks(minerB, walletName, walletPassword, walletAccount, 4);
+
+                // Syncer now connects to both miners.
+                TestHelper.Connect(syncer, minerA);
+                TestHelper.Connect(syncer, minerB);
+
+                // Ensure that Syncer has synced with Miner A which is the node with the best tip.
+                TestHelper.WaitLoop(() => TestHelper.AreNodesSynced(syncer, minerA));
+
+                // Miner A needs to mine 20 more blocks so that Miner B can be disconnected from syncer.
+                TestHelper.MineBlocks(minerA, walletName, walletPassword, walletAccount, 20);
+
+                // Ensure that Syncer is not connected to miner B any longer.
+                TestHelper.WaitLoop(() => !TestHelper.IsNodeConnectedTo(syncer, minerB));
+
+                // Reconnect Miner B to Miner A and ensure the sync
+                TestHelper.Connect(minerB, minerA);
+                TestHelper.IsNodeConnectedTo(minerB, minerA);
+
+                TestHelper.WaitLoop(() => TestHelper.AreNodesSynced(minerA, minerB));
+            }
+        }
+    }
+}

--- a/src/Stratis.Bitcoin/BlockPulling/BlockPuller.cs
+++ b/src/Stratis.Bitcoin/BlockPulling/BlockPuller.cs
@@ -296,7 +296,7 @@ namespace Stratis.Bitcoin.BlockPulling
         {
             lock (this.peerLock)
             {
-                return this.pullerBehaviorsByPeerId.Where(p => p.Value.SpeedBytesPerSecond > 0).Sum(x => x.Value.SpeedBytesPerSecond);
+                return this.pullerBehaviorsByPeerId.Sum(x => x.Value.SpeedBytesPerSecond);
             }
         }
 

--- a/src/Stratis.Bitcoin/BlockPulling/BlockPuller.cs
+++ b/src/Stratis.Bitcoin/BlockPulling/BlockPuller.cs
@@ -296,7 +296,7 @@ namespace Stratis.Bitcoin.BlockPulling
         {
             lock (this.peerLock)
             {
-                return this.pullerBehaviorsByPeerId.Sum(x => x.Value.SpeedBytesPerSecond);
+                return this.pullerBehaviorsByPeerId.Where(p => p.Value.SpeedBytesPerSecond > 0).Sum(x => x.Value.SpeedBytesPerSecond);
             }
         }
 
@@ -1063,13 +1063,13 @@ namespace Stratis.Bitcoin.BlockPulling
             // TODO: do that when component is activated.
             // TODO move to nodestats and not bench
             // just for logging
-	        // show it as a part of nodestats, not separated spammer:
-		    // avg download speed
-		    // peer quality score (sort by quality score)
-		    // number of assigned blocks
-		    // MaxBlocksBeingDownloaded
-		    // amount of blocks being downloaded
-		    // show actual speed (no 1mb limit)
+            // show it as a part of nodestats, not separated spammer:
+            // avg download speed
+            // peer quality score (sort by quality score)
+            // number of assigned blocks
+            // MaxBlocksBeingDownloaded
+            // amount of blocks being downloaded
+            // show actual speed (no 1mb limit)
 
             this.logger.LogTrace("(-)");
         }

--- a/src/Stratis.Bitcoin/Consensus/ConsensusManager.cs
+++ b/src/Stratis.Bitcoin/Consensus/ConsensusManager.cs
@@ -464,9 +464,11 @@ namespace Stratis.Bitcoin.Consensus
                 }
             }
 
-            bool nextValidationNeeded = chainedHeaderBlocksToValidate != null;
-            bool fullValidationFailed = (connectBlocksResult != null) && !connectBlocksResult.Succeeded;
-            if (nextValidationNeeded && !fullValidationFailed)
+            // Partial validation should continue if:
+            //  1: There are more blocks to validate.
+            //  2: A full validation was done and succeeded.
+            bool fullValidationSucceeded = (connectBlocksResult != null) && connectBlocksResult.Succeeded;
+            if ((chainedHeaderBlocksToValidate != null) && fullValidationSucceeded)
             {
                 this.logger.LogTrace("Partial validation of {0} block will be started.", chainedHeaderBlocksToValidate.Count);
 

--- a/src/Stratis.Bitcoin/Consensus/ConsensusManager.cs
+++ b/src/Stratis.Bitcoin/Consensus/ConsensusManager.cs
@@ -464,7 +464,9 @@ namespace Stratis.Bitcoin.Consensus
                 }
             }
 
-            if (chainedHeaderBlocksToValidate != null)
+            bool nextValidationNeeded = chainedHeaderBlocksToValidate != null;
+            bool fullValidationFailed = (connectBlocksResult != null) && !connectBlocksResult.Succeeded;
+            if (nextValidationNeeded && !fullValidationFailed)
             {
                 this.logger.LogTrace("Partial validation of {0} block will be started.", chainedHeaderBlocksToValidate.Count);
 


### PR DESCRIPTION
Slimmed down version #2216.

@noescape00 after this change I get this null reference in the block puller when calculating speed? Without that where clause one of the peers has speed of -173382348 something like that. Maybe you can shed some light on this?