### PR TITLE
Added microsoft.bcl.build

### DIFF
--- a/src/Stratis.Bitcoin/Stratis.Bitcoin.csproj
+++ b/src/Stratis.Bitcoin/Stratis.Bitcoin.csproj
@@ -26,6 +26,7 @@
   <ItemGroup>
     <PackageReference Include="ConcurrentHashSet" Version="1.0.2" />
     <PackageReference Include="DBreeze" Version="1.89.0" />
+    <PackageReference Include="Microsoft.Bcl.Build" Version="1.0.21" />
     <PackageReference Include="NLog" Version="5.0.0-beta09" />
     <PackageReference Include="Fody" Version="3.2.4" />
     <PackageReference Include="NLog.Extensions.Logging" Version="1.0.0-rtm-beta5" />


### PR DESCRIPTION
Microsoft.Bcl.Build it is basicly a way for older packages that targeted older .Net to build and compile with no problems on new .Nets

Info: 

http://blogs.msdn.com/b/dotnet/archive/2013/11/13/pcl-and-net-nuget-libraries-are-now-enabled-for-xamarin.aspx
http://blogs.msdn.com/b/dotnet/archive/2013/08/12/improved-package-restore.aspx

Why we need this? 

On some PCs with old .nets or several versions of it `dotnet build` command will fail with:
```
Assembly with same name is already loaded Confirm that the <UsingTask> declaration is correct, 
that the assembly and all its dependencies are available, and that the task contains a public
class that implements Microsoft.Build.Framework.ITask. 
[C:\Users\user\Desktop\StratisRepo\src\Stratis.Bitcoin\Stratis.Bitcoin.csproj]
```