### PR TITLE
[SC] BalanceState and Transfer fixes

### DIFF
--- a/src/Stratis.Bitcoin.Features.SmartContracts.Tests/StateTests.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts.Tests/StateTests.cs
@@ -105,14 +105,14 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Tests
 
             ulong initialBalance = 123456;
             uint160 initialAddress = uint160.One;
-            state.AddInitialBalance(new TransferInfo { Value = initialBalance, To = initialAddress});
+            state.AddInitialTransfer(new TransferInfo { Value = initialBalance, To = initialAddress});
 
             IState newState = state.Snapshot();
 
-            Assert.Equal(initialBalance, state.BalanceState.InitialBalance.Value);
-            Assert.Equal(initialAddress, state.BalanceState.InitialBalance.To);
-            Assert.Same(state.BalanceState.InitialBalance, newState.BalanceState.InitialBalance);
-            Assert.Equal(state.BalanceState.InitialBalance, newState.BalanceState.InitialBalance);
+            Assert.Equal(initialBalance, state.BalanceState.InitialTransfer.Value);
+            Assert.Equal(initialAddress, state.BalanceState.InitialTransfer.To);
+            Assert.Same(state.BalanceState.InitialTransfer, newState.BalanceState.InitialTransfer);
+            Assert.Equal(state.BalanceState.InitialTransfer, newState.BalanceState.InitialTransfer);
         }
 
         [Fact]

--- a/src/Stratis.Bitcoin.Features.SmartContracts.Tests/StateTests.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts.Tests/StateTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using Moq;
+using NBitcoin;
 using Stratis.SmartContracts.Core.State;
 using Stratis.SmartContracts.Core.State.AccountAbstractionLayer;
 using Stratis.SmartContracts.Executor.Reflection;
@@ -95,6 +96,23 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Tests
             IState newState = state.Snapshot();
 
             Assert.NotSame(state.BalanceState, newState.BalanceState);
+        }
+
+        [Fact]
+        public void State_Snapshot_BalanceState_Has_Original_InitialBalance()
+        {
+            var state = new State(null, this.contractStateRoot.Object, this.contractLogHolder.Object, new List<TransferInfo>(), null, null, null);
+
+            ulong initialBalance = 123456;
+            uint160 initialAddress = uint160.One;
+            state.AddInitialBalance(initialBalance, initialAddress);
+
+            IState newState = state.Snapshot();
+
+            Assert.Equal(initialBalance, state.BalanceState.InitialBalance.Item1);
+            Assert.Equal(initialAddress, state.BalanceState.InitialBalance.Item2);
+            Assert.Equal(state.BalanceState.InitialBalance.Item1, newState.BalanceState.InitialBalance.Item1);
+            Assert.Equal(state.BalanceState.InitialBalance.Item2, newState.BalanceState.InitialBalance.Item2);
         }
 
         [Fact]

--- a/src/Stratis.Bitcoin.Features.SmartContracts.Tests/StateTests.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts.Tests/StateTests.cs
@@ -29,7 +29,7 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Tests
         [Fact]
         public void State_Snapshot_Uses_Tracked_ContractState()
         {
-            var state = new State(null, this.contractStateRoot.Object, this.contractLogHolder.Object, new List<TransferInfo>(), null, null, 0, null);
+            var state = new State(null, this.contractStateRoot.Object, this.contractLogHolder.Object, new List<TransferInfo>(), null, null, null);
 
             IState newState = state.Snapshot();
 
@@ -50,7 +50,7 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Tests
                     new RawLog(null, null)
                 });
 
-            var state = new State(null, this.contractStateRoot.Object, this.contractLogHolder.Object, new List<TransferInfo>(), null, null, 0, null);
+            var state = new State(null, this.contractStateRoot.Object, this.contractLogHolder.Object, new List<TransferInfo>(), null, null, null);
 
             IState newState = state.Snapshot();
 
@@ -73,7 +73,7 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Tests
                 new TransferInfo()
             };
 
-            var state = new State(null, this.contractStateRoot.Object, this.contractLogHolder.Object, transfers, null, null, 0, null);
+            var state = new State(null, this.contractStateRoot.Object, this.contractLogHolder.Object, transfers, null, null, null);
 
             IState newState = state.Snapshot();
 
