### PR TITLE
[PH] DNS Seed nodes to prefer using PH enabled nodes

### DIFF
--- a/src/NBitcoin/Protocol/Versions.cs
+++ b/src/NBitcoin/Protocol/Versions.cs
@@ -66,7 +66,7 @@
         WITNESS_VERSION = 70012,
 
         /// <summary>
-        /// ! Communication between nodes with proven headers is possible after this version.
+        /// Communication between nodes with proven headers is possible after this version.
         /// This is for stratis only. Temporary solution, refers to issue #2144
         /// https://github.com/stratisproject/StratisBitcoinFullNode/issues/2144
         /// </summary>

--- a/src/NBitcoin/Protocol/Versions.cs
+++ b/src/NBitcoin/Protocol/Versions.cs
@@ -66,6 +66,13 @@
         WITNESS_VERSION = 70012,
 
         /// <summary>
+        /// ! Communication between nodes with proven headers is possible after this version.
+        /// This is for stratis only. Temporary solution, refers to issue #2144
+        /// https://github.com/stratisproject/StratisBitcoinFullNode/issues/2144
+        /// </summary>
+        PROVEN_HEADER_VERSION = 70012,
+
+        /// <summary>
         /// shord-id-based block download starts with this version.
         /// </summary>
         SHORT_IDS_BLOCKS_VERSION = 70014

--- a/src/Stratis.Bitcoin.Features.Dns/DnsFeature.cs
+++ b/src/Stratis.Bitcoin.Features.Dns/DnsFeature.cs
@@ -88,7 +88,7 @@ namespace Stratis.Bitcoin.Features.Dns
         private bool disposed = false;
 
         /// <summary>
-        /// The service provider that allow to get required services.
+        /// The service provider that allows getting required services.
         /// </summary>
         private IFullNodeServiceProvider services;
 
@@ -248,8 +248,6 @@ namespace Stratis.Bitcoin.Features.Dns
             this.nodeLifetime.ApplicationStopping,
             repeatEvery: TimeSpan.FromSeconds(30));
         }
-
-
 
         /// <inheritdoc />
         public override void ValidateDependencies(IFullNodeServiceProvider services)

--- a/src/Stratis.Bitcoin.Features.Dns/DnsFeature.cs
+++ b/src/Stratis.Bitcoin.Features.Dns/DnsFeature.cs
@@ -1,10 +1,15 @@
 ﻿using System;
 using System.Text;
 using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using NBitcoin;
+using Stratis.Bitcoin.Base;
+using Stratis.Bitcoin.Builder;
 using Stratis.Bitcoin.Builder.Feature;
 using Stratis.Bitcoin.Configuration;
+using Stratis.Bitcoin.Connection;
+using Stratis.Bitcoin.P2P.Peer;
 using Stratis.Bitcoin.Utilities;
 
 namespace Stratis.Bitcoin.Features.Dns
@@ -34,7 +39,7 @@ namespace Stratis.Bitcoin.Features.Dns
         /// </summary>
         private readonly IWhitelistManager whitelistManager;
 
-       /// <summary>
+        /// <summary>
         /// Defines the logger.
         /// </summary>
         private readonly ILogger logger;
@@ -69,14 +74,23 @@ namespace Stratis.Bitcoin.Features.Dns
         /// </summary>
         private readonly IAsyncLoopFactory asyncLoopFactory;
 
+        /// <summary>Manager of node's network connections.</summary>
+        private readonly IConnectionManager connectionManager;
+
         /// <summary>
         /// The async loop to refresh the whitelist.
         /// </summary>
         private IAsyncLoop whitelistRefreshLoop;
+
         /// <summary>
         /// Defines a flag used to indicate whether the object has been disposed or not.
         /// </summary>
         private bool disposed = false;
