### PR TITLE
Minor test fix

### DIFF
--- a/src/Stratis.Bitcoin.IntegrationTests.Common/Runners/BitcoinCoreRunner.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests.Common/Runners/BitcoinCoreRunner.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Diagnostics;
 using System.IO;
+using System.Runtime.InteropServices;
 using System.Threading;
 using Stratis.Bitcoin.Tests.Common;
 
@@ -52,6 +53,15 @@ namespace Stratis.Bitcoin.IntegrationTests.Common.Runners
         {
             string logMode = Debugger.IsAttached ? "-debug=net" : string.Empty;
             TimeSpan duration = TimeSpan.FromSeconds(15);
+
+            // The complete path bitcoind uses to locate (e.g.) the block files consists of the source code build folder,
+            // the relative path within the test case folders, and the bitcoind network-specific path to its block database
+            // This adds roughly 37 characters onto the full data folder path: \regtest\blocks\index/MANIFEST-000001
+
+            // By throwing here we avoid a pointless 5-minute wait for bitcoind to start up (it will 'start' and then soon
+            // crash, which results in the getblockhash RPC call timing out later on in the startup sequence).
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && (new FileInfo(this.DataFolder).FullName.Length > 222))
+                throw new Exception("Path is too long for bitcoind to function.");
 
             TestHelper.WaitLoop(() =>
             {

--- a/src/Stratis.Bitcoin.IntegrationTests/API/ApiSteps.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/API/ApiSteps.cs
@@ -416,7 +416,7 @@ namespace Stratis.Bitcoin.IntegrationTests.API
         {
             var commands = JsonDataSerializer.Instance.Deserialize<List<RpcCommandModel>>(this.responseText);
 
-            commands.Count.Should().Be(16);
+            commands.Count.Should().Be(20);
             commands.Should().Contain(x => x.Command == "stop");
             commands.Should().Contain(x => x.Command == "getrawtransaction <txid> [<verbose>]");
             commands.Should().Contain(x => x.Command == "gettxout <txid> <vout> [<includemempool>]");
@@ -433,6 +433,10 @@ namespace Stratis.Bitcoin.IntegrationTests.API
             commands.Should().Contain(x => x.Command == "startstaking <walletname> <walletpassword>");
             commands.Should().Contain(x => x.Command == "getstakinginfo [<isjsonformat>]");
             commands.Should().Contain(x => x.Command == "sendtoaddress <bitcoinaddress> <amount>");
+            commands.Should().Contain(x => x.Command == "getnewaddress");
+            commands.Should().Contain(x => x.Command == "sendrawtransaction <hex>");
+            commands.Should().Contain(x => x.Command == "decoderawtransaction <hex>");
+            commands.Should().Contain(x => x.Command == "getblock <blockhash> [<isjsonformat>]");
         }
 
         private void status_information_is_returned()


### PR DESCRIPTION
1. Some new RPCs have been added, which broke a relatively pointless test.

2. Tests using `bitcoind` on Windows are highly sensitive to path length. While this cannot be solved from within the tests, it can at least be made to fail rapidly, rather than wasting 5 minutes of execution time per test in some cases.