@@ -90,7 +90,7 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Tests
         [Fact]
         public void State_Snapshot_Has_New_BalanceState()
         {
-            var state = new State(null, this.contractStateRoot.Object, this.contractLogHolder.Object, new List<TransferInfo>(), null, null, 0, null);
+            var state = new State(null, this.contractStateRoot.Object, this.contractLogHolder.Object, new List<TransferInfo>(), null, null, null);
 
             IState newState = state.Snapshot();
 
@@ -100,7 +100,7 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Tests
         [Fact]
         public void State_Snapshot_Has_Original_NonceGenerator()
         {
-            var state = new State(null, this.contractStateRoot.Object, this.contractLogHolder.Object, new List<TransferInfo>(), null, null, 100_000, null);
+            var state = new State(null, this.contractStateRoot.Object, this.contractLogHolder.Object, new List<TransferInfo>(), null, null, null);
 
             IState newState = state.Snapshot();
 
@@ -110,7 +110,7 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Tests
         [Fact]
         public void TransitionTo_Fails_If_New_State_Is_Not_Child()
         {
-            var state = new State(null, this.contractStateRoot.Object, this.contractLogHolder.Object, new List<TransferInfo>(), null, null, 0, null);
+            var state = new State(null, this.contractStateRoot.Object, this.contractLogHolder.Object, new List<TransferInfo>(), null, null, null);
 
             IState newState = state.Snapshot();
 
@@ -122,7 +122,7 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Tests
         [Fact]
         public void TransitionTo_Updates_State_Correctly()
         {
-            var state = new State(null, this.contractStateRoot.Object, this.contractLogHolder.Object, new List<TransferInfo>(), null, null, 0, null);
+            var state = new State(null, this.contractStateRoot.Object, this.contractLogHolder.Object, new List<TransferInfo>(), null, null, null);
 
             var newTransfers = new List<TransferInfo>
             {
@@ -167,7 +167,7 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Tests
         [Fact]
         public void New_State_NonceGenerator_Generates_Zero_Nonce()
         {
-            var state = new State(null, this.contractStateRoot.Object, this.contractLogHolder.Object, new List<TransferInfo>(), null, null, 0, null);
+            var state = new State(null, this.contractStateRoot.Object, this.contractLogHolder.Object, new List<TransferInfo>(), null, null, null);
             
             Assert.Equal(0UL, state.NonceGenerator.Next);
         }

--- a/src/Stratis.Bitcoin.Features.SmartContracts.Tests/StateTests.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts.Tests/StateTests.cs
@@ -98,17 +98,6 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Tests
         }
 
         [Fact]
-        public void State_Snapshot_BalanceState_Has_Original_TxOut()
-        {
-            ulong initialTxOut = 100_000;
-            var state = new State(null, this.contractStateRoot.Object, this.contractLogHolder.Object, new List<TransferInfo>(), null, null, initialTxOut, null);
-
-            IState newState = state.Snapshot();
-
-            Assert.Equal(initialTxOut, newState.BalanceState.TxAmount);
-        }
-
-        [Fact]
         public void State_Snapshot_Has_Original_NonceGenerator()
         {
             var state = new State(null, this.contractStateRoot.Object, this.contractLogHolder.Object, new List<TransferInfo>(), null, null, 100_000, null);

--- a/src/Stratis.Bitcoin.Features.SmartContracts.Tests/StateTests.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts.Tests/StateTests.cs
@@ -105,14 +105,14 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Tests
 
             ulong initialBalance = 123456;
             uint160 initialAddress = uint160.One;
-            state.AddInitialBalance(initialBalance, initialAddress);
+            state.AddInitialBalance(new TransferInfo { Value = initialBalance, To = initialAddress});
 
             IState newState = state.Snapshot();
 
-            Assert.Equal(initialBalance, state.BalanceState.InitialBalance.Item1);
-            Assert.Equal(initialAddress, state.BalanceState.InitialBalance.Item2);
-            Assert.Equal(state.BalanceState.InitialBalance.Item1, newState.BalanceState.InitialBalance.Item1);
-            Assert.Equal(state.BalanceState.InitialBalance.Item2, newState.BalanceState.InitialBalance.Item2);
+            Assert.Equal(initialBalance, state.BalanceState.InitialBalance.Value);
+            Assert.Equal(initialAddress, state.BalanceState.InitialBalance.To);
+            Assert.Same(state.BalanceState.InitialBalance, newState.BalanceState.InitialBalance);
+            Assert.Equal(state.BalanceState.InitialBalance, newState.BalanceState.InitialBalance);
         }
 
         [Fact]

--- a/src/Stratis.Bitcoin.Features.SmartContracts.Tests/StateTransitionSpecification.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts.Tests/StateTransitionSpecification.cs
@@ -54,6 +54,8 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Tests
 
             StateTransitionResult result = stateProcessor.Apply(state.Object, externalCreateMessage);
 
+            state.Verify(s => s.AddInitialBalance(externalCreateMessage.Amount, newContractAddress));
+
             state.Verify(s => s.GenerateAddress(this.addressGenerator.Object), Times.Once);
 
             this.contractStateRoot.Verify(s => s.CreateAccount(newContractAddress), Times.Once);
@@ -144,6 +146,8 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Tests
             var stateProcessor = new StateProcessor(this.vm.Object, this.addressGenerator.Object);
 
             StateTransitionResult result = stateProcessor.Apply(state.Object, externalCallMessage);
+
+            state.Verify(s => s.AddInitialBalance(externalCallMessage.Amount, externalCallMessage.To));
 
             this.contractStateRoot.Verify(sr => sr.GetCode(externalCallMessage.To), Times.Once);
 

--- a/src/Stratis.Bitcoin.Features.SmartContracts.Tests/StateTransitionSpecification.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts.Tests/StateTransitionSpecification.cs
@@ -54,7 +54,7 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Tests
 
             StateTransitionResult result = stateProcessor.Apply(state.Object, externalCreateMessage);
 
-            state.Verify(s => s.AddInitialBalance(It.Is<TransferInfo>(t => t.Value == externalCreateMessage.Amount && t.To == newContractAddress)));
+            state.Verify(s => s.AddInitialTransfer(It.Is<TransferInfo>(t => t.Value == externalCreateMessage.Amount && t.To == newContractAddress)));
 
             state.Verify(s => s.GenerateAddress(this.addressGenerator.Object), Times.Once);
 
@@ -147,7 +147,7 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Tests
 
             StateTransitionResult result = stateProcessor.Apply(state.Object, externalCallMessage);
 
-            state.Verify(s => s.AddInitialBalance(It.Is<TransferInfo>(t => t.Value == externalCallMessage.Amount && t.To == externalCallMessage.To)));
+            state.Verify(s => s.AddInitialTransfer(It.Is<TransferInfo>(t => t.Value == externalCallMessage.Amount && t.To == externalCallMessage.To)));
 
             this.contractStateRoot.Verify(sr => sr.GetCode(externalCallMessage.To), Times.Once);
 

--- a/src/Stratis.Bitcoin.Features.SmartContracts.Tests/StateTransitionSpecification.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts.Tests/StateTransitionSpecification.cs
@@ -142,7 +142,7 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Tests
 
             var state = new Mock<IState>();
             state.SetupGet(s => s.ContractState).Returns(this.contractStateRoot.Object);
-
+            
             var stateProcessor = new StateProcessor(this.vm.Object, this.addressGenerator.Object);
 
             StateTransitionResult result = stateProcessor.Apply(state.Object, externalCallMessage);

--- a/src/Stratis.Bitcoin.Features.SmartContracts.Tests/StateTransitionSpecification.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts.Tests/StateTransitionSpecification.cs
@@ -54,7 +54,7 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Tests
 
             StateTransitionResult result = stateProcessor.Apply(state.Object, externalCreateMessage);
 
-            state.Verify(s => s.AddInitialBalance(externalCreateMessage.Amount, newContractAddress));
+            state.Verify(s => s.AddInitialBalance(It.Is<TransferInfo>(t => t.Value == externalCreateMessage.Amount && t.To == newContractAddress)));
 
             state.Verify(s => s.GenerateAddress(this.addressGenerator.Object), Times.Once);
 
@@ -147,7 +147,7 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Tests
 
             StateTransitionResult result = stateProcessor.Apply(state.Object, externalCallMessage);
 
-            state.Verify(s => s.AddInitialBalance(externalCallMessage.Amount, externalCallMessage.To));
+            state.Verify(s => s.AddInitialBalance(It.Is<TransferInfo>(t => t.Value == externalCallMessage.Amount && t.To == externalCallMessage.To)));
 
             this.contractStateRoot.Verify(sr => sr.GetCode(externalCallMessage.To), Times.Once);
 

--- a/src/Stratis.SmartContracts.Executor.Reflection/BalanceState.cs
+++ b/src/Stratis.SmartContracts.Executor.Reflection/BalanceState.cs
@@ -22,18 +22,18 @@ namespace Stratis.SmartContracts.Executor.Reflection
         }
 
         public BalanceState(IBalanceRepository repository, IReadOnlyList<TransferInfo> internalTransfers,
-            TransferInfo initialBalance)
+            TransferInfo initialTransfer)
         {
             this.repository = repository;
             this.internalTransfers = internalTransfers;
-            this.InitialBalance = initialBalance;
+            this.InitialTransfer = initialTransfer;
         }
 
-        public TransferInfo InitialBalance { get; private set; }
+        public TransferInfo InitialTransfer { get; private set; }
 
-        public void AddInitialBalance(TransferInfo transferInfo)
+        public void AddInitialTransfer(TransferInfo transferInfo)
         {
-            this.InitialBalance = transferInfo;
+            this.InitialTransfer = transferInfo;
         }
 
         public ulong GetBalance(uint160 address)
@@ -44,7 +44,7 @@ namespace Stratis.SmartContracts.Executor.Reflection
 
         private ulong GetPendingBalance(uint160 address)
         {
-            ulong ret = this.InitialBalance?.To != null ? this.InitialBalance.Value : 0UL;
+            ulong ret = this.InitialTransfer?.To != null ? this.InitialTransfer.Value : 0UL;
 
             foreach (TransferInfo transfer in this.internalTransfers.Where(x => x.To == address))
             {

--- a/src/Stratis.SmartContracts.Executor.Reflection/BalanceState.cs
+++ b/src/Stratis.SmartContracts.Executor.Reflection/BalanceState.cs
@@ -58,7 +58,7 @@ namespace Stratis.SmartContracts.Executor.Reflection
 
         private ulong GetPendingBalance(uint160 address)
         {
-            ulong ret = this.InitialTransfer?.To != null ? this.InitialTransfer.Value : 0UL;
+            ulong ret = this.InitialTransfer != null && this.InitialTransfer.To == address ? this.InitialTransfer.Value : 0UL;
 
             foreach (TransferInfo transfer in this.internalTransfers.Where(x => x.To == address))
             {

--- a/src/Stratis.SmartContracts.Executor.Reflection/BalanceState.cs
+++ b/src/Stratis.SmartContracts.Executor.Reflection/BalanceState.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using NBitcoin;
 using Stratis.SmartContracts.Core.State;
@@ -37,10 +38,15 @@ namespace Stratis.SmartContracts.Executor.Reflection
         /// <summary>
         /// Adds a single value transfer to an address, which will be used in all future accounting.
         /// Used when performing an external contract create/call to reflect the value sent with
-        /// the contract invocation transaction.
+        /// the contract invocation transaction. This method can only be used to set an initial transfer once.
         /// </summary>
         public void AddInitialTransfer(TransferInfo transferInfo)
         {
+            if (this.InitialTransfer != null)
+            {
+                throw new Exception("Cannot add an initial transfer twice!");
+            }
+
             this.InitialTransfer = transferInfo;
         }
 

--- a/src/Stratis.SmartContracts.Executor.Reflection/BalanceState.cs
+++ b/src/Stratis.SmartContracts.Executor.Reflection/BalanceState.cs
@@ -15,19 +15,15 @@ namespace Stratis.SmartContracts.Executor.Reflection
         private readonly IBalanceRepository repository;
         private readonly IReadOnlyList<TransferInfo> internalTransfers;
 
-        public BalanceState(IBalanceRepository repository, ulong txAmount, IReadOnlyList<TransferInfo> internalTransfers)
+        public BalanceState(IBalanceRepository repository, IReadOnlyList<TransferInfo> internalTransfers)
         {
             this.repository = repository;
-            this.TxAmount = txAmount;
             this.internalTransfers = internalTransfers;
         }
-        
-        public ulong TxAmount { get; }
 
         public ulong GetBalance(uint160 address)
         {
             return this.repository.GetCurrentBalance(address) 
-                   + this.TxAmount 
                    + this.GetPendingBalance(address);
         }
 

--- a/src/Stratis.SmartContracts.Executor.Reflection/BalanceState.cs
+++ b/src/Stratis.SmartContracts.Executor.Reflection/BalanceState.cs
@@ -29,8 +29,16 @@ namespace Stratis.SmartContracts.Executor.Reflection
             this.InitialTransfer = initialTransfer;
         }
 
+        /// <summary>
+        /// The initial value transfer to the contract's address.
+        /// </summary>
         public TransferInfo InitialTransfer { get; private set; }
 
+        /// <summary>
+        /// Adds a single value transfer to an address, which will be used in all future accounting.
+        /// Used when performing an external contract create/call to reflect the value sent with
+        /// the contract invocation transaction.
+        /// </summary>
         public void AddInitialTransfer(TransferInfo transferInfo)
         {
             this.InitialTransfer = transferInfo;

--- a/src/Stratis.SmartContracts.Executor.Reflection/BalanceState.cs
+++ b/src/Stratis.SmartContracts.Executor.Reflection/BalanceState.cs
@@ -21,6 +21,21 @@ namespace Stratis.SmartContracts.Executor.Reflection
             this.internalTransfers = internalTransfers;
         }
 
+        public BalanceState(IBalanceRepository repository, IReadOnlyList<TransferInfo> internalTransfers,
+            (ulong, uint160) initialBalance)
+        {
+            this.repository = repository;
+            this.internalTransfers = internalTransfers;
+            this.InitialBalance = initialBalance;
+        }
+
+        public (ulong, uint160) InitialBalance { get; private set; }
+
+        public void AddInitialBalance(ulong messageAmount, uint160 address)
+        {
+            this.InitialBalance = (messageAmount, address);
+        }
+
         public ulong GetBalance(uint160 address)
         {
             return this.repository.GetCurrentBalance(address) 
@@ -29,7 +44,9 @@ namespace Stratis.SmartContracts.Executor.Reflection
 
         private ulong GetPendingBalance(uint160 address)
         {
-            ulong ret = 0;
+            (var balance, var contractAddress) = this.InitialBalance;
+
+            ulong ret = address == contractAddress ? balance : 0UL;
 
             foreach (TransferInfo transfer in this.internalTransfers.Where(x => x.To == address))
             {

--- a/src/Stratis.SmartContracts.Executor.Reflection/BalanceState.cs
+++ b/src/Stratis.SmartContracts.Executor.Reflection/BalanceState.cs
@@ -38,15 +38,10 @@ namespace Stratis.SmartContracts.Executor.Reflection
         /// <summary>
         /// Adds a single value transfer to an address, which will be used in all future accounting.
         /// Used when performing an external contract create/call to reflect the value sent with
-        /// the contract invocation transaction. This method can only be used to set an initial transfer once.
+        /// the contract invocation transaction.
         /// </summary>
         public void AddInitialTransfer(TransferInfo transferInfo)
         {
-            if (this.InitialTransfer != null)
-            {
-                throw new Exception("Cannot add an initial transfer twice!");
-            }
-
             this.InitialTransfer = transferInfo;
         }
 

--- a/src/Stratis.SmartContracts.Executor.Reflection/BalanceState.cs
+++ b/src/Stratis.SmartContracts.Executor.Reflection/BalanceState.cs
@@ -22,18 +22,18 @@ namespace Stratis.SmartContracts.Executor.Reflection
         }
 
         public BalanceState(IBalanceRepository repository, IReadOnlyList<TransferInfo> internalTransfers,
-            (ulong, uint160) initialBalance)
+            TransferInfo initialBalance)
         {
             this.repository = repository;
             this.internalTransfers = internalTransfers;
             this.InitialBalance = initialBalance;
         }
 
-        public (ulong, uint160) InitialBalance { get; private set; }
+        public TransferInfo InitialBalance { get; private set; }
 
-        public void AddInitialBalance(ulong messageAmount, uint160 address)
+        public void AddInitialBalance(TransferInfo transferInfo)
         {
-            this.InitialBalance = (messageAmount, address);
+            this.InitialBalance = transferInfo;
         }
 
         public ulong GetBalance(uint160 address)
@@ -44,9 +44,7 @@ namespace Stratis.SmartContracts.Executor.Reflection
 
         private ulong GetPendingBalance(uint160 address)
         {
-            (var balance, var contractAddress) = this.InitialBalance;
-
-            ulong ret = address == contractAddress ? balance : 0UL;
+            ulong ret = this.InitialBalance?.To != null ? this.InitialBalance.Value : 0UL;
 
             foreach (TransferInfo transfer in this.internalTransfers.Where(x => x.To == address))
             {

--- a/src/Stratis.SmartContracts.Executor.Reflection/ContractExecutor.cs
+++ b/src/Stratis.SmartContracts.Executor.Reflection/ContractExecutor.cs
@@ -77,7 +77,6 @@ namespace Stratis.SmartContracts.Executor.Reflection
                     callData.MethodParameters
                 );
 
-
                 result = this.stateProcessor.Apply(newState, message);
             }
             else

--- a/src/Stratis.SmartContracts.Executor.Reflection/IState.cs
+++ b/src/Stratis.SmartContracts.Executor.Reflection/IState.cs
@@ -23,6 +23,6 @@ namespace Stratis.SmartContracts.Executor.Reflection
         ulong GetBalance(uint160 address);
         uint160 GenerateAddress(IAddressGenerator addressGenerator);
         ISmartContractState CreateSmartContractState(IState state, GasMeter gasMeter, uint160 address, BaseMessage message, IStateRepository repository);
-        void AddInitialBalance(ulong messageAmount, uint160 address);
+        void AddInitialBalance(TransferInfo initialTransfer);
     }
 }

--- a/src/Stratis.SmartContracts.Executor.Reflection/IState.cs
+++ b/src/Stratis.SmartContracts.Executor.Reflection/IState.cs
@@ -23,6 +23,6 @@ namespace Stratis.SmartContracts.Executor.Reflection
         ulong GetBalance(uint160 address);
         uint160 GenerateAddress(IAddressGenerator addressGenerator);
         ISmartContractState CreateSmartContractState(IState state, GasMeter gasMeter, uint160 address, BaseMessage message, IStateRepository repository);
-        void AddInitialBalance(TransferInfo initialTransfer);
+        void AddInitialTransfer(TransferInfo initialTransfer);
     }
 }

--- a/src/Stratis.SmartContracts.Executor.Reflection/IState.cs
+++ b/src/Stratis.SmartContracts.Executor.Reflection/IState.cs
@@ -23,5 +23,6 @@ namespace Stratis.SmartContracts.Executor.Reflection
         ulong GetBalance(uint160 address);
         uint160 GenerateAddress(IAddressGenerator addressGenerator);
         ISmartContractState CreateSmartContractState(IState state, GasMeter gasMeter, uint160 address, BaseMessage message, IStateRepository repository);
+        void AddInitialBalance(ulong messageAmount, uint160 address);
     }
 }

