### PR TITLE
Fody tracer- adding entry\exit logs on compilation

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -39,6 +39,7 @@ init:
 build_script:
 - ps: |
       cd src
+      dotnet remove Stratis.Bitcoin/Stratis.Bitcoin.csproj package Fody
       Write-Host "[$env:configuration] STARTED dotnet build" -foregroundcolor "magenta"
       dotnet build -c $env:configuration -v m 
       Write-Host "[$env:configuration] FINISHED dotnet build" -foregroundcolor "magenta"

--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,12 @@
 #!/bin/bash
 dotnet --info
-echo STARTED dotnet build
+
+echo disabling Fody because it is not needed for CI
+
 cd src
+dotnet remove Stratis.Bitcoin/Stratis.Bitcoin.csproj package Fody
+
+echo STARTED dotnet build
 dotnet build -c Release ${path} -v m
 
 echo STARTED dotnet test

--- a/src/FodyNlogAdapter/Adapters/LogManagerAdapter.cs
+++ b/src/FodyNlogAdapter/Adapters/LogManagerAdapter.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace FodyNlogAdapter.Adapters
+{
+    public static class LogManagerAdapter
+    {
+        public static LoggerAdapter GetLogger(Type type)
+        {
+            return new LoggerAdapter(type);
+        }
+    }
+}

--- a/src/FodyNlogAdapter/Adapters/LoggerAdapter.cs
+++ b/src/FodyNlogAdapter/Adapters/LoggerAdapter.cs
@@ -1,0 +1,785 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Reflection;
+using System.Text;
+using NLog;
+
+namespace FodyNlogAdapter.Adapters
+{
+    public class LoggerAdapter
+    {
+        private const string NullString = "<NULL>";
+        private readonly ILogger _logger;
+        private readonly string _typeName;
+
+        private const string TYPE_INFO = "TypeInfo";
+        private const string METHOD_INFO = "MethodInfo";
+        private readonly string _specialPrefix;
+
+        public LoggerAdapter(Type type)
+        {
+            _typeName = PrettyFormat(type);
+            _logger = FixLoggerLoggerType(LogManager.GetLogger(type.FullName));
+            var configPrefix = Environment.GetEnvironmentVariable("TracerFodySpecialKeyPrefix");
+            _specialPrefix = string.IsNullOrWhiteSpace(configPrefix) ? "$" : configPrefix;
+        }
+
+        private static readonly FieldInfo LoggerTypeField = typeof(Logger).GetField("loggerType", BindingFlags.Instance | BindingFlags.NonPublic);
+
+        private static Logger FixLoggerLoggerType(Logger logger)
+        {
+            if (LoggerTypeField != null)
+            {
+                LoggerTypeField.SetValue(logger, typeof(LoggerAdapter));
+            }
+            return logger;
+        }
+
+        #region Methods required for trace enter and leave
+
+        public void TraceEnter(string methodInfo, string[] paramNames, object[] paramValues)
+        {
+            if (_logger.IsTraceEnabled)
+            {
+                string message;
+                var propDict = new Dictionary<string, object>();
+                propDict["trace"] = "ENTER";
+
+                if (paramNames != null)
+                {
+                    var parameters = new StringBuilder();
+                    for (int i = 0; i < paramNames.Length; i++)
+                    {
+                        parameters.AppendFormat("{0}={1}", paramNames[i], GetRenderedFormat(paramValues[i], NullString));
+                        if (i < paramNames.Length - 1) parameters.Append(", ");
+                    }
+                    var argInfo = parameters.ToString();
+                    propDict["arguments"] = argInfo;
+                    message = String.Format("Entered into {0} ({1}).", methodInfo, argInfo);
+                }
+                else
+                {
+                    message = String.Format("Entered into {0}.", methodInfo);
+                }
+                LogTrace(LogLevel.Trace, methodInfo, message, null, propDict);
+            }
+        }
+
+        public void TraceLeave(string methodInfo, long startTicks, long endTicks, string[] paramNames, object[] paramValues)
+        {
+            if (_logger.IsTraceEnabled)
+            {
+                var propDict = new Dictionary<string, object>();
+                propDict["trace"] = "LEAVE";
+
+                string returnValue = null;
+                if (paramNames != null)
+                {
+                    var parameters = new StringBuilder();
+                    for (int i = 0; i < paramNames.Length; i++)
+                    {
+                        parameters.AppendFormat("{0}={1}", FixSpecialParameterName(paramNames[i] ?? "$return"), GetRenderedFormat(paramValues[i], NullString));
+                        if (i < paramNames.Length - 1) parameters.Append(", ");
+                    }
+                    returnValue = parameters.ToString();
+                    propDict["arguments"] = returnValue;
+                }
+
+                var timeTaken = ConvertTicksToMilliseconds(endTicks - startTicks);
+                propDict["startTicks"] = startTicks;
+                propDict["endTicks"] = endTicks;
+                propDict["timeTaken"] = timeTaken;
+
+                LogTrace(LogLevel.Trace, methodInfo,
+                    String.Format("Returned from {1} ({2}). Time taken: {0:0.00} ms.",
+                        timeTaken, methodInfo, returnValue), null, propDict);
+            }
+        }
+
+        private string FixSpecialParameterName(string paramName)
+        {
+            if (paramName[0] == '$')
+            {
+                return _specialPrefix + paramName.Substring(1);
+            }
+
+            return paramName;
+        }
+
+        private static void AddGenericPrettyFormat(StringBuilder sb, Type[] genericArgumentTypes)
+        {
+            sb.Append("<");
+            for (var i = 0; i < genericArgumentTypes.Length; i++)
+            {
+                sb.Append(genericArgumentTypes[i].Name);
+                if (i < genericArgumentTypes.Length - 1) sb.Append(", ");
+            }
+            sb.Append(">");
+        }
+
+        private static double ConvertTicksToMilliseconds(long ticks)
+        {
+            //ticks * tickFrequency * 10000
+            return ticks * (10000000 / (double)Stopwatch.Frequency) / 10000L;
+        }
+
+        private static string PrettyFormat(Type type)
+        {
+            var sb = new StringBuilder();
+            if (type.IsGenericType)
+            {
+                sb.Append(type.Name.Remove(type.Name.IndexOf('`')));
+                AddGenericPrettyFormat(sb, type.GetGenericArguments());
+            }
+            else
+            {
+                sb.Append(type.Name);
+            }
+            return sb.ToString();
+        }
+
+        private string GetRenderedFormat(object message, string stringRepresentationOfNull = "")
+        {
+            if (message == null)
+                return stringRepresentationOfNull;
+            if (message is string)
+                return (string)message;
+            return message.ToString();
+        }
+
+        private void LogTrace(LogLevel level, string methodInfo, string message, Exception exception = null, Dictionary<string, object> properties = null)
+        {
+            var eventData = new LogEventInfo();
+            eventData.Exception = exception;
+            eventData.Message = message;
+            eventData.Level = level;
+            eventData.LoggerName = _logger.Name;
+
+            eventData.Properties.Add(TYPE_INFO, _typeName);
+            eventData.Properties.Add(METHOD_INFO, methodInfo);
+
+            if (properties != null)
+            {
+                foreach (var property in properties)
+                    eventData.Properties.Add(property.Key, property.Value);
+            }
+
+            _logger.Log(typeof(LoggerAdapter), eventData);
+        }
+
+        #endregion
+
+        public ILogger LogOriginalLogger
+        {
+            get { return _logger; }
+        }
+
+        public bool LogIsTraceEnabled
+        {
+            get { return _logger.IsTraceEnabled; }
+        }
+
+
+        public bool LogIsDebugEnabled
+        {
+            get { return _logger.IsDebugEnabled; }
+        }
+
+        public bool LogIsInfoEnabled
+        {
+            get { return _logger.IsInfoEnabled; }
+        }
+
+        public bool LogIsWarnEnabled
+        {
+            get { return _logger.IsWarnEnabled; }
+        }
+
+        public bool LogIsErrorEnabled
+        {
+            get { return _logger.IsErrorEnabled; }
+        }
+
+        public bool LogIsFatalEnabled
+        {
+            get { return _logger.IsFatalEnabled; }
+        }
+
+        #region Trace() overloads
+
+        public void LogTrace<T>(string methodInfo, T value)
+        {
+            _logger.Trace(value);
+        }
+
+        public void LogTrace<T>(string methodInfo, IFormatProvider formatProvider, T value)
+        {
+            _logger.Trace(formatProvider, value);
+        }
+
+        public void LogTrace(string methodInfo, LogMessageGenerator messageFunc)
+        {
+            _logger.Trace(messageFunc);
+        }
+
+        public void LogTraceException(string methodInfo, string message, Exception exception)
+        {
+            _logger.Trace(message, exception);
+        }
+
+        public void LogTrace(string methodInfo, Exception exception, string message)
+        {
+            _logger.Trace(exception, message);
+        }
+
+        public void LogTrace(string methodInfo, Exception exception, string message, params object[] args)
+        {
+            _logger.Trace(exception, message, args);
+        }
+
+        public void LogTrace(string methodInfo, Exception exception, IFormatProvider formatProvider, string message,
+            params object[] args)
+        {
+            _logger.Trace(exception, formatProvider, message, args);
+        }
+
+        public void LogTrace(string methodInfo, IFormatProvider formatProvider, string message, params object[] args)
+        {
+            _logger.Trace(formatProvider, message, args);
+        }
+
+        public void LogTrace(string methodInfo, string message)
+        {
+            _logger.Trace(message);
+        }
+
+        public void LogTrace(string methodInfo, string message, params object[] args)
+        {
+            _logger.Trace(message, args);
+        }
+
+        public void LogTrace(string methodInfo, string message, Exception exception)
+        {
+            _logger.Trace(message, exception);
+        }
+
+        public void LogTrace<TArgument>(string methodInfo, IFormatProvider formatProvider, string message,
+            TArgument argument)
+        {
+            _logger.Trace(formatProvider, message, argument);
+        }
+
+        public void LogTrace<TArgument>(string methodInfo, string message, TArgument argument)
+        {
+            _logger.Trace(message, argument);
+        }
+
+        public void LogTrace<TArgument1, TArgument2>(string methodInfo, IFormatProvider formatProvider, string message,
+            TArgument1 argument1, TArgument2 argument2)
+        {
+            _logger.Trace(formatProvider, message, argument1, argument2);
+        }
+
+        public void LogTrace<TArgument1, TArgument2>(string methodInfo, string message, TArgument1 argument1,
+            TArgument2 argument2)
+        {
+            _logger.Trace(message, argument1, argument2);
+        }
+
+        public void LogTrace<TArgument1, TArgument2, TArgument3>(string methodInfo, IFormatProvider formatProvider,
+            string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3)
+        {
+            _logger.Trace(formatProvider, message, argument1, argument2, argument3);
+        }
+
+        public void LogTrace<TArgument1, TArgument2, TArgument3>(string methodInfo, string message, TArgument1 argument1,
+            TArgument2 argument2, TArgument3 argument3)
+        {
+            _logger.Trace(message, argument1, argument2, argument3);
+        }
+
+
+        #endregion
+
+        #region Debug() overloads
+
+        public void LogDebug<T>(string methodInfo, T value)
+        {
+            _logger.Debug(value);
+        }
+
+        public void LogDebug<T>(string methodInfo, IFormatProvider formatProvider, T value)
+        {
+            _logger.Debug(formatProvider, value);
+        }
+
+        public void LogDebug(string methodInfo, LogMessageGenerator messageFunc)
+        {
+            _logger.Debug(messageFunc);
+        }
+
+        public void LogDebugException(string methodInfo, string message, Exception exception)
+        {
+            _logger.Debug(message, exception);
+        }
+
+        public void LogDebug(string methodInfo, Exception exception, string message)
+        {
+            _logger.Debug(exception, message);
+        }
+
+        public void LogDebug(string methodInfo, Exception exception, string message, params object[] args)
+        {
+            _logger.Debug(exception, message, args);
+        }
+
+        public void LogDebug(string methodInfo, Exception exception, IFormatProvider formatProvider, string message,
+            params object[] args)
+        {
+            _logger.Debug(exception, formatProvider, message, args);
+        }
+
+        public void LogDebug(string methodInfo, IFormatProvider formatProvider, string message, params object[] args)
+        {
+            _logger.Debug(formatProvider, message, args);
+        }
+
+        public void LogDebug(string methodInfo, string message)
+        {
+            _logger.Debug(message);
+        }
+
+        public void LogDebug(string methodInfo, string message, params object[] args)
+        {
+            _logger.Debug(message, args);
+        }
+
+        public void LogDebug(string methodInfo, string message, Exception exception)
+        {
+            _logger.Debug(message, exception);
+        }
+
+        public void LogDebug<TArgument>(string methodInfo, IFormatProvider formatProvider, string message,
+            TArgument argument)
+        {
+            _logger.Debug(formatProvider, message, argument);
+        }
+
+        public void LogDebug<TArgument>(string methodInfo, string message, TArgument argument)
+        {
+            _logger.Debug(message, argument);
+        }
+
+        public void LogDebug<TArgument1, TArgument2>(string methodInfo, IFormatProvider formatProvider, string message,
+            TArgument1 argument1, TArgument2 argument2)
+        {
+            _logger.Debug(formatProvider, message, argument1, argument2);
+        }
+
+        public void LogDebug<TArgument1, TArgument2>(string methodInfo, string message, TArgument1 argument1,
+            TArgument2 argument2)
+        {
+            _logger.Debug(message, argument1, argument2);
+        }
+
+        public void LogDebug<TArgument1, TArgument2, TArgument3>(string methodInfo, IFormatProvider formatProvider,
+            string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3)
+        {
+            _logger.Debug(formatProvider, message, argument1, argument2, argument3);
+        }
+
+        public void LogDebug<TArgument1, TArgument2, TArgument3>(string methodInfo, string message, TArgument1 argument1,
+            TArgument2 argument2, TArgument3 argument3)
+        {
+            _logger.Debug(message, argument1, argument2, argument3);
+        }
+
+
+        #endregion
+
+        #region Info() overloads
+
+        public void LogInfo<T>(string methodInfo, T value)
+        {
+            _logger.Info(value);
+        }
+
+        public void LogInfo<T>(string methodInfo, IFormatProvider formatProvider, T value)
+        {
+            _logger.Info(formatProvider, value);
+        }
+
+        public void LogInfo(string methodInfo, LogMessageGenerator messageFunc)
+        {
+            _logger.Info(messageFunc);
+        }
+
+        public void LogInfoException(string methodInfo, string message, Exception exception)
+        {
+            _logger.Info(message, exception);
+        }
+
+        public void LogInfo(string methodInfo, Exception exception, string message)
+        {
+            _logger.Info(exception, message);
+        }
+
+        public void LogInfo(string methodInfo, Exception exception, string message, params object[] args)
+        {
+            _logger.Info(exception, message, args);
+        }
+
+        public void LogInfo(string methodInfo, Exception exception, IFormatProvider formatProvider, string message,
+            params object[] args)
+        {
+            _logger.Info(exception, formatProvider, message, args);
+        }
+
+        public void LogInfo(string methodInfo, IFormatProvider formatProvider, string message, params object[] args)
+        {
+            _logger.Info(formatProvider, message, args);
+        }
+
+        public void LogInfo(string methodInfo, string message)
+        {
+            _logger.Info(message);
+        }
+
+        public void LogInfo(string methodInfo, string message, params object[] args)
+        {
+            _logger.Info(message, args);
+        }
+
+        public void LogInfo(string methodInfo, string message, Exception exception)
+        {
+            _logger.Info(message, exception);
+        }
+
+        public void LogInfo<TArgument>(string methodInfo, IFormatProvider formatProvider, string message,
+            TArgument argument)
+        {
+            _logger.Info(formatProvider, message, argument);
+        }
+
+        public void LogInfo<TArgument>(string methodInfo, string message, TArgument argument)
+        {
+            _logger.Info(message, argument);
+        }
+
+        public void LogInfo<TArgument1, TArgument2>(string methodInfo, IFormatProvider formatProvider, string message,
+            TArgument1 argument1, TArgument2 argument2)
+        {
+            _logger.Info(formatProvider, message, argument1, argument2);
+        }
+
+        public void LogInfo<TArgument1, TArgument2>(string methodInfo, string message, TArgument1 argument1,
+            TArgument2 argument2)
+        {
+            _logger.Info(message, argument1, argument2);
+        }
+
+        public void LogInfo<TArgument1, TArgument2, TArgument3>(string methodInfo, IFormatProvider formatProvider,
+            string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3)
+        {
+            _logger.Info(formatProvider, message, argument1, argument2, argument3);
+        }
+
+        public void LogInfo<TArgument1, TArgument2, TArgument3>(string methodInfo, string message, TArgument1 argument1,
+            TArgument2 argument2, TArgument3 argument3)
+        {
+            _logger.Info(message, argument1, argument2, argument3);
+        }
+
+
+        #endregion
+
+        #region Warn() overloads
+
+        public void LogWarn<T>(string methodInfo, T value)
+        {
+            _logger.Warn(value);
+        }
+
+        public void LogWarn<T>(string methodInfo, IFormatProvider formatProvider, T value)
+        {
+            _logger.Warn(formatProvider, value);
+        }
+
+        public void LogWarn(string methodInfo, LogMessageGenerator messageFunc)
+        {
+            _logger.Warn(messageFunc);
+        }
+
+        public void LogWarnException(string methodInfo, string message, Exception exception)
+        {
+            _logger.Warn(message, exception);
+        }
+
+        public void LogWarn(string methodInfo, Exception exception, string message)
+        {
+            _logger.Warn(exception, message);
+        }
+
+        public void LogWarn(string methodInfo, Exception exception, string message, params object[] args)
+        {
+            _logger.Warn(exception, message, args);
+        }
+
+        public void LogWarn(string methodInfo, Exception exception, IFormatProvider formatProvider, string message,
+            params object[] args)
+        {
+            _logger.Warn(exception, formatProvider, message, args);
+        }
+
+        public void LogWarn(string methodInfo, IFormatProvider formatProvider, string message, params object[] args)
+        {
+            _logger.Warn(formatProvider, message, args);
+        }
+
+        public void LogWarn(string methodInfo, string message)
+        {
+            _logger.Warn(message);
+        }
+
+        public void LogWarn(string methodInfo, string message, params object[] args)
+        {
+            _logger.Warn(message, args);
+        }
+
+        public void LogWarn(string methodInfo, string message, Exception exception)
+        {
+            _logger.Warn(message, exception);
+        }
+
+        public void LogWarn<TArgument>(string methodInfo, IFormatProvider formatProvider, string message,
+            TArgument argument)
+        {
+            _logger.Warn(formatProvider, message, argument);
+        }
+
+        public void LogWarn<TArgument>(string methodInfo, string message, TArgument argument)
+        {
+            _logger.Warn(message, argument);
+        }
+
+        public void LogWarn<TArgument1, TArgument2>(string methodInfo, IFormatProvider formatProvider, string message,
+            TArgument1 argument1, TArgument2 argument2)
+        {
+            _logger.Warn(formatProvider, message, argument1, argument2);
+        }
+
+        public void LogWarn<TArgument1, TArgument2>(string methodInfo, string message, TArgument1 argument1,
+            TArgument2 argument2)
+        {
+            _logger.Warn(message, argument1, argument2);
+        }
+
+        public void LogWarn<TArgument1, TArgument2, TArgument3>(string methodInfo, IFormatProvider formatProvider,
+            string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3)
+        {
+            _logger.Warn(formatProvider, message, argument1, argument2, argument3);
+        }
+
+        public void LogWarn<TArgument1, TArgument2, TArgument3>(string methodInfo, string message, TArgument1 argument1,
+            TArgument2 argument2, TArgument3 argument3)
+        {
+            _logger.Warn(message, argument1, argument2, argument3);
+        }
+
+
+        #endregion
+
+        #region Error() overloads
+
+        public void LogError<T>(string methodInfo, T value)
+        {
+            _logger.Error(value);
+        }
+
+        public void LogError<T>(string methodInfo, IFormatProvider formatProvider, T value)
+        {
+            _logger.Error(formatProvider, value);
+        }
+
+        public void LogError(string methodInfo, LogMessageGenerator messageFunc)
+        {
+            _logger.Error(messageFunc);
+        }
+
+        public void LogErrorException(string methodInfo, string message, Exception exception)
+        {
+            _logger.Error(message, exception);
+        }
+
+        public void LogError(string methodInfo, Exception exception, string message)
+        {
+            _logger.Error(exception, message);
+        }
+
+        public void LogError(string methodInfo, Exception exception, string message, params object[] args)
+        {
+            _logger.Error(exception, message, args);
+        }
+
+        public void LogError(string methodInfo, Exception exception, IFormatProvider formatProvider, string message,
+            params object[] args)
+        {
+            _logger.Error(exception, formatProvider, message, args);
+        }
+
+        public void LogError(string methodInfo, IFormatProvider formatProvider, string message, params object[] args)
+        {
+            _logger.Error(formatProvider, message, args);
+        }
+
+        public void LogError(string methodInfo, string message)
+        {
+            _logger.Error(message);
+        }
+
+        public void LogError(string methodInfo, string message, params object[] args)
+        {
+            _logger.Error(message, args);
+        }
+
+        public void LogError(string methodInfo, string message, Exception exception)
+        {
+            _logger.Error(message, exception);
+        }
+
+        public void LogError<TArgument>(string methodInfo, IFormatProvider formatProvider, string message,
+            TArgument argument)
+        {
+            _logger.Error(formatProvider, message, argument);
+        }
+
+        public void LogError<TArgument>(string methodInfo, string message, TArgument argument)
+        {
+            _logger.Error(message, argument);
+        }
+
+        public void LogError<TArgument1, TArgument2>(string methodInfo, IFormatProvider formatProvider, string message,
+            TArgument1 argument1, TArgument2 argument2)
+        {
+            _logger.Error(formatProvider, message, argument1, argument2);
+        }
+
+        public void LogError<TArgument1, TArgument2>(string methodInfo, string message, TArgument1 argument1,
+            TArgument2 argument2)
+        {
+            _logger.Error(message, argument1, argument2);
+        }
+
+        public void LogError<TArgument1, TArgument2, TArgument3>(string methodInfo, IFormatProvider formatProvider,
+            string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3)
+        {
+            _logger.Error(formatProvider, message, argument1, argument2, argument3);
+        }
+
+        public void LogError<TArgument1, TArgument2, TArgument3>(string methodInfo, string message, TArgument1 argument1,
+            TArgument2 argument2, TArgument3 argument3)
+        {
+            _logger.Error(message, argument1, argument2, argument3);
+        }
+
+
+        #endregion
+
+        #region Fatal() overloads
+
+        public void LogFatal<T>(string methodInfo, T value)
+        {
+            _logger.Fatal(value);
+        }
+
+        public void LogFatal<T>(string methodInfo, IFormatProvider formatProvider, T value)
+        {
+            _logger.Fatal(formatProvider, value);
+        }
+
+        public void LogFatal(string methodInfo, LogMessageGenerator messageFunc)
+        {
+            _logger.Fatal(messageFunc);
+        }
+
+        public void LogFatalException(string methodInfo, string message, Exception exception)
+        {
+            _logger.Fatal(message, exception);
+        }
+
+        public void LogFatal(string methodInfo, Exception exception, string message)
+        {
+            _logger.Fatal(exception, message);
+        }
+
+        public void LogFatal(string methodInfo, Exception exception, string message, params object[] args)
+        {
+            _logger.Fatal(exception, message, args);
+        }
+
+        public void LogFatal(string methodInfo, Exception exception, IFormatProvider formatProvider, string message,
+            params object[] args)
+        {
+            _logger.Fatal(exception, formatProvider, message, args);
+        }
+
+        public void LogFatal(string methodInfo, IFormatProvider formatProvider, string message, params object[] args)
+        {
+            _logger.Fatal(formatProvider, message, args);
+        }
+
+        public void LogFatal(string methodInfo, string message)
+        {
+            _logger.Fatal(message);
+        }
+
+        public void LogFatal(string methodInfo, string message, params object[] args)
+        {
+            _logger.Fatal(message, args);
+        }
+
+        public void LogFatal(string methodInfo, string message, Exception exception)
+        {
+            _logger.Fatal(message, exception);
+        }
+
+        public void LogFatal<TArgument>(string methodInfo, IFormatProvider formatProvider, string message,
+            TArgument argument)
+        {
+            _logger.Fatal(formatProvider, message, argument);
+        }
+
+        public void LogFatal<TArgument>(string methodInfo, string message, TArgument argument)
+        {
+            _logger.Fatal(message, argument);
+        }
+
+        public void LogFatal<TArgument1, TArgument2>(string methodInfo, IFormatProvider formatProvider, string message,
+            TArgument1 argument1, TArgument2 argument2)
+        {
+            _logger.Fatal(formatProvider, message, argument1, argument2);
+        }
+
+        public void LogFatal<TArgument1, TArgument2>(string methodInfo, string message, TArgument1 argument1,
+            TArgument2 argument2)
+        {
+            _logger.Fatal(message, argument1, argument2);
+        }
+
+        public void LogFatal<TArgument1, TArgument2, TArgument3>(string methodInfo, IFormatProvider formatProvider,
+            string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3)
+        {
+            _logger.Fatal(formatProvider, message, argument1, argument2, argument3);
+        }
+
+        public void LogFatal<TArgument1, TArgument2, TArgument3>(string methodInfo, string message, TArgument1 argument1,
+            TArgument2 argument2, TArgument3 argument3)
+        {
+            _logger.Fatal(message, argument1, argument2, argument3);
+        }
+
+
+        #endregion
+    }
+}

