### PR TITLE
[SC] Blacklist new object creation

### DIFF
--- a/src/Stratis.Bitcoin.Features.SmartContracts.Tests/FormatValidationTests.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts.Tests/FormatValidationTests.cs
@@ -383,6 +383,8 @@ public class Test : SmartContract
             var result = validator.Validate(decomp.ModuleDefinition);
 
             Assert.False(result.IsValid);
+            Assert.Single(result.Errors);
+            Assert.IsType<NewObjValidator.NewObjValidationResult>(result.Errors.First());
         }
 
         [Fact]
@@ -418,7 +420,7 @@ public class Test : SmartContract
             var result = validator.Validate(decomp.ModuleDefinition);
 
             Assert.True(result.IsValid);
-    }
+        }
 
         [Fact]
         public void SmartContract_ValidateFormat_NewArray_Succeeds()
@@ -448,7 +450,6 @@ public class Test : SmartContract
 
             Assert.True(result.IsValid);
         }
-
 
         [Fact]
         public void SmartContract_ValidateFormat_NewShortArray_Succeeds()

--- a/src/Stratis.Bitcoin.Features.SmartContracts.Tests/FormatValidationTests.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts.Tests/FormatValidationTests.cs
@@ -356,6 +356,129 @@ public class Test2 {
             Assert.Equal(2, result.Errors.Count());
         }
 
+        [Fact]
+        public void SmartContract_ValidateFormat_NewObj_Fails()
+        {
+            var adjustedSource = @"
+using System;
+using Stratis.SmartContracts;
+
+public class Test : SmartContract
+{
+    public Test(ISmartContractState state) : base(state) {}
+
+    public void CreateNewObject() {
+        var obj = new object();
+    }
+}
+";
+            ContractCompilationResult compilationResult = ContractCompiler.Compile(adjustedSource);
+            Assert.True(compilationResult.Success);
+
+            var validator = new SmartContractFormatValidator();
+
+            byte[] assemblyBytes = compilationResult.Compilation;
+            IContractModuleDefinition decomp = ContractDecompiler.GetModuleDefinition(assemblyBytes).Value;
+
+            var result = validator.Validate(decomp.ModuleDefinition);
+
+            Assert.False(result.IsValid);
+        }
+
+        [Fact]
+        public void SmartContract_ValidateFormat_NewStruct_Succeeds()
+        {
+            var adjustedSource = @"
+using System;
+using Stratis.SmartContracts;
+
+public class Test : SmartContract
+{
+    public struct Item
+    {
+        public int Number;
+        public string Name;
+    }
+
+    public Test(ISmartContractState state) : base(state) {}
+
+    public void CreateNewStruct() {
+        var item = new Item();
+    }
+}
+";
+            ContractCompilationResult compilationResult = ContractCompiler.Compile(adjustedSource);
+            Assert.True(compilationResult.Success);
+
+            var validator = new SmartContractFormatValidator();
+
+            byte[] assemblyBytes = compilationResult.Compilation;
+            IContractModuleDefinition decomp = ContractDecompiler.GetModuleDefinition(assemblyBytes).Value;
+
+            var result = validator.Validate(decomp.ModuleDefinition);
+
+            Assert.True(result.IsValid);
+    }
+
+        [Fact]
+        public void SmartContract_ValidateFormat_NewArray_Succeeds()
+        {
+            var adjustedSource = @"
+using System;
+using Stratis.SmartContracts;
+
+public class Test : SmartContract
+{
+    public Test(ISmartContractState state) : base(state) {}
+
+    public void CreateNewStruct() {
+        var item = new [] { 1, 2, 3, 4, 5 };
+    }
+}
+";
+            ContractCompilationResult compilationResult = ContractCompiler.Compile(adjustedSource);
+            Assert.True(compilationResult.Success);
+
+            var validator = new SmartContractFormatValidator();
+
+            byte[] assemblyBytes = compilationResult.Compilation;
+            IContractModuleDefinition decomp = ContractDecompiler.GetModuleDefinition(assemblyBytes).Value;
+
+            var result = validator.Validate(decomp.ModuleDefinition);
+
+            Assert.True(result.IsValid);
+        }
+
+
+        [Fact]
+        public void SmartContract_ValidateFormat_NewShortArray_Succeeds()
+        {
+            var adjustedSource = @"
+using System;
+using Stratis.SmartContracts;
+
+public class Test : SmartContract
+{
+    public Test(ISmartContractState state) : base(state) {}
+
+    public void CreateNewStruct() {
+        var item = new [] { 1 };
+    }
+}
+";
+            ContractCompilationResult compilationResult = ContractCompiler.Compile(adjustedSource);
+            Assert.True(compilationResult.Success);
+
+            var validator = new SmartContractFormatValidator();
+
+            byte[] assemblyBytes = compilationResult.Compilation;
+            IContractModuleDefinition decomp = ContractDecompiler.GetModuleDefinition(assemblyBytes).Value;
+
+            var result = validator.Validate(decomp.ModuleDefinition);
+
+            Assert.True(result.IsValid);
+        }
+
         /// <summary>
         /// Get the compiled bytecode for the specified C# source code.
         /// </summary>