--- a/src/Stratis.SmartContracts.Executor.Reflection/State.cs
+++ b/src/Stratis.SmartContracts.Executor.Reflection/State.cs
@@ -42,7 +42,7 @@ namespace Stratis.SmartContracts.Executor.Reflection
             this.internalTransfers = new List<TransferInfo>(state.InternalTransfers);
 
             // Create a new balance state based off the old one but with the repository and internal transfers list reference
-            this.BalanceState = new BalanceState(this.ContractState, this.internalTransfers, state.BalanceState.InitialBalance);
+            this.BalanceState = new BalanceState(this.ContractState, this.internalTransfers, state.BalanceState.InitialTransfer);
             this.Network = state.Network;
             this.NonceGenerator = state.NonceGenerator;
             this.Block = state.Block;
@@ -93,9 +93,9 @@ namespace Stratis.SmartContracts.Executor.Reflection
             return this.smartContractStateFactory.Create(state, gasMeter, address, message, repository);
         }
 
-        public void AddInitialBalance(TransferInfo initialTransfer)
+        public void AddInitialTransfer(TransferInfo initialTransfer)
         {
-            this.BalanceState.AddInitialBalance(initialTransfer);
+            this.BalanceState.AddInitialTransfer(initialTransfer);
         }
 
         /// <summary>

