### PR TITLE
[SC] Set single state field on contract

### DIFF
--- a/src/Stratis.Bitcoin.Features.SmartContracts.Tests/ContractTests.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts.Tests/ContractTests.cs
@@ -237,29 +237,8 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Tests
 
             this.contract.Invoke(methodCall);
 
-            var gasMeter = this.instance.GetBaseTypePrivateFieldValue("gasMeter");
-            var block = this.instance.GetBaseTypePrivateFieldValue("Block");
-            var getBalance = this.instance.GetBaseTypePrivateFieldValue("getBalance");
-            var internalTransactionExecutor = this.instance.GetBaseTypePrivateFieldValue("internalTransactionExecutor");
-            var internalHashHelper = this.instance.GetBaseTypePrivateFieldValue("internalHashHelper");
-            var message = this.instance.GetBaseTypePrivateFieldValue("Message");
-            var persistentState = this.instance.GetBaseTypePrivateFieldValue("PersistentState");
             var smartContractState = this.instance.GetBaseTypePrivateFieldValue("state");
 
-            Assert.NotNull(gasMeter);
-            Assert.Equal(this.state.GasMeter, gasMeter);
-            Assert.NotNull(block);
-            Assert.Equal(this.state.Block, block);
-            Assert.NotNull(getBalance);
-            Assert.Equal(this.state.GetBalance, getBalance);
-            Assert.NotNull(internalTransactionExecutor);
-            Assert.Equal(this.state.InternalTransactionExecutor, internalTransactionExecutor);
-            Assert.NotNull(internalHashHelper);
-            Assert.Equal(this.state.InternalHashHelper, internalHashHelper);
-            Assert.NotNull(message);
-            Assert.Equal(this.state.Message, message);
-            Assert.NotNull(persistentState);
-            Assert.Equal(this.state.PersistentState, persistentState);
             Assert.NotNull(smartContractState);
             Assert.Equal(this.state, smartContractState);
         }
@@ -369,29 +348,8 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Tests
 
             receiveContract.Invoke(methodCall);
 
-            var gasMeter = receiveInstance.GetBaseTypePrivateFieldValue("gasMeter");
-            var block = receiveInstance.GetBaseTypePrivateFieldValue("Block");
-            var getBalance = receiveInstance.GetBaseTypePrivateFieldValue("getBalance");
-            var internalTransactionExecutor = receiveInstance.GetBaseTypePrivateFieldValue("internalTransactionExecutor");
-            var internalHashHelper = receiveInstance.GetBaseTypePrivateFieldValue("internalHashHelper");
-            var message = receiveInstance.GetBaseTypePrivateFieldValue("Message");
-            var persistentState = receiveInstance.GetBaseTypePrivateFieldValue("PersistentState");
             var smartContractState = receiveInstance.GetBaseTypePrivateFieldValue("state");
 
-            Assert.NotNull(gasMeter);
-            Assert.Equal(this.state.GasMeter, gasMeter);
-            Assert.NotNull(block);
-            Assert.Equal(this.state.Block, block);
-            Assert.NotNull(getBalance);
-            Assert.Equal(this.state.GetBalance, getBalance);
-            Assert.NotNull(internalTransactionExecutor);
-            Assert.Equal(this.state.InternalTransactionExecutor, internalTransactionExecutor);
-            Assert.NotNull(internalHashHelper);
-            Assert.Equal(this.state.InternalHashHelper, internalHashHelper);
-            Assert.NotNull(message);
-            Assert.Equal(this.state.Message, message);
-            Assert.NotNull(persistentState);
-            Assert.Equal(this.state.PersistentState, persistentState);
             Assert.NotNull(smartContractState);
             Assert.Equal(this.state, smartContractState);
         }

