### PR TITLE
Bug/2406 node shutdown

### DIFF
--- a/src/Stratis.Bitcoin.Features.RPC.Tests/Controller/FullNodeControllerTest.cs
+++ b/src/Stratis.Bitcoin.Features.RPC.Tests/Controller/FullNodeControllerTest.cs
@@ -27,6 +27,7 @@ namespace Stratis.Bitcoin.Features.RPC.Tests.Controller
     public class FullNodeControllerTest : LogsTestBase
     {
         private ConcurrentChain chain;
+        private readonly Mock<INodeLifetime> nodeLifeTime;
         private readonly Mock<IFullNode> fullNode;
         private readonly Mock<IChainState> chainState;
         private readonly Mock<IConnectionManager> connectionManager;
@@ -42,7 +43,9 @@ namespace Stratis.Bitcoin.Features.RPC.Tests.Controller
 
         public FullNodeControllerTest()
         {
+            this.nodeLifeTime = new Mock<INodeLifetime>();
             this.fullNode = new Mock<IFullNode>();
+            this.fullNode.SetupGet(p => p.NodeLifetime).Returns(this.nodeLifeTime.Object);
             this.chainState = new Mock<IChainState>();
             this.connectionManager = new Mock<IConnectionManager>();
             this.network = KnownNetworks.TestNet;
@@ -74,7 +77,7 @@ namespace Stratis.Bitcoin.Features.RPC.Tests.Controller
         {
             await this.controller.Stop().ConfigureAwait(false);
 
-            this.fullNode.Verify(f => f.Dispose());
+            this.nodeLifeTime.Verify(n => n.StopApplication());
         }
 
         [Fact]

--- a/src/Stratis.Bitcoin.Features.RPC/Controllers/FullNodeController.cs
+++ b/src/Stratis.Bitcoin.Features.RPC/Controllers/FullNodeController.cs
@@ -79,7 +79,7 @@ namespace Stratis.Bitcoin.Features.RPC.Controllers
         {
             if (this.FullNode != null)
             {
-                this.FullNode.Dispose();
+                this.FullNode.NodeLifetime.StopApplication();
                 this.FullNode = null;
             }
 

--- a/src/Stratis.Bitcoin.Tests/Controllers/NodeControllerTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Controllers/NodeControllerTest.cs
@@ -66,7 +66,7 @@ namespace Stratis.Bitcoin.Tests.Controllers
         public void Stop_WithFullNode_DisposesFullNode()
         {
             var isDisposed = false;
-            this.fullNode.Setup(f => f.Dispose()).Callback(() => isDisposed = true);
+            this.fullNode.Setup(f => f.NodeLifetime.StopApplication()).Callback(() => isDisposed = true);
 
             IActionResult result = this.controller.Shutdown(true);
 

--- a/src/Stratis.Bitcoin/Controllers/NodeController.cs
+++ b/src/Stratis.Bitcoin/Controllers/NodeController.cs
@@ -391,8 +391,9 @@ namespace Stratis.Bitcoin.Controllers
         [Route("stop")]
         public IActionResult Shutdown([FromBody] bool corsProtection = true)
         {
-            // Start the node shutdown process.
-            this.fullNode?.Dispose();
+            // Start the node shutdown process, by calling StopApplication, which will signal to
+            // the full node RunAsync to continuee processing, which calls Dispose on the node.
+            this.fullNode?.NodeLifetime.StopApplication();
 
             return this.Ok();
         }

--- a/src/Stratis.Bitcoin/Controllers/NodeController.cs
+++ b/src/Stratis.Bitcoin/Controllers/NodeController.cs
@@ -392,7 +392,7 @@ namespace Stratis.Bitcoin.Controllers
         public IActionResult Shutdown([FromBody] bool corsProtection = true)
         {
             // Start the node shutdown process, by calling StopApplication, which will signal to
-            // the full node RunAsync to continuee processing, which calls Dispose on the node.
+            // the full node RunAsync to continue processing, which calls Dispose on the node.
             this.fullNode?.NodeLifetime.StopApplication();
 
             return this.Ok();


### PR DESCRIPTION
Closes #2406

- The daemon/node does not gracefully shut down when calling the shutdown API.
- Instead of calling Dispose directly in the Shutdown method, the StopApplication should be called, which will signal to the RunAsync wait to continue processing, which in turn calls node.Dispose.