--- a/src/Stratis.SmartContracts.Executor.Reflection/State.cs
+++ b/src/Stratis.SmartContracts.Executor.Reflection/State.cs
@@ -102,7 +102,7 @@ namespace Stratis.SmartContracts.Executor.Reflection
         {
             if (this.BalanceState.InitialTransfer != null)
             {
-                throw new Exception("Cannot add an initial transfer twice!");
+                throw new NotSupportedException("Cannot add an initial transfer twice!");
             }
 
             this.BalanceState.AddInitialTransfer(initialTransfer);

--- a/src/Stratis.SmartContracts.Executor.Reflection/State.cs
+++ b/src/Stratis.SmartContracts.Executor.Reflection/State.cs
@@ -96,9 +96,15 @@ namespace Stratis.SmartContracts.Executor.Reflection
         /// <summary>
         /// Adds the initial transfer to the BalanceState. It is necessary to call this method if an external create or call
         /// is being executed in order to reflect the balance of the of the UTXO sent along with the contract invocation transaction.
+        /// This method can only be used to set an initial transfer once.
         /// </summary>
         public void AddInitialTransfer(TransferInfo initialTransfer)
         {
+            if (this.BalanceState.InitialTransfer != null)
+            {
+                throw new Exception("Cannot add an initial transfer twice!");
+            }
+
             this.BalanceState.AddInitialTransfer(initialTransfer);
         }
 

--- a/src/Stratis.SmartContracts.Executor.Reflection/State.cs
+++ b/src/Stratis.SmartContracts.Executor.Reflection/State.cs
@@ -27,7 +27,6 @@ namespace Stratis.SmartContracts.Executor.Reflection
     public class State : IState
     {
         private readonly List<TransferInfo> internalTransfers;
-
         private IState child;
         private readonly ISmartContractStateFactory smartContractStateFactory;
 
@@ -43,7 +42,7 @@ namespace Stratis.SmartContracts.Executor.Reflection
             this.internalTransfers = new List<TransferInfo>(state.InternalTransfers);
 
             // Create a new balance state based off the old one but with the repository and internal transfers list reference
-            this.BalanceState = new BalanceState(this.ContractState, state.BalanceState.TxAmount, this.internalTransfers);
+            this.BalanceState = new BalanceState(this.ContractState, this.internalTransfers, state.BalanceState.InitialBalance);
             this.Network = state.Network;
             this.NonceGenerator = state.NonceGenerator;
             this.Block = state.Block;
@@ -51,20 +50,18 @@ namespace Stratis.SmartContracts.Executor.Reflection
             this.smartContractStateFactory = state.smartContractStateFactory;
         }
 
-        public State(
-            ISmartContractStateFactory smartContractStateFactory, 
+        public State(ISmartContractStateFactory smartContractStateFactory,
             IStateRepository repository,
             IContractLogHolder contractLogHolder,
             List<TransferInfo> internalTransfers,
             IBlock block,
             Network network,
-            ulong txAmount,
             uint256 transactionHash)
         {
             this.ContractState = repository;
             this.LogHolder = contractLogHolder;
             this.internalTransfers = internalTransfers;
-            this.BalanceState = new BalanceState(this.ContractState, txAmount, this.InternalTransfers);
+            this.BalanceState = new BalanceState(this.ContractState, this.InternalTransfers);
             this.Network = network;
             this.NonceGenerator = new NonceGenerator();
             this.Block = block;
@@ -91,9 +88,14 @@ namespace Stratis.SmartContracts.Executor.Reflection
         /// <summary>
         /// Sets up a new <see cref="ISmartContractState"/> based on the current state.
         /// </summary>
-         public ISmartContractState CreateSmartContractState(IState state, GasMeter gasMeter, uint160 address, BaseMessage message, IStateRepository repository) 
+        public ISmartContractState CreateSmartContractState(IState state, GasMeter gasMeter, uint160 address, BaseMessage message, IStateRepository repository) 
         {
             return this.smartContractStateFactory.Create(state, gasMeter, address, message, repository);
+        }
+
+        public void AddInitialBalance(ulong messageAmount, uint160 address)
+        {
+            this.BalanceState.AddInitialBalance(messageAmount, address);
         }
 
         /// <summary>

--- a/src/Stratis.SmartContracts.Executor.Reflection/State.cs
+++ b/src/Stratis.SmartContracts.Executor.Reflection/State.cs
@@ -93,6 +93,10 @@ namespace Stratis.SmartContracts.Executor.Reflection
             return this.smartContractStateFactory.Create(state, gasMeter, address, message, repository);
         }
 
+        /// <summary>
+        /// Adds the initial transfer to the BalanceState. It is necessary to call this method if an external create or call
+        /// is being executed in order to reflect the balance of the of the UTXO sent along with the contract invocation transaction.
+        /// </summary>
         public void AddInitialTransfer(TransferInfo initialTransfer)
         {
             this.BalanceState.AddInitialTransfer(initialTransfer);

--- a/src/Stratis.SmartContracts.Executor.Reflection/State.cs
+++ b/src/Stratis.SmartContracts.Executor.Reflection/State.cs
@@ -93,9 +93,9 @@ namespace Stratis.SmartContracts.Executor.Reflection
             return this.smartContractStateFactory.Create(state, gasMeter, address, message, repository);
         }
 
-        public void AddInitialBalance(ulong messageAmount, uint160 address)
+        public void AddInitialBalance(TransferInfo initialTransfer)
         {
-            this.BalanceState.AddInitialBalance(messageAmount, address);
+            this.BalanceState.AddInitialBalance(initialTransfer);
         }
 
         /// <summary>

--- a/src/Stratis.SmartContracts.Executor.Reflection/StateFactory.cs
+++ b/src/Stratis.SmartContracts.Executor.Reflection/StateFactory.cs
@@ -26,7 +26,7 @@ namespace Stratis.SmartContracts.Executor.Reflection
         {
             var logHolder = new ContractLogHolder(this.network);
             var internalTransfers = new List<TransferInfo>();
-            return new State(this.smartContractStateFactory, stateRoot, logHolder, internalTransfers, block, this.network, txOutValue, transactionHash);
+            return new State(this.smartContractStateFactory, stateRoot, logHolder, internalTransfers, block, this.network, transactionHash);
         }
     }
 }

