### PR TITLE
Add missing nuget package reference to Tracer.4NLog.Fody

### DIFF
--- a/src/FodyNlogAdapter/FodyNlogAdapter.csproj
+++ b/src/FodyNlogAdapter/FodyNlogAdapter.csproj
@@ -6,6 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="NLog" Version="5.0.0-beta09" />
+    <PackageReference Include="Tracer.4NLog.Fody" Version="2.2.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Master won't build locally without this.