--- a/src/Stratis.Bitcoin.Features.SmartContracts.Tests/ContractTests.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts.Tests/ContractTests.cs
@@ -278,7 +278,6 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Tests
         public void HasNoReceive_Returns_Correct_Receive()
         {
             var receiveContract = Contract.CreateUninitialized(typeof(HasNoReceive), this.state, this.address);
-            var receiveInstance = (HasNoReceive)receiveContract.GetPrivateFieldValue("instance");
 
             // ReceiveHandler should be null here because we set the binding flags to only resolve methods on the declared type
             var receiveMethod = ((Contract)receiveContract).ReceiveHandler;

--- a/src/Stratis.Bitcoin.Features.SmartContracts.Tests/ContractTests.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts.Tests/ContractTests.cs
@@ -244,7 +244,7 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Tests
             var internalHashHelper = this.instance.GetBaseTypePrivateFieldValue("internalHashHelper");
             var message = this.instance.GetBaseTypePrivateFieldValue("Message");
             var persistentState = this.instance.GetBaseTypePrivateFieldValue("PersistentState");
-            var smartContractState = this.instance.GetBaseTypePrivateFieldValue("smartContractState");
+            var smartContractState = this.instance.GetBaseTypePrivateFieldValue("state");
 
             Assert.NotNull(gasMeter);
             Assert.Equal(this.state.GasMeter, gasMeter);
@@ -376,7 +376,7 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Tests
             var internalHashHelper = receiveInstance.GetBaseTypePrivateFieldValue("internalHashHelper");
             var message = receiveInstance.GetBaseTypePrivateFieldValue("Message");
             var persistentState = receiveInstance.GetBaseTypePrivateFieldValue("PersistentState");
-            var smartContractState = receiveInstance.GetBaseTypePrivateFieldValue("smartContractState");
+            var smartContractState = receiveInstance.GetBaseTypePrivateFieldValue("state");
 
             Assert.NotNull(gasMeter);
             Assert.Equal(this.state.GasMeter, gasMeter);

--- a/src/Stratis.Bitcoin.Features.SmartContracts.Tests/ObserverTests.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts.Tests/ObserverTests.cs
@@ -223,10 +223,10 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Tests
 
             // TODO: Un-hard-code this. 
             // Constructor: 15
-            // Property setter: 12
+            // Property setter: 22
             // Storage: 150
             // "string newString = this.Owner + 1;": 36
-            Assert.Equal((Gas)213, this.gasMeter.GasConsumed);
+            Assert.Equal((Gas)223, this.gasMeter.GasConsumed);
         }
 
         [Fact]
@@ -249,9 +249,9 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Tests
             IContractInvocationResult result = contract.InvokeConstructor(new[] { "Test Owner" });
 
             // Constructor: 15
-            // Property setter: 12
+            // Property setter: 17
             // Storage: 150
-            Assert.Equal((Gas)177, this.gasMeter.GasConsumed);
+            Assert.Equal((Gas)182, this.gasMeter.GasConsumed);
         }
 
         [Fact]

--- a/src/Stratis.SmartContracts.Executor.Reflection/Contract.cs
+++ b/src/Stratis.SmartContracts.Executor.Reflection/Contract.cs
@@ -235,7 +235,7 @@ namespace Stratis.SmartContracts.Executor.Reflection
                     case "PersistentState":
                         field.SetValue(smartContract, contractState.PersistentState);
                         break;
-                    case "smartContractState":
+                    case "state":
                         field.SetValue(smartContract, contractState);
                         break;
                     case "Serializer":

--- a/src/Stratis.SmartContracts.Executor.Reflection/Contract.cs
+++ b/src/Stratis.SmartContracts.Executor.Reflection/Contract.cs
@@ -19,7 +19,7 @@ namespace Stratis.SmartContracts.Executor.Reflection
         /// </summary>
         private const BindingFlags DefaultReceiveLookup = BindingFlags.DeclaredOnly | BindingFlags.Instance | BindingFlags.Public;
 
-        protected internal const BindingFlags DefaultBindingFlags = BindingFlags.Instance | BindingFlags.NonPublic;
+        private const BindingFlags DefaultBindingFlags = BindingFlags.Instance | BindingFlags.NonPublic;
 
         private readonly SmartContract instance;
 

--- a/src/Stratis.SmartContracts.Executor.Reflection/Contract.cs
+++ b/src/Stratis.SmartContracts.Executor.Reflection/Contract.cs
@@ -19,6 +19,8 @@ namespace Stratis.SmartContracts.Executor.Reflection
         /// </summary>
         private const BindingFlags DefaultReceiveLookup = BindingFlags.DeclaredOnly | BindingFlags.Instance | BindingFlags.Public;
 
+        protected internal const BindingFlags DefaultBindingFlags = BindingFlags.Instance | BindingFlags.NonPublic;
+
         private readonly SmartContract instance;
 
         /// <summary>
@@ -154,7 +156,7 @@ namespace Stratis.SmartContracts.Executor.Reflection
         private void EnsureInitialized()
         {
             if (!this.initialized)
-                SetStateFields(this.instance, this.State);
+                SetStateField(this.instance, this.State);
 
             this.initialized = true;
         }