+
+        /// <summary>
+        /// The service provider that allow to get required services.
+        /// </summary>
+        private IFullNodeServiceProvider services;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DnsFeature"/> class.
@@ -86,9 +100,11 @@ namespace Stratis.Bitcoin.Features.Dns
         /// <param name="loggerFactory">The factory to create the logger.</param>
         /// <param name="nodeLifetime">The node lifetime object used for graceful shutdown.</param>
         /// <param name="nodeSettings">The node settings object containing node configuration.</param>
+        /// <param name="dnsSettings">Defines the DNS settings for the node</param>
         /// <param name="dataFolders">The data folders of the system.</param>
         /// <param name="asyncLoopFactory">The asynchronous loop factory.</param>
-        public DnsFeature(IDnsServer dnsServer, IWhitelistManager whitelistManager, ILoggerFactory loggerFactory, INodeLifetime nodeLifetime, DnsSettings dnsSettings, NodeSettings nodeSettings, DataFolder dataFolders, IAsyncLoopFactory asyncLoopFactory)
+        /// <param name="connectionManager">Manager of node's network connections.</param>
+        public DnsFeature(IDnsServer dnsServer, IWhitelistManager whitelistManager, ILoggerFactory loggerFactory, INodeLifetime nodeLifetime, DnsSettings dnsSettings, NodeSettings nodeSettings, DataFolder dataFolders, IAsyncLoopFactory asyncLoopFactory, IConnectionManager connectionManager)
         {
             Guard.NotNull(dnsServer, nameof(dnsServer));
             Guard.NotNull(whitelistManager, nameof(whitelistManager));
@@ -97,6 +113,7 @@ namespace Stratis.Bitcoin.Features.Dns
             Guard.NotNull(nodeSettings, nameof(nodeSettings));
             Guard.NotNull(dataFolders, nameof(dataFolders));
             Guard.NotNull(asyncLoopFactory, nameof(asyncLoopFactory));
+            Guard.NotNull(connectionManager, nameof(connectionManager));
 
             this.dnsServer = dnsServer;
             this.whitelistManager = whitelistManager;
@@ -106,6 +123,7 @@ namespace Stratis.Bitcoin.Features.Dns
             this.nodeSettings = nodeSettings;
             this.dnsSettings = dnsSettings;
             this.dataFolders = dataFolders;
+            this.connectionManager = connectionManager;
         }
 
         /// <summary>
@@ -117,14 +135,17 @@ namespace Stratis.Bitcoin.Features.Dns
             this.dnsTask = Task.Factory.StartNew(this.RunDnsService, TaskCreationOptions.LongRunning);
 
             this.StartWhitelistRefreshLoop();
-            
+
+            IServiceProvider serviceProvider = this.services.ServiceProvider;
+            NetworkPeerConnectionParameters connectionParameters = this.connectionManager.Parameters;
+            connectionParameters.TemplateBehaviors.Add(serviceProvider.GetService<UnreliablePeerBehavior>());
+
             return Task.CompletedTask;
         }
 
         /// <summary>
         /// Runs the DNS service until the node is stopped.
         /// </summary>
-        /// <returns>A task used to allow the caller to await the operation.</returns>
         private void RunDnsService()
         {
             // Initialize DNS server.
@@ -226,6 +247,17 @@ namespace Stratis.Bitcoin.Features.Dns
             },
             this.nodeLifetime.ApplicationStopping,
             repeatEvery: TimeSpan.FromSeconds(30));
+        }
+
+
+
+        /// <inheritdoc />
+        public override void ValidateDependencies(IFullNodeServiceProvider services)
+        {
+            //TODO: this property should be exposed by FullNodeFeature base class as protected
+            this.services = services;
+
+            services.EnsureServiceIsRegistered<Network>();
         }
     }
 }

--- a/src/Stratis.Bitcoin.Features.Dns/IFullNodeBuilderExtensions.cs
+++ b/src/Stratis.Bitcoin.Features.Dns/IFullNodeBuilderExtensions.cs
@@ -33,8 +33,8 @@ namespace Stratis.Bitcoin.Features.Dns
                     services.AddSingleton<IUdpClient, DnsSeedUdpClient>();
                     services.AddSingleton<IWhitelistManager, WhitelistManager>();
 