--- a/src/FodyNlogAdapter/Adapters/LoggerAdapter.cs
+++ b/src/FodyNlogAdapter/Adapters/LoggerAdapter.cs
@@ -10,19 +10,19 @@ namespace FodyNlogAdapter.Adapters
     public class LoggerAdapter
     {
         private const string NullString = "<NULL>";
-        private readonly ILogger _logger;
-        private readonly string _typeName;
+        private readonly ILogger logger;
+        private readonly string typeName;
 
         private const string TYPE_INFO = "TypeInfo";
         private const string METHOD_INFO = "MethodInfo";
-        private readonly string _specialPrefix;
+        private readonly string specialPrefix;
 
         public LoggerAdapter(Type type)
         {
-            _typeName = PrettyFormat(type);
-            _logger = FixLoggerLoggerType(LogManager.GetLogger(type.FullName));
-            var configPrefix = Environment.GetEnvironmentVariable("TracerFodySpecialKeyPrefix");
-            _specialPrefix = string.IsNullOrWhiteSpace(configPrefix) ? "$" : configPrefix;
+            this.typeName = PrettyFormat(type);
+            this.logger = FixLoggerLoggerType(LogManager.GetLogger(type.FullName));
+            string configPrefix = Environment.GetEnvironmentVariable("TracerFodySpecialKeyPrefix");
+            this.specialPrefix = string.IsNullOrWhiteSpace(configPrefix) ? "$" : configPrefix;
         }
 
         private static readonly FieldInfo LoggerTypeField = typeof(Logger).GetField("loggerType", BindingFlags.Instance | BindingFlags.NonPublic);
@@ -36,11 +36,9 @@ namespace FodyNlogAdapter.Adapters
             return logger;
         }
 
