### PR TITLE
Rpc allow ip any

### DIFF
--- a/src/Stratis.Bitcoin.Features.RPC.Tests/RPCAuthorizationTest.cs
+++ b/src/Stratis.Bitcoin.Features.RPC.Tests/RPCAuthorizationTest.cs
@@ -79,5 +79,25 @@ namespace Stratis.Bitcoin.Features.RPC.Tests
 
             Assert.False(result);
         }
+
+        [Fact]
+        public void IsAuthorizedWhenIPv6AnyAllowedReturnsTrueForEverything()
+        {
+            this.authorization.AllowIp.Add(IPAddress.IPv6Any);
+
+            Assert.True(this.authorization.IsAuthorized(IPAddress.Parse("127.1.1.15")));
+            Assert.True(this.authorization.IsAuthorized(IPAddress.Parse("4.5.6.7")));
+            Assert.True(this.authorization.IsAuthorized(IPAddress.Parse("::")));
+            Assert.True(this.authorization.IsAuthorized(IPAddress.Parse("2001:0db8:85a3:0000:0000:8a2e:0370:7334")));
+        }
+
+        [Fact]
+        public void IsAuthorizedWhenIPv4AnyAllowedReturnsTrueForIPv4FalseForIPv6()
+        {
+            this.authorization.AllowIp.Add(IPAddress.Any);
+
+            Assert.True(this.authorization.IsAuthorized(IPAddress.Parse("127.1.1.15")));
+            Assert.False(this.authorization.IsAuthorized(IPAddress.Parse("2001:0db8:85a3:0000:0000:8a2e:0370:7334")));
+        }
     }
 }

--- a/src/Stratis.Bitcoin.Features.RPC/RPCAuthorization.cs
+++ b/src/Stratis.Bitcoin.Features.RPC/RPCAuthorization.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
+using NBitcoin;
 using Stratis.Bitcoin.Utilities;
 
 namespace Stratis.Bitcoin.Features.RPC
@@ -39,6 +40,12 @@ namespace Stratis.Bitcoin.Features.RPC
         public bool IsAuthorized(IPAddress ip)
         {
             Guard.NotNull(ip, nameof(ip));
+
+            if (this.AllowIp.Contains(IPAddress.IPv6Any))
+                return true;
+
+            if (ip.IsIPv4() && this.AllowIp.Contains(IPAddress.Any))
+                return true;
 
             if (this.AllowIp.Count == 0)
                 return true;

--- a/src/Stratis.Bitcoin.Features.RPC/RpcSettings.cs
+++ b/src/Stratis.Bitcoin.Features.RPC/RpcSettings.cs
@@ -82,7 +82,7 @@ namespace Stratis.Bitcoin.Features.RPC
                 {
                     this.AllowIp = config
                         .GetAll("rpcallowip", this.logger)
-                        .Select(p => p=="*" ? IPAddress.Any : IPAddress.Parse(p))
+                        .Select(p => p == "*" ? IPAddress.IPv6Any : IPAddress.Parse(p))
                         .ToList();
                 }
                 catch (FormatException)

--- a/src/Stratis.Bitcoin.Features.RPC/RpcSettings.cs
+++ b/src/Stratis.Bitcoin.Features.RPC/RpcSettings.cs
@@ -82,7 +82,7 @@ namespace Stratis.Bitcoin.Features.RPC
                 {
                     this.AllowIp = config
                         .GetAll("rpcallowip", this.logger)
-                        .Select(p => IPAddress.Parse(p))
+                        .Select(p => p=="*" ? IPAddress.Any : IPAddress.Parse(p))
                         .ToList();
                 }
                 catch (FormatException)

--- a/src/Stratis.Bitcoin.IntegrationTests/RPC/RPCSettingsTest.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/RPC/RPCSettingsTest.cs
@@ -1,4 +1,5 @@
-﻿using Stratis.Bitcoin.Builder;
+﻿using System.Net;
+using Stratis.Bitcoin.Builder;
 using Stratis.Bitcoin.Configuration;
 using Stratis.Bitcoin.Features.Consensus;
 using Stratis.Bitcoin.Features.RPC;
@@ -32,6 +33,22 @@ namespace Stratis.Bitcoin.IntegrationTests.RPC
             Assert.Equal("abc", settings.RpcUser);	
             Assert.Equal("def", settings.RpcPassword);	
             Assert.Equal(91, settings.RPCPort);	
-        }	
+        }
+
+        [Fact]
+        public void SupportForStarOnRpcAllowIP()
+        {
+            var nodeSettings = new NodeSettings(this.Network, args: new [] { "-rpcallowip=*", "-server=1" });
+
+            IFullNode node = new FullNodeBuilder()
+                .UseNodeSettings(nodeSettings)
+                .UsePowConsensus()
+                .AddRPC()
+                .Build();
+
+            var settings = node.NodeService<RpcSettings>();
+
+            Assert.Contains(IPAddress.IPv6Any, settings.AllowIp);
+        }
     }	
 }

