### PR TITLE
[Integration Tests] Clean up NotInIBD

### DIFF
--- a/src/Stratis.Bitcoin.IntegrationTests.Common/EnvironmentMockUpHelpers/CoreNode.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests.Common/EnvironmentMockUpHelpers/CoreNode.cs
@@ -53,6 +53,8 @@ namespace Stratis.Bitcoin.IntegrationTests.Common.EnvironmentMockUpHelpers
 
         public Mnemonic Mnemonic { get; set; }
 
+        private bool builderNotInIbd;
+
         public CoreNode(NodeRunner runner, NodeConfigParameters configParameters, string configfile, bool useCookieAuth = false)
         {
             this.runner = runner;
@@ -91,8 +93,7 @@ namespace Stratis.Bitcoin.IntegrationTests.Common.EnvironmentMockUpHelpers
 
         public CoreNode NotInIBD()
         {
-            ((InitialBlockDownloadStateMock)this.FullNode.NodeService<IInitialBlockDownloadState>()).SetIsInitialBlockDownload(false, DateTime.UtcNow.AddMinutes(5));
-
+            this.builderNotInIbd = true;
             return this;
         }
 
@@ -204,6 +205,9 @@ namespace Stratis.Bitcoin.IntegrationTests.Common.EnvironmentMockUpHelpers
             TestHelper.WaitLoop(() => this.runner.FullNode.State == FullNodeState.Started,
                 cancellationToken: new CancellationTokenSource(timeToNodeStart).Token,
                 failureReason: $"Failed to achieve state = started within {timeToNodeStart}");
+
+            if (this.builderNotInIbd)
+                ((InitialBlockDownloadStateMock)this.FullNode.NodeService<IInitialBlockDownloadState>()).SetIsInitialBlockDownload(false, DateTime.UtcNow.AddMinutes(5));
         }
 
         public void Broadcast(Transaction transaction)