-        #region Methods required for trace enter and leave
-
         public void TraceEnter(string methodInfo, string[] paramNames, object[] paramValues)
         {
-            if (_logger.IsTraceEnabled)
+            if (this.logger.IsTraceEnabled)
             {
                 string message;
                 var propDict = new Dictionary<string, object>();
@@ -51,24 +49,26 @@ namespace FodyNlogAdapter.Adapters
                     var parameters = new StringBuilder();
                     for (int i = 0; i < paramNames.Length; i++)
                     {
-                        parameters.AppendFormat("{0}={1}", paramNames[i], GetRenderedFormat(paramValues[i], NullString));
+                        parameters.AppendFormat("{0}={1}", paramNames[i], this.GetRenderedFormat(paramValues[i], NullString));
                         if (i < paramNames.Length - 1) parameters.Append(", ");
                     }
-                    var argInfo = parameters.ToString();
+
+                    string argInfo = parameters.ToString();
                     propDict["arguments"] = argInfo;
-                    message = String.Format("Entered into {0} ({1}).", methodInfo, argInfo);
+                    message = $"Entered into {methodInfo} ({argInfo}).";
                 }
                 else
                 {
-                    message = String.Format("Entered into {0}.", methodInfo);
+                    message = "()";
                 }
-                LogTrace(LogLevel.Trace, methodInfo, message, null, propDict);
+
+                this.LogTrace(LogLevel.Trace, methodInfo, message, null, propDict);
             }
         }
 
         public void TraceLeave(string methodInfo, long startTicks, long endTicks, string[] paramNames, object[] paramValues)
         {
-            if (_logger.IsTraceEnabled)
+            if (this.logger.IsTraceEnabled)
             {
                 var propDict = new Dictionary<string, object>();
                 propDict["trace"] = "LEAVE";
@@ -79,21 +79,20 @@ namespace FodyNlogAdapter.Adapters
                     var parameters = new StringBuilder();
                     for (int i = 0; i < paramNames.Length; i++)
                     {
-                        parameters.AppendFormat("{0}={1}", FixSpecialParameterName(paramNames[i] ?? "$return"), GetRenderedFormat(paramValues[i], NullString));
+                        parameters.AppendFormat("{0}={1}", this.FixSpecialParameterName(paramNames[i] ?? "$return"), this.GetRenderedFormat(paramValues[i], NullString));
                         if (i < paramNames.Length - 1) parameters.Append(", ");
                     }
                     returnValue = parameters.ToString();
                     propDict["arguments"] = returnValue;
                 }
 
-                var timeTaken = ConvertTicksToMilliseconds(endTicks - startTicks);
+                double timeTaken = ConvertTicksToMilliseconds(endTicks - startTicks);
                 propDict["startTicks"] = startTicks;
                 propDict["endTicks"] = endTicks;
                 propDict["timeTaken"] = timeTaken;
 
-                LogTrace(LogLevel.Trace, methodInfo,
-                    String.Format("Returned from {1} ({2}). Time taken: {0:0.00} ms.",
-                        timeTaken, methodInfo, returnValue), null, propDict);
+                this.LogTrace(LogLevel.Trace, methodInfo, message: $"({returnValue}). Elapsed: {timeTaken:0.00} ms.",
+                    exception: null, properties: propDict);
             }
         }
 
@@ -101,7 +100,7 @@ namespace FodyNlogAdapter.Adapters
         {
             if (paramName[0] == '$')
             {
-                return _specialPrefix + paramName.Substring(1);
+                return this.specialPrefix + paramName.Substring(1);
             }
 
             return paramName;
@@ -110,32 +109,33 @@ namespace FodyNlogAdapter.Adapters
         private static void AddGenericPrettyFormat(StringBuilder sb, Type[] genericArgumentTypes)
         {
             sb.Append("<");
-            for (var i = 0; i < genericArgumentTypes.Length; i++)
+            for (int i = 0; i < genericArgumentTypes.Length; i++)
             {
                 sb.Append(genericArgumentTypes[i].Name);
                 if (i < genericArgumentTypes.Length - 1) sb.Append(", ");
             }
+
             sb.Append(">");
         }
 
         private static double ConvertTicksToMilliseconds(long ticks)
         {
-            //ticks * tickFrequency * 10000
+            // ticks * tickFrequency * 10000
             return ticks * (10000000 / (double)Stopwatch.Frequency) / 10000L;
         }
 
         private static string PrettyFormat(Type type)
         {
             var sb = new StringBuilder();
+
             if (type.IsGenericType)
             {
                 sb.Append(type.Name.Remove(type.Name.IndexOf('`')));
                 AddGenericPrettyFormat(sb, type.GetGenericArguments());
             }
             else
-            {
                 sb.Append(type.Name);
-            }
+
             return sb.ToString();
         }
 
@@ -143,8 +143,10 @@ namespace FodyNlogAdapter.Adapters
         {
             if (message == null)
                 return stringRepresentationOfNull;
+
             if (message is string)
                 return (string)message;
+
             return message.ToString();
         }
 
@@ -154,149 +156,125 @@ namespace FodyNlogAdapter.Adapters
             eventData.Exception = exception;
             eventData.Message = message;
             eventData.Level = level;
-            eventData.LoggerName = _logger.Name;
+            eventData.LoggerName = this.logger.Name;
 
-            eventData.Properties.Add(TYPE_INFO, _typeName);
+            eventData.Properties.Add(TYPE_INFO, this.typeName);
             eventData.Properties.Add(METHOD_INFO, methodInfo);
 
             if (properties != null)
             {
-                foreach (var property in properties)
+                foreach (KeyValuePair<string, object> property in properties)
                     eventData.Properties.Add(property.Key, property.Value);
             }
 
-            _logger.Log(typeof(LoggerAdapter), eventData);
+            this.logger.Log(typeof(LoggerAdapter), eventData);
         }
 
-        #endregion
+        public ILogger LogOriginalLogger => this.logger;
 
-        public ILogger LogOriginalLogger
-        {
-            get { return _logger; }
-        }
+        public bool LogIsTraceEnabled => this.logger.IsTraceEnabled;
 
-        public bool LogIsTraceEnabled
-        {
-            get { return _logger.IsTraceEnabled; }
-        }
+        public bool LogIsDebugEnabled => this.logger.IsDebugEnabled;
 
+        public bool LogIsInfoEnabled => this.logger.IsInfoEnabled;
 
-        public bool LogIsDebugEnabled
-        {
-            get { return _logger.IsDebugEnabled; }
-        }
+        public bool LogIsWarnEnabled => this.logger.IsWarnEnabled;
 
-        public bool LogIsInfoEnabled
-        {
-            get { return _logger.IsInfoEnabled; }
-        }
+        public bool LogIsErrorEnabled => this.logger.IsErrorEnabled;
 
-        public bool LogIsWarnEnabled
-        {
-            get { return _logger.IsWarnEnabled; }
-        }
-
-        public bool LogIsErrorEnabled
-        {
-            get { return _logger.IsErrorEnabled; }
-        }
-
-        public bool LogIsFatalEnabled
-        {
-            get { return _logger.IsFatalEnabled; }
-        }
+        public bool LogIsFatalEnabled => this.logger.IsFatalEnabled;
 
         #region Trace() overloads
 
         public void LogTrace<T>(string methodInfo, T value)
         {
-            _logger.Trace(value);
+            this.logger.Trace(value);
         }
 
         public void LogTrace<T>(string methodInfo, IFormatProvider formatProvider, T value)
         {
-            _logger.Trace(formatProvider, value);
+            this.logger.Trace(formatProvider, value);
         }
 
         public void LogTrace(string methodInfo, LogMessageGenerator messageFunc)
         {
-            _logger.Trace(messageFunc);
+            this.logger.Trace(messageFunc);
         }
 
         public void LogTraceException(string methodInfo, string message, Exception exception)
         {
-            _logger.Trace(message, exception);
+            this.logger.Trace(message, exception);
         }
 
         public void LogTrace(string methodInfo, Exception exception, string message)
         {
-            _logger.Trace(exception, message);
+            this.logger.Trace(exception, message);
         }
 
         public void LogTrace(string methodInfo, Exception exception, string message, params object[] args)
         {
-            _logger.Trace(exception, message, args);
+            this.logger.Trace(exception, message, args);
         }
 
         public void LogTrace(string methodInfo, Exception exception, IFormatProvider formatProvider, string message,
             params object[] args)
         {
-            _logger.Trace(exception, formatProvider, message, args);
+            this.logger.Trace(exception, formatProvider, message, args);
         }
 
         public void LogTrace(string methodInfo, IFormatProvider formatProvider, string message, params object[] args)
         {
-            _logger.Trace(formatProvider, message, args);
+            this.logger.Trace(formatProvider, message, args);
         }
 
         public void LogTrace(string methodInfo, string message)
         {
-            _logger.Trace(message);
+            this.logger.Trace(message);
         }
 
         public void LogTrace(string methodInfo, string message, params object[] args)
         {
-            _logger.Trace(message, args);
+            this.logger.Trace(message, args);
         }
 
         public void LogTrace(string methodInfo, string message, Exception exception)
         {
-            _logger.Trace(message, exception);
+            this.logger.Trace(message, exception);
         }
 
         public void LogTrace<TArgument>(string methodInfo, IFormatProvider formatProvider, string message,
             TArgument argument)
         {
-            _logger.Trace(formatProvider, message, argument);
+            this.logger.Trace(formatProvider, message, argument);
         }
 
         public void LogTrace<TArgument>(string methodInfo, string message, TArgument argument)
         {
-            _logger.Trace(message, argument);
+            this.logger.Trace(message, argument);
         }
 
         public void LogTrace<TArgument1, TArgument2>(string methodInfo, IFormatProvider formatProvider, string message,
             TArgument1 argument1, TArgument2 argument2)
         {
-            _logger.Trace(formatProvider, message, argument1, argument2);
+            this.logger.Trace(formatProvider, message, argument1, argument2);
         }
 
         public void LogTrace<TArgument1, TArgument2>(string methodInfo, string message, TArgument1 argument1,
             TArgument2 argument2)
         {
-            _logger.Trace(message, argument1, argument2);
+            this.logger.Trace(message, argument1, argument2);
         }
 
         public void LogTrace<TArgument1, TArgument2, TArgument3>(string methodInfo, IFormatProvider formatProvider,
             string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3)
         {
-            _logger.Trace(formatProvider, message, argument1, argument2, argument3);
+            this.logger.Trace(formatProvider, message, argument1, argument2, argument3);
         }
 
         public void LogTrace<TArgument1, TArgument2, TArgument3>(string methodInfo, string message, TArgument1 argument1,
             TArgument2 argument2, TArgument3 argument3)
         {
-            _logger.Trace(message, argument1, argument2, argument3);
+            this.logger.Trace(message, argument1, argument2, argument3);
         }
 
 
@@ -306,93 +284,93 @@ namespace FodyNlogAdapter.Adapters
 
         public void LogDebug<T>(string methodInfo, T value)
         {
-            _logger.Debug(value);
+            this.logger.Debug(value);
         }
 
         public void LogDebug<T>(string methodInfo, IFormatProvider formatProvider, T value)
         {
-            _logger.Debug(formatProvider, value);
+            this.logger.Debug(formatProvider, value);
         }
 
         public void LogDebug(string methodInfo, LogMessageGenerator messageFunc)
         {
-            _logger.Debug(messageFunc);
+            this.logger.Debug(messageFunc);
         }
 
         public void LogDebugException(string methodInfo, string message, Exception exception)
         {
-            _logger.Debug(message, exception);
+            this.logger.Debug(message, exception);
         }
 
         public void LogDebug(string methodInfo, Exception exception, string message)
         {
-            _logger.Debug(exception, message);
+            this.logger.Debug(exception, message);
         }
 
         public void LogDebug(string methodInfo, Exception exception, string message, params object[] args)
         {
-            _logger.Debug(exception, message, args);
+            this.logger.Debug(exception, message, args);
         }
 
         public void LogDebug(string methodInfo, Exception exception, IFormatProvider formatProvider, string message,
             params object[] args)
         {
-            _logger.Debug(exception, formatProvider, message, args);
+            this.logger.Debug(exception, formatProvider, message, args);
         }
 
         public void LogDebug(string methodInfo, IFormatProvider formatProvider, string message, params object[] args)
         {
-            _logger.Debug(formatProvider, message, args);
+            this.logger.Debug(formatProvider, message, args);
         }
 
         public void LogDebug(string methodInfo, string message)
         {
-            _logger.Debug(message);
+            this.logger.Debug(message);
         }
 
         public void LogDebug(string methodInfo, string message, params object[] args)
         {
-            _logger.Debug(message, args);
+            this.logger.Debug(message, args);
         }
 
         public void LogDebug(string methodInfo, string message, Exception exception)
         {
-            _logger.Debug(message, exception);
+            this.logger.Debug(message, exception);
         }
 
         public void LogDebug<TArgument>(string methodInfo, IFormatProvider formatProvider, string message,
             TArgument argument)
         {
-            _logger.Debug(formatProvider, message, argument);
+            this.logger.Debug(formatProvider, message, argument);
         }
 
         public void LogDebug<TArgument>(string methodInfo, string message, TArgument argument)
         {
-            _logger.Debug(message, argument);
+            this.logger.Debug(message, argument);
         }
 
         public void LogDebug<TArgument1, TArgument2>(string methodInfo, IFormatProvider formatProvider, string message,
             TArgument1 argument1, TArgument2 argument2)
         {
-            _logger.Debug(formatProvider, message, argument1, argument2);
+            this.logger.Debug(formatProvider, message, argument1, argument2);
         }
 
         public void LogDebug<TArgument1, TArgument2>(string methodInfo, string message, TArgument1 argument1,
             TArgument2 argument2)
         {
-            _logger.Debug(message, argument1, argument2);
+            this.logger.Debug(message, argument1, argument2);
         }
 
         public void LogDebug<TArgument1, TArgument2, TArgument3>(string methodInfo, IFormatProvider formatProvider,
             string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3)
         {
-            _logger.Debug(formatProvider, message, argument1, argument2, argument3);
+            this.logger.Debug(formatProvider, message, argument1, argument2, argument3);
         }
 
         public void LogDebug<TArgument1, TArgument2, TArgument3>(string methodInfo, string message, TArgument1 argument1,
             TArgument2 argument2, TArgument3 argument3)
         {
-            _logger.Debug(message, argument1, argument2, argument3);
+            this.logger.Debug(message, argument1, argument2, argument3);
         }
 
 