--- a/src/Stratis.Bitcoin.Tests/P2P/SelfEndpointTrackerTests.cs
+++ b/src/Stratis.Bitcoin.Tests/P2P/SelfEndpointTrackerTests.cs
@@ -16,7 +16,7 @@ namespace Stratis.Bitcoin.Tests.P2P
         {
             this.extendedLoggerFactory = new ExtendedLoggerFactory();
             this.selfEndpointTracker = new SelfEndpointTracker(this.extendedLoggerFactory);
-        } 
+        }
 
         [Fact]
         public void Add_OneIpEndpoint_GetsAdded()
@@ -80,7 +80,7 @@ namespace Stratis.Bitcoin.Tests.P2P
         {
             var oldIpEndpoint = new IPEndPoint(IPAddress.Parse("1.2.3.4"), 1234);
             var newIpEndpoint = new IPEndPoint(IPAddress.Parse("5.6.7.8"), 5678);
-            
+
             const int initialPeerScore = 2;
             this.selfEndpointTracker.UpdateAndAssignMyExternalAddress(oldIpEndpoint, false);
             this.selfEndpointTracker.UpdateAndAssignMyExternalAddress(oldIpEndpoint, false);
@@ -98,7 +98,7 @@ namespace Stratis.Bitcoin.Tests.P2P
             var newIpEndpoint1 = new IPEndPoint(IPAddress.Parse("0.0.0.1"), 1);
             var newIpEndpoint2 = new IPEndPoint(IPAddress.Parse("0.0.0.2"), 2);
             var newIpEndpoint3 = new IPEndPoint(IPAddress.Parse("0.0.0.3"), 3);
-            
+
             this.selfEndpointTracker.UpdateAndAssignMyExternalAddress(oldIpEndpoint, false);
 
             // When count reaches zero external address updates and score reset to 1.
@@ -110,5 +110,11 @@ namespace Stratis.Bitcoin.Tests.P2P
             Assert.Equal(1, this.selfEndpointTracker.MyExternalAddressPeerScore);
         }
 
+
+        [Fact]
+        public void IPAddressParse()
+        {
+            IPAddress.Parse("*");
+        }
     }
 }

--- a/src/Stratis.Bitcoin.Tests/P2P/SelfEndpointTrackerTests.cs
+++ b/src/Stratis.Bitcoin.Tests/P2P/SelfEndpointTrackerTests.cs
@@ -110,11 +110,5 @@ namespace Stratis.Bitcoin.Tests.P2P
             Assert.Equal(1, this.selfEndpointTracker.MyExternalAddressPeerScore);
         }
 
-
-        [Fact]
-        public void IPAddressParse()
-        {
-            IPAddress.Parse("*");
-        }
     }
 }


### PR DESCRIPTION
bitcoind and stratisd support -rpcallowip=*  so added this support to Full node so that it is an easier direct swap for other services.  Eg Block explorer like Nako @dangershony 