### PR TITLE
[SC] Use shared nonce state during tx execution

### DIFF
--- a/src/Stratis.Bitcoin.Features.SmartContracts.Tests/NonceGeneratorTests.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts.Tests/NonceGeneratorTests.cs
@@ -1,0 +1,26 @@
+﻿using Stratis.SmartContracts.Executor.Reflection;
+using Xunit;
+
+namespace Stratis.Bitcoin.Features.SmartContracts.Tests
+{
+    public class NonceGeneratorTests
+    {
+        [Fact]
+        public void Initial_Value_Should_Be_Correct()
+        {
+            var initial = 123UL;
+            var nonce = new NonceGenerator(initial);
+            Assert.Equal(initial, nonce.Next);
+        }
+
+        [Fact]
+        public void NextValues_Should_Be_Correct()
+        {
+            var nonceGenerator = new NonceGenerator();
+            Assert.Equal(0UL, nonceGenerator.Next);
+            Assert.Equal(1UL, nonceGenerator.Next);
+            Assert.Equal(2UL, nonceGenerator.Next);
+            Assert.Equal(3UL, nonceGenerator.Next);
+        }
+    }
+}

--- a/src/Stratis.Bitcoin.Features.SmartContracts.Tests/StateTests.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts.Tests/StateTests.cs
@@ -109,6 +109,16 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Tests
         }
 
         [Fact]
+        public void State_Snapshot_Has_Original_NonceGenerator()
+        {
+            var state = new State(null, this.contractStateRoot.Object, this.contractLogHolder.Object, new List<TransferInfo>(), null, null, 100_000, null);
+
+            IState newState = state.Snapshot();
+
+            Assert.Same(state.NonceGenerator, newState.NonceGenerator);
+        }
+
+        [Fact]
         public void TransitionTo_Fails_If_New_State_Is_Not_Child()
         {
             var state = new State(null, this.contractStateRoot.Object, this.contractLogHolder.Object, new List<TransferInfo>(), null, null, 0, null);
@@ -138,8 +148,6 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Tests
                 new RawLog(null, null)
             };
 
-            ulong newNonce = 999;
-
             var testLogHolder = new Mock<IContractLogHolder>();
             testLogHolder.Setup(lh => lh.GetRawLogs())
                 .Returns(newLogs);
@@ -151,8 +159,6 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Tests
                 .Returns(testLogHolder.Object);
             testState.Setup(ts => ts.ContractState)
                 .Returns(this.trackedState.Object);
-            testState.Setup(ts => ts.Nonce)
-                .Returns(newNonce);
 
             state.SetPrivateFieldValue("child", testState.Object);
 
@@ -167,7 +173,14 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Tests
             Assert.Contains(newTransfers[0], state.InternalTransfers);
             Assert.Contains(newTransfers[1], state.InternalTransfers);
             Assert.Contains(newTransfers[2], state.InternalTransfers);
-            Assert.Equal(newNonce, state.Nonce);
+        }
+
+        [Fact]
+        public void New_State_NonceGenerator_Generates_Zero_Nonce()
+        {
+            var state = new State(null, this.contractStateRoot.Object, this.contractLogHolder.Object, new List<TransferInfo>(), null, null, 0, null);
+            
+            Assert.Equal(0UL, state.NonceGenerator.Next);
         }
     }
 }

--- a/src/Stratis.Bitcoin.Features.SmartContracts.Tests/StateTransitionSpecification.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts.Tests/StateTransitionSpecification.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using NBitcoin;
 using Stratis.SmartContracts;
-using Stratis.SmartContracts.Core;
 using Stratis.SmartContracts.Core.State;
 using Stratis.SmartContracts.Core.State.AccountAbstractionLayer;
 using Stratis.SmartContracts.Executor.Reflection;

--- a/src/Stratis.SmartContracts.Executor.Reflection/IState.cs
+++ b/src/Stratis.SmartContracts.Executor.Reflection/IState.cs
@@ -17,7 +17,7 @@ namespace Stratis.SmartContracts.Executor.Reflection
         IReadOnlyList<TransferInfo> InternalTransfers { get; }
         IContractLogHolder LogHolder { get; }
         IState Snapshot();
-        ulong Nonce { get; }
+        NonceGenerator NonceGenerator { get; }
         void TransitionTo(IState state);
         void AddInternalTransfer(TransferInfo transferInfo);
         ulong GetBalance(uint160 address);

--- a/src/Stratis.SmartContracts.Executor.Reflection/NonceGenerator.cs
+++ b/src/Stratis.SmartContracts.Executor.Reflection/NonceGenerator.cs
@@ -1,0 +1,31 @@
+﻿using System;
+
+namespace Stratis.SmartContracts.Executor.Reflection
+{
+    /// <summary>
+    /// Generates an sequence of sequential numbers for one-time use.
+    /// </summary>
+    public class NonceGenerator
+    {
+        private ulong value;
+
+        /// <summary>
+        /// Creates a new <see cref="NonceGenerator"/>.
+        /// </summary>
+        /// <param name="value">The initial value of the NonceGenerator, defaulting to 0.</param>
+        public NonceGenerator(ulong value = 0)
+        {
+            this.value = value;
+        }
+
+        /// <summary>
+        /// Returns the next value in the sequence.
+        /// </summary>
+        public ulong Next => this.value++;
+
+        public override string ToString()
+        {
+            return this.value.ToString();
+        }
+    }
+}

--- a/src/Stratis.SmartContracts.IntegrationTests/ContractExecutionFailureTests.cs
+++ b/src/Stratis.SmartContracts.IntegrationTests/ContractExecutionFailureTests.cs
@@ -34,7 +34,7 @@ namespace Stratis.SmartContracts.IntegrationTests
 
         // Also check that validation and base cost fees are being applied correctly.
 
-        // TODO: Nonce Behaviour.
+        // TODO: NonceGenerator Behaviour.
 
         // TODO: Calls to methods with incorrect parameters
 


### PR DESCRIPTION
Closes #2259.

Uses a shared `NonceGenerator` during the lifetime of `State`, which corresponds to the lifetime of a transaction execution. If `State` is snapshotted, the snapshot will use the original `NonceGenerator` ensuring that even if execution fails, nonces will still increment.