@@ -402,93 +380,93 @@ namespace FodyNlogAdapter.Adapters
 
         public void LogInfo<T>(string methodInfo, T value)
         {
-            _logger.Info(value);
+            this.logger.Info(value);
         }
 
         public void LogInfo<T>(string methodInfo, IFormatProvider formatProvider, T value)
         {
-            _logger.Info(formatProvider, value);
+            this.logger.Info(formatProvider, value);
         }
 
         public void LogInfo(string methodInfo, LogMessageGenerator messageFunc)
         {
-            _logger.Info(messageFunc);
+            this.logger.Info(messageFunc);
         }
 
         public void LogInfoException(string methodInfo, string message, Exception exception)
         {
-            _logger.Info(message, exception);
+            this.logger.Info(message, exception);
         }
 
         public void LogInfo(string methodInfo, Exception exception, string message)
         {
-            _logger.Info(exception, message);
+            this.logger.Info(exception, message);
         }
 
         public void LogInfo(string methodInfo, Exception exception, string message, params object[] args)
         {
-            _logger.Info(exception, message, args);
+            this.logger.Info(exception, message, args);
         }
 
         public void LogInfo(string methodInfo, Exception exception, IFormatProvider formatProvider, string message,
             params object[] args)
         {
-            _logger.Info(exception, formatProvider, message, args);
+            this.logger.Info(exception, formatProvider, message, args);
         }
 
         public void LogInfo(string methodInfo, IFormatProvider formatProvider, string message, params object[] args)
         {
-            _logger.Info(formatProvider, message, args);
+            this.logger.Info(formatProvider, message, args);
         }
 
         public void LogInfo(string methodInfo, string message)
         {
-            _logger.Info(message);
+            this.logger.Info(message);
         }
 
         public void LogInfo(string methodInfo, string message, params object[] args)
         {
-            _logger.Info(message, args);
+            this.logger.Info(message, args);
         }
 
         public void LogInfo(string methodInfo, string message, Exception exception)
         {
-            _logger.Info(message, exception);
+            this.logger.Info(message, exception);
         }
 
         public void LogInfo<TArgument>(string methodInfo, IFormatProvider formatProvider, string message,
             TArgument argument)
         {
-            _logger.Info(formatProvider, message, argument);
+            this.logger.Info(formatProvider, message, argument);
         }
 
         public void LogInfo<TArgument>(string methodInfo, string message, TArgument argument)
         {
-            _logger.Info(message, argument);
+            this.logger.Info(message, argument);
         }
 
         public void LogInfo<TArgument1, TArgument2>(string methodInfo, IFormatProvider formatProvider, string message,
             TArgument1 argument1, TArgument2 argument2)
         {
-            _logger.Info(formatProvider, message, argument1, argument2);
+            this.logger.Info(formatProvider, message, argument1, argument2);
         }
 
         public void LogInfo<TArgument1, TArgument2>(string methodInfo, string message, TArgument1 argument1,
             TArgument2 argument2)
         {
-            _logger.Info(message, argument1, argument2);
+            this.logger.Info(message, argument1, argument2);
         }
 
         public void LogInfo<TArgument1, TArgument2, TArgument3>(string methodInfo, IFormatProvider formatProvider,
             string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3)
         {
-            _logger.Info(formatProvider, message, argument1, argument2, argument3);
+            this.logger.Info(formatProvider, message, argument1, argument2, argument3);
         }
 
         public void LogInfo<TArgument1, TArgument2, TArgument3>(string methodInfo, string message, TArgument1 argument1,
             TArgument2 argument2, TArgument3 argument3)
         {
-            _logger.Info(message, argument1, argument2, argument3);
+            this.logger.Info(message, argument1, argument2, argument3);
         }
 
 
@@ -498,93 +476,93 @@ namespace FodyNlogAdapter.Adapters
 
         public void LogWarn<T>(string methodInfo, T value)
         {
-            _logger.Warn(value);
+            this.logger.Warn(value);
         }
 
         public void LogWarn<T>(string methodInfo, IFormatProvider formatProvider, T value)
         {
-            _logger.Warn(formatProvider, value);
+            this.logger.Warn(formatProvider, value);
         }
 
         public void LogWarn(string methodInfo, LogMessageGenerator messageFunc)
         {
-            _logger.Warn(messageFunc);
+            this.logger.Warn(messageFunc);
         }
 
         public void LogWarnException(string methodInfo, string message, Exception exception)
         {
-            _logger.Warn(message, exception);
+            this.logger.Warn(message, exception);
         }
 
         public void LogWarn(string methodInfo, Exception exception, string message)
         {
-            _logger.Warn(exception, message);
+            this.logger.Warn(exception, message);
         }
 
         public void LogWarn(string methodInfo, Exception exception, string message, params object[] args)
         {
-            _logger.Warn(exception, message, args);
+            this.logger.Warn(exception, message, args);
         }
 
         public void LogWarn(string methodInfo, Exception exception, IFormatProvider formatProvider, string message,
             params object[] args)
         {
-            _logger.Warn(exception, formatProvider, message, args);
+            this.logger.Warn(exception, formatProvider, message, args);
         }
 
         public void LogWarn(string methodInfo, IFormatProvider formatProvider, string message, params object[] args)
         {
-            _logger.Warn(formatProvider, message, args);
+            this.logger.Warn(formatProvider, message, args);
         }
 
         public void LogWarn(string methodInfo, string message)
         {
-            _logger.Warn(message);
+            this.logger.Warn(message);
         }
 
         public void LogWarn(string methodInfo, string message, params object[] args)
         {
-            _logger.Warn(message, args);
+            this.logger.Warn(message, args);
         }
 
         public void LogWarn(string methodInfo, string message, Exception exception)
         {
-            _logger.Warn(message, exception);
+            this.logger.Warn(message, exception);
         }
 
         public void LogWarn<TArgument>(string methodInfo, IFormatProvider formatProvider, string message,
             TArgument argument)
         {
-            _logger.Warn(formatProvider, message, argument);
+            this.logger.Warn(formatProvider, message, argument);
         }
 
         public void LogWarn<TArgument>(string methodInfo, string message, TArgument argument)
         {
-            _logger.Warn(message, argument);
+            this.logger.Warn(message, argument);
         }
 
         public void LogWarn<TArgument1, TArgument2>(string methodInfo, IFormatProvider formatProvider, string message,
             TArgument1 argument1, TArgument2 argument2)
         {
-            _logger.Warn(formatProvider, message, argument1, argument2);
+            this.logger.Warn(formatProvider, message, argument1, argument2);
         }
 
         public void LogWarn<TArgument1, TArgument2>(string methodInfo, string message, TArgument1 argument1,
             TArgument2 argument2)
         {
-            _logger.Warn(message, argument1, argument2);
+            this.logger.Warn(message, argument1, argument2);
         }
 
         public void LogWarn<TArgument1, TArgument2, TArgument3>(string methodInfo, IFormatProvider formatProvider,
             string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3)
         {
-            _logger.Warn(formatProvider, message, argument1, argument2, argument3);
+            this.logger.Warn(formatProvider, message, argument1, argument2, argument3);
         }
 
         public void LogWarn<TArgument1, TArgument2, TArgument3>(string methodInfo, string message, TArgument1 argument1,
             TArgument2 argument2, TArgument3 argument3)
         {
-            _logger.Warn(message, argument1, argument2, argument3);
+            this.logger.Warn(message, argument1, argument2, argument3);
         }
 
 
@@ -594,93 +572,93 @@ namespace FodyNlogAdapter.Adapters
 
         public void LogError<T>(string methodInfo, T value)
         {
-            _logger.Error(value);
+            this.logger.Error(value);
         }
 
         public void LogError<T>(string methodInfo, IFormatProvider formatProvider, T value)
         {
-            _logger.Error(formatProvider, value);
+            this.logger.Error(formatProvider, value);
         }
 
         public void LogError(string methodInfo, LogMessageGenerator messageFunc)
         {
-            _logger.Error(messageFunc);
+            this.logger.Error(messageFunc);
         }
 
         public void LogErrorException(string methodInfo, string message, Exception exception)
         {
-            _logger.Error(message, exception);
+            this.logger.Error(message, exception);
         }
 
         public void LogError(string methodInfo, Exception exception, string message)
         {
-            _logger.Error(exception, message);
+            this.logger.Error(exception, message);
         }
 
         public void LogError(string methodInfo, Exception exception, string message, params object[] args)
         {
-            _logger.Error(exception, message, args);
+            this.logger.Error(exception, message, args);
         }
 
         public void LogError(string methodInfo, Exception exception, IFormatProvider formatProvider, string message,
             params object[] args)
         {
-            _logger.Error(exception, formatProvider, message, args);
+            this.logger.Error(exception, formatProvider, message, args);
         }
 
         public void LogError(string methodInfo, IFormatProvider formatProvider, string message, params object[] args)
         {
-            _logger.Error(formatProvider, message, args);
+            this.logger.Error(formatProvider, message, args);
         }
 
         public void LogError(string methodInfo, string message)
         {
-            _logger.Error(message);
+            this.logger.Error(message);
         }
 
         public void LogError(string methodInfo, string message, params object[] args)
         {
-            _logger.Error(message, args);
+            this.logger.Error(message, args);
         }
 
         public void LogError(string methodInfo, string message, Exception exception)
         {
-            _logger.Error(message, exception);
+            this.logger.Error(message, exception);
         }
 
         public void LogError<TArgument>(string methodInfo, IFormatProvider formatProvider, string message,
             TArgument argument)
         {
-            _logger.Error(formatProvider, message, argument);
+            this.logger.Error(formatProvider, message, argument);
         }
 
         public void LogError<TArgument>(string methodInfo, string message, TArgument argument)
         {
-            _logger.Error(message, argument);
+            this.logger.Error(message, argument);
         }
 
         public void LogError<TArgument1, TArgument2>(string methodInfo, IFormatProvider formatProvider, string message,
             TArgument1 argument1, TArgument2 argument2)
         {
-            _logger.Error(formatProvider, message, argument1, argument2);
+            this.logger.Error(formatProvider, message, argument1, argument2);
         }
 
         public void LogError<TArgument1, TArgument2>(string methodInfo, string message, TArgument1 argument1,
             TArgument2 argument2)
         {
-            _logger.Error(message, argument1, argument2);
+            this.logger.Error(message, argument1, argument2);
         }
 
         public void LogError<TArgument1, TArgument2, TArgument3>(string methodInfo, IFormatProvider formatProvider,
             string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3)
         {
-            _logger.Error(formatProvider, message, argument1, argument2, argument3);
+            this.logger.Error(formatProvider, message, argument1, argument2, argument3);
         }
 
         public void LogError<TArgument1, TArgument2, TArgument3>(string methodInfo, string message, TArgument1 argument1,
             TArgument2 argument2, TArgument3 argument3)
         {
-            _logger.Error(message, argument1, argument2, argument3);
+            this.logger.Error(message, argument1, argument2, argument3);
         }
 
 