--- a/src/Stratis.SmartContracts.Core.Validation.Tests/SmartContractDeterminismValidatorTests.cs
+++ b/src/Stratis.SmartContracts.Core.Validation.Tests/SmartContractDeterminismValidatorTests.cs
@@ -99,29 +99,6 @@ public class Test : SmartContract
         }
 
         [Fact]
-        public void SmartContractValidator_Should_Allow_New_TransferFundsToContract()
-        {
-            const string source = @"using System;
-                                            using Stratis.SmartContracts;
-
-                                            public class Test : SmartContract
-                                            {
-                                                public struct A {}
-
-                                                public Test(ISmartContractState state)
-                                                    : base(state) { }
-
-                                                public void B() { var test = new TransferFundsToContract(); }
-                                            }";
-
-            var decompilation = CompileToModuleDef(source);
-
-            var result = new SmartContractValidator().Validate(decompilation.ModuleDefinition);
-
-            Assert.Empty(result.Errors);
-        }
-
-        [Fact]
         public void SmartContractValidator_Should_Not_Allow_New()
         {
             const string source = @"using System;

--- a/src/Stratis.SmartContracts.Core.Validation/FormatPolicy.cs
+++ b/src/Stratis.SmartContracts.Core.Validation/FormatPolicy.cs
@@ -38,6 +38,7 @@ namespace Stratis.SmartContracts.Core.Validation
             .NestedTypeDefValidator(new NestedTypesAreValueTypesValidator())
             .MethodDefValidator(new TryCatchValidator())
             .MethodDefValidator(new MethodParamValidator())
-            .InstructionValidator(new MultiDimensionalArrayValidator());
+            .InstructionValidator(new MultiDimensionalArrayValidator())
+            .InstructionValidator(new NewObjValidator());
     }   
 }