--- a/src/Stratis.SmartContracts.Executor.Reflection/StateProcessor.cs
+++ b/src/Stratis.SmartContracts.Executor.Reflection/StateProcessor.cs
@@ -56,7 +56,7 @@ namespace Stratis.SmartContracts.Executor.Reflection
 
             // For external creates we need to increment the balance state to take into
             // account any funds sent as part of the original transaction.
-            state.AddInitialBalance(new TransferInfo { Value = message.Amount, To = address, From = message.From});
+            state.AddInitialTransfer(new TransferInfo { Value = message.Amount, To = address, From = message.From});
 
             return this.ApplyCreate(state, message.Parameters, message.Code, message, address);
         }
@@ -169,7 +169,7 @@ namespace Stratis.SmartContracts.Executor.Reflection
 
             // For external calls we need to increment the balance state to take into
             // account any funds sent as part of the original transaction.
-            state.AddInitialBalance(new TransferInfo { Value = message.Amount, To = message.To, From = message.From });
+            state.AddInitialTransfer(new TransferInfo { Value = message.Amount, To = message.To, From = message.From });
 
             return this.ApplyCall(state, message, contractCode);
         }

--- a/src/Stratis.SmartContracts.Executor.Reflection/StateProcessor.cs
+++ b/src/Stratis.SmartContracts.Executor.Reflection/StateProcessor.cs
@@ -24,6 +24,8 @@ namespace Stratis.SmartContracts.Executor.Reflection
 
             uint160 address = state.GenerateAddress(this.AddressGenerator);
 