-                    // Transient, means that every time this service is requested, a new instance is created.
-                    services.AddTransient<UnreliablePeerBehavior, UnreliablePeerBehavior>();
+                    // TODO: using Transient and a factory could allow us to get rid of Clone method.
+                    services.AddSingleton<UnreliablePeerBehavior, UnreliablePeerBehavior>();
                 });
             });
 

--- a/src/Stratis.Bitcoin.Features.Dns/IFullNodeBuilderExtensions.cs
+++ b/src/Stratis.Bitcoin.Features.Dns/IFullNodeBuilderExtensions.cs
@@ -11,7 +11,7 @@ namespace Stratis.Bitcoin.Features.Dns
     public static class IFullNodeBuilderExtensions
     {
         /// <summary>
-        /// Configures the Dns feature. 
+        /// Configures the Dns feature.
         /// </summary>
         /// <param name="fullNodeBuilder">Full node builder used to configure the feature.</param>
         /// <returns>The full node builder with the Dns feature configured.</returns>
@@ -23,6 +23,7 @@ namespace Stratis.Bitcoin.Features.Dns
             {
                 features
                 .AddFeature<DnsFeature>()
+                //TODO add DependsOn to specify which feature the DnsFeature requires
                 .FeatureServices(services =>
                 {
                     services.AddSingleton(fullNodeBuilder);
@@ -31,6 +32,9 @@ namespace Stratis.Bitcoin.Features.Dns
                     services.AddSingleton<DnsSettings>();
                     services.AddSingleton<IUdpClient, DnsSeedUdpClient>();
                     services.AddSingleton<IWhitelistManager, WhitelistManager>();
+
+                    // transient, means that every time this service is requested, a new instance is created
+                    services.AddTransient<UnreliablePeerBehavior, UnreliablePeerBehavior>();
                 });
             });
 

--- a/src/Stratis.Bitcoin.Features.Dns/IFullNodeBuilderExtensions.cs
+++ b/src/Stratis.Bitcoin.Features.Dns/IFullNodeBuilderExtensions.cs
@@ -33,7 +33,7 @@ namespace Stratis.Bitcoin.Features.Dns
                     services.AddSingleton<IUdpClient, DnsSeedUdpClient>();
                     services.AddSingleton<IWhitelistManager, WhitelistManager>();
 
-                    // transient, means that every time this service is requested, a new instance is created
+                    // Transient, means that every time this service is requested, a new instance is created.
                     services.AddTransient<UnreliablePeerBehavior, UnreliablePeerBehavior>();
                 });
             });