--- a/src/Stratis.Bitcoin.IntegrationTests/API/ApiSteps.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/API/ApiSteps.cs
@@ -157,9 +157,9 @@ namespace Stratis.Bitcoin.IntegrationTests.API
 
         private void a_proof_of_work_node_with_api_enabled()
         {
-            this.firstStratisPowApiNode = this.powNodeBuilder.CreateStratisPowNode(this.powNetwork);
+            this.firstStratisPowApiNode = this.powNodeBuilder.CreateStratisPowNode(this.powNetwork).NotInIBD();
             this.firstStratisPowApiNode.Start();
-            this.firstStratisPowApiNode.NotInIBD().WithWallet();
+            this.firstStratisPowApiNode.WithWallet();
 
             this.firstStratisPowApiNode.FullNode.Network.Consensus.CoinbaseMaturity = this.maturity;
             this.apiUri = this.firstStratisPowApiNode.FullNode.NodeService<ApiSettings>().ApiUri;
@@ -167,9 +167,9 @@ namespace Stratis.Bitcoin.IntegrationTests.API
 
         private void a_second_proof_of_work_node_with_api_enabled()
         {
-            this.secondStratisPowApiNode = this.powNodeBuilder.CreateStratisPowNode(this.powNetwork);
+            this.secondStratisPowApiNode = this.powNodeBuilder.CreateStratisPowNode(this.powNetwork).NotInIBD();
             this.secondStratisPowApiNode.Start();
-            this.secondStratisPowApiNode.NotInIBD().WithWallet();
+            this.secondStratisPowApiNode.WithWallet();
         }
 
         protected void a_block_is_mined_creating_spendable_coins()

--- a/src/Stratis.Bitcoin.IntegrationTests/BlockStore/BlockStoreTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/BlockStore/BlockStoreTests.cs
@@ -77,15 +77,13 @@ namespace Stratis.Bitcoin.IntegrationTests.BlockStore
         {
             using (NodeBuilder builder = NodeBuilder.Create(this))
             {
-                CoreNode stratisNodeSync = builder.CreateStratisPowNode(this.regTest);
-                CoreNode stratisNode1 = builder.CreateStratisPowNode(this.regTest);
-                CoreNode stratisNode2 = builder.CreateStratisPowNode(this.regTest);
+                CoreNode stratisNodeSync = builder.CreateStratisPowNode(this.regTest).NotInIBD();
+                CoreNode stratisNode1 = builder.CreateStratisPowNode(this.regTest).NotInIBD();
+                CoreNode stratisNode2 = builder.CreateStratisPowNode(this.regTest).NotInIBD();
 
                 builder.StartAll();
 
-                stratisNodeSync.NotInIBD().WithWallet();
-                stratisNode1.NotInIBD();
-                stratisNode2.NotInIBD();
+                stratisNodeSync.WithWallet();
 
                 // generate blocks and wait for the downloader to pickup
                 TestHelper.MineBlocks(stratisNodeSync, 10); // coinbase maturity = 10
@@ -121,11 +119,11 @@ namespace Stratis.Bitcoin.IntegrationTests.BlockStore
         {
             using (NodeBuilder builder = NodeBuilder.Create(this))
             {
-                CoreNode stratisNodeSync = builder.CreateStratisPowNode(this.regTest);
+                CoreNode stratisNodeSync = builder.CreateStratisPowNode(this.regTest).NotInIBD();
 
                 builder.StartAll();
 
-                stratisNodeSync.NotInIBD().WithWallet();
+                stratisNodeSync.WithWallet();
 
                 TestHelper.MineBlocks(stratisNodeSync, 10);
 
@@ -151,15 +149,14 @@ namespace Stratis.Bitcoin.IntegrationTests.BlockStore
         {
             using (NodeBuilder builder = NodeBuilder.Create(this))
             {
-                CoreNode stratisNodeSync = builder.CreateStratisPowNode(this.regTest);
-                CoreNode stratisNode1 = builder.CreateStratisPowNode(this.regTest);
-                CoreNode stratisNode2 = builder.CreateStratisPowNode(this.regTest);
+                CoreNode stratisNodeSync = builder.CreateStratisPowNode(this.regTest).NotInIBD();
+                CoreNode stratisNode1 = builder.CreateStratisPowNode(this.regTest).NotInIBD();
+                CoreNode stratisNode2 = builder.CreateStratisPowNode(this.regTest).NotInIBD();
 
                 builder.StartAll();
 
-                stratisNodeSync.NotInIBD();
-                stratisNode1.NotInIBD().WithWallet();
-                stratisNode2.NotInIBD().WithWallet();
+                stratisNode1.WithWallet();
+                stratisNode2.WithWallet();
 
                 // sync both nodes
                 stratisNodeSync.CreateRPCClient().AddNode(stratisNode1.Endpoint, true);
@@ -203,13 +200,12 @@ namespace Stratis.Bitcoin.IntegrationTests.BlockStore
         {
             using (NodeBuilder builder = NodeBuilder.Create(this))
             {
-                CoreNode stratisNode1 = builder.CreateStratisPowNode(this.regTest);
-                CoreNode stratisNode2 = builder.CreateStratisPowNode(this.regTest);
+                CoreNode stratisNode1 = builder.CreateStratisPowNode(this.regTest).NotInIBD();
+                CoreNode stratisNode2 = builder.CreateStratisPowNode(this.regTest).NotInIBD();
 
                 builder.StartAll();
 
-                stratisNode1.NotInIBD().WithWallet();
-                stratisNode2.NotInIBD();
+                stratisNode1.WithWallet();
 
                 // sync both nodes
                 stratisNode1.CreateRPCClient().AddNode(stratisNode2.Endpoint, true);
@@ -234,9 +230,8 @@ namespace Stratis.Bitcoin.IntegrationTests.BlockStore
         {
             using (NodeBuilder builder = NodeBuilder.Create(this))
             {
-                CoreNode node = builder.CreateStratisPowNode(this.regTest);
+                CoreNode node = builder.CreateStratisPowNode(this.regTest).NotInIBD();
                 builder.StartAll();
-                node.NotInIBD();
                 uint256 genesisHash = node.FullNode.Chain.Genesis.HashBlock;
                 Block genesisBlock = node.FullNode.BlockStore().GetBlockAsync(genesisHash).Result;
                 Assert.Equal(genesisHash, genesisBlock.GetHash());

--- a/src/Stratis.Bitcoin.IntegrationTests/BlockStore/ProofOfWorkSpendingSteps.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/BlockStore/ProofOfWorkSpendingSteps.cs
@@ -45,13 +45,13 @@ namespace Stratis.Bitcoin.IntegrationTests.BlockStore
 
         protected void a_sending_and_receiving_stratis_bitcoin_node_and_wallet()
         {
-            this.sendingStratisBitcoinNode = this.nodeBuilder.CreateStratisPowNode(this.network);
+            this.sendingStratisBitcoinNode = this.nodeBuilder.CreateStratisPowNode(this.network).NotInIBD();
             this.sendingStratisBitcoinNode.Start();
-            this.sendingStratisBitcoinNode.NotInIBD().WithWallet();
+            this.sendingStratisBitcoinNode.WithWallet();
 
-            this.receivingStratisBitcoinNode = this.nodeBuilder.CreateStratisPowNode(this.network);
+            this.receivingStratisBitcoinNode = this.nodeBuilder.CreateStratisPowNode(this.network).NotInIBD();
             this.receivingStratisBitcoinNode.Start();
-            this.receivingStratisBitcoinNode.NotInIBD().WithWallet();
+            this.receivingStratisBitcoinNode.WithWallet();
 
             TestHelper.Connect(this.sendingStratisBitcoinNode, this.receivingStratisBitcoinNode);
 

--- a/src/Stratis.Bitcoin.IntegrationTests/BlockStore/ReorgToLongestChainSteps.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/BlockStore/ReorgToLongestChainSteps.cs
@@ -44,21 +44,21 @@ namespace Stratis.Bitcoin.IntegrationTests.BlockStore
 
         private void four_miners()
         {
-            this.jingNode = this.nodeBuilder.CreateStratisPowNode(this.network);
+            this.jingNode = this.nodeBuilder.CreateStratisPowNode(this.network).NotInIBD();
             this.jingNode.Start();
-            this.jingNode.NotInIBD().WithWallet();
+            this.jingNode.WithWallet();
 
-            this.bobNode = this.nodeBuilder.CreateStratisPowNode(this.network);
+            this.bobNode = this.nodeBuilder.CreateStratisPowNode(this.network).NotInIBD();
             this.bobNode.Start();
-            this.bobNode.NotInIBD().WithWallet();
+            this.bobNode.WithWallet();
 
-            this.charlieNode = this.nodeBuilder.CreateStratisPowNode(this.network);
+            this.charlieNode = this.nodeBuilder.CreateStratisPowNode(this.network).NotInIBD();
             this.charlieNode.Start();
-            this.charlieNode.NotInIBD().WithWallet();
+            this.charlieNode.WithWallet();
 
-            this.daveNode = this.nodeBuilder.CreateStratisPowNode(this.network);
+            this.daveNode = this.nodeBuilder.CreateStratisPowNode(this.network).NotInIBD();
             this.daveNode.Start();
-            this.daveNode.NotInIBD().WithWallet();
+            this.daveNode.WithWallet();
 
             TestHelper.Connect(this.jingNode, this.bobNode);
             TestHelper.Connect(this.bobNode, this.charlieNode);

--- a/src/Stratis.Bitcoin.IntegrationTests/BlockStore/RetrieveFromBlockStoreSteps.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/BlockStore/RetrieveFromBlockStoreSteps.cs
@@ -56,16 +56,16 @@ namespace Stratis.Bitcoin.IntegrationTests.BlockStore
 
         private void a_pow_node_running()
         {
-            this.node = this.builder.CreateStratisPowNode(this.network);
+            this.node = this.builder.CreateStratisPowNode(this.network).NotInIBD();
             this.node.Start();
-            this.node.NotInIBD().WithWallet();
+            this.node.WithWallet();
         }
 
         private void a_pow_node_to_transact_with()
         {
-            this.transactionNode = this.builder.CreateStratisPowNode(this.network);
+            this.transactionNode = this.builder.CreateStratisPowNode(this.network).NotInIBD();
             this.transactionNode.Start();
-            this.transactionNode.NotInIBD().WithWallet();
+            this.transactionNode.WithWallet();
 
             this.transactionNode.CreateRPCClient().AddNode(this.node.Endpoint, true);
             TestHelper.WaitForNodeToSync(this.node, this.transactionNode);

--- a/src/Stratis.Bitcoin.IntegrationTests/ConsensusManagerTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/ConsensusManagerTests.cs
@@ -3,13 +3,11 @@ using System.Threading.Tasks;
 using NBitcoin;
 using Stratis.Bitcoin.Consensus;
 using Stratis.Bitcoin.Consensus.Rules;
-using Stratis.Bitcoin.Features.BlockStore;
 using Stratis.Bitcoin.Features.Miner.Interfaces;
 using Stratis.Bitcoin.Features.Miner.Staking;
 using Stratis.Bitcoin.IntegrationTests.Common;
 using Stratis.Bitcoin.IntegrationTests.Common.EnvironmentMockUpHelpers;
 using Stratis.Bitcoin.Networks;
-using Stratis.Bitcoin.Tests.Common;
 using Xunit;
 
 namespace Stratis.Bitcoin.IntegrationTests
@@ -55,8 +53,7 @@ namespace Stratis.Bitcoin.IntegrationTests
 
         public class FailValidation : FullValidationConsensusRule
         {
-            private int failheight;
-
+            private readonly int failheight;
             private int failcount;
 
             public FailValidation(int failheight, int failcount = 1)
@@ -85,15 +82,14 @@ namespace Stratis.Bitcoin.IntegrationTests
         {
             using (NodeBuilder builder = NodeBuilder.Create(this))
             {
-                var minerA = builder.CreateStratisPosNode(this.posNetwork);
-                var minerB = builder.CreateStratisPosNode(this.posNetwork);
-                var syncer = builder.CreateStratisPosNode(this.posNetwork);
+                var minerA = builder.CreateStratisPosNode(this.posNetwork).NotInIBD();
+                var minerB = builder.CreateStratisPosNode(this.posNetwork).NotInIBD();
+                var syncer = builder.CreateStratisPosNode(this.posNetwork).NotInIBD();
 
                 builder.StartAll();
 
-                minerA.NotInIBD().WithWallet();
-                minerB.NotInIBD().WithWallet();
-                syncer.NotInIBD();
+                minerA.WithWallet();
+                minerB.WithWallet();
 
                 // MinerA mines to height 10.
                 TestHelper.MineBlocks(minerA, 10);
@@ -136,15 +132,13 @@ namespace Stratis.Bitcoin.IntegrationTests
         {
             using (NodeBuilder builder = NodeBuilder.Create(this))
             {
-                var minerA = builder.CreateStratisPosNode(this.posNetwork);
-                var minerB = builder.CreateStratisPosNode(this.posNetwork);
-                var syncer = builder.CreateStratisPosNode(this.posNetwork);
+                var minerA = builder.CreateStratisPosNode(this.posNetwork).NotInIBD();
+                var minerB = builder.CreateStratisPosNode(this.posNetwork).NotInIBD();
+                var syncer = builder.CreateStratisPosNode(this.posNetwork).NotInIBD();
 
                 builder.StartAll();
 
-                minerA.NotInIBD().WithWallet();
-                minerB.NotInIBD();
-                syncer.NotInIBD();
+                minerA.WithWallet();
 
                 // MinerA mines to height 15.
                 TestHelper.MineBlocks(minerA, 15);
@@ -200,15 +194,14 @@ namespace Stratis.Bitcoin.IntegrationTests
         {
             using (NodeBuilder builder = NodeBuilder.Create(this))
             {
-                var minerA = builder.CreateStratisPosNode(this.posNetwork);
-                var minerB = builder.CreateStratisPosNode(this.posNetwork);
-                var syncer = builder.CreateStratisPosNode(this.posNetwork);
+                var minerA = builder.CreateStratisPosNode(this.posNetwork).NotInIBD();
+                var minerB = builder.CreateStratisPosNode(this.posNetwork).NotInIBD();
+                var syncer = builder.CreateStratisPosNode(this.posNetwork).NotInIBD();
 
                 builder.StartAll();
 
-                minerA.NotInIBD().WithWallet();
-                minerB.NotInIBD().WithWallet();
-                syncer.NotInIBD();
+                minerA.WithWallet();
+                minerB.WithWallet();
 
                 // MinerA mines to height 20.
                 TestHelper.MineBlocks(minerA, 20);
@@ -253,15 +246,14 @@ namespace Stratis.Bitcoin.IntegrationTests
         {
             using (NodeBuilder builder = NodeBuilder.Create(this))
             {
-                var minerA = builder.CreateStratisPowNode(this.powNetwork);
-                var minerB = builder.CreateStratisPowNode(this.powNetwork);
-                var syncer = builder.CreateStratisPowNode(this.powNetwork);
+                var minerA = builder.CreateStratisPowNode(this.powNetwork).NotInIBD();
+                var minerB = builder.CreateStratisPowNode(this.powNetwork).NotInIBD();
+                var syncer = builder.CreateStratisPowNode(this.powNetwork).NotInIBD();
 
                 builder.StartAll();
 
-                minerA.NotInIBD().WithWallet();
-                minerB.NotInIBD().WithWallet();
-                syncer.NotInIBD();
+                minerA.WithWallet();
+                minerB.WithWallet();
 
                 // MinerA mines to height 10.
                 TestHelper.MineBlocks(minerA, 10);
@@ -307,15 +299,14 @@ namespace Stratis.Bitcoin.IntegrationTests
             {
                 var syncerNetwork = new StratisOverrideRegTest();
 
-                var minerA = builder.CreateStratisPosNode(this.posNetwork);
-                var minerB = builder.CreateStratisPosNode(this.posNetwork);
-                var syncer = builder.CreateStratisPosNode(syncerNetwork);
+                var minerA = builder.CreateStratisPosNode(this.posNetwork).NotInIBD();
+                var minerB = builder.CreateStratisPosNode(this.posNetwork).NotInIBD();
+                var syncer = builder.CreateStratisPosNode(syncerNetwork).NotInIBD();
 
                 builder.StartAll();
 
-                minerA.NotInIBD().WithWallet();
-                minerB.NotInIBD().WithWallet();
-                syncer.NotInIBD();
+                minerA.WithWallet();
+                minerB.WithWallet();
 
                 // MinerA mines to height 10.
                 TestHelper.MineBlocks(minerA, 10);
@@ -343,7 +334,7 @@ namespace Stratis.Bitcoin.IntegrationTests
 
                 // Miner B should become disconnected.
                 TestHelper.WaitLoop(() => !TestHelper.IsNodeConnectedTo(syncer, minerB));
-                
+
                 // Make sure syncer rolled back.
                 Assert.True(syncer.FullNode.ConsensusManager().Tip.Height == 20);
 
@@ -359,15 +350,14 @@ namespace Stratis.Bitcoin.IntegrationTests
             {
                 var syncerNetwork = new BitcoinOverrideRegTest();
 
-                var minerA = builder.CreateStratisPowNode(this.powNetwork);
-                var minerB = builder.CreateStratisPowNode(this.powNetwork);
-                var syncer = builder.CreateStratisPowNode(syncerNetwork);
+                var minerA = builder.CreateStratisPowNode(this.powNetwork).NotInIBD();
+                var minerB = builder.CreateStratisPowNode(this.powNetwork).NotInIBD();
+                var syncer = builder.CreateStratisPowNode(syncerNetwork).NotInIBD();
 
                 builder.StartAll();
 
-                minerA.NotInIBD().WithWallet();
-                minerB.NotInIBD().WithWallet();
-                syncer.NotInIBD();
+                minerA.WithWallet();
+                minerB.WithWallet();
 
                 // MinerA mines to height 10.
                 TestHelper.MineBlocks(minerA, 10);
@@ -411,13 +401,12 @@ namespace Stratis.Bitcoin.IntegrationTests
             {
                 var syncerNetwork = new StratisOverrideRegTest();
 
-                var minerA = builder.CreateStratisPosNode(this.posNetwork);
-                var syncer = builder.CreateStratisPosNode(syncerNetwork);
+                var minerA = builder.CreateStratisPosNode(this.posNetwork).NotInIBD();
+                var syncer = builder.CreateStratisPosNode(syncerNetwork).NotInIBD();
 
                 builder.StartAll();
 
-                minerA.NotInIBD().WithWallet();
-                syncer.NotInIBD();
+                minerA.WithWallet();
 
                 // Miner A mines to height 11.
                 TestHelper.MineBlocks(minerA, 11);

--- a/src/Stratis.Bitcoin.IntegrationTests/Mempool/MemoryPoolTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/Mempool/MemoryPoolTests.cs
@@ -26,11 +26,11 @@ namespace Stratis.Bitcoin.IntegrationTests.Mempool
         {
             using (NodeBuilder builder = NodeBuilder.Create(this))
             {
-                CoreNode stratisNodeSync = builder.CreateStratisPowNode(this.network);
+                CoreNode stratisNodeSync = builder.CreateStratisPowNode(this.network).NotInIBD();
 
                 builder.StartAll();
 
-                stratisNodeSync.NotInIBD().WithWallet();
+                stratisNodeSync.WithWallet();
 
                 TestHelper.MineBlocks(stratisNodeSync, 105); // coinbase maturity = 100
                 TestHelper.WaitLoop(() => stratisNodeSync.FullNode.ConsensusManager().Tip.HashBlock == stratisNodeSync.FullNode.Chain.Tip.HashBlock);
@@ -57,11 +57,11 @@ namespace Stratis.Bitcoin.IntegrationTests.Mempool
         {
             using (NodeBuilder builder = NodeBuilder.Create(this))
             {
-                CoreNode stratisNodeSync = builder.CreateStratisPowNode(this.network);
+                CoreNode stratisNodeSync = builder.CreateStratisPowNode(this.network).NotInIBD();
 
                 builder.StartAll();
 
-                stratisNodeSync.NotInIBD().WithWallet();
+                stratisNodeSync.WithWallet();
 
                 TestHelper.MineBlocks(stratisNodeSync, 105); // coinbase maturity = 100
                 TestHelper.WaitLoop(() => stratisNodeSync.FullNode.ConsensusManager().Tip.HashBlock == stratisNodeSync.FullNode.Chain.Tip.HashBlock);
@@ -102,9 +102,9 @@ namespace Stratis.Bitcoin.IntegrationTests.Mempool
         {
             using (NodeBuilder builder = NodeBuilder.Create(this))
             {
-                CoreNode stratisNodeSync = builder.CreateStratisPowNode(this.network);
+                CoreNode stratisNodeSync = builder.CreateStratisPowNode(this.network).NotInIBD();
                 builder.StartAll();
-                stratisNodeSync.NotInIBD().WithWallet();
+                stratisNodeSync.WithWallet();
 
                 TestHelper.MineBlocks(stratisNodeSync, 201); // coinbase maturity = 100
                 TestHelper.WaitLoop(() => stratisNodeSync.FullNode.ConsensusManager().Tip.HashBlock == stratisNodeSync.FullNode.Chain.Tip.HashBlock);
@@ -139,11 +139,11 @@ namespace Stratis.Bitcoin.IntegrationTests.Mempool
         {
             using (NodeBuilder builder = NodeBuilder.Create(this))
             {
-                CoreNode stratisNodeSync = builder.CreateStratisPowNode(this.network);
+                CoreNode stratisNodeSync = builder.CreateStratisPowNode(this.network).NotInIBD();
 
                 builder.StartAll();
 
-                stratisNodeSync.NotInIBD().WithWallet();
+                stratisNodeSync.WithWallet();
 
                 stratisNodeSync.FullNode.NodeService<MempoolSettings>().RequireStandard = true; // make sure to test standard tx
 
@@ -283,11 +283,11 @@ namespace Stratis.Bitcoin.IntegrationTests.Mempool
         {
             using (NodeBuilder builder = NodeBuilder.Create(this))
             {
-                CoreNode stratisNodeSync = builder.CreateStratisPowNode(this.network);
+                CoreNode stratisNodeSync = builder.CreateStratisPowNode(this.network).NotInIBD();
 
                 builder.StartAll();
 
-                stratisNodeSync.NotInIBD().WithWallet();
+                stratisNodeSync.WithWallet();
 
                 TestHelper.MineBlocks(stratisNodeSync, 101); // coinbase maturity = 100
                 TestHelper.WaitLoop(() => stratisNodeSync.FullNode.ConsensusManager().Tip.HashBlock == stratisNodeSync.FullNode.Chain.Tip.HashBlock);
@@ -326,15 +326,13 @@ namespace Stratis.Bitcoin.IntegrationTests.Mempool
         {
             using (NodeBuilder builder = NodeBuilder.Create(this))
             {
-                CoreNode stratisNodeSync = builder.CreateStratisPowNode(this.network);
-                CoreNode stratisNode1 = builder.CreateStratisPowNode(this.network);
-                CoreNode stratisNode2 = builder.CreateStratisPowNode(this.network);
+                CoreNode stratisNodeSync = builder.CreateStratisPowNode(this.network).NotInIBD();
+                CoreNode stratisNode1 = builder.CreateStratisPowNode(this.network).NotInIBD();
+                CoreNode stratisNode2 = builder.CreateStratisPowNode(this.network).NotInIBD();
 
                 builder.StartAll();
 
-                stratisNodeSync.NotInIBD().WithWallet();
-                stratisNode1.NotInIBD();
-                stratisNode2.NotInIBD();
+                stratisNodeSync.WithWallet();
 
                 // generate blocks and wait for the downloader to pickup
                 TestHelper.MineBlocks(stratisNodeSync, 105); // coinbase maturity = 100

--- a/src/Stratis.Bitcoin.IntegrationTests/Mempool/MempoolRelaySpecification_Steps.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/Mempool/MempoolRelaySpecification_Steps.cs
@@ -40,14 +40,12 @@ namespace Stratis.Bitcoin.IntegrationTests.Mempool
         {
             Network regTest = KnownNetworks.RegTest;
 
-            this.nodeA = this.nodeBuilder.CreateStratisPowNode(regTest);
-            this.nodeB = this.nodeBuilder.CreateStratisPowNode(regTest);
-            this.nodeC = this.nodeBuilder.CreateStratisPowNode(regTest);
+            this.nodeA = this.nodeBuilder.CreateStratisPowNode(regTest).NotInIBD();
+            this.nodeB = this.nodeBuilder.CreateStratisPowNode(regTest).NotInIBD();
+            this.nodeC = this.nodeBuilder.CreateStratisPowNode(regTest).NotInIBD();
 
             this.nodeBuilder.StartAll();
-            this.nodeA.NotInIBD().WithWallet();
-            this.nodeB.NotInIBD();
-            this.nodeC.NotInIBD();
+            this.nodeA.WithWallet();
 
             this.coinbaseMaturity = (int)this.nodeA.FullNode.Network.Consensus.CoinbaseMaturity;
         }

--- a/src/Stratis.Bitcoin.IntegrationTests/MinerTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/MinerTests.cs
@@ -225,7 +225,7 @@ namespace Stratis.Bitcoin.IntegrationTests
 
                     var res = await this.consensus.BlockMinedAsync(block);
 
-                    if(res == null)
+                    if (res == null)
                         throw new InvalidOperationException();
 
                     blocks.Add(block);
@@ -363,10 +363,9 @@ namespace Stratis.Bitcoin.IntegrationTests
         {
             using (NodeBuilder builder = NodeBuilder.Create(this))
             {
-                CoreNode miner = builder.CreateStratisPowNode(this.network);
+                CoreNode miner = builder.CreateStratisPowNode(this.network).NotInIBD();
 
                 builder.StartAll();
-                miner.NotInIBD();
                 miner.SetDummyMinerSecret(new BitcoinSecret(new Key(), miner.FullNode.Network));
                 TestHelper.MineBlocks(miner, 1);
 
@@ -471,10 +470,9 @@ namespace Stratis.Bitcoin.IntegrationTests
         {
             using (NodeBuilder builder = NodeBuilder.Create(this))
             {
-                CoreNode miner = builder.CreateStratisPowNode(this.network);
+                CoreNode miner = builder.CreateStratisPowNode(this.network).NotInIBD();
 
                 builder.StartAll();
-                miner.NotInIBD();
                 miner.SetDummyMinerSecret(new BitcoinSecret(new Key(), miner.FullNode.Network));
                 TestHelper.MineBlocks(miner, 1);
 
@@ -686,9 +684,8 @@ namespace Stratis.Bitcoin.IntegrationTests
         {
             using (NodeBuilder builder = NodeBuilder.Create(this))
             {
-                CoreNode node = builder.CreateStratisPowNode(KnownNetworks.RegTest);
+                CoreNode node = builder.CreateStratisPowNode(KnownNetworks.RegTest).NotInIBD();
                 builder.StartAll();
-                node.NotInIBD();
 
                 node.SetDummyMinerSecret(new BitcoinSecret(new Key(), node.FullNode.Network));
 
@@ -711,13 +708,10 @@ namespace Stratis.Bitcoin.IntegrationTests
         {
             using (NodeBuilder builder = NodeBuilder.Create(this))
             {
-                CoreNode miner = builder.CreateStratisPowNode(KnownNetworks.RegTest);
-                CoreNode syncer = builder.CreateStratisPowNode(KnownNetworks.RegTest);
+                CoreNode miner = builder.CreateStratisPowNode(KnownNetworks.RegTest).NotInIBD();
+                CoreNode syncer = builder.CreateStratisPowNode(KnownNetworks.RegTest).NotInIBD();
 
                 builder.StartAll();
-
-                miner.NotInIBD();
-                syncer.NotInIBD();
 
                 miner.CreateRPCClient().AddNode(syncer.Endpoint, true);
 
@@ -734,12 +728,10 @@ namespace Stratis.Bitcoin.IntegrationTests
         {
             using (NodeBuilder builder = NodeBuilder.Create(this))
             {
-                CoreNode miner = builder.CreateStratisPowNode(KnownNetworks.RegTest);
-                CoreNode syncer = builder.CreateStratisPowNode(KnownNetworks.RegTest);
+                CoreNode miner = builder.CreateStratisPowNode(KnownNetworks.RegTest).NotInIBD();
+                CoreNode syncer = builder.CreateStratisPowNode(KnownNetworks.RegTest).NotInIBD();
 
                 builder.StartAll();
-                miner.NotInIBD();
-                syncer.NotInIBD();
 
                 miner.SetDummyMinerSecret(new BitcoinSecret(new Key(), miner.FullNode.Network));
 

--- a/src/Stratis.Bitcoin.IntegrationTests/NodeSyncTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/NodeSyncTests.cs
@@ -79,11 +79,10 @@ namespace Stratis.Bitcoin.IntegrationTests
         {
             using (NodeBuilder builder = NodeBuilder.Create(this))
             {
-                CoreNode node1 = builder.CreateStratisPowNode(this.powNetwork);
-                CoreNode node2 = builder.CreateStratisPowNode(this.powNetwork);
+                CoreNode node1 = builder.CreateStratisPowNode(this.powNetwork).NotInIBD();
+                CoreNode node2 = builder.CreateStratisPowNode(this.powNetwork).NotInIBD();
                 builder.StartAll();
-                node1.NotInIBD();
-                node2.NotInIBD();
+
                 Assert.Empty(node1.FullNode.ConnectionManager.ConnectedPeers);
                 Assert.Empty(node2.FullNode.ConnectionManager.ConnectedPeers);
                 RPCClient rpc1 = node1.CreateRPCClient();
@@ -105,11 +104,9 @@ namespace Stratis.Bitcoin.IntegrationTests
         {
             using (NodeBuilder builder = NodeBuilder.Create(this))
             {
-                CoreNode stratisNode = builder.CreateStratisPowNode(this.powNetwork);
+                CoreNode stratisNode = builder.CreateStratisPowNode(this.powNetwork).NotInIBD();
                 CoreNode coreNode = builder.CreateBitcoinCoreNode();
                 builder.StartAll();
-
-                stratisNode.NotInIBD();
 
                 Block tip = coreNode.FindBlock(10).Last();
                 RPCClient stratisNodeRpcClient = stratisNode.CreateRPCClient();
@@ -136,13 +133,10 @@ namespace Stratis.Bitcoin.IntegrationTests
         {
             using (NodeBuilder builder = NodeBuilder.Create(this))
             {
-                CoreNode stratisNode = builder.CreateStratisPowNode(this.powNetwork);
-                CoreNode stratisNodeSync = builder.CreateStratisPowNode(this.powNetwork);
+                CoreNode stratisNode = builder.CreateStratisPowNode(this.powNetwork).NotInIBD();
+                CoreNode stratisNodeSync = builder.CreateStratisPowNode(this.powNetwork).NotInIBD();
                 CoreNode coreCreateNode = builder.CreateBitcoinCoreNode();
                 builder.StartAll();
-
-                stratisNode.NotInIBD();
-                stratisNodeSync.NotInIBD();
 
                 // first seed a core node with blocks and sync them to a stratis node
                 // and wait till the stratis node is fully synced
@@ -168,13 +162,11 @@ namespace Stratis.Bitcoin.IntegrationTests
         {
             using (NodeBuilder builder = NodeBuilder.Create(this))
             {
-                CoreNode stratisNode = builder.CreateStratisPowNode(this.powNetwork);
+                CoreNode stratisNode = builder.CreateStratisPowNode(this.powNetwork).NotInIBD();
                 CoreNode coreNodeSync = builder.CreateBitcoinCoreNode();
                 CoreNode coreCreateNode = builder.CreateBitcoinCoreNode();
 
                 builder.StartAll();
-
-                stratisNode.NotInIBD();
 
                 // first seed a core node with blocks and sync them to a stratis node
                 // and wait till the stratis node is fully synced
@@ -202,14 +194,13 @@ namespace Stratis.Bitcoin.IntegrationTests
         {
             using (NodeBuilder builder = NodeBuilder.Create(this))
             {
-                CoreNode stratisMiner = builder.CreateStratisPosNode(this.posNetwork);
-                CoreNode stratisSyncer = builder.CreateStratisPosNode(this.posNetwork);
-                CoreNode stratisReorg = builder.CreateStratisPosNode(this.posNetwork);
+                CoreNode stratisMiner = builder.CreateStratisPosNode(this.posNetwork).NotInIBD();
+                CoreNode stratisSyncer = builder.CreateStratisPosNode(this.posNetwork).NotInIBD();
+                CoreNode stratisReorg = builder.CreateStratisPosNode(this.posNetwork).NotInIBD();
 
                 builder.StartAll();
-                stratisMiner.NotInIBD().WithWallet();
-                stratisSyncer.NotInIBD();
-                stratisReorg.NotInIBD().WithWallet();
+                stratisMiner.WithWallet();
+                stratisReorg.WithWallet();
 
                 TestHelper.MineBlocks(stratisMiner, 1);
 
@@ -274,14 +265,14 @@ namespace Stratis.Bitcoin.IntegrationTests
             using (NodeBuilder builder = NodeBuilder.Create(this))
             {
                 // This represents local node.
-                CoreNode stratisMinerLocal = builder.CreateStratisPosNode(this.posNetwork);
+                CoreNode stratisMinerLocal = builder.CreateStratisPosNode(this.posNetwork).NotInIBD();
 
                 // This represents remote, which blocks are received by local node using its puller.
-                CoreNode stratisMinerRemote = builder.CreateStratisPosNode(this.posNetwork);
+                CoreNode stratisMinerRemote = builder.CreateStratisPosNode(this.posNetwork).NotInIBD();
 
                 builder.StartAll();
-                stratisMinerLocal.NotInIBD().WithWallet();
-                stratisMinerRemote.NotInIBD().WithWallet();
+                stratisMinerLocal.WithWallet();
+                stratisMinerRemote.WithWallet();
 
                 // Let's mine block Ap and Bp.
                 TestHelper.MineBlocks(stratisMinerRemote, 2);
@@ -331,21 +322,21 @@ namespace Stratis.Bitcoin.IntegrationTests
 
             using (NodeBuilder nodeBuilder = NodeBuilder.Create(testFolderPath))
             {
-                CoreNode minerNode = nodeBuilder.CreateStratisPowNode(this.powNetwork);
+                CoreNode minerNode = nodeBuilder.CreateStratisPowNode(this.powNetwork).NotInIBD();
                 minerNode.Start();
-                minerNode.NotInIBD().WithWallet();
+                minerNode.WithWallet();
 
-                CoreNode connectorNode = nodeBuilder.CreateStratisPowNode(this.powNetwork);
+                CoreNode connectorNode = nodeBuilder.CreateStratisPowNode(this.powNetwork).NotInIBD();
                 connectorNode.Start();
-                connectorNode.NotInIBD().WithWallet();
+                connectorNode.WithWallet();
 
-                CoreNode firstNode = nodeBuilder.CreateStratisPowNode(this.powNetwork);
+                CoreNode firstNode = nodeBuilder.CreateStratisPowNode(this.powNetwork).NotInIBD();
                 firstNode.Start();
-                firstNode.NotInIBD().WithWallet();
+                firstNode.WithWallet();
 
                 CoreNode secondNode = nodeBuilder.CreateStratisPowNode(this.powNetwork);
                 secondNode.Start();
-                secondNode.NotInIBD().WithWallet();
+                secondNode.WithWallet();
 
                 TestHelper.Connect(minerNode, connectorNode);
                 TestHelper.Connect(connectorNode, firstNode);

--- a/src/Stratis.Bitcoin.IntegrationTests/ProofOfStakeSteps.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/ProofOfStakeSteps.cs
@@ -42,9 +42,9 @@ namespace Stratis.Bitcoin.IntegrationTests
 
         public void PremineNodeWithWallet()
         {
-            this.PremineNodeWithCoins = this.nodeBuilder.CreateStratisPosNode(KnownNetworks.StratisRegTest);
+            this.PremineNodeWithCoins = this.nodeBuilder.CreateStratisPosNode(KnownNetworks.StratisRegTest).NotInIBD();
             this.PremineNodeWithCoins.Start();
-            this.PremineNodeWithCoins.NotInIBD().WithWallet();
+            this.PremineNodeWithCoins.WithWallet();
         }
 
         public void MineGenesisAndPremineBlocks()

--- a/src/Stratis.Bitcoin.IntegrationTests/RPC/RPCTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/RPC/RPCTests.cs
@@ -20,9 +20,9 @@ namespace Stratis.Bitcoin.IntegrationTests.RPC
         protected override void InitializeFixture()
         {
             this.Builder = NodeBuilder.Create(this);
-            this.Node = this.Builder.CreateStratisPowNode(KnownNetworks.RegTest);
+            this.Node = this.Builder.CreateStratisPowNode(KnownNetworks.RegTest).NotInIBD();
             this.Builder.StartAll();
-            this.Node.NotInIBD();
+
             this.RpcClient = this.Node.CreateRPCClient();
             this.NetworkPeerClient = this.Node.CreateNetworkPeerClient();
             this.NetworkPeerClient.VersionHandshakeAsync().GetAwaiter().GetResult();
@@ -232,7 +232,7 @@ namespace Stratis.Bitcoin.IntegrationTests.RPC
         public void GetNewAddress()
         {
             BitcoinAddress address = this.rpcTestFixture.RpcClient.GetNewAddress();
-            Assert.NotNull(address);            
+            Assert.NotNull(address);
         }
 
         // TODO: implement the RPC methods used below

--- a/src/Stratis.Bitcoin.IntegrationTests/RPC/RPCTestsMutable.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/RPC/RPCTestsMutable.cs
@@ -17,11 +17,11 @@ namespace Stratis.Bitcoin.IntegrationTests.RPC
         {
             using (NodeBuilder builder = NodeBuilder.Create(this))
             {
-                var node = builder.CreateStratisPowNode(KnownNetworks.RegTest);
+                var node = builder.CreateStratisPowNode(KnownNetworks.RegTest).NotInIBD();
                 builder.StartAll();
                 RPCClient rpcClient = node.CreateRPCClient();
-                node.NotInIBD().WithWallet();               
-                TestHelper.MineBlocks(node, 2);               
+                node.WithWallet();
+                TestHelper.MineBlocks(node, 2);
                 TestHelper.WaitLoop(() => node.FullNode.GetBlockStoreTip().Height == 2);
 
                 uint256 blockId = rpcClient.GetBestBlockHash();

--- a/src/Stratis.Bitcoin.IntegrationTests/Transactions/TransactionWithNullDataSteps.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/Transactions/TransactionWithNullDataSteps.cs
@@ -49,13 +49,13 @@ namespace Stratis.Bitcoin.IntegrationTests.Transactions
 
         private void two_proof_of_work_nodes()
         {
-            this.senderNode = this.builder.CreateStratisPowNode(KnownNetworks.RegTest);
-            this.receiverNode = this.builder.CreateStratisPowNode(KnownNetworks.RegTest);
+            this.senderNode = this.builder.CreateStratisPowNode(KnownNetworks.RegTest).NotInIBD();
+            this.receiverNode = this.builder.CreateStratisPowNode(KnownNetworks.RegTest).NotInIBD();
 
             this.builder.StartAll();
 
-            this.senderNode.NotInIBD().WithWallet();
-            this.receiverNode.NotInIBD().WithWallet();
+            this.senderNode.WithWallet();
+            this.receiverNode.WithWallet();
         }
 
         private void a_sending_and_a_receiving_wallet()

--- a/src/Stratis.Bitcoin.IntegrationTests/Wallet/SendingStakedCoinsBeforeMaturity_Steps.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/Wallet/SendingStakedCoinsBeforeMaturity_Steps.cs
@@ -43,9 +43,9 @@ namespace Stratis.Bitcoin.IntegrationTests.Wallet
             this.proofOfStakeSteps.PremineNodeWithWallet();
             this.proofOfStakeSteps.MineGenesisAndPremineBlocks();
 
-            this.receiverNode = this.proofOfStakeSteps.nodeBuilder.CreateStratisPosNode(KnownNetworks.StratisRegTest);
+            this.receiverNode = this.proofOfStakeSteps.nodeBuilder.CreateStratisPosNode(KnownNetworks.StratisRegTest).NotInIBD();
             this.receiverNode.Start();
-            this.receiverNode.NotInIBD().WithWallet();
+            this.receiverNode.WithWallet();
 
             TestHelper.ConnectAndSync(this.proofOfStakeSteps.PremineNodeWithCoins, this.receiverNode);
         }

--- a/src/Stratis.Bitcoin.IntegrationTests/Wallet/SendingToAndFromManyAddressesSpecification_Steps.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/Wallet/SendingToAndFromManyAddressesSpecification_Steps.cs
@@ -50,13 +50,13 @@ namespace Stratis.Bitcoin.IntegrationTests.Wallet
 
         private void two_connected_nodes()
         {
-            this.firstNode = this.nodeBuilder.CreateStratisPowNode(this.network);
+            this.firstNode = this.nodeBuilder.CreateStratisPowNode(this.network).NotInIBD();
             this.firstNode.Start();
-            this.firstNode.NotInIBD().WithWallet();
+            this.firstNode.WithWallet();
 
-            this.secondNode = this.nodeBuilder.CreateStratisPowNode(this.network);
+            this.secondNode = this.nodeBuilder.CreateStratisPowNode(this.network).NotInIBD();
             this.secondNode.Start();
-            this.secondNode.NotInIBD().WithWallet();
+            this.secondNode.WithWallet();
 
             TestHelper.Connect(this.firstNode, this.secondNode);
         }

--- a/src/Stratis.Bitcoin.IntegrationTests/Wallet/SendingTransactionOverPolicyByteLimitSpecification_Steps.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/Wallet/SendingTransactionOverPolicyByteLimitSpecification_Steps.cs
@@ -47,13 +47,13 @@ namespace Stratis.Bitcoin.IntegrationTests.Wallet
 
         private void two_connected_nodes()
         {
-            this.firstNode = this.nodeBuilder.CreateStratisPowNode(this.network);
+            this.firstNode = this.nodeBuilder.CreateStratisPowNode(this.network).NotInIBD();
             this.firstNode.Start();
-            this.firstNode.NotInIBD().WithWallet();
+            this.firstNode.WithWallet();
 
-            this.secondNode = this.nodeBuilder.CreateStratisPowNode(this.network);
+            this.secondNode = this.nodeBuilder.CreateStratisPowNode(this.network).NotInIBD();
             this.secondNode.Start();
-            this.secondNode.NotInIBD().WithWallet();
+            this.secondNode.WithWallet();
 
             TestHelper.Connect(this.firstNode, this.secondNode);
         }

--- a/src/Stratis.Bitcoin.IntegrationTests/Wallet/SendingTxWithDoubleSpendSpecification_Steps.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/Wallet/SendingTxWithDoubleSpendSpecification_Steps.cs
@@ -33,13 +33,13 @@ namespace Stratis.Bitcoin.IntegrationTests.Wallet
         protected override void BeforeTest()
         {
             this.builder = NodeBuilder.Create(this);
-            this.stratisSender = this.builder.CreateStratisPowNode(KnownNetworks.RegTest);
-            this.stratisReceiver = this.builder.CreateStratisPowNode(KnownNetworks.RegTest);
+            this.stratisSender = this.builder.CreateStratisPowNode(KnownNetworks.RegTest).NotInIBD();
+            this.stratisReceiver = this.builder.CreateStratisPowNode(KnownNetworks.RegTest).NotInIBD();
             this.mempoolValidationState = new MempoolValidationState(true);
 
             this.builder.StartAll();
-            this.stratisSender.NotInIBD().WithWallet();
-            this.stratisReceiver.NotInIBD().WithWallet();
+            this.stratisSender.WithWallet();
+            this.stratisReceiver.WithWallet();
         }
 
         protected override void AfterTest()

--- a/src/Stratis.Bitcoin.IntegrationTests/Wallet/WalletAddressGenerationAndFundsVisibility_Steps.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/Wallet/WalletAddressGenerationAndFundsVisibility_Steps.cs
@@ -62,13 +62,13 @@ namespace Stratis.Bitcoin.IntegrationTests.Wallet
 
         private void a_default_gap_limit_of_20()
         {
-            this.sendingStratisBitcoinNode = this.nodeBuilder.CreateStratisPowNode(this.network);
+            this.sendingStratisBitcoinNode = this.nodeBuilder.CreateStratisPowNode(this.network).NotInIBD();
             this.sendingStratisBitcoinNode.Start();
-            this.sendingStratisBitcoinNode.Mnemonic = this.sendingStratisBitcoinNode.NotInIBD().WithWallet();
+            this.sendingStratisBitcoinNode.Mnemonic = this.sendingStratisBitcoinNode.WithWallet();
 
-            this.receivingStratisBitcoinNode = this.nodeBuilder.CreateStratisPowNode(this.network);
+            this.receivingStratisBitcoinNode = this.nodeBuilder.CreateStratisPowNode(this.network).NotInIBD();
             this.receivingStratisBitcoinNode.Start();
-            this.receivingStratisBitcoinNode.Mnemonic = this.receivingStratisBitcoinNode.NotInIBD().WithWallet();
+            this.receivingStratisBitcoinNode.Mnemonic = this.receivingStratisBitcoinNode.WithWallet();
 
             TestHelper.ConnectAndSync(this.sendingStratisBitcoinNode, this.receivingStratisBitcoinNode);
             this.MineSpendableCoins();
@@ -79,13 +79,13 @@ namespace Stratis.Bitcoin.IntegrationTests.Wallet
             int customUnusedAddressBuffer = 21;
             var configParameters = new NodeConfigParameters { { "walletaddressbuffer", customUnusedAddressBuffer.ToString() } };
 
-            this.sendingStratisBitcoinNode = this.nodeBuilder.CreateStratisPowNode(this.network);
+            this.sendingStratisBitcoinNode = this.nodeBuilder.CreateStratisPowNode(this.network).NotInIBD();
             this.sendingStratisBitcoinNode.Start();
-            this.sendingStratisBitcoinNode.Mnemonic = this.sendingStratisBitcoinNode.NotInIBD().WithWallet();
+            this.sendingStratisBitcoinNode.Mnemonic = this.sendingStratisBitcoinNode.WithWallet();
 
-            this.receivingStratisBitcoinNode = this.nodeBuilder.CreateStratisCustomPowNode(this.network, configParameters);
+            this.receivingStratisBitcoinNode = this.nodeBuilder.CreateStratisCustomPowNode(this.network, configParameters).NotInIBD();
             this.receivingStratisBitcoinNode.Start();
-            this.receivingStratisBitcoinNode.Mnemonic = this.receivingStratisBitcoinNode.NotInIBD().WithWallet();
+            this.receivingStratisBitcoinNode.Mnemonic = this.receivingStratisBitcoinNode.WithWallet();
 
             TestHelper.ConnectAndSync(this.sendingStratisBitcoinNode, this.receivingStratisBitcoinNode);
             this.MineSpendableCoins();

--- a/src/Stratis.Bitcoin.IntegrationTests/Wallet/WalletTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/Wallet/WalletTests.cs
@@ -33,12 +33,12 @@ namespace Stratis.Bitcoin.IntegrationTests.Wallet
         {
             using (NodeBuilder builder = NodeBuilder.Create(this))
             {
-                CoreNode stratisSender = builder.CreateStratisPowNode(this.network);
-                CoreNode stratisReceiver = builder.CreateStratisPowNode(this.network);
+                CoreNode stratisSender = builder.CreateStratisPowNode(this.network).NotInIBD();
+                CoreNode stratisReceiver = builder.CreateStratisPowNode(this.network).NotInIBD();
 
                 builder.StartAll();
-                stratisSender.NotInIBD().WithWallet();
-                stratisReceiver.NotInIBD().WithWallet();
+                stratisSender.WithWallet();
+                stratisReceiver.WithWallet();
 
                 int maturity = (int)stratisSender.FullNode.Network.Consensus.CoinbaseMaturity;
                 TestHelper.MineBlocks(stratisSender, maturity + 5);
@@ -112,15 +112,15 @@ namespace Stratis.Bitcoin.IntegrationTests.Wallet
 
             using (NodeBuilder builder = NodeBuilder.Create(this))
             {
-                CoreNode stratisSender = builder.CreateStratisPowNode(this.network);
-                CoreNode stratisReceiver = builder.CreateStratisPowNode(this.network);
-                CoreNode stratisReorg = builder.CreateStratisPowNode(this.network);
+                CoreNode stratisSender = builder.CreateStratisPowNode(this.network).NotInIBD();
+                CoreNode stratisReceiver = builder.CreateStratisPowNode(this.network).NotInIBD();
+                CoreNode stratisReorg = builder.CreateStratisPowNode(this.network).NotInIBD();
 
                 builder.StartAll();
 
-                stratisSender.NotInIBD().WithWallet();
-                stratisReceiver.NotInIBD().WithWallet();
-                stratisReorg.NotInIBD().WithWallet();
+                stratisSender.WithWallet();
+                stratisReceiver.WithWallet();
+                stratisReorg.WithWallet();
 
                 int maturity = (int)stratisSender.FullNode.Network.Consensus.CoinbaseMaturity;
                 TestHelper.MineBlocks(stratisSender, maturity + 15);
@@ -254,15 +254,14 @@ namespace Stratis.Bitcoin.IntegrationTests.Wallet
         {
             using (NodeBuilder builder = NodeBuilder.Create(this))
             {
-                CoreNode stratisSender = builder.CreateStratisPowNode(this.network);
-                CoreNode stratisReceiver = builder.CreateStratisPowNode(this.network);
-                CoreNode stratisReorg = builder.CreateStratisPowNode(this.network);
+                CoreNode stratisSender = builder.CreateStratisPowNode(this.network).NotInIBD();
+                CoreNode stratisReceiver = builder.CreateStratisPowNode(this.network).NotInIBD();
+                CoreNode stratisReorg = builder.CreateStratisPowNode(this.network).NotInIBD();
 
                 builder.StartAll();
 
-                stratisSender.NotInIBD().WithWallet();
-                stratisReceiver.NotInIBD();
-                stratisReorg.NotInIBD().WithWallet();
+                stratisSender.WithWallet();
+                stratisReorg.WithWallet();
 
                 TestHelper.MineBlocks(stratisSender, 10);
 
@@ -307,15 +306,14 @@ namespace Stratis.Bitcoin.IntegrationTests.Wallet
         {
             using (NodeBuilder builder = NodeBuilder.Create(this))
             {
-                CoreNode stratisSender = builder.CreateStratisPowNode(this.network);
-                CoreNode stratisReceiver = builder.CreateStratisPowNode(this.network);
-                CoreNode stratisReorg = builder.CreateStratisPowNode(this.network);
+                CoreNode stratisSender = builder.CreateStratisPowNode(this.network).NotInIBD();
+                CoreNode stratisReceiver = builder.CreateStratisPowNode(this.network).NotInIBD();
+                CoreNode stratisReorg = builder.CreateStratisPowNode(this.network).NotInIBD();
 
                 builder.StartAll();
 
-                stratisSender.NotInIBD().WithWallet();
-                stratisReceiver.NotInIBD();
-                stratisReorg.NotInIBD().WithWallet();
+                stratisSender.WithWallet();
+                stratisReorg.WithWallet();
 
                 TestHelper.MineBlocks(stratisSender, 10);
 
@@ -360,10 +358,10 @@ namespace Stratis.Bitcoin.IntegrationTests.Wallet
         {
             using (NodeBuilder builder = NodeBuilder.Create(this))
             {
-                CoreNode stratisminer = builder.CreateStratisPowNode(this.network);
+                CoreNode stratisminer = builder.CreateStratisPowNode(this.network).NotInIBD();
 
                 builder.StartAll();
-                stratisminer.NotInIBD().WithWallet();
+                stratisminer.WithWallet();
 
                 TestHelper.MineBlocks(stratisminer, 10);
 
@@ -380,9 +378,9 @@ namespace Stratis.Bitcoin.IntegrationTests.Wallet
         {
             using (NodeBuilder builder = NodeBuilder.Create(this))
             {
-                CoreNode stratisNodeSync = builder.CreateStratisPowNode(this.network);
+                CoreNode stratisNodeSync = builder.CreateStratisPowNode(this.network).NotInIBD();
                 builder.StartAll();
-                stratisNodeSync.NotInIBD().WithWallet();
+                stratisNodeSync.WithWallet();
 
                 TestHelper.MineBlocks(stratisNodeSync, 10);
 

--- a/src/Stratis.SmartContracts.IntegrationTests/MockChain/Chain.cs
+++ b/src/Stratis.SmartContracts.IntegrationTests/MockChain/Chain.cs
@@ -39,7 +39,7 @@ namespace Stratis.SmartContracts.IntegrationTests.MockChain
 
             for (int i = 0; i < numNodes; i++)
             {
-                CoreNode node = this.builder.CreateSmartContractPowNode();
+                CoreNode node = this.builder.CreateSmartContractPowNode().NotInIBD();
                 node.Start();
                 // Add other nodes
                 RPCClient rpcClient = node.CreateRPCClient();

--- a/src/Stratis.SmartContracts.IntegrationTests/MockChain/Node.cs
+++ b/src/Stratis.SmartContracts.IntegrationTests/MockChain/Node.cs
@@ -85,8 +85,8 @@ namespace Stratis.SmartContracts.IntegrationTests.MockChain
         {
             this.CoreNode = coreNode;
             this.chain = chain;
+
             // Set up address and mining
-            this.CoreNode.NotInIBD();
             this.CoreNode.FullNode.WalletManager().CreateWallet(this.Password, this.WalletName, this.Passphrase);
             this.MinerAddress = this.CoreNode.FullNode.WalletManager().GetUnusedAddress(new WalletAccountReference(this.WalletName, this.AccountName));
             Wallet wallet = this.CoreNode.FullNode.WalletManager().GetWalletByName(this.WalletName);
@@ -141,7 +141,7 @@ namespace Stratis.SmartContracts.IntegrationTests.MockChain
                 return Result.Fail<WalletSendTransactionModel>(errorResponse.Errors[0].Message);
             }
 
-            JsonResult response = (JsonResult) result;
+            JsonResult response = (JsonResult)result;
             return Result.Ok((WalletSendTransactionModel)response.Value);
         }
 

--- a/src/Stratis.SmartContracts.IntegrationTests/SmartContractNodeSyncTests.cs
+++ b/src/Stratis.SmartContracts.IntegrationTests/SmartContractNodeSyncTests.cs
@@ -12,11 +12,10 @@ namespace Stratis.SmartContracts.IntegrationTests
         {
             using (NodeBuilder builder = NodeBuilder.Create(this))
             {
-                var node1 = builder.CreateSmartContractPowNode();
-                var node2 = builder.CreateSmartContractPowNode();
+                var node1 = builder.CreateSmartContractPowNode().NotInIBD();
+                var node2 = builder.CreateSmartContractPowNode().NotInIBD();
                 builder.StartAll();
-                node1.NotInIBD();
-                node2.NotInIBD();
+
                 Assert.Empty(node1.FullNode.ConnectionManager.ConnectedPeers);
                 Assert.Empty(node2.FullNode.ConnectionManager.ConnectedPeers);
                 var rpc1 = node1.CreateRPCClient();

--- a/src/Stratis.SmartContracts.IntegrationTests/SmartContractWalletOnPosNetworkTests.cs
+++ b/src/Stratis.SmartContracts.IntegrationTests/SmartContractWalletOnPosNetworkTests.cs
@@ -32,13 +32,13 @@ namespace Stratis.SmartContracts.IntegrationTests
         {
             using (NodeBuilder builder = NodeBuilder.Create(this))
             {
-                CoreNode scSender = builder.CreateSmartContractPosNode();
-                CoreNode scReceiver = builder.CreateSmartContractPosNode();
+                CoreNode scSender = builder.CreateSmartContractPosNode().NotInIBD();
+                CoreNode scReceiver = builder.CreateSmartContractPosNode().NotInIBD();
 
                 builder.StartAll();
 
-                scSender.NotInIBD().WithWallet(Password, WalletName, Passphrase);
-                scReceiver.NotInIBD().WithWallet(Password, WalletName, Passphrase);
+                scSender.WithWallet(Password, WalletName, Passphrase);
+                scReceiver.WithWallet(Password, WalletName, Passphrase);
 
                 var maturity = (int)scSender.FullNode.Network.Consensus.CoinbaseMaturity;
                 HdAddress senderAddress = TestHelper.MineBlocks(scSender, maturity + 5, WalletName, Password, AccountName).AddressUsed;


### PR DESCRIPTION
Move this method to the builder so that it checks after the node has started whether or not to set it's IBD state.

After this I'll move the WithWallet() method which will clean up the code even more.