--- a/src/Stratis.SmartContracts.Core.Validation/Validators/Instruction/NewObjValidator.cs
+++ b/src/Stratis.SmartContracts.Core.Validation/Validators/Instruction/NewObjValidator.cs
@@ -1,0 +1,49 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+using Stratis.ModuleValidation.Net;
+
+namespace Stratis.SmartContracts.Core.Validation
+{
+    /// <summary>
+    /// Validates that an instruction is not creating a new instance of an object.
+    /// </summary>
+    public class NewObjValidator : IInstructionValidator
+    {
+        public static readonly string ErrorType = "New Objects Are Supported";
+
+        public IEnumerable<ValidationResult> Validate(Instruction instruction, MethodDefinition method)
+        {
+            // Docs suggest that while OpCodes.Newobj can be used to create both objects and value-types,
+            // OpCodes.Initobj is only be used to create value types. We only need to check Newobj.
+            // Ref. https://docs.microsoft.com/en-US/dotnet/api/system.reflection.emit.opcodes.newobj?view=netcore-2.1
+            // Ref. https://docs.microsoft.com/en-US/dotnet/api/system.reflection.emit.opcodes.initobj?view=netcore-2.1
+
+            if (instruction.OpCode.Code == Code.Newobj)
+            {
+                if (instruction.Operand is MethodReference methodRef)
+                {
+                    if (!methodRef.DeclaringType.IsValueType)
+                    {
+                        return new List<ValidationResult>
+                        {
+                            new NewObjValidationResult(method)
+                        };
+                    }
+                }
+            }
+
+            return Enumerable.Empty<NewObjValidationResult>();
+        }
+
+        public class NewObjValidationResult : MethodDefinitionValidationResult
+        {
+
+            public NewObjValidationResult(MethodDefinition method) 
+                : base(method, "", $"{method.FullName} is invalid [{ErrorType}]")
+            {
+            }
+        }
+    }
+}

--- a/src/Stratis.SmartContracts.Core.Validation/Validators/Instruction/NewObjValidator.cs
+++ b/src/Stratis.SmartContracts.Core.Validation/Validators/Instruction/NewObjValidator.cs
@@ -19,7 +19,6 @@ namespace Stratis.SmartContracts.Core.Validation
             // OpCodes.Initobj is only be used to create value types, so we only need to check Newobj.
             // Ref. https://docs.microsoft.com/en-US/dotnet/api/system.reflection.emit.opcodes.newobj?view=netcore-2.1
             // Ref. https://docs.microsoft.com/en-US/dotnet/api/system.reflection.emit.opcodes.initobj?view=netcore-2.1
-
             if (instruction.OpCode.Code == Code.Newobj)
             {
                 if (instruction.Operand is MethodReference methodRef)

--- a/src/Stratis.SmartContracts.Core.Validation/Validators/Instruction/NewObjValidator.cs
+++ b/src/Stratis.SmartContracts.Core.Validation/Validators/Instruction/NewObjValidator.cs
@@ -16,7 +16,7 @@ namespace Stratis.SmartContracts.Core.Validation
         public IEnumerable<ValidationResult> Validate(Instruction instruction, MethodDefinition method)
         {
             // Docs suggest that while OpCodes.Newobj can be used to create both objects and value-types,
-            // OpCodes.Initobj is only be used to create value types. We only need to check Newobj.
+            // OpCodes.Initobj is only be used to create value types, so we only need to check Newobj.
             // Ref. https://docs.microsoft.com/en-US/dotnet/api/system.reflection.emit.opcodes.newobj?view=netcore-2.1
             // Ref. https://docs.microsoft.com/en-US/dotnet/api/system.reflection.emit.opcodes.initobj?view=netcore-2.1
 
@@ -39,7 +39,6 @@ namespace Stratis.SmartContracts.Core.Validation
 
         public class NewObjValidationResult : MethodDefinitionValidationResult
         {
-
             public NewObjValidationResult(MethodDefinition method) 
                 : base(method, "", $"{method.FullName} is invalid [{ErrorType}]")
             {

--- a/src/Stratis.SmartContracts.Core.Validation/Validators/Instruction/NewObjValidator.cs
+++ b/src/Stratis.SmartContracts.Core.Validation/Validators/Instruction/NewObjValidator.cs
@@ -11,7 +11,7 @@ namespace Stratis.SmartContracts.Core.Validation
     /// </summary>
     public class NewObjValidator : IInstructionValidator
     {
-        public static readonly string ErrorType = "New Objects Are Supported";
+        public static readonly string ErrorType = "Creation Of New Objects Is Not Supported";
 
         public IEnumerable<ValidationResult> Validate(Instruction instruction, MethodDefinition method)
         {


### PR DESCRIPTION
Closes #1921. Prevents all usages of `newobj` except when it is being used to create value types.