### PR TITLE
PeriodicLog bugfix

### DIFF
--- a/src/Stratis.Bitcoin/Consensus/ConsensusManager.cs
+++ b/src/Stratis.Bitcoin/Consensus/ConsensusManager.cs
@@ -1287,26 +1287,12 @@ namespace Stratis.Bitcoin.Consensus
 
             lock (this.peerLock)
             {
-                string unconsumedBlocks = this.formatBigNumber(this.chainedHeaderTree.UnconsumedBlocksCount);
-
-                string unconsumedBytes = this.formatBigNumber(this.chainedHeaderTree.UnconsumedBlocksDataBytes);
-                string maxUnconsumedBytes = this.formatBigNumber(MaxUnconsumedBlocksDataBytes);
-
                 double filledPercentage = Math.Round((this.chainedHeaderTree.UnconsumedBlocksDataBytes / (double)MaxUnconsumedBlocksDataBytes) * 100, 2);
 
-                log.AppendLine($"Unconsumed blocks: {unconsumedBlocks} -- ({unconsumedBytes} / {maxUnconsumedBytes} bytes). Cache is filled by: {filledPercentage}%");
+                log.AppendLine($"Unconsumed blocks: {this.chainedHeaderTree.UnconsumedBlocksCount} -- ({this.chainedHeaderTree.UnconsumedBlocksDataBytes} / {MaxUnconsumedBlocksDataBytes} bytes). Cache is filled by: {filledPercentage}%");
             }
 
             this.logger.LogTrace("(-)");
-        }
-
-        /// <summary>Formats the big number.</summary>
-        /// <remarks><c>123456789</c> => <c>123 456 789</c></remarks>
-        private string formatBigNumber(long number)
-        {
-            string temp = number.ToString("N").Replace(',', ' ');
-            temp = temp.Substring(0, temp.IndexOf(".00"));
-            return temp;
         }
 
         /// <inheritdoc />

--- a/src/Stratis.Bitcoin/Consensus/ConsensusManager.cs
+++ b/src/Stratis.Bitcoin/Consensus/ConsensusManager.cs
@@ -1287,12 +1287,31 @@ namespace Stratis.Bitcoin.Consensus
 
             lock (this.peerLock)
             {
+                string unconsumedBlocks = this.formatBigNumber(this.chainedHeaderTree.UnconsumedBlocksCount);
+
+                string unconsumedBytes = this.formatBigNumber(this.chainedHeaderTree.UnconsumedBlocksDataBytes);
+                string maxUnconsumedBytes = this.formatBigNumber(MaxUnconsumedBlocksDataBytes);
+
                 double filledPercentage = Math.Round((this.chainedHeaderTree.UnconsumedBlocksDataBytes / (double)MaxUnconsumedBlocksDataBytes) * 100, 2);
 
-                log.AppendLine($"Unconsumed blocks: {this.chainedHeaderTree.UnconsumedBlocksCount} -- ({this.chainedHeaderTree.UnconsumedBlocksDataBytes} / {MaxUnconsumedBlocksDataBytes} bytes). Cache is filled by: {filledPercentage}%");
+                log.AppendLine($"Unconsumed blocks: {unconsumedBlocks} -- ({unconsumedBytes} / {maxUnconsumedBytes} bytes). Cache is filled by: {filledPercentage}%");
             }
 
             this.logger.LogTrace("(-)");
+        }
+
+        /// <summary>Formats the big number.</summary>
+        /// <remarks><c>123456789</c> => <c>123 456 789</c></remarks>
+        private string formatBigNumber(long number)
+        {
+            string temp = number.ToString("N").Replace(',', ' ');
+
+            int index = temp.IndexOf(".00");
+
+            if (index != -1)
+                temp = temp.Substring(0, index);
+
+            return temp;
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
Log provided by Kevin:

```
crit: Stratis.Bitcoin.FullNode[0]
      PeriodicLog threw an unhandled exception
System.ArgumentOutOfRangeException: Length cannot be less than zero.
Parameter name: length
   at System.String.Substring(Int32 startIndex, Int32 length)
   at Stratis.Bitcoin.Consensus.ConsensusManager.formatBigNumber(Int64 number) in C:\Users\Kevin\Downloads\Projects\DotNET\StratisBitcoinFullNode\src\Stratis.Bitcoin\Consensus\ConsensusManager.cs:line 1308
   at Stratis.Bitcoin.Consensus.ConsensusManager.AddComponentStats(StringBuilder log) in C:\Users\Kevin\Downloads\Projects\DotNET\StratisBitcoinFullNode\src\Stratis.Bitcoin\Consensus\ConsensusManager.cs:line 1290
   at Stratis.Bitcoin.Utilities.NodeStats.GetStats() in C:\Users\Kevin\Downloads\Projects\DotNET\StratisBitcoinFullNode\src\Stratis.Bitcoin\Utilities\NodeStats.cs:line 71
   at Stratis.Bitcoin.FullNode.<StartPeriodicLog>b__76_0(CancellationToken cancellation) in C:\Users\Kevin\Downloads\Projects\DotNET\StratisBitcoinFullNode\src\Stratis.Bitcoin\FullNode.cs:line 235
   at Stratis.Bitcoin.Utilities.AsyncLoop.<>c__DisplayClass16_0.<<StartAsync>b__0>d.MoveNext() in C:\Users\Kevin\Downloads\Projects\DotNET\StratisBitcoinFullNode\src\Stratis.Bitcoin\Utilities\AsyncLoop.cs:line 136
```