@@ -204,50 +206,13 @@ namespace Stratis.SmartContracts.Executor.Reflection
         }
 
         /// <summary>
-        /// Uses reflection to set the state fields on the contract object.
+        /// Uses reflection to set the state field on the contract object.
         /// </summary>
-        private static void SetStateFields(SmartContract smartContract, ISmartContractState contractState)
+        private static void SetStateField(SmartContract smartContract, ISmartContractState contractState)
         {
-            FieldInfo[] fields = typeof(SmartContract).GetFields(BindingFlags.Instance | BindingFlags.NonPublic);
+            FieldInfo field = typeof(SmartContract).GetField("state", DefaultBindingFlags);
 
-            foreach (FieldInfo field in fields)
-            {
-                switch (field.Name)
-                {
-                    case "gasMeter":
-                        field.SetValue(smartContract, contractState.GasMeter);
-                        break;
-                    case "Block":
-                        field.SetValue(smartContract, contractState.Block);
-                        break;
-                    case "getBalance":
-                        field.SetValue(smartContract, contractState.GetBalance);
-                        break;
-                    case "internalTransactionExecutor":
-                        field.SetValue(smartContract, contractState.InternalTransactionExecutor);
-                        break;
-                    case "internalHashHelper":
-                        field.SetValue(smartContract, contractState.InternalHashHelper);
-                        break;
-                    case "Message":
-                        field.SetValue(smartContract, contractState.Message);
-                        break;
-                    case "PersistentState":
-                        field.SetValue(smartContract, contractState.PersistentState);
-                        break;
-                    case "state":
-                        field.SetValue(smartContract, contractState);
-                        break;
-                    case "Serializer":
-                        field.SetValue(smartContract, contractState.Serializer);
-                        break;
-                    case "contractLogger":
-                        field.SetValue(smartContract, contractState.ContractLogger);
-                        break;
-                    default:
-                        break;
-                }
-            }
+            field.SetValue(smartContract, contractState);
         }
     }
 }

--- a/src/Stratis.SmartContracts/SmartContract.cs
+++ b/src/Stratis.SmartContracts/SmartContract.cs
@@ -65,21 +65,21 @@ namespace Stratis.SmartContracts
         /// <summary>
         /// The current state of the blockchain and current transaction.
         /// </summary>
-        private readonly ISmartContractState smartContractState;
+        private readonly ISmartContractState state;
 
-        public SmartContract(ISmartContractState smartContractState)
+        public SmartContract(ISmartContractState state)
         {
             CultureInfo.CurrentCulture = new CultureInfo("en-US");
 
-            this.Block = smartContractState.Block;
-            this.getBalance = smartContractState.GetBalance;
-            this.contractLogger = smartContractState.ContractLogger;
-            this.internalTransactionExecutor = smartContractState.InternalTransactionExecutor;
-            this.internalHashHelper = smartContractState.InternalHashHelper;
-            this.Message = smartContractState.Message;
-            this.PersistentState = smartContractState.PersistentState;
-            this.Serializer = smartContractState.Serializer;
-            this.smartContractState = smartContractState;
+            this.Block = state.Block;
+            this.getBalance = state.GetBalance;
+            this.contractLogger = state.ContractLogger;
+            this.internalTransactionExecutor = state.InternalTransactionExecutor;
+            this.internalHashHelper = state.InternalHashHelper;
+            this.Message = state.Message;
+            this.PersistentState = state.PersistentState;
+            this.Serializer = state.Serializer;
+            this.state = state;
         }
 
         /// <summary>
@@ -91,7 +91,7 @@ namespace Stratis.SmartContracts
         /// <param name="amountToTransfer">The amount of funds to transfer in satoshi.</param>
         protected ITransferResult Transfer(Address addressTo, ulong amountToTransfer)
         {
-            return this.internalTransactionExecutor.Transfer(this.smartContractState, addressTo, amountToTransfer);
+            return this.internalTransactionExecutor.Transfer(this.state, addressTo, amountToTransfer);
         }
 
         /// <summary>
@@ -104,7 +104,7 @@ namespace Stratis.SmartContracts
         /// <param name="gasLimit">The total amount of gas to allow this call to take up. Default is to use all remaining gas.</param>
         protected ITransferResult Call(Address addressTo, ulong amountToTransfer, string methodName, object[] parameters = null, ulong gasLimit = 0)
         {
-            return this.internalTransactionExecutor.Call(this.smartContractState, addressTo, amountToTransfer, methodName, parameters, gasLimit);
+            return this.internalTransactionExecutor.Call(this.state, addressTo, amountToTransfer, methodName, parameters, gasLimit);
         }
 
         /// <summary>
