### PR TITLE
[Logging] Add debugger step through to TraceEnter and TraceLeave

### DIFF
--- a/src/FodyNlogAdapter/Adapters/LoggerAdapter.cs
+++ b/src/FodyNlogAdapter/Adapters/LoggerAdapter.cs
@@ -37,6 +37,7 @@ namespace FodyNlogAdapter.Adapters
             return logger;
         }
 
+        [DebuggerStepThrough]
         public void TraceEnter(string methodInfo, string[] paramNames, object[] paramValues)
         {
             if (this.logger.IsTraceEnabled)
@@ -70,6 +71,7 @@ namespace FodyNlogAdapter.Adapters
             }
         }
 
+        [DebuggerStepThrough]
         public void TraceLeave(string methodInfo, long startTicks, long endTicks, string[] paramNames, object[] paramValues)
         {
             if (this.logger.IsTraceEnabled)


### PR DESCRIPTION
Add the ability for the debugger to not step into these methods to make debugging a bit more efficient.