+            state.AddInitialBalance(message.Amount, address);
+
             state.ContractState.CreateAccount(address);
 
             ISmartContractState smartContractState = state.CreateSmartContractState(state, gasMeter, address, message, state.ContractState);
@@ -85,6 +87,8 @@ namespace Stratis.SmartContracts.Executor.Reflection
 
         private StateTransitionResult ApplyCall(IState state, CallMessage message, byte[] contractCode)
         {
+            state.AddInitialBalance(message.Amount, message.To);
+
             var gasMeter = new GasMeter(message.GasLimit);
 
             gasMeter.Spend((Gas)GasPriceList.BaseCost);

--- a/src/Stratis.SmartContracts.Executor.Reflection/StateProcessor.cs
+++ b/src/Stratis.SmartContracts.Executor.Reflection/StateProcessor.cs
@@ -55,7 +55,7 @@ namespace Stratis.SmartContracts.Executor.Reflection
             uint160 address = state.GenerateAddress(this.AddressGenerator);
 
             // For external creates we need to increment the balance state to take into
-            // account any funds sent as part of the original transaction.
+            // account any funds sent as part of the original contract invocation transaction.
             state.AddInitialTransfer(new TransferInfo { Value = message.Amount, To = address, From = message.From});
 
             return this.ApplyCreate(state, message.Parameters, message.Code, message, address);
@@ -75,7 +75,8 @@ namespace Stratis.SmartContracts.Executor.Reflection
 
             uint160 address = state.GenerateAddress(this.AddressGenerator);
 
-            // For successful internal creates we need to add the transfer to the internal transfer list.
+            // For internal creates we need to add the value contained in the contract invocation transaction
+            // to the internal transfer list. This must occur before we apply the message to the state.
             // For external creates we do not need to do this.
             state.AddInternalTransfer(new TransferInfo
             {
@@ -140,8 +141,9 @@ namespace Stratis.SmartContracts.Executor.Reflection
             {
                 return StateTransitionResult.Fail((Gas)0, StateTransitionErrorKind.NoCode);
             }
-            
-            // For successful internal calls we need to add the transfer to the internal transfer list.
+
+            // For internal calls we need to add the value contained in the contract invocation transaction
+            // to the internal transfer list. This must occur before we apply the message to the state.
             // For external calls we do not need to do this.
             state.AddInternalTransfer(new TransferInfo
             {
@@ -168,7 +170,7 @@ namespace Stratis.SmartContracts.Executor.Reflection
             }
 
             // For external calls we need to increment the balance state to take into
-            // account any funds sent as part of the original transaction.
+            // account any funds sent as part of the original contract invocation transaction.
             state.AddInitialTransfer(new TransferInfo { Value = message.Amount, To = message.To, From = message.From });
 
             return this.ApplyCall(state, message, contractCode);
@@ -201,7 +203,8 @@ namespace Stratis.SmartContracts.Executor.Reflection
                 return StateTransitionResult.Ok((Gas)0, message.To);
             }
 
-            // For internal contract-contract transfers we need to add the transfer to the internal transfer list.            
+            // For internal contract-contract transfers we need to add the value contained in the contract invocation transaction
+            // to the internal transfer list. This must occur before we apply the message to the state.
             state.AddInternalTransfer(new TransferInfo
             {
                 From = message.From,

--- a/src/Stratis.SmartContracts.Executor.Reflection/StateProcessor.cs
+++ b/src/Stratis.SmartContracts.Executor.Reflection/StateProcessor.cs
@@ -61,7 +61,7 @@ namespace Stratis.SmartContracts.Executor.Reflection
         /// </summary>
         public StateTransitionResult Apply(IState state, InternalCreateMessage message)
         {
-            bool enoughBalance = this.EnsureContractHasEnoughBalance(state, message.From, message.Amount);
+            bool enoughBalance = this.EnsureSenderHasEnoughBalance(state, message.From, message.Amount);
 
             if (!enoughBalance)
                 return StateTransitionResult.Fail((Gas)0, StateTransitionErrorKind.InsufficientBalance);
@@ -127,7 +127,7 @@ namespace Stratis.SmartContracts.Executor.Reflection
         /// </summary>
         public StateTransitionResult Apply(IState state, InternalCallMessage message)
         {
-            bool enoughBalance = this.EnsureContractHasEnoughBalance(state, message.From, message.Amount);
+            bool enoughBalance = this.EnsureSenderHasEnoughBalance(state, message.From, message.Amount);
 
             if (!enoughBalance)
                 return StateTransitionResult.Fail((Gas)0, StateTransitionErrorKind.InsufficientBalance);
@@ -176,7 +176,7 @@ namespace Stratis.SmartContracts.Executor.Reflection
         /// </summary>
         public StateTransitionResult Apply(IState state, ContractTransferMessage message)
         {
-            bool enoughBalance = this.EnsureContractHasEnoughBalance(state, message.From, message.Amount);
+            bool enoughBalance = this.EnsureSenderHasEnoughBalance(state, message.From, message.Amount);
 
             if (!enoughBalance)
                 return StateTransitionResult.Fail((Gas)0, StateTransitionErrorKind.InsufficientBalance);
@@ -217,7 +217,7 @@ namespace Stratis.SmartContracts.Executor.Reflection
         /// <summary>
         /// Checks whether a contract has enough funds to make this transaction.
         /// </summary>
-        private bool EnsureContractHasEnoughBalance(IState state, uint160 contractAddress, ulong amountToTransfer)
+        private bool EnsureSenderHasEnoughBalance(IState state, uint160 contractAddress, ulong amountToTransfer)
         {
             ulong balance = state.GetBalance(contractAddress);
 

--- a/src/Stratis.SmartContracts.Executor.Reflection/StateProcessor.cs
+++ b/src/Stratis.SmartContracts.Executor.Reflection/StateProcessor.cs
@@ -87,8 +87,6 @@ namespace Stratis.SmartContracts.Executor.Reflection
 
         private StateTransitionResult ApplyCall(IState state, CallMessage message, byte[] contractCode)
         {
-            state.AddInitialBalance(message.Amount, message.To);
-
             var gasMeter = new GasMeter(message.GasLimit);
 
             gasMeter.Spend((Gas)GasPriceList.BaseCost);
@@ -167,6 +165,8 @@ namespace Stratis.SmartContracts.Executor.Reflection
             {
                 return StateTransitionResult.Fail((Gas)0, StateTransitionErrorKind.NoCode);
             }
+
+            state.AddInitialBalance(message.Amount, message.To);
 
             return this.ApplyCall(state, message, contractCode);
         }

--- a/src/Stratis.SmartContracts.Executor.Reflection/StateProcessor.cs
+++ b/src/Stratis.SmartContracts.Executor.Reflection/StateProcessor.cs
@@ -56,7 +56,7 @@ namespace Stratis.SmartContracts.Executor.Reflection
 
             // For external creates we need to increment the balance state to take into
             // account any funds sent as part of the original transaction.
-            state.AddInitialBalance(message.Amount, address);
+            state.AddInitialBalance(new TransferInfo { Value = message.Amount, To = address, From = message.From});
 
             return this.ApplyCreate(state, message.Parameters, message.Code, message, address);
         }
@@ -169,7 +169,7 @@ namespace Stratis.SmartContracts.Executor.Reflection
 
             // For external calls we need to increment the balance state to take into
             // account any funds sent as part of the original transaction.
-            state.AddInitialBalance(message.Amount, message.To);
+            state.AddInitialBalance(new TransferInfo { Value = message.Amount, To = message.To, From = message.From });
 
             return this.ApplyCall(state, message, contractCode);
         }

--- a/src/Stratis.SmartContracts.Executor.Reflection/StateProcessor.cs
+++ b/src/Stratis.SmartContracts.Executor.Reflection/StateProcessor.cs
@@ -54,6 +54,8 @@ namespace Stratis.SmartContracts.Executor.Reflection
             // We need to generate an address here so that we can set the initial balance.
             uint160 address = state.GenerateAddress(this.AddressGenerator);
 
+            // For external creates we need to increment the balance state to take into
+            // account any funds sent as part of the original transaction.
             state.AddInitialBalance(message.Amount, address);
 
             return this.ApplyCreate(state, message.Parameters, message.Code, message, address);
@@ -165,6 +167,8 @@ namespace Stratis.SmartContracts.Executor.Reflection
                 return StateTransitionResult.Fail((Gas)0, StateTransitionErrorKind.NoCode);
             }
 
+            // For external calls we need to increment the balance state to take into
+            // account any funds sent as part of the original transaction.
             state.AddInitialBalance(message.Amount, message.To);
 
             return this.ApplyCall(state, message, contractCode);

--- a/src/Stratis.SmartContracts.IntegrationTests/ContractInternalTransferTests.cs
+++ b/src/Stratis.SmartContracts.IntegrationTests/ContractInternalTransferTests.cs
@@ -336,7 +336,7 @@ namespace Stratis.SmartContracts.IntegrationTests
         }
 
         [Fact]
-        public void Internal_Nested_Call_Balance_Correct()
+        public void Internal_Nested_Transfer_Balance_Correct()
         {
             // Ensure fixture is funded.
             this.node1.MineBlocks(1);
@@ -382,7 +382,7 @@ namespace Stratis.SmartContracts.IntegrationTests
         }
 
         [Fact]
-        public void Internal_Nested_Call_To_Self_Balance_Correct()
+        public void Internal_Nested_Call_Transfer_To_Self_Balance_Correct()
         {
             // Ensure fixture is funded.
             this.node1.MineBlocks(1);

--- a/src/Stratis.SmartContracts.IntegrationTests/ContractInternalTransferTests.cs
+++ b/src/Stratis.SmartContracts.IntegrationTests/ContractInternalTransferTests.cs
@@ -260,7 +260,7 @@ namespace Stratis.SmartContracts.IntegrationTests
         }
 
         [Fact]
-        public void InternalTransfer_Nested_Balance_Correct()
+        public void InternalTransfer_Nested_Create_Balance_Correct()
         {
             // Ensure fixture is funded.
             this.node1.MineBlocks(1);
@@ -280,6 +280,36 @@ namespace Stratis.SmartContracts.IntegrationTests
             byte[] saved = this.node1.GetStorageValue(internalContract.ToAddress(this.mockChain.Network), "Balance");
             ulong savedUlong = BitConverter.ToUInt64(saved);
             Assert.Equal((ulong) 10, savedUlong);
+        }
+
+        [Fact]
+        public void External_Call_Balance_Correct()
+        {
+            // Ensure fixture is funded.
+            this.node1.MineBlocks(1);
+
+            // Deploy contract
+            ContractCompilationResult compilationResult = ContractCompiler.CompileFile("SmartContracts/ReceiveFundsTest.cs");
+            Assert.True(compilationResult.Success);
+            BuildCreateContractTransactionResponse response = this.node1.SendCreateContractTransaction(compilationResult.Compilation, 0);
+            this.node2.WaitMempoolCount(1);
+            this.node2.MineBlocks(1);
+            Assert.NotNull(this.node1.GetCode(response.NewContractAddress));
+            uint160 contractAddress = this.addressGenerator.GenerateAddress(response.TransactionId, 0);
+
+            ulong amount = 123;
+
+            BuildCallContractTransactionResponse callResponse = this.node1.SendCallContractTransaction(
+                nameof(BalanceTest.MethodReceiveFunds),
+                response.NewContractAddress,
+                amount);
+            this.node2.WaitMempoolCount(1);
+            this.node2.MineBlocks(1);
+
+            // Stored balance in PersistentState should be only that which was sent
+            byte[] saved = this.node1.GetStorageValue(contractAddress.ToAddress(this.mockChain.Network), "Balance");
+            ulong savedUlong = BitConverter.ToUInt64(saved);
+            Assert.True((new Money(amount, MoneyUnit.BTC) == new Money(savedUlong, MoneyUnit.Satoshi)));
         }
     }
 }

--- a/src/Stratis.SmartContracts.IntegrationTests/ContractInternalTransferTests.cs
+++ b/src/Stratis.SmartContracts.IntegrationTests/ContractInternalTransferTests.cs
@@ -256,7 +256,7 @@ namespace Stratis.SmartContracts.IntegrationTests
         [Fact]
         public void ExternalTransfer_ReceiveHandler_WithValue()
         {
-            //Regular value transfer
+            // Regular value transfer
             // Ensure fixture is funded.
             this.node1.MineBlocks(1);
 
@@ -279,7 +279,7 @@ namespace Stratis.SmartContracts.IntegrationTests
             this.node2.MineBlocks(1);
 
             // Stored balance in PersistentState should be only that which was sent
-            byte[] saved = this.node1.GetStorageValue(contractAddress.ToAddress(this.mockChain.Network), "Balance");
+            byte[] saved = this.node1.GetStorageValue(contractAddress.ToAddress(this.mockChain.Network), "ReceiveBalance");
             ulong savedUlong = BitConverter.ToUInt64(saved);
             Assert.True((new Money(amount, MoneyUnit.BTC) == new Money(savedUlong, MoneyUnit.Satoshi)));
         }
@@ -301,7 +301,7 @@ namespace Stratis.SmartContracts.IntegrationTests
             Assert.NotNull(this.node1.GetCode(response.NewContractAddress));
             uint160 contractAddress = this.addressGenerator.GenerateAddress(response.TransactionId, 0);
 
-            // Stored balance in PersistentState should be only that which was sent (10)
+            // Stored balance in PersistentState should be only that which was sent
             byte[] saved = this.node1.GetStorageValue(contractAddress.ToAddress(this.mockChain.Network), "Balance");
             ulong savedUlong = BitConverter.ToUInt64(saved);
             Assert.True((new Money(amount, MoneyUnit.BTC) == new Money(savedUlong, MoneyUnit.Satoshi)));
@@ -400,8 +400,8 @@ namespace Stratis.SmartContracts.IntegrationTests
             this.node2.WaitMempoolCount(1);
             this.node2.MineBlocks(1);
 
-            // Stored balance in PersistentState should be only that which was sent (10)
-            byte[] saved = this.node1.GetStorageValue(contract2Address.ToAddress(this.mockChain.Network), "Balance");
+            // Stored balance in PersistentState should be only that which was sent
+            byte[] saved = this.node1.GetStorageValue(contract2Address.ToAddress(this.mockChain.Network), "ReceiveBalance");
             ulong savedUlong = BitConverter.ToUInt64(saved);
             Assert.Equal(transferredAmount, savedUlong);
         }
@@ -440,9 +440,11 @@ namespace Stratis.SmartContracts.IntegrationTests
             this.node2.WaitMempoolCount(1);
             this.node2.MineBlocks(1);
 
-            // Stored balance in PersistentState should be only that which was sent (10)
-            byte[] saved = this.node1.GetStorageValue(contract1Address.ToAddress(this.mockChain.Network), "Balance");
+            // Stored balance in PersistentState should be only that which was sent
+            byte[] saved = this.node1.GetStorageValue(contract1Address.ToAddress(this.mockChain.Network), "ReceiveBalance");
             ulong savedUlong = BitConverter.ToUInt64(saved);
+
+            // Balance should be the same as the initial amount
             Assert.True((new Money(amount, MoneyUnit.BTC) == new Money(savedUlong, MoneyUnit.Satoshi)));
         }
     }