@@ -690,93 +668,93 @@ namespace FodyNlogAdapter.Adapters
 
         public void LogFatal<T>(string methodInfo, T value)
         {
-            _logger.Fatal(value);
+            this.logger.Fatal(value);
         }
 
         public void LogFatal<T>(string methodInfo, IFormatProvider formatProvider, T value)
         {
-            _logger.Fatal(formatProvider, value);
+            this.logger.Fatal(formatProvider, value);
         }
 
         public void LogFatal(string methodInfo, LogMessageGenerator messageFunc)
         {
-            _logger.Fatal(messageFunc);
+            this.logger.Fatal(messageFunc);
         }
 
         public void LogFatalException(string methodInfo, string message, Exception exception)
         {
-            _logger.Fatal(message, exception);
+            this.logger.Fatal(message, exception);
         }
 
         public void LogFatal(string methodInfo, Exception exception, string message)
         {
-            _logger.Fatal(exception, message);
+            this.logger.Fatal(exception, message);
         }
 
         public void LogFatal(string methodInfo, Exception exception, string message, params object[] args)
         {
-            _logger.Fatal(exception, message, args);
+            this.logger.Fatal(exception, message, args);
         }
 
         public void LogFatal(string methodInfo, Exception exception, IFormatProvider formatProvider, string message,
             params object[] args)
         {
-            _logger.Fatal(exception, formatProvider, message, args);
+            this.logger.Fatal(exception, formatProvider, message, args);
         }
 
         public void LogFatal(string methodInfo, IFormatProvider formatProvider, string message, params object[] args)
         {
-            _logger.Fatal(formatProvider, message, args);
+            this.logger.Fatal(formatProvider, message, args);
         }
 
         public void LogFatal(string methodInfo, string message)
         {
-            _logger.Fatal(message);
+            this.logger.Fatal(message);
         }
 
         public void LogFatal(string methodInfo, string message, params object[] args)
         {
-            _logger.Fatal(message, args);
+            this.logger.Fatal(message, args);
         }
 
         public void LogFatal(string methodInfo, string message, Exception exception)
         {
-            _logger.Fatal(message, exception);
+            this.logger.Fatal(message, exception);
         }
 
         public void LogFatal<TArgument>(string methodInfo, IFormatProvider formatProvider, string message,
             TArgument argument)
         {
-            _logger.Fatal(formatProvider, message, argument);
+            this.logger.Fatal(formatProvider, message, argument);
         }
 
         public void LogFatal<TArgument>(string methodInfo, string message, TArgument argument)
         {
-            _logger.Fatal(message, argument);
+            this.logger.Fatal(message, argument);
         }
 
         public void LogFatal<TArgument1, TArgument2>(string methodInfo, IFormatProvider formatProvider, string message,
             TArgument1 argument1, TArgument2 argument2)
         {
-            _logger.Fatal(formatProvider, message, argument1, argument2);
+            this.logger.Fatal(formatProvider, message, argument1, argument2);
         }
 
         public void LogFatal<TArgument1, TArgument2>(string methodInfo, string message, TArgument1 argument1,
             TArgument2 argument2)
         {
-            _logger.Fatal(message, argument1, argument2);
+            this.logger.Fatal(message, argument1, argument2);
         }
 
         public void LogFatal<TArgument1, TArgument2, TArgument3>(string methodInfo, IFormatProvider formatProvider,
             string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3)
         {
-            _logger.Fatal(formatProvider, message, argument1, argument2, argument3);
+            this.logger.Fatal(formatProvider, message, argument1, argument2, argument3);
         }
 
         public void LogFatal<TArgument1, TArgument2, TArgument3>(string methodInfo, string message, TArgument1 argument1,
             TArgument2 argument2, TArgument3 argument3)
         {
-            _logger.Fatal(message, argument1, argument2, argument3);
+            this.logger.Fatal(message, argument1, argument2, argument3);
         }
 
 

--- a/src/FodyNlogAdapter/FodyNlogAdapter.csproj
+++ b/src/FodyNlogAdapter/FodyNlogAdapter.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NLog" Version="4.5.10" />
+    <PackageReference Include="NLog" Version="5.0.0-beta09" />
   </ItemGroup>
 
 </Project>

--- a/src/FodyNlogAdapter/FodyNlogAdapter.csproj
+++ b/src/FodyNlogAdapter/FodyNlogAdapter.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NLog" Version="4.5.10" />
+  </ItemGroup>
+
+</Project>