@@ -116,7 +116,7 @@ namespace Stratis.SmartContracts
         /// <param name="gasLimit">The total amount of gas to allow this call to take up. Default is to use all remaining gas.</param>
         protected ICreateResult Create<T>(ulong amountToTransfer = 0, object[] parameters = null, ulong gasLimit = 0) where T : SmartContract
         {
-            return this.internalTransactionExecutor.Create<T>(this.smartContractState, amountToTransfer, parameters, gasLimit);
+            return this.internalTransactionExecutor.Create<T>(this.state, amountToTransfer, parameters, gasLimit);
         }
 
 
@@ -146,7 +146,7 @@ namespace Stratis.SmartContracts
         /// <param name="toLog">Object with fields to save in logs.</param>
         protected void Log<T>(T toLog) where T : struct
         {
-            this.contractLogger.Log(this.smartContractState, toLog);
+            this.contractLogger.Log(this.state, toLog);
         }
 
         /// The fallback method, invoked when a transaction provides a method name of <see cref="string.Empty"/>.

--- a/src/Stratis.SmartContracts/SmartContract.cs
+++ b/src/Stratis.SmartContracts/SmartContract.cs
@@ -118,9 +118,9 @@ namespace Stratis.SmartContracts
             this.state.ContractLogger.Log(this.state, toLog);
         }
 
-        /// The fallback method, invoked when a transaction provides a method name of <see cref="string.Empty"/>.
-        /// The fallback method. Override this method to define behaviour when the contract receives funds and the method name in the calling transaction equals <see cref="string.Empty"/>.
-        /// Override this method to define behaviour when the contract receives funds and the method name in the calling transaction equals <see cref="string.Empty"/>.
+        /// <summary>
+        /// Default method used to handle the receipt of funds. Override this method to define behaviour when the contract receives funds and
+        /// no method name is provided or the method name in the calling transaction equals <see cref="string.Empty"/>.
         /// <para>
         /// This occurs when a contract sends funds to another contract using <see cref="Transfer"/>.
         /// </para>

--- a/src/Stratis.SmartContracts/SmartContract.cs
+++ b/src/Stratis.SmartContracts/SmartContract.cs
@@ -42,11 +42,6 @@ namespace Stratis.SmartContracts
         protected readonly ISerializer Serializer;
 
         /// <summary>
-        /// Tracks the gas usage for this contract instance.
-        /// </summary>
-        private readonly IGasMeter gasMeter;
-
-        /// <summary>
         /// Gets the balance of the contract, if applicable.
         /// </summary>
         private readonly Func<ulong> getBalance;
