### PR TITLE
Fixing the ReadWriteHash functionality

### DIFF
--- a/src/NBitcoin/BlockHeader.cs
+++ b/src/NBitcoin/BlockHeader.cs
@@ -98,7 +98,12 @@ namespace NBitcoin
         /// <summary>Populates stream with items that will be used during hash calculation.</summary>
         protected virtual void ReadWriteHashingStream(BitcoinStream stream)
         {
-            this.ReadWrite(stream);
+            stream.ReadWrite(ref this.version);
+            stream.ReadWrite(ref this.hashPrevBlock);
+            stream.ReadWrite(ref this.hashMerkleRoot);
+            stream.ReadWrite(ref this.time);
+            stream.ReadWrite(ref this.bits);
+            stream.ReadWrite(ref this.nonce);
         }
 
         /// <summary>

--- a/src/NBitcoin/ProvenBlockHeader.cs
+++ b/src/NBitcoin/ProvenBlockHeader.cs
@@ -110,20 +110,6 @@ namespace NBitcoin
         }
 
         /// <inheritdoc />
-        protected override uint256 CalculateHash()
-        {
-            using (var hs = new HashStream())
-            {
-                // We are using base serialization to avoid serializing properties
-                // on the current component (signature, merkle root, coinstake).
-
-                base.ReadWrite(new BitcoinStream(hs, true));
-                uint256 hash = hs.GetHash();
-                return hash;
-            }
-        }
-
-        /// <inheritdoc />
         public override string ToString()
         {
             return this.GetHash().ToString();

--- a/src/Stratis.Bitcoin.Features.PoA/PoABlockHeader.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/PoABlockHeader.cs
@@ -21,11 +21,5 @@ namespace Stratis.Bitcoin.Features.PoA
             // Adding the signature to header because it will be needed for header validation on PoA networks.
             stream.ReadWrite(ref this.blockSignature);
         }
-
-        /// <inheritdoc />
-        protected override void ReadWriteHashingStream(BitcoinStream stream)
-        {
-            base.ReadWrite(stream);
-        }
     }
 }

--- a/src/Stratis.Bitcoin.Features.SmartContracts/Consensus/SmartContractBlockHeader.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts/Consensus/SmartContractBlockHeader.cs
@@ -40,5 +40,17 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Consensus
             stream.ReadWrite(ref this.receiptRoot);
             stream.ReadWrite(ref this.logsBloom);
         }
+
+        /// <summary>
+        /// Overridden so we can add these fields to the hash.
+        /// </summary>
+        protected override void ReadWriteHashingStream(BitcoinStream stream)
+        {
+            base.ReadWriteHashingStream(stream);
+            stream.ReadWrite(ref this.hashStateRoot);
+            stream.ReadWrite(ref this.receiptRoot);
+            stream.ReadWrite(ref this.logsBloom);
+        }
+
     }
 }


### PR DESCRIPTION
I merged #2538 but unfortunately it wasn't quite correct. 

This fixes the broken build.

We have separated the serialization of blocks from hash retrieval, as there are cases where we wish to add to the serialization but not to the hash (e.g. PH, PoA).

And base.ReadWrite wasn't going to last because we have to add to add extra fields to the hash in the case of smart contracts or other extensions