--- a/src/Stratis.SmartContracts.IntegrationTests/ContractInternalTransferTests.cs
+++ b/src/Stratis.SmartContracts.IntegrationTests/ContractInternalTransferTests.cs
@@ -259,7 +259,7 @@ namespace Stratis.SmartContracts.IntegrationTests
             //Create with value transfer
         }
 
-        [Fact(Skip = "Currently fails, shows issue with BalanceState.")]
+        [Fact]
         public void InternalTransfer_Nested_Balance_Correct()
         {
             // Ensure fixture is funded.

--- a/src/Stratis.SmartContracts.IntegrationTests/SmartContracts/BalanceTest.cs
+++ b/src/Stratis.SmartContracts.IntegrationTests/SmartContracts/BalanceTest.cs
@@ -1,5 +1,7 @@
 ﻿using Stratis.SmartContracts;
 
+using Stratis.SmartContracts;
+
 [Deploy]
 public class BalanceTest : SmartContract
 {

--- a/src/Stratis.SmartContracts.IntegrationTests/SmartContracts/BalanceTest.cs
+++ b/src/Stratis.SmartContracts.IntegrationTests/SmartContracts/BalanceTest.cs
@@ -1,7 +1,5 @@
 ﻿using Stratis.SmartContracts;
 
-using Stratis.SmartContracts;
-
 [Deploy]
 public class BalanceTest : SmartContract
 {

--- a/src/Stratis.SmartContracts.IntegrationTests/SmartContracts/ReceiveFundsTest.cs
+++ b/src/Stratis.SmartContracts.IntegrationTests/SmartContracts/ReceiveFundsTest.cs
@@ -20,6 +20,6 @@ public class ReceiveFundsTest : SmartContract
 
     public override void Receive()
     {
-        this.PersistentState.SetUInt64("Balance", this.Balance);
+        this.PersistentState.SetUInt64("ReceiveBalance", this.Balance);
     }
 }

--- a/src/Stratis.SmartContracts.IntegrationTests/SmartContracts/ReceiveFundsTest.cs
+++ b/src/Stratis.SmartContracts.IntegrationTests/SmartContracts/ReceiveFundsTest.cs
@@ -12,4 +12,14 @@ public class ReceiveFundsTest : SmartContract
     {
         this.PersistentState.SetUInt64("Balance", this.Balance);
     }
+
+    public void TransferFunds(Address other, ulong amount)
+    {
+        Transfer(other, amount);
+    }
+
+    public override void Receive()
+    {
+        this.PersistentState.SetUInt64("Balance", this.Balance);
+    }
 }

--- a/src/Stratis.SmartContracts.IntegrationTests/SmartContracts/ReceiveFundsTest.cs
+++ b/src/Stratis.SmartContracts.IntegrationTests/SmartContracts/ReceiveFundsTest.cs
@@ -1,0 +1,15 @@
+﻿using Stratis.SmartContracts;
+
+[Deploy]
+public class ReceiveFundsTest : SmartContract
+{
+    public ReceiveFundsTest(ISmartContractState smartContractState) : base(smartContractState)
+    {
+        this.PersistentState.SetUInt64("Balance", this.Balance);
+    }
+
+    public void MethodReceiveFunds()
+    {
+        this.PersistentState.SetUInt64("Balance", this.Balance);
+    }
+}

--- a/src/Stratis.SmartContracts.IntegrationTests/Stratis.SmartContracts.IntegrationTests.csproj
+++ b/src/Stratis.SmartContracts.IntegrationTests/Stratis.SmartContracts.IntegrationTests.csproj
@@ -73,6 +73,9 @@
     <Compile Update="SmartContracts\NonDeterministicContract.cs">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Compile>
+    <Compile Update="SmartContracts\ReceiveFundsTest.cs">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Compile>
     <Compile Update="SmartContracts\ReceiveHandlerContract.cs">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Compile>


### PR DESCRIPTION
Closes #2364 and #2349.

* For external calls/creates, store initial UTXO value to balance state against the contract's address
* For internal calls/creates/transfers, add internal transfers before applying the message to the state.
* Add tests