@@ -76,7 +71,6 @@ namespace Stratis.SmartContracts
         {
             CultureInfo.CurrentCulture = new CultureInfo("en-US");
 
-            this.gasMeter = smartContractState.GasMeter;
             this.Block = smartContractState.Block;
             this.getBalance = smartContractState.GetBalance;
             this.contractLogger = smartContractState.ContractLogger;

--- a/src/Stratis.SmartContracts/SmartContract.cs
+++ b/src/Stratis.SmartContracts/SmartContract.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Globalization;
+﻿using System.Globalization;
 
 namespace Stratis.SmartContracts
 {
@@ -14,53 +13,32 @@ namespace Stratis.SmartContracts
         /// <summary>
         /// The address of the smart contract.
         /// </summary>
-        protected Address Address { get { return this.Message.ContractAddress; } }
+        protected Address Address => this.state.Message.ContractAddress;
 
         /// <summary>
         /// Returns the balance of the smart contract.
         /// </summary>
-        public ulong Balance { get { return this.getBalance(); } }
+        public ulong Balance => this.state.GetBalance();
 
         /// <summary>
         /// Holds details about the current block.
         /// </summary>
-        protected readonly IBlock Block;
+        public IBlock Block => this.state.Block;
 
         /// <summary>
         /// Holds details about the current transaction that has been sent.
         /// </summary>
-        protected readonly IMessage Message;
+        public IMessage Message => this.state.Message;
 
         /// <summary>
         ///  Provides functionality for the saving and retrieval of objects inside smart contracts.
         /// </summary>
-        protected readonly IPersistentState PersistentState;
+        public IPersistentState PersistentState => this.state.PersistentState;
 
         /// <summary>
         /// Provides functionality for the serialization and deserialization of primitives to bytes inside smart contracts.
         /// </summary>
-        protected readonly ISerializer Serializer;
-
-        /// <summary>
-        /// Gets the balance of the contract, if applicable.
-        /// </summary>
-        private readonly Func<ulong> getBalance;
-
-        /// <summary>
-        /// Saves any logs during contract execution.
-        /// </summary>
-        private readonly IContractLogger contractLogger;
-
-        /// <summary>
-        /// Executes any internal calls or creates to other smart contracts.
-        /// </summary>
-        private readonly IInternalTransactionExecutor internalTransactionExecutor;
-
-
-        /// <summary>
-        /// Provides access to internal hashing functions.
-        /// </summary>
-        private readonly IInternalHashHelper internalHashHelper;
+        public ISerializer Serializer => this.state.Serializer;
 
         /// <summary>
         /// The current state of the blockchain and current transaction.
@@ -70,15 +48,6 @@ namespace Stratis.SmartContracts
         public SmartContract(ISmartContractState state)
         {
             CultureInfo.CurrentCulture = new CultureInfo("en-US");
-
-            this.Block = state.Block;
-            this.getBalance = state.GetBalance;
-            this.contractLogger = state.ContractLogger;
-            this.internalTransactionExecutor = state.InternalTransactionExecutor;
-            this.internalHashHelper = state.InternalHashHelper;
-            this.Message = state.Message;
-            this.PersistentState = state.PersistentState;
-            this.Serializer = state.Serializer;
             this.state = state;
         }
 
@@ -91,7 +60,7 @@ namespace Stratis.SmartContracts
         /// <param name="amountToTransfer">The amount of funds to transfer in satoshi.</param>
         protected ITransferResult Transfer(Address addressTo, ulong amountToTransfer)
         {
-            return this.internalTransactionExecutor.Transfer(this.state, addressTo, amountToTransfer);
+            return this.state.InternalTransactionExecutor.Transfer(this.state, addressTo, amountToTransfer);
         }
 
         /// <summary>
@@ -104,7 +73,7 @@ namespace Stratis.SmartContracts
         /// <param name="gasLimit">The total amount of gas to allow this call to take up. Default is to use all remaining gas.</param>
         protected ITransferResult Call(Address addressTo, ulong amountToTransfer, string methodName, object[] parameters = null, ulong gasLimit = 0)
         {
-            return this.internalTransactionExecutor.Call(this.state, addressTo, amountToTransfer, methodName, parameters, gasLimit);
+            return this.state.InternalTransactionExecutor.Call(this.state, addressTo, amountToTransfer, methodName, parameters, gasLimit);
         }
 
         /// <summary>
@@ -116,7 +85,7 @@ namespace Stratis.SmartContracts
         /// <param name="gasLimit">The total amount of gas to allow this call to take up. Default is to use all remaining gas.</param>
         protected ICreateResult Create<T>(ulong amountToTransfer = 0, object[] parameters = null, ulong gasLimit = 0) where T : SmartContract
         {
-            return this.internalTransactionExecutor.Create<T>(this.state, amountToTransfer, parameters, gasLimit);
+            return this.state.InternalTransactionExecutor.Create<T>(this.state, amountToTransfer, parameters, gasLimit);
         }
 
 
@@ -127,7 +96,7 @@ namespace Stratis.SmartContracts
         /// <returns></returns>
         protected byte[] Keccak256(byte[] toHash)
         {
-            return this.internalHashHelper.Keccak256(toHash);
+            return this.state.InternalHashHelper.Keccak256(toHash);
         }
 
         /// <summary>
@@ -146,7 +115,7 @@ namespace Stratis.SmartContracts
         /// <param name="toLog">Object with fields to save in logs.</param>
         protected void Log<T>(T toLog) where T : struct
         {
-            this.contractLogger.Log(this.state, toLog);
+            this.state.ContractLogger.Log(this.state, toLog);
         }
 
         /// The fallback method, invoked when a transaction provides a method name of <see cref="string.Empty"/>.


### PR DESCRIPTION
Closes #2152. Replace all state fields with a single field. Fix docs on receive handler.

Note that this will make all accesses to the state fields more Gas expensive, as they now require a method invocation to retrieve. We can address this further with #2268.