--- a/src/Stratis.Bitcoin.Features.Dns/UnreliablePeerBehavior.cs
+++ b/src/Stratis.Bitcoin.Features.Dns/UnreliablePeerBehavior.cs
@@ -84,16 +84,17 @@ namespace Stratis.Bitcoin.Features.Dns
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         private Task OnMessageReceivedAsync(INetworkPeer peer, IncomingMessage message)
         {
-            if (message.Message.Payload is VersionPayload version)
+            switch (message.Message.Payload)
             {
-                // If current node is on POS, and ProvenHeaders is activated, check if current connected peer can serve Proven Headers.
-                // If it can't, disconnect from him and ban for few minutes
-                if (this.IsProvenHeaderActivated() && !this.CanServeProvenHeader(version))
-                {
-                    TimeSpan banDuration = TimeSpan.FromMinutes(1);
-                    this.logger.LogDebug("Peer '{0}' has been banned for {1} because can't serve proven headers. Peer Version: {2}", peer.RemoteSocketEndpoint, banDuration, version.Version);
-                    this.peerBanning.BanAndDisconnectPeer(peer.PeerEndPoint, "Can't serve proven headers.");
-                }
+                case VersionPayload version:
+                    // If current node is on POS, and ProvenHeaders is activated, check if current connected peer can serve Proven Headers.
+                    // If it can't, disconnect from him and ban for few minutes
+                    if (this.IsProvenHeaderActivated() && !this.CanServeProvenHeader(version))
+                    {
+                        this.logger.LogDebug("Peer '{0}' has been banned because can't serve proven headers. Peer Version: {1}", peer.RemoteSocketEndpoint, version.Version);
+                        this.peerBanning.BanAndDisconnectPeer(peer.PeerEndPoint, "Can't serve proven headers.");
+                    }
+                    break;
             }
 
             return Task.CompletedTask;

--- a/src/Stratis.Bitcoin.Features.Dns/UnreliablePeerBehavior.cs
+++ b/src/Stratis.Bitcoin.Features.Dns/UnreliablePeerBehavior.cs
@@ -79,14 +79,9 @@ namespace Stratis.Bitcoin.Features.Dns
         /// <param name="peer">Peer that sent us the message.</param>
         /// <param name="message">Received message.</param>
         /// <remarks>
-        /// This handler only cares about "verack" messages, which are only sent once per node
-        /// and at the time they are sent the time offset information is parsed by underlaying logic.
-        /// <para>
-        /// Note that it is not possible to use "version" message here as <see cref="INetworkPeer"/>
-        /// does not deliver this message for inbound peers to node behaviors.
-        /// </para>
+        /// This handler only cares about "version" messages, which are only sent once per node.
         /// </remarks>
-        /// <returns><placeholder>A <see cref="Task"/> representing the asynchronous operation.</placeholder></returns>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         private Task OnMessageReceivedAsync(INetworkPeer peer, IncomingMessage message)
         {
             if (message.Message.Payload is VersionPayload version)

--- a/src/Stratis.Bitcoin.Features.Dns/UnreliablePeerBehavior.cs
+++ b/src/Stratis.Bitcoin.Features.Dns/UnreliablePeerBehavior.cs
@@ -1,0 +1,141 @@
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using NBitcoin;
+using Stratis.Bitcoin.Base;
+using Stratis.Bitcoin.Configuration;
+using Stratis.Bitcoin.Connection;
+using Stratis.Bitcoin.P2P.Peer;
+using Stratis.Bitcoin.P2P.Protocol;
+using Stratis.Bitcoin.P2P.Protocol.Behaviors;
+using Stratis.Bitcoin.P2P.Protocol.Payloads;
+using Stratis.Bitcoin.Utilities;
+
+namespace Stratis.Bitcoin.Features.Dns
+{
+    /// <summary>
+    /// A behaviour that will manage the lifetime of peers that aren't considered worthy to be served to DNS queries.
+    /// </summary>
+    public class UnreliablePeerBehavior : NetworkPeerBehavior
+    {
+        /// <summary>
+        /// Defines the network the node runs on, e.g. regtest/testnet/mainnet.
+        /// </summary>
+        private readonly Network network;
+
+        /// <summary>Information about node's chain.</summary>
+        private readonly IChainState chainState;
+
+        /// <summary>Logger factory to create loggers.</summary>
+        private readonly ILoggerFactory loggerFactory;
+
+        /// <summary>Handle the lifetime of a peer.</summary>
+        private readonly IPeerBanning peerBanning;
+
+        /// <summary>The node settings.</summary>
+        private readonly NodeSettings nodeSettings;
+
+        /// <summary>Instance logger.</summary>
+        private readonly ILogger logger;
+
+        public UnreliablePeerBehavior(Network network, IChainState chainState, ILoggerFactory loggerFactory, IPeerBanning peerBanning, NodeSettings nodeSettings)
+        {
+            Guard.NotNull(network, nameof(network));
+            Guard.NotNull(chainState, nameof(chainState));
+            Guard.NotNull(loggerFactory, nameof(loggerFactory));
+            Guard.NotNull(peerBanning, nameof(nodeSettings));
+            Guard.NotNull(nodeSettings, nameof(nodeSettings));
+
+            this.network = network;
+            this.chainState = chainState;
+            this.loggerFactory = loggerFactory;
+            this.peerBanning = peerBanning;
+            this.nodeSettings = nodeSettings;
+
+            this.logger = loggerFactory.CreateLogger(this.GetType().FullName);
+        }
+
+        /// <inheritdoc />
+        public override object Clone()
+        {
+            return new UnreliablePeerBehavior(this.network, this.chainState, this.loggerFactory, this.peerBanning, this.nodeSettings);
+        }
+
+        /// <inheritdoc />
+        protected override void AttachCore()
+        {
+            this.AttachedPeer.MessageReceived.Register(this.OnMessageReceivedAsync);
+        }
+
+        /// <inheritdoc />
+        protected override void DetachCore()
+        {
+            this.AttachedPeer.MessageReceived.Unregister(this.OnMessageReceivedAsync);
+        }
+
+        /// <summary>
+        /// Event handler that is called when the node receives a network message from the attached peer.
+        /// </summary>
+        /// <param name="peer">Peer that sent us the message.</param>
+        /// <param name="message">Received message.</param>
+        /// <remarks>
+        /// This handler only cares about "verack" messages, which are only sent once per node
+        /// and at the time they are sent the time offset information is parsed by underlaying logic.
+        /// <para>
+        /// Note that it is not possible to use "version" message here as <see cref="INetworkPeer"/>
+        /// does not deliver this message for inbound peers to node behaviors.
+        /// </para>
+        /// </remarks>
+        /// <returns><placeholder>A <see cref="Task"/> representing the asynchronous operation.</placeholder></returns>
+        private Task OnMessageReceivedAsync(INetworkPeer peer, IncomingMessage message)
+        {
+            if (message.Message.Payload is VersionPayload version)
+            {
+                // If current node is on POS, and ProvenHeaders is activated, check if current connected peer can serve Proven Headers.
+                // If it can't, disconnect from him and ban for few minutes
+                if (IsProvenHeaderActivated())
+                {
+                    if (!CanServeProvenHeader(version))
+                    {
+                        TimeSpan banDuration = TimeSpan.FromMinutes(1);
+                        this.logger.LogDebug("Peer '{0}' has been disconnected for {1} because can't serve proven headers. Peer Version: {2}", peer.RemoteSocketEndpoint, banDuration, version.Version);
+                        this.peerBanning.BanAndDisconnectPeer(peer.PeerEndPoint, "Can't serve proven headers.");
+                    }
+                }
+            }
+
+            return Task.CompletedTask;
+        }
+
+        /// <summary>
+        /// Determines whether proven headers are activated based on the proven header activation height and applicable network.
+        /// </summary>
+        /// <returns>
+        /// <c>true</c> if proven header height is past the activation height for the corresponding network;
+        /// otherwise, <c>false</c>.
+        /// </returns>
+        private bool IsProvenHeaderActivated()
+        {
+            if (this.network.Consensus.Options is PosConsensusOptions options)
+            {
+                long currentHeight = this.chainState.ConsensusTip.Height;
+                return options.ProvenHeadersActivationHeight > 0 && currentHeight >= options.ProvenHeadersActivationHeight;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Determines whether the specified peer can serve proven header.
+        /// </summary>
+        /// <param name="version">The version of the connected peer.</param>
+        /// <returns>
+        ///   <c>true</c> if this instance [can serve proven header] the specified peer; otherwise, <c>false</c>.
+        /// </returns>
+        private bool CanServeProvenHeader(VersionPayload version)
+        {
+            this.logger.LogTrace("Ensuring Peer can serve Proven Header");
+            return version.Version >= NBitcoin.Protocol.ProtocolVersion.PROVEN_HEADER_VERSION;
+        }
+    }
+}

--- a/src/Stratis.Bitcoin/Builder/Feature/MissingServiceException.cs
+++ b/src/Stratis.Bitcoin/Builder/Feature/MissingServiceException.cs
@@ -1,0 +1,48 @@
+﻿using System;
+
+namespace Stratis.Bitcoin.Builder.Feature
+{
+    /// <summary>
+    /// Exception thrown when a required service has not been registered into <see cref="IFullNodeServiceProvider"/>.
+    /// </summary>
+    public class MissingServiceException : Exception
+    {
+        /// <summary>
+        /// The Type of the missing service.
+        /// </summary>
+        public Type MissingServiceType { get; private set; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MissingDependencyException"/> class.
+        /// </summary>
+        /// <param name="missingServiceType">Type of the missing service.</param>
+        public MissingServiceException(Type missingServiceType)
+            : base($"The service {missingServiceType.FullName} has not been registered. Missing feature?")
+        {
+            this.MissingServiceType = missingServiceType;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MissingDependencyException"/> class.
+        /// </summary>
+        /// <param name="missingServiceType">Type of the missing service.</param>
+        /// <param name="message">The message.</param>
+        public MissingServiceException(Type missingServiceType, string message)
+            : base(message)
+        {
+            this.MissingServiceType = missingServiceType;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MissingDependencyException"/> class.
+        /// </summary>
+        /// <param name="missingServiceType">Type of the missing service.</param>
+        /// <param name="message">The message.</param>
+        /// <param name="innerException">The inner exception.</param>
+        public MissingServiceException(Type missingServiceType, string message, Exception innerException)
+            : base(message, innerException)
+        {
+            this.MissingServiceType = missingServiceType;
+        }
+    }
+}

--- a/src/Stratis.Bitcoin/Builder/FullNodeServiceProvider.cs
+++ b/src/Stratis.Bitcoin/Builder/FullNodeServiceProvider.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using Microsoft.Extensions.DependencyInjection;
 using Stratis.Bitcoin.Builder.Feature;
 using Stratis.Bitcoin.Utilities;
 
@@ -15,6 +16,22 @@ namespace Stratis.Bitcoin.Builder
 
         /// <summary>Provider to registered services.</summary>
         IServiceProvider ServiceProvider { get; }
+
+        /// <summary>
+        /// Determines whether the service of the specified type T is registered.
+        /// </summary>
+        /// <typeparam name="T">A type to query against the service provider.</typeparam>
+        /// <returns>
+        ///   <c>true</c> if this instance is registered; otherwise, <c>false</c>.
+        /// </returns>
+        bool IsServiceRegistered<T>();
+
+        /// <summary>
+        /// Guard method that check whether the service of the specified type T is registered.
+        /// If it doesn't exists, thrown an exception.
+        /// </summary>
+        /// <typeparam name="T">A type to query against the service provider.</typeparam>
+        void EnsureServiceIsRegistered<T>();
     }
 
     /// <summary>
@@ -52,6 +69,19 @@ namespace Stratis.Bitcoin.Builder
 
             this.ServiceProvider = serviceProvider;
             this.featureTypes = featureTypes;
+        }
+
+        /// <inheritdoc />
+        public bool IsServiceRegistered<T>()
+        {
+            return this.ServiceProvider.GetService<T>() != null;
+        }
+
+        /// <inheritdoc />
+        public void EnsureServiceIsRegistered<T>()
+        {
+            if (!this.IsServiceRegistered<T>())
+                throw new MissingServiceException(typeof(T));
         }
     }
 }


### PR DESCRIPTION
Implementation of #2147 

nodes that connects to our DNS node when PH gets activated, will be disconnected if they can't serve PH.

Extended the IFullNodeServiceProvider/FullNodeServiceProvider and used a better way to instance and register PeerBehavior like per issue #2402

Fixed tests