### PR TITLE
refactory of Stopwatch usage in DnsSeedServer

### DIFF
--- a/src/Stratis.Bitcoin.Features.Dns/DnsSeedServer.cs
+++ b/src/Stratis.Bitcoin.Features.Dns/DnsSeedServer.cs
@@ -213,15 +213,11 @@ namespace Stratis.Bitcoin.Features.Dns
 
                         this.logger.LogTrace("DNS request received of size {0} from endpoint {1}.", request.Item2.Length, request.Item1);
 
-                        // Received a request, now handle it.
-                        var stopWatch = new Stopwatch();
-                        stopWatch.Start();
-
-                        await this.HandleRequestAsync(request);
-
-                        stopWatch.Stop();
-
-                        this.metrics.CaptureRequestMetrics(this.GetPeerCount(), stopWatch.ElapsedTicks, false);
+                        // Received a request, now handle it. (measured)
+                        using (new StopwatchDisposable((elapsed) => { this.metrics.CaptureRequestMetrics(this.GetPeerCount(), elapsed, false); }))
+                        {
+                            await this.HandleRequestAsync(request);
+                        }
                     }
                     catch (ArgumentException e)
                     {
@@ -355,7 +351,7 @@ namespace Stratis.Bitcoin.Features.Dns
 
             // Set new start index.
             Interlocked.Increment(ref this.startIndex);
-            
+
             return response;
         }
 

--- a/src/Stratis.Bitcoin.Tests/Utilities/StopwatchTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Utilities/StopwatchTest.cs
@@ -16,6 +16,7 @@ namespace Stratis.Bitcoin.Tests.Utilities
         /// instead of <see cref="System.Diagnostics.Stopwatch"/>. It was argued that there was some kind of measurement
         /// error when the later was used. Most likely the problem was in mixing <see cref="System.DateTime.Ticks"/>
         /// units with incompatible <see cref="System.Diagnostics.Stopwatch.ElapsedTicks"/>.
+        /// Issue that cover this subject is <see href="https://github.com/stratisproject/StratisBitcoinFullNode/issues/2391"/>.
         /// <para>
         /// This test aims to verify that the time measurement with the disposable stopwatch achieves correct results.
         /// It performs a series of small work simlating delays which represent a measured code block. Each delay

--- a/src/Stratis.Bitcoin/Consensus/PerformanceCounters/ConsensusManager/ConsensusManagerPerformanceSnapshot.cs
+++ b/src/Stratis.Bitcoin/Consensus/PerformanceCounters/ConsensusManager/ConsensusManagerPerformanceSnapshot.cs
@@ -54,7 +54,7 @@ namespace Stratis.Bitcoin.Consensus.PerformanceCounters.ConsensusManager
 
         public double GetAvgExecutionTimeMs()
         {
-            return Math.Round((this.totalDelayTicks / (double)this.totalExecutionsCount) / 10000.0, 4);
+            return Math.Round(TimeSpan.FromTicks(this.totalDelayTicks).TotalMilliseconds / this.totalExecutionsCount, 4);
         }
 
         public void Increment(long elapsedTicks)

--- a/src/Stratis.Bitcoin/Utilities/Stopwatch.cs
+++ b/src/Stratis.Bitcoin/Utilities/Stopwatch.cs
@@ -12,6 +12,7 @@ namespace Stratis.Bitcoin.Utilities
     /// <remarks>
     /// Note that we are using <see cref="DateTime.Ticks"/> as a basic unit of measurement,
     /// not <see cref="System.Diagnostics.Stopwatch.ElapsedTicks"/>.
+    /// Issue that cover this subject is <see href="https://github.com/stratisproject/StratisBitcoinFullNode/issues/2391"/>.
     /// </remarks>
     /// <example>
     /// <code>


### PR DESCRIPTION
refactory of Stopwatch usage in DnsSeedServer class and documented Stopwatch implication of ElapsedTicks usage as per issue #2391