--- a/src/FodyNlogAdapter/Log.cs
+++ b/src/FodyNlogAdapter/Log.cs
@@ -1,0 +1,1034 @@
+﻿using System;
+using NLog;
+
+namespace FodyNlogAdapter
+{
+    public static class Log
+    {
+        /// <summary>
+        /// Returns the logger wrapped by the rewriter
+        /// </summary>
+        public static ILogger OriginalLogger { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether logging is enabled for the <c>Trace</c> level.
+        /// </summary>
+        /// <returns>A value of <see langword="true" /> if logging is enabled for the <c>Trace</c> level, otherwise it returns <see langword="false" />.</returns>
+        public static bool IsTraceEnabled { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether logging is enabled for the <c>Debug</c> level.
+        /// </summary>
+        /// <returns>A value of <see langword="true" /> if logging is enabled for the <c>Debug</c> level, otherwise it returns <see langword="false" />.</returns>
+        public static bool IsDebugEnabled { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether logging is enabled for the <c>Info</c> level.
+        /// </summary>
+        /// <returns>A value of <see langword="true" /> if logging is enabled for the <c>Info</c> level, otherwise it returns <see langword="false" />.</returns>
+        public static bool IsInfoEnabled { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether logging is enabled for the <c>Warn</c> level.
+        /// </summary>
+        /// <returns>A value of <see langword="true" /> if logging is enabled for the <c>Warn</c> level, otherwise it returns <see langword="false" />.</returns>
+        public static bool IsWarnEnabled { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether logging is enabled for the <c>Error</c> level.
+        /// </summary>
+        /// <returns>A value of <see langword="true" /> if logging is enabled for the <c>Error</c> level, otherwise it returns <see langword="false" />.</returns>
+        public static bool IsErrorEnabled { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether logging is enabled for the <c>Fatal</c> level.
+        /// </summary>
+        /// <returns>A value of <see langword="true" /> if logging is enabled for the <c>Fatal</c> level, otherwise it returns <see langword="false" />.</returns>
+        public static bool IsFatalEnabled { get; }
+
+        #region Trace() overloads
+
+        /// <overloads>
+        /// Writes the diagnostic message at the <c>Trace</c> level using the specified format provider and format parameters.
+        /// </overloads>
+        /// <summary>
+        /// Writes the diagnostic message at the <c>Trace</c> level.
+        /// </summary>
+        /// <typeparam name="T">Type of the value.</typeparam>
+        /// <param name="value">The value to be written.</param>
+        public static void Trace<T>(T value) { }
+
+        /// <summary>
+        /// Writes the diagnostic message at the <c>Trace</c> level.
+        /// </summary>
+        /// <typeparam name="T">Type of the value.</typeparam>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="value">The value to be written.</param>
+        public static void Trace<T>(IFormatProvider formatProvider, T value) { }
+
+        /// <summary>
+        /// Writes the diagnostic message at the <c>Trace</c> level.
+        /// </summary>
+        /// <param name="messageFunc">A function returning message to be written. Function is not evaluated if logging is not enabled.</param>
+        public static void Trace(LogMessageGenerator messageFunc) { }
+
+        /// <summary>
+        /// Writes the diagnostic message and exception at the <c>Trace</c> level.
+        /// </summary>
+        /// <param name="message">A <see langword="string" /> to be written.</param>
+        /// <param name="exception">An exception to be logged.</param>
+        /// <remarks>This method was marked as obsolete before NLog 4.3.11 and it may be removed in a future release.</remarks>
+        [Obsolete("Use Trace(Exception exception, string message, params object[] args) method instead. Marked obsolete before v4.3.11")]
+        public static void TraceException(string message, Exception exception) { }
+
+        /// <summary>
+        /// Writes the diagnostic message and exception at the <c>Trace</c> level.
+        /// </summary>
+        /// <param name="message">A <see langword="string" /> to be written.</param>
+        /// <param name="exception">An exception to be logged.</param>
+        public static void Trace(Exception exception, string message) { }
+
+        /// <summary>
+        /// Writes the diagnostic message and exception at the <c>Trace</c> level.
+        /// </summary>
+        /// <param name="message">A <see langword="string" /> to be written.</param>
+        /// <param name="exception">An exception to be logged.</param>
+        /// <param name="args">Arguments to format.</param>
+
+        public static void Trace(Exception exception, string message, params object[] args) { }
+
+        /// <summary>
+        /// Writes the diagnostic message and exception at the <c>Trace</c> level.
+        /// </summary>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">A <see langword="string" /> to be written.</param>
+        /// <param name="exception">An exception to be logged.</param>
+        /// <param name="args">Arguments to format.</param>
+
+        public static void Trace(Exception exception, IFormatProvider formatProvider, string message, params object[] args) { }
+
+        /// <summary>
+        /// Writes the diagnostic message at the <c>Trace</c> level using the specified parameters and formatting them with the supplied format provider.
+        /// </summary>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">A <see langword="string" /> containing format items.</param>
+        /// <param name="args">Arguments to format.</param>
+
+        public static void Trace(IFormatProvider formatProvider, string message, params object[] args) { }
+
+        /// <summary>
+        /// Writes the diagnostic message at the <c>Trace</c> level.
+        /// </summary>
+        /// <param name="message">Log message.</param>
+        public static void Trace(string message) { }
+
+        /// <summary>
+        /// Writes the diagnostic message at the <c>Trace</c> level using the specified parameters.
+        /// </summary>
+        /// <param name="message">A <see langword="string" /> containing format items.</param>
+        /// <param name="args">Arguments to format.</param>
+
+        public static void Trace(string message, params object[] args) { }
+
+        /// <summary>
+        /// Writes the diagnostic message and exception at the <c>Trace</c> level.
+        /// </summary>
+        /// <param name="message">A <see langword="string" /> to be written.</param>
+        /// <param name="exception">An exception to be logged.</param>
+        /// <remarks>This method was marked as obsolete before NLog 4.3.11 and it may be removed in a future release.</remarks>
+        [Obsolete("Use Trace(Exception exception, string message, params object[] args) method instead. Marked obsolete before v4.3.11")]
+        public static void Trace(string message, Exception exception) { }
+
+        /// <summary>
+        /// Writes the diagnostic message at the <c>Trace</c> level using the specified parameter and formatting it with the supplied format provider.
+        /// </summary>
+        /// <typeparam name="TArgument">The type of the argument.</typeparam>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">A <see langword="string" /> containing one format item.</param>
+        /// <param name="argument">The argument to format.</param>
+
+        public static void Trace<TArgument>(IFormatProvider formatProvider, string message, TArgument argument) { }
+
+        /// <summary>
+        /// Writes the diagnostic message at the <c>Trace</c> level using the specified parameter.
+        /// </summary>
+        /// <typeparam name="TArgument">The type of the argument.</typeparam>
+        /// <param name="message">A <see langword="string" /> containing one format item.</param>
+        /// <param name="argument">The argument to format.</param>
+
+        public static void Trace<TArgument>(string message, TArgument argument) { }
+
+        /// <summary>
+        /// Writes the diagnostic message at the <c>Trace</c> level using the specified arguments formatting it with the supplied format provider.
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the first argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the second argument.</typeparam>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">A <see langword="string" /> containing one format item.</param>
+        /// <param name="argument1">The first argument to format.</param>
+        /// <param name="argument2">The second argument to format.</param>
+
+        public static void Trace<TArgument1, TArgument2>(IFormatProvider formatProvider, string message, TArgument1 argument1, TArgument2 argument2) { }
+
+        /// <summary>
+        /// Writes the diagnostic message at the <c>Trace</c> level using the specified parameters.
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the first argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the second argument.</typeparam>
+        /// <param name="message">A <see langword="string" /> containing one format item.</param>
+        /// <param name="argument1">The first argument to format.</param>
+        /// <param name="argument2">The second argument to format.</param>
+
+        public static void Trace<TArgument1, TArgument2>(string message, TArgument1 argument1, TArgument2 argument2) { }
+
+        /// <summary>
+        /// Writes the diagnostic message at the <c>Trace</c> level using the specified arguments formatting it with the supplied format provider.
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the first argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the second argument.</typeparam>
+        /// <typeparam name="TArgument3">The type of the third argument.</typeparam>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">A <see langword="string" /> containing one format item.</param>
+        /// <param name="argument1">The first argument to format.</param>
+        /// <param name="argument2">The second argument to format.</param>
+        /// <param name="argument3">The third argument to format.</param>
+
+        public static void Trace<TArgument1, TArgument2, TArgument3>(IFormatProvider formatProvider, string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3) { }
+
+        /// <summary>
+        /// Writes the diagnostic message at the <c>Trace</c> level using the specified parameters.
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the first argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the second argument.</typeparam>
+        /// <typeparam name="TArgument3">The type of the third argument.</typeparam>
+        /// <param name="message">A <see langword="string" /> containing one format item.</param>
+        /// <param name="argument1">The first argument to format.</param>
+        /// <param name="argument2">The second argument to format.</param>
+        /// <param name="argument3">The third argument to format.</param>
+
+        public static void Trace<TArgument1, TArgument2, TArgument3>(string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3) { }
+
+        #endregion
+
+        #region Debug() overloads
+
+        /// <overloads>
+        /// Writes the diagnostic message at the <c>Debug</c> level using the specified format provider and format parameters.
+        /// </overloads>
+        /// <summary>
+        /// Writes the diagnostic message at the <c>Debug</c> level.
+        /// </summary>
+        /// <typeparam name="T">Type of the value.</typeparam>
+        /// <param name="value">The value to be written.</param>
+        public static void Debug<T>(T value) { }
+
+        /// <summary>
+        /// Writes the diagnostic message at the <c>Debug</c> level.
+        /// </summary>
+        /// <typeparam name="T">Type of the value.</typeparam>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="value">The value to be written.</param>
+        public static void Debug<T>(IFormatProvider formatProvider, T value) { }
+
+        /// <summary>
+        /// Writes the diagnostic message at the <c>Debug</c> level.
+        /// </summary>
+        /// <param name="messageFunc">A function returning message to be written. Function is not evaluated if logging is not enabled.</param>
+        public static void Debug(LogMessageGenerator messageFunc) { }
+
+        /// <summary>
+        /// Writes the diagnostic message and exception at the <c>Debug</c> level.
+        /// </summary>
+        /// <param name="message">A <see langword="string" /> to be written.</param>
+        /// <param name="exception">An exception to be logged.</param>
+        /// <remarks>This method was marked as obsolete before NLog 4.3.11 and it may be removed in a future release.</remarks>
+        [Obsolete("Use Debug(Exception exception, string message, params object[] args) method instead. Marked obsolete before v4.3.11")]
+        public static void DebugException(string message, Exception exception) { }
+
+        /// <summary>
+        /// Writes the diagnostic message and exception at the <c>Debug</c> level.
+        /// </summary>
+        /// <param name="message">A <see langword="string" /> to be written.</param>
+        /// <param name="exception">An exception to be logged.</param>
+        public static void Debug(Exception exception, string message) { }
+
+        /// <summary>
+        /// Writes the diagnostic message and exception at the <c>Debug</c> level.
+        /// </summary>
+        /// <param name="message">A <see langword="string" /> to be written.</param>
+        /// <param name="exception">An exception to be logged.</param>
+        /// <param name="args">Arguments to format.</param>
+
+        public static void Debug(Exception exception, string message, params object[] args) { }
+
+        /// <summary>
+        /// Writes the diagnostic message and exception at the <c>Debug</c> level.
+        /// </summary>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">A <see langword="string" /> to be written.</param>
+        /// <param name="exception">An exception to be logged.</param>
+        /// <param name="args">Arguments to format.</param>
+
+        public static void Debug(Exception exception, IFormatProvider formatProvider, string message, params object[] args) { }
+
+        /// <summary>
+        /// Writes the diagnostic message at the <c>Debug</c> level using the specified parameters and formatting them with the supplied format provider.
+        /// </summary>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">A <see langword="string" /> containing format items.</param>
+        /// <param name="args">Arguments to format.</param>
+
+        public static void Debug(IFormatProvider formatProvider, string message, params object[] args) { }
+
+        /// <summary>
+        /// Writes the diagnostic message at the <c>Debug</c> level.
+        /// </summary>
+        /// <param name="message">Log message.</param>
+        public static void Debug(string message) { }
+
+        /// <summary>
+        /// Writes the diagnostic message at the <c>Debug</c> level using the specified parameters.
+        /// </summary>
+        /// <param name="message">A <see langword="string" /> containing format items.</param>
+        /// <param name="args">Arguments to format.</param>
+
+        public static void Debug(string message, params object[] args) { }
+
+        /// <summary>
+        /// Writes the diagnostic message and exception at the <c>Debug</c> level.
+        /// </summary>
+        /// <param name="message">A <see langword="string" /> to be written.</param>
+        /// <param name="exception">An exception to be logged.</param>
+        /// <remarks>This method was marked as obsolete before NLog 4.3.11 and it may be removed in a future release.</remarks>
+        [Obsolete("Use Debug(Exception exception, string message, params object[] args) method instead. Marked obsolete before v4.3.11")]
+        public static void Debug(string message, Exception exception) { }
+
+        /// <summary>
+        /// Writes the diagnostic message at the <c>Debug</c> level using the specified parameter and formatting it with the supplied format provider.
+        /// </summary>
+        /// <typeparam name="TArgument">The type of the argument.</typeparam>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">A <see langword="string" /> containing one format item.</param>
+        /// <param name="argument">The argument to format.</param>
+
+        public static void Debug<TArgument>(IFormatProvider formatProvider, string message, TArgument argument) { }
+
+        /// <summary>
+        /// Writes the diagnostic message at the <c>Debug</c> level using the specified parameter.
+        /// </summary>
+        /// <typeparam name="TArgument">The type of the argument.</typeparam>
+        /// <param name="message">A <see langword="string" /> containing one format item.</param>
+        /// <param name="argument">The argument to format.</param>
+
+        public static void Debug<TArgument>(string message, TArgument argument) { }
+
+        /// <summary>
+        /// Writes the diagnostic message at the <c>Debug</c> level using the specified arguments formatting it with the supplied format provider.
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the first argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the second argument.</typeparam>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">A <see langword="string" /> containing one format item.</param>
+        /// <param name="argument1">The first argument to format.</param>
+        /// <param name="argument2">The second argument to format.</param>
+
+        public static void Debug<TArgument1, TArgument2>(IFormatProvider formatProvider, string message, TArgument1 argument1, TArgument2 argument2) { }
+
+        /// <summary>
+        /// Writes the diagnostic message at the <c>Debug</c> level using the specified parameters.
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the first argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the second argument.</typeparam>
+        /// <param name="message">A <see langword="string" /> containing one format item.</param>
+        /// <param name="argument1">The first argument to format.</param>
+        /// <param name="argument2">The second argument to format.</param>
+
+        public static void Debug<TArgument1, TArgument2>(string message, TArgument1 argument1, TArgument2 argument2) { }
+
+        /// <summary>
+        /// Writes the diagnostic message at the <c>Debug</c> level using the specified arguments formatting it with the supplied format provider.
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the first argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the second argument.</typeparam>
+        /// <typeparam name="TArgument3">The type of the third argument.</typeparam>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">A <see langword="string" /> containing one format item.</param>
+        /// <param name="argument1">The first argument to format.</param>
+        /// <param name="argument2">The second argument to format.</param>
+        /// <param name="argument3">The third argument to format.</param>
+
+        public static void Debug<TArgument1, TArgument2, TArgument3>(IFormatProvider formatProvider, string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3) { }
+
+        /// <summary>
+        /// Writes the diagnostic message at the <c>Debug</c> level using the specified parameters.
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the first argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the second argument.</typeparam>
+        /// <typeparam name="TArgument3">The type of the third argument.</typeparam>
+        /// <param name="message">A <see langword="string" /> containing one format item.</param>
+        /// <param name="argument1">The first argument to format.</param>
+        /// <param name="argument2">The second argument to format.</param>
+        /// <param name="argument3">The third argument to format.</param>
+
+        public static void Debug<TArgument1, TArgument2, TArgument3>(string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3) { }
+
+        #endregion
+
+        #region Info() overloads
+
+        /// <overloads>
+        /// Writes the diagnostic message at the <c>Info</c> level using the specified format provider and format parameters.
+        /// </overloads>
+        /// <summary>
+        /// Writes the diagnostic message at the <c>Info</c> level.
+        /// </summary>
+        /// <typeparam name="T">Type of the value.</typeparam>
+        /// <param name="value">The value to be written.</param>
+        public static void Info<T>(T value) { }
+
+        /// <summary>
+        /// Writes the diagnostic message at the <c>Info</c> level.
+        /// </summary>
+        /// <typeparam name="T">Type of the value.</typeparam>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="value">The value to be written.</param>
+        public static void Info<T>(IFormatProvider formatProvider, T value) { }
+
+        /// <summary>
+        /// Writes the diagnostic message at the <c>Info</c> level.
+        /// </summary>
+        /// <param name="messageFunc">A function returning message to be written. Function is not evaluated if logging is not enabled.</param>
+        public static void Info(LogMessageGenerator messageFunc) { }
+
+        /// <summary>
+        /// Writes the diagnostic message and exception at the <c>Info</c> level.
+        /// </summary>
+        /// <param name="message">A <see langword="string" /> to be written.</param>
+        /// <param name="exception">An exception to be logged.</param>
+        /// <remarks>This method was marked as obsolete before NLog 4.3.11 and it may be removed in a future release.</remarks>
+        [Obsolete("Use Info(Exception exception, string message, params object[] args) method instead. Marked obsolete before v4.3.11")]
+        public static void InfoException(string message, Exception exception) { }
+
+        /// <summary>
+        /// Writes the diagnostic message and exception at the <c>Info</c> level.
+        /// </summary>
+        /// <param name="message">A <see langword="string" /> to be written.</param>
+        /// <param name="exception">An exception to be logged.</param>
+        public static void Info(Exception exception, string message) { }
+
+        /// <summary>
+        /// Writes the diagnostic message and exception at the <c>Info</c> level.
+        /// </summary>
+        /// <param name="message">A <see langword="string" /> to be written.</param>
+        /// <param name="exception">An exception to be logged.</param>
+        /// <param name="args">Arguments to format.</param>
+
+        public static void Info(Exception exception, string message, params object[] args) { }
+
+        /// <summary>
+        /// Writes the diagnostic message and exception at the <c>Info</c> level.
+        /// </summary>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">A <see langword="string" /> to be written.</param>
+        /// <param name="exception">An exception to be logged.</param>
+        /// <param name="args">Arguments to format.</param>
+
+        public static void Info(Exception exception, IFormatProvider formatProvider, string message, params object[] args) { }
+
+        /// <summary>
+        /// Writes the diagnostic message at the <c>Info</c> level using the specified parameters and formatting them with the supplied format provider.
+        /// </summary>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">A <see langword="string" /> containing format items.</param>
+        /// <param name="args">Arguments to format.</param>
+
+        public static void Info(IFormatProvider formatProvider, string message, params object[] args) { }
+
+        /// <summary>
+        /// Writes the diagnostic message at the <c>Info</c> level.
+        /// </summary>
+        /// <param name="message">Log message.</param>
+        public static void Info(string message) { }
+
+        /// <summary>
+        /// Writes the diagnostic message at the <c>Info</c> level using the specified parameters.
+        /// </summary>
+        /// <param name="message">A <see langword="string" /> containing format items.</param>
+        /// <param name="args">Arguments to format.</param>
+
+        public static void Info(string message, params object[] args) { }
+
+        /// <summary>
+        /// Writes the diagnostic message and exception at the <c>Info</c> level.
+        /// </summary>
+        /// <param name="message">A <see langword="string" /> to be written.</param>
+        /// <param name="exception">An exception to be logged.</param>
+        /// <remarks>This method was marked as obsolete before NLog 4.3.11 and it may be removed in a future release.</remarks>
+        [Obsolete("Use Info(Exception exception, string message, params object[] args) method instead. Marked obsolete before v4.3.11")]
+        public static void Info(string message, Exception exception) { }
+
+        /// <summary>
+        /// Writes the diagnostic message at the <c>Info</c> level using the specified parameter and formatting it with the supplied format provider.
+        /// </summary>
+        /// <typeparam name="TArgument">The type of the argument.</typeparam>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">A <see langword="string" /> containing one format item.</param>
+        /// <param name="argument">The argument to format.</param>
+
+        public static void Info<TArgument>(IFormatProvider formatProvider, string message, TArgument argument) { }
+
+        /// <summary>
+        /// Writes the diagnostic message at the <c>Info</c> level using the specified parameter.
+        /// </summary>
+        /// <typeparam name="TArgument">The type of the argument.</typeparam>
+        /// <param name="message">A <see langword="string" /> containing one format item.</param>
+        /// <param name="argument">The argument to format.</param>
+
+        public static void Info<TArgument>(string message, TArgument argument) { }
+
+        /// <summary>
+        /// Writes the diagnostic message at the <c>Info</c> level using the specified arguments formatting it with the supplied format provider.
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the first argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the second argument.</typeparam>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">A <see langword="string" /> containing one format item.</param>
+        /// <param name="argument1">The first argument to format.</param>
+        /// <param name="argument2">The second argument to format.</param>
+
+        public static void Info<TArgument1, TArgument2>(IFormatProvider formatProvider, string message, TArgument1 argument1, TArgument2 argument2) { }
+
+        /// <summary>
+        /// Writes the diagnostic message at the <c>Info</c> level using the specified parameters.
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the first argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the second argument.</typeparam>
+        /// <param name="message">A <see langword="string" /> containing one format item.</param>
+        /// <param name="argument1">The first argument to format.</param>
+        /// <param name="argument2">The second argument to format.</param>
+
+        public static void Info<TArgument1, TArgument2>(string message, TArgument1 argument1, TArgument2 argument2) { }
+
+        /// <summary>
+        /// Writes the diagnostic message at the <c>Info</c> level using the specified arguments formatting it with the supplied format provider.
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the first argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the second argument.</typeparam>
+        /// <typeparam name="TArgument3">The type of the third argument.</typeparam>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">A <see langword="string" /> containing one format item.</param>
+        /// <param name="argument1">The first argument to format.</param>
+        /// <param name="argument2">The second argument to format.</param>
+        /// <param name="argument3">The third argument to format.</param>
+
+        public static void Info<TArgument1, TArgument2, TArgument3>(IFormatProvider formatProvider, string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3) { }
+
+        /// <summary>
+        /// Writes the diagnostic message at the <c>Info</c> level using the specified parameters.
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the first argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the second argument.</typeparam>
+        /// <typeparam name="TArgument3">The type of the third argument.</typeparam>
+        /// <param name="message">A <see langword="string" /> containing one format item.</param>
+        /// <param name="argument1">The first argument to format.</param>
+        /// <param name="argument2">The second argument to format.</param>
+        /// <param name="argument3">The third argument to format.</param>
+
+        public static void Info<TArgument1, TArgument2, TArgument3>(string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3) { }
+
+        #endregion
+
+        #region Warn() overloads
+
+        /// <overloads>
+        /// Writes the diagnostic message at the <c>Warn</c> level using the specified format provider and format parameters.
+        /// </overloads>
+        /// <summary>
+        /// Writes the diagnostic message at the <c>Warn</c> level.
+        /// </summary>
+        /// <typeparam name="T">Type of the value.</typeparam>
+        /// <param name="value">The value to be written.</param>
+        public static void Warn<T>(T value) { }
+
+        /// <summary>
+        /// Writes the diagnostic message at the <c>Warn</c> level.
+        /// </summary>
+        /// <typeparam name="T">Type of the value.</typeparam>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="value">The value to be written.</param>
+        public static void Warn<T>(IFormatProvider formatProvider, T value) { }
+
+        /// <summary>
+        /// Writes the diagnostic message at the <c>Warn</c> level.
+        /// </summary>
+        /// <param name="messageFunc">A function returning message to be written. Function is not evaluated if logging is not enabled.</param>
+        public static void Warn(LogMessageGenerator messageFunc) { }
+
+        /// <summary>
+        /// Writes the diagnostic message and exception at the <c>Warn</c> level.
+        /// </summary>
+        /// <param name="message">A <see langword="string" /> to be written.</param>
+        /// <param name="exception">An exception to be logged.</param>
+        /// <remarks>This method was marked as obsolete before NLog 4.3.11 and it may be removed in a future release.</remarks>
+        [Obsolete("Use Warn(Exception exception, string message, params object[] args) method instead. Marked obsolete before v4.3.11")]
+        public static void WarnException(string message, Exception exception) { }
+
+        /// <summary>
+        /// Writes the diagnostic message and exception at the <c>Warn</c> level.
+        /// </summary>
+        /// <param name="message">A <see langword="string" /> to be written.</param>
+        /// <param name="exception">An exception to be logged.</param>
+        public static void Warn(Exception exception, string message) { }
+
+        /// <summary>
+        /// Writes the diagnostic message and exception at the <c>Warn</c> level.
+        /// </summary>
+        /// <param name="message">A <see langword="string" /> to be written.</param>
+        /// <param name="exception">An exception to be logged.</param>
+        /// <param name="args">Arguments to format.</param>
+
+        public static void Warn(Exception exception, string message, params object[] args) { }
+
+        /// <summary>
+        /// Writes the diagnostic message and exception at the <c>Warn</c> level.
+        /// </summary>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">A <see langword="string" /> to be written.</param>
+        /// <param name="exception">An exception to be logged.</param>
+        /// <param name="args">Arguments to format.</param>
+
+        public static void Warn(Exception exception, IFormatProvider formatProvider, string message, params object[] args) { }
+
+        /// <summary>
+        /// Writes the diagnostic message at the <c>Warn</c> level using the specified parameters and formatting them with the supplied format provider.
+        /// </summary>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">A <see langword="string" /> containing format items.</param>
+        /// <param name="args">Arguments to format.</param>
+
+        public static void Warn(IFormatProvider formatProvider, string message, params object[] args) { }
+
+        /// <summary>
+        /// Writes the diagnostic message at the <c>Warn</c> level.
+        /// </summary>
+        /// <param name="message">Log message.</param>
+        public static void Warn(string message) { }
+
+        /// <summary>
+        /// Writes the diagnostic message at the <c>Warn</c> level using the specified parameters.
+        /// </summary>
+        /// <param name="message">A <see langword="string" /> containing format items.</param>
+        /// <param name="args">Arguments to format.</param>
+
+        public static void Warn(string message, params object[] args) { }
+
+        /// <summary>
+        /// Writes the diagnostic message and exception at the <c>Warn</c> level.
+        /// </summary>
+        /// <param name="message">A <see langword="string" /> to be written.</param>
+        /// <param name="exception">An exception to be logged.</param>
+        /// <remarks>This method was marked as obsolete before NLog 4.3.11 and it may be removed in a future release.</remarks>
+        [Obsolete("Use Warn(Exception exception, string message, params object[] args) method instead. Marked obsolete before v4.3.11")]
+        public static void Warn(string message, Exception exception) { }
+
+        /// <summary>
+        /// Writes the diagnostic message at the <c>Warn</c> level using the specified parameter and formatting it with the supplied format provider.
+        /// </summary>
+        /// <typeparam name="TArgument">The type of the argument.</typeparam>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">A <see langword="string" /> containing one format item.</param>
+        /// <param name="argument">The argument to format.</param>
+
+        public static void Warn<TArgument>(IFormatProvider formatProvider, string message, TArgument argument) { }
+
+        /// <summary>
+        /// Writes the diagnostic message at the <c>Warn</c> level using the specified parameter.
+        /// </summary>
+        /// <typeparam name="TArgument">The type of the argument.</typeparam>
+        /// <param name="message">A <see langword="string" /> containing one format item.</param>
+        /// <param name="argument">The argument to format.</param>
+
+        public static void Warn<TArgument>(string message, TArgument argument) { }
+
+        /// <summary>
+        /// Writes the diagnostic message at the <c>Warn</c> level using the specified arguments formatting it with the supplied format provider.
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the first argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the second argument.</typeparam>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">A <see langword="string" /> containing one format item.</param>
+        /// <param name="argument1">The first argument to format.</param>
+        /// <param name="argument2">The second argument to format.</param>
+
+        public static void Warn<TArgument1, TArgument2>(IFormatProvider formatProvider, string message, TArgument1 argument1, TArgument2 argument2) { }
+
+        /// <summary>
+        /// Writes the diagnostic message at the <c>Warn</c> level using the specified parameters.
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the first argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the second argument.</typeparam>
+        /// <param name="message">A <see langword="string" /> containing one format item.</param>
+        /// <param name="argument1">The first argument to format.</param>
+        /// <param name="argument2">The second argument to format.</param>
+
+        public static void Warn<TArgument1, TArgument2>(string message, TArgument1 argument1, TArgument2 argument2) { }
+
+        /// <summary>
+        /// Writes the diagnostic message at the <c>Warn</c> level using the specified arguments formatting it with the supplied format provider.
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the first argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the second argument.</typeparam>
+        /// <typeparam name="TArgument3">The type of the third argument.</typeparam>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">A <see langword="string" /> containing one format item.</param>
+        /// <param name="argument1">The first argument to format.</param>
+        /// <param name="argument2">The second argument to format.</param>
+        /// <param name="argument3">The third argument to format.</param>
+
+        public static void Warn<TArgument1, TArgument2, TArgument3>(IFormatProvider formatProvider, string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3) { }
+
+        /// <summary>
+        /// Writes the diagnostic message at the <c>Warn</c> level using the specified parameters.
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the first argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the second argument.</typeparam>
+        /// <typeparam name="TArgument3">The type of the third argument.</typeparam>
+        /// <param name="message">A <see langword="string" /> containing one format item.</param>
+        /// <param name="argument1">The first argument to format.</param>
+        /// <param name="argument2">The second argument to format.</param>
+        /// <param name="argument3">The third argument to format.</param>
+
+        public static void Warn<TArgument1, TArgument2, TArgument3>(string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3) { }
+
+        #endregion
+
+        #region Error() overloads
+
+        /// <overloads>
+        /// Writes the diagnostic message at the <c>Error</c> level using the specified format provider and format parameters.
+        /// </overloads>
+        /// <summary>
+        /// Writes the diagnostic message at the <c>Error</c> level.
+        /// </summary>
+        /// <typeparam name="T">Type of the value.</typeparam>
+        /// <param name="value">The value to be written.</param>
+        public static void Error<T>(T value) { }
+
+        /// <summary>
+        /// Writes the diagnostic message at the <c>Error</c> level.
+        /// </summary>
+        /// <typeparam name="T">Type of the value.</typeparam>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="value">The value to be written.</param>
+        public static void Error<T>(IFormatProvider formatProvider, T value) { }
+
+        /// <summary>
+        /// Writes the diagnostic message at the <c>Error</c> level.
+        /// </summary>
+        /// <param name="messageFunc">A function returning message to be written. Function is not evaluated if logging is not enabled.</param>
+        public static void Error(LogMessageGenerator messageFunc) { }
+
+        /// <summary>
+        /// Writes the diagnostic message and exception at the <c>Error</c> level.
+        /// </summary>
+        /// <param name="message">A <see langword="string" /> to be written.</param>
+        /// <param name="exception">An exception to be logged.</param>
+        /// <remarks>This method was marked as obsolete before NLog 4.3.11 and it may be removed in a future release.</remarks>
+        [Obsolete("Use Error(Exception exception, string message, params object[] args) method instead. Marked obsolete before v4.3.11")]
+        public static void ErrorException(string message, Exception exception) { }
+
+        /// <summary>
+        /// Writes the diagnostic message and exception at the <c>Error</c> level.
+        /// </summary>
+        /// <param name="message">A <see langword="string" /> to be written.</param>
+        /// <param name="exception">An exception to be logged.</param>
+        public static void Error(Exception exception, string message) { }
+
+        /// <summary>
+        /// Writes the diagnostic message and exception at the <c>Error</c> level.
+        /// </summary>
+        /// <param name="message">A <see langword="string" /> to be written.</param>
+        /// <param name="exception">An exception to be logged.</param>
+        /// <param name="args">Arguments to format.</param>
+
+        public static void Error(Exception exception, string message, params object[] args) { }
+
+        /// <summary>
+        /// Writes the diagnostic message and exception at the <c>Error</c> level.
+        /// </summary>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">A <see langword="string" /> to be written.</param>
+        /// <param name="exception">An exception to be logged.</param>
+        /// <param name="args">Arguments to format.</param>
+
+        public static void Error(Exception exception, IFormatProvider formatProvider, string message, params object[] args) { }
+
+
+        /// <summary>
+        /// Writes the diagnostic message at the <c>Error</c> level using the specified parameters and formatting them with the supplied format provider.
+        /// </summary>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">A <see langword="string" /> containing format items.</param>
+        /// <param name="args">Arguments to format.</param>
+
+        public static void Error(IFormatProvider formatProvider, string message, params object[] args) { }
+
+        /// <summary>
+        /// Writes the diagnostic message at the <c>Error</c> level.
+        /// </summary>
+        /// <param name="message">Log message.</param>
+        public static void Error(string message) { }
+
+        /// <summary>
+        /// Writes the diagnostic message at the <c>Error</c> level using the specified parameters.
+        /// </summary>
+        /// <param name="message">A <see langword="string" /> containing format items.</param>
+        /// <param name="args">Arguments to format.</param>
+
+        public static void Error(string message, params object[] args) { }
+
+        /// <summary>
+        /// Writes the diagnostic message and exception at the <c>Error</c> level.
+        /// </summary>
+        /// <param name="message">A <see langword="string" /> to be written.</param>
+        /// <param name="exception">An exception to be logged.</param>
+        /// <remarks>This method was marked as obsolete before NLog 4.3.11 and it may be removed in a future release.</remarks>
+        [Obsolete("Use Error(Exception exception, string message, params object[] args) method instead. Marked obsolete before v4.3.11")]
+        public static void Error(string message, Exception exception) { }
+
+        /// <summary>
+        /// Writes the diagnostic message at the <c>Error</c> level using the specified parameter and formatting it with the supplied format provider.
+        /// </summary>
+        /// <typeparam name="TArgument">The type of the argument.</typeparam>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">A <see langword="string" /> containing one format item.</param>
+        /// <param name="argument">The argument to format.</param>
+
+        public static void Error<TArgument>(IFormatProvider formatProvider, string message, TArgument argument) { }
+
+        /// <summary>
+        /// Writes the diagnostic message at the <c>Error</c> level using the specified parameter.
+        /// </summary>
+        /// <typeparam name="TArgument">The type of the argument.</typeparam>
+        /// <param name="message">A <see langword="string" /> containing one format item.</param>
+        /// <param name="argument">The argument to format.</param>
+
+        public static void Error<TArgument>(string message, TArgument argument) { }
+
+        /// <summary>
+        /// Writes the diagnostic message at the <c>Error</c> level using the specified arguments formatting it with the supplied format provider.
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the first argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the second argument.</typeparam>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">A <see langword="string" /> containing one format item.</param>
+        /// <param name="argument1">The first argument to format.</param>
+        /// <param name="argument2">The second argument to format.</param>
+
+        public static void Error<TArgument1, TArgument2>(IFormatProvider formatProvider, string message, TArgument1 argument1, TArgument2 argument2) { }
+
+        /// <summary>
+        /// Writes the diagnostic message at the <c>Error</c> level using the specified parameters.
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the first argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the second argument.</typeparam>
+        /// <param name="message">A <see langword="string" /> containing one format item.</param>
+        /// <param name="argument1">The first argument to format.</param>
+        /// <param name="argument2">The second argument to format.</param>
+
+        public static void Error<TArgument1, TArgument2>(string message, TArgument1 argument1, TArgument2 argument2) { }
+
+        /// <summary>
+        /// Writes the diagnostic message at the <c>Error</c> level using the specified arguments formatting it with the supplied format provider.
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the first argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the second argument.</typeparam>
+        /// <typeparam name="TArgument3">The type of the third argument.</typeparam>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">A <see langword="string" /> containing one format item.</param>
+        /// <param name="argument1">The first argument to format.</param>
+        /// <param name="argument2">The second argument to format.</param>
+        /// <param name="argument3">The third argument to format.</param>
+
+        public static void Error<TArgument1, TArgument2, TArgument3>(IFormatProvider formatProvider, string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3) { }
+
+        /// <summary>
+        /// Writes the diagnostic message at the <c>Error</c> level using the specified parameters.
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the first argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the second argument.</typeparam>
+        /// <typeparam name="TArgument3">The type of the third argument.</typeparam>
+        /// <param name="message">A <see langword="string" /> containing one format item.</param>
+        /// <param name="argument1">The first argument to format.</param>
+        /// <param name="argument2">The second argument to format.</param>
+        /// <param name="argument3">The third argument to format.</param>
+
+        public static void Error<TArgument1, TArgument2, TArgument3>(string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3) { }
+
+        #endregion
+
+        #region Fatal() overloads
+
+        /// <overloads>
+        /// Writes the diagnostic message at the <c>Fatal</c> level using the specified format provider and format parameters.
+        /// </overloads>
+        /// <summary>
+        /// Writes the diagnostic message at the <c>Fatal</c> level.
+        /// </summary>
+        /// <typeparam name="T">Type of the value.</typeparam>
+        /// <param name="value">The value to be written.</param>
+        public static void Fatal<T>(T value) { }
+
+        /// <summary>
+        /// Writes the diagnostic message at the <c>Fatal</c> level.
+        /// </summary>
+        /// <typeparam name="T">Type of the value.</typeparam>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="value">The value to be written.</param>
+        public static void Fatal<T>(IFormatProvider formatProvider, T value) { }
+
+        /// <summary>
+        /// Writes the diagnostic message at the <c>Fatal</c> level.
+        /// </summary>
+        /// <param name="messageFunc">A function returning message to be written. Function is not evaluated if logging is not enabled.</param>
+        public static void Fatal(LogMessageGenerator messageFunc) { }
+
+        /// <summary>
+        /// Writes the diagnostic message and exception at the <c>Fatal</c> level.
+        /// </summary>
+        /// <param name="message">A <see langword="string" /> to be written.</param>
+        /// <param name="exception">An exception to be logged.</param>
+        /// <remarks>This method was marked as obsolete before NLog 4.3.11 and it may be removed in a future release.</remarks>
+        [Obsolete("Use Fatal(Exception exception, string message, params object[] args) method instead. Marked obsolete before v4.3.11")]
+        public static void FatalException(string message, Exception exception) { }
+
+        /// <summary>
+        /// Writes the diagnostic message and exception at the <c>Fatal</c> level.
+        /// </summary>
+        /// <param name="message">A <see langword="string" /> to be written.</param>
+        /// <param name="exception">An exception to be logged.</param>
+        public static void Fatal(Exception exception, string message) { }
+
+        /// <summary>
+        /// Writes the diagnostic message and exception at the <c>Fatal</c> level.
+        /// </summary>
+        /// <param name="message">A <see langword="string" /> to be written.</param>
+        /// <param name="exception">An exception to be logged.</param>
+        /// <param name="args">Arguments to format.</param>
+
+        public static void Fatal(Exception exception, string message, params object[] args) { }
+
+        /// <summary>
+        /// Writes the diagnostic message and exception at the <c>Fatal</c> level.
+        /// </summary>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">A <see langword="string" /> to be written.</param>
+        /// <param name="exception">An exception to be logged.</param>
+        /// <param name="args">Arguments to format.</param>
+
+        public static void Fatal(Exception exception, IFormatProvider formatProvider, string message, params object[] args) { }
+
+        /// <summary>
+        /// Writes the diagnostic message at the <c>Fatal</c> level using the specified parameters and formatting them with the supplied format provider.
+        /// </summary>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">A <see langword="string" /> containing format items.</param>
+        /// <param name="args">Arguments to format.</param>
+
+        public static void Fatal(IFormatProvider formatProvider, string message, params object[] args) { }
+
+        /// <summary>
+        /// Writes the diagnostic message at the <c>Fatal</c> level.
+        /// </summary>
+        /// <param name="message">Log message.</param>
+        public static void Fatal(string message) { }
+
+        /// <summary>
+        /// Writes the diagnostic message at the <c>Fatal</c> level using the specified parameters.
+        /// </summary>
+        /// <param name="message">A <see langword="string" /> containing format items.</param>
+        /// <param name="args">Arguments to format.</param>
+
+        public static void Fatal(string message, params object[] args) { }
+
+        /// <summary>
+        /// Writes the diagnostic message and exception at the <c>Fatal</c> level.
+        /// </summary>
+        /// <param name="message">A <see langword="string" /> to be written.</param>
+        /// <param name="exception">An exception to be logged.</param>
+        /// <remarks>This method was marked as obsolete before NLog 4.3.11 and it may be removed in a future release.</remarks>
+        [Obsolete("Use Fatal(Exception exception, string message, params object[] args) method instead. Marked obsolete before v4.3.11")]
+        public static void Fatal(string message, Exception exception) { }
+
+        /// <summary>
+        /// Writes the diagnostic message at the <c>Fatal</c> level using the specified parameter and formatting it with the supplied format provider.
+        /// </summary>
+        /// <typeparam name="TArgument">The type of the argument.</typeparam>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">A <see langword="string" /> containing one format item.</param>
+        /// <param name="argument">The argument to format.</param>
+
+        public static void Fatal<TArgument>(IFormatProvider formatProvider, string message, TArgument argument) { }
+
+        /// <summary>
+        /// Writes the diagnostic message at the <c>Fatal</c> level using the specified parameter.
+        /// </summary>
+        /// <typeparam name="TArgument">The type of the argument.</typeparam>
+        /// <param name="message">A <see langword="string" /> containing one format item.</param>
+        /// <param name="argument">The argument to format.</param>
+
+        public static void Fatal<TArgument>(string message, TArgument argument) { }
+
+        /// <summary>
+        /// Writes the diagnostic message at the <c>Fatal</c> level using the specified arguments formatting it with the supplied format provider.
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the first argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the second argument.</typeparam>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">A <see langword="string" /> containing one format item.</param>
+        /// <param name="argument1">The first argument to format.</param>
+        /// <param name="argument2">The second argument to format.</param>
+
+        public static void Fatal<TArgument1, TArgument2>(IFormatProvider formatProvider, string message, TArgument1 argument1, TArgument2 argument2) { }
+
+        /// <summary>
+        /// Writes the diagnostic message at the <c>Fatal</c> level using the specified parameters.
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the first argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the second argument.</typeparam>
+        /// <param name="message">A <see langword="string" /> containing one format item.</param>
+        /// <param name="argument1">The first argument to format.</param>
+        /// <param name="argument2">The second argument to format.</param>
+
+        public static void Fatal<TArgument1, TArgument2>(string message, TArgument1 argument1, TArgument2 argument2) { }
+
+        /// <summary>
+        /// Writes the diagnostic message at the <c>Fatal</c> level using the specified arguments formatting it with the supplied format provider.
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the first argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the second argument.</typeparam>
+        /// <typeparam name="TArgument3">The type of the third argument.</typeparam>
+        /// <param name="formatProvider">An IFormatProvider that supplies culture-specific formatting information.</param>
+        /// <param name="message">A <see langword="string" /> containing one format item.</param>
+        /// <param name="argument1">The first argument to format.</param>
+        /// <param name="argument2">The second argument to format.</param>
+        /// <param name="argument3">The third argument to format.</param>
+
+        public static void Fatal<TArgument1, TArgument2, TArgument3>(IFormatProvider formatProvider, string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3) { }
+
+        /// <summary>
+        /// Writes the diagnostic message at the <c>Fatal</c> level using the specified parameters.
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the first argument.</typeparam>
+        /// <typeparam name="TArgument2">The type of the second argument.</typeparam>
+        /// <typeparam name="TArgument3">The type of the third argument.</typeparam>
+        /// <param name="message">A <see langword="string" /> containing one format item.</param>
+        /// <param name="argument1">The first argument to format.</param>
+        /// <param name="argument2">The second argument to format.</param>
+        /// <param name="argument3">The third argument to format.</param>
+
+        public static void Fatal<TArgument1, TArgument2, TArgument3>(string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3) { }
+
+        #endregion
+    }
+}

--- a/src/FodyNlogAdapter/TracerAttributes.cs
+++ b/src/FodyNlogAdapter/TracerAttributes.cs
@@ -1,0 +1,38 @@
+﻿using System;
+
+// ReSharper disable once CheckNamespace
+namespace TracerAttributes
+{
+    /// <summary>
+    /// This attributes specifies that the marked element(s) should be traced.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method | AttributeTargets.Property | AttributeTargets.Constructor | AttributeTargets.Struct, AllowMultiple = true, Inherited = true)]
+    public class TraceOn : Attribute
+    {
+        public TraceTarget Target { get; set; }
+
+        public TraceOn()
+        { }
+
+        public TraceOn(TraceTarget traceTarget)
+        {
+            Target = traceTarget;
+        }
+    }
+
+    /// <summary>
+    /// This attribute excludes the marked element from tracing.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method | AttributeTargets.Property | AttributeTargets.Constructor | AttributeTargets.Struct, AllowMultiple = true, Inherited = true)]
+    public class NoTrace : Attribute
+    {
+    }
+
+    public enum TraceTarget
+    {
+        Public,
+        Internal,
+        Protected,
+        Private
+    }
+}

--- a/src/FodyWeavers.xml
+++ b/src/FodyWeavers.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Weavers>
+  <Tracer adapterAssembly="FodyNlogAdapter"
+      logManager="FodyNlogAdapter.Adapters.LogManagerAdapter"      
+      logger="FodyNlogAdapter.Adapters.LoggerAdapter"
+      staticLogger="FodyNlogAdapter.Log"
+      traceConstructors="false"
+      traceProperties="false">
+      <TraceOn namespace="Stratis.Bitcoin.Base+*" class="private" method="private" />
+	  <!--
+			<TraceOn namespace="Root+*" class="public" method="public" />
+	  -->
+  </Tracer>  
+</Weavers>

--- a/src/FodyWeavers.xml
+++ b/src/FodyWeavers.xml
@@ -7,5 +7,7 @@
       traceConstructors="false"
       traceProperties="false">
       <TraceOn namespace="Stratis.Bitcoin+*" class="private" method="private" />
+      <NoTrace namespace="*.Tests+*" />
+      <NoTrace namespace="*.IntegrationTests+*" />
   </Tracer>  
 </Weavers>

--- a/src/FodyWeavers.xml
+++ b/src/FodyWeavers.xml
@@ -7,6 +7,8 @@
       traceConstructors="false"
       traceProperties="false">
       <TraceOn namespace="Stratis.Bitcoin+*" class="private" method="private" />
+      <TraceOn namespace="Stratis.SmartContracts.Core+*" class="private" method="private" />
+      <TraceOn namespace="Stratis.SmartContracts.Executor.Reflection+*" class="private" method="private" />
       <NoTrace namespace="*.Tests+*" />
       <NoTrace namespace="*.IntegrationTests+*" />
   </Tracer>  

--- a/src/FodyWeavers.xml
+++ b/src/FodyWeavers.xml
@@ -6,9 +6,6 @@
       staticLogger="FodyNlogAdapter.Log"
       traceConstructors="false"
       traceProperties="false">
-      <TraceOn namespace="Stratis.Bitcoin.Base+*" class="private" method="private" />
-	  <!--
-			<TraceOn namespace="Root+*" class="public" method="public" />
-	  -->
+      <TraceOn namespace="Stratis.Bitcoin+*" class="private" method="private" />
   </Tracer>  
 </Weavers>

--- a/src/Stratis.Bitcoin.FullNode.sln
+++ b/src/Stratis.Bitcoin.FullNode.sln
@@ -132,6 +132,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RuntimeObserver", "RuntimeO
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Stratis.SmartContracts.IntegrationTests", "Stratis.SmartContracts.IntegrationTests\Stratis.SmartContracts.IntegrationTests.csproj", "{BBE830D7-3AD3-41D9-8257-8CAA06F38E40}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FodyNlogAdapter", "FodyNlogAdapter\FodyNlogAdapter.csproj", "{C4494C72-2423-4A2C-9E81-1C065C7F8291}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -346,6 +348,10 @@ Global
 		{BBE830D7-3AD3-41D9-8257-8CAA06F38E40}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{BBE830D7-3AD3-41D9-8257-8CAA06F38E40}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{BBE830D7-3AD3-41D9-8257-8CAA06F38E40}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C4494C72-2423-4A2C-9E81-1C065C7F8291}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C4494C72-2423-4A2C-9E81-1C065C7F8291}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C4494C72-2423-4A2C-9E81-1C065C7F8291}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C4494C72-2423-4A2C-9E81-1C065C7F8291}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -395,6 +401,7 @@ Global
 		{247C062D-8A16-4DD8-93B4-1D1C3D49B498} = {1B9A916F-DDAC-4675-B424-EDEDC1A58231}
 		{38F49E88-545A-437B-9225-0BC8815B0281} = {1B9A916F-DDAC-4675-B424-EDEDC1A58231}
 		{BBE830D7-3AD3-41D9-8257-8CAA06F38E40} = {EAE139C2-B19C-4905-9117-8A4068ABD3D2}
+		{C4494C72-2423-4A2C-9E81-1C065C7F8291} = {1B9A916F-DDAC-4675-B424-EDEDC1A58231}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {6C780ABA-5872-4B83-AD3F-A5BD423AD907}

--- a/src/Stratis.Bitcoin/Stratis.Bitcoin.csproj
+++ b/src/Stratis.Bitcoin/Stratis.Bitcoin.csproj
@@ -27,6 +27,7 @@
     <PackageReference Include="ConcurrentHashSet" Version="1.0.2" />
     <PackageReference Include="DBreeze" Version="1.89.0" />
     <PackageReference Include="NLog" Version="5.0.0-beta09" />
+    <PackageReference Include="Fody" Version="3.2.4" />
     <PackageReference Include="NLog.Extensions.Logging" Version="1.0.0-rtm-beta5" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.0.2" />
     <PackageReference Include="System.Reactive" Version="4.0.0" />
@@ -47,6 +48,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\FodyNlogAdapter\FodyNlogAdapter.csproj" />
     <ProjectReference Include="..\NBitcoin\NBitcoin.csproj" />
     <ProjectReference Include="..\Stratis.Bitcoin.Networks\Stratis.Bitcoin.Networks.csproj" />
   </ItemGroup>


### PR DESCRIPTION
Adds additional compilation step that will add trace logging to all classes under Stratis.Bitcoin namespace.

This implements first step from list of steps covered in #2249 

PS:
to review this compile the solution, run it with trace logging on (any target with namespace Stratis.Bitcoin will do)- logs will contain entry and exit logs for every method. 

PSS:
To understand how exactly it works read links supplied in #2249 