### PR TITLE
[Mempool] CheckSigOps using incorrect constant (#2470)

### DIFF
--- a/src/NBitcoin/ConsensusOptions.cs
+++ b/src/NBitcoin/ConsensusOptions.cs
@@ -7,7 +7,7 @@
     public class ConsensusOptions
     {
         /// <summary>
-        /// Flag used to detect SegWit transactions.  
+        /// Flag used to detect SegWit transactions.
         /// </summary>
         public const int SerializeTransactionNoWitness = 0x40000000;
 
@@ -39,6 +39,9 @@
         /// <summary>The maximum allowed number of signature check operations in a block (network rule).</summary>
         public int MaxBlockSigopsCost { get; set; }
 
+        /// <summary>The maximum number of sigops we're willing to relay/mine in a single tx.</summary>
+        public int MaxStandardTxSigopsCost { get; set; }
+
         /// <summary>
         /// Initializes the default values. Currently only used for initialising Bitcoin networks and testing.
         /// </summary>
@@ -52,6 +55,7 @@
             this.MaxStandardTxWeight = 400000;
             this.MaxBlockBaseSize = 1000000;
             this.MaxBlockSigopsCost = 80000;
+            this.MaxStandardTxSigopsCost = this.MaxBlockSigopsCost / 5;
         }
 
         /// <summary>
@@ -64,7 +68,8 @@
             int witnessScaleFactor,
             int maxStandardVersion,
             int maxStandardTxWeight,
-            int maxBlockSigopsCost)
+            int maxBlockSigopsCost,
+            int maxStandardTxSigopsCost)
         {
             this.MaxBlockBaseSize = maxBlockBaseSize;
             this.MaxBlockWeight = maxBlockWeight;
@@ -73,6 +78,7 @@
             this.MaxStandardVersion = maxStandardVersion;
             this.MaxStandardTxWeight = maxStandardTxWeight;
             this.MaxBlockSigopsCost = maxBlockSigopsCost;
+            this.MaxStandardTxSigopsCost = maxStandardTxSigopsCost;
         }
 
         /// <summary>
@@ -82,7 +88,8 @@
             uint maxBlockBaseSize,
             int maxStandardVersion,
             int maxStandardTxWeight,
-            int maxBlockSigopsCost)
+            int maxBlockSigopsCost,
+            int maxStandardTxSigopsCost)
         {
             this.MaxBlockBaseSize = maxBlockBaseSize;
 
@@ -95,12 +102,13 @@
             this.MaxStandardVersion = maxStandardVersion;
             this.MaxStandardTxWeight = maxStandardTxWeight;
             this.MaxBlockSigopsCost = maxBlockSigopsCost;
+            this.MaxStandardTxSigopsCost = maxStandardTxSigopsCost;
         }
     }
 
     /// <summary>
     /// Extension to ConsensusOptions for PoS-related parameters.
-    /// 
+    ///
     /// TODO: When moving rules to be part of consensus for network, move this class to the appropriate project too.
     /// Doesn't make much sense for it to be in NBitcoin. Also remove the CoinstakeMinConfirmation consts and set CointakeMinConfirmation in Network building.
     /// </summary>
@@ -154,7 +162,8 @@
             int maxStandardVersion,
             int maxStandardTxWeight,
             int maxBlockSigopsCost,
-            int provenHeadersActivationHeight) : base(maxBlockBaseSize, maxBlockWeight, maxBlockSerializedSize, witnessScaleFactor, maxStandardVersion, maxStandardTxWeight, maxBlockSigopsCost)
+            int maxStandardTxSigopsCost,
+            int provenHeadersActivationHeight) : base(maxBlockBaseSize, maxBlockWeight, maxBlockSerializedSize, witnessScaleFactor, maxStandardVersion, maxStandardTxWeight, maxBlockSigopsCost, maxStandardTxSigopsCost)
         {
             this.ProvenHeadersActivationHeight = provenHeadersActivationHeight;
         }
@@ -167,7 +176,8 @@
             int maxStandardVersion,
             int maxStandardTxWeight,
             int maxBlockSigopsCost,
-            int provenHeadersActivationHeight) : base(maxBlockBaseSize, maxStandardVersion, maxStandardTxWeight, maxBlockSigopsCost)
+            int maxStandardTxSigopsCost,
+            int provenHeadersActivationHeight) : base(maxBlockBaseSize, maxStandardVersion, maxStandardTxWeight, maxBlockSigopsCost, maxStandardTxSigopsCost)
         {
             this.ProvenHeadersActivationHeight = provenHeadersActivationHeight;
         }

--- a/src/Stratis.Bitcoin.Features.MemoryPool/MempoolValidator.cs
+++ b/src/Stratis.Bitcoin.Features.MemoryPool/MempoolValidator.cs
@@ -765,7 +765,7 @@ namespace Stratis.Bitcoin.Features.MemoryPool
             // itself can contain sigops MAX_STANDARD_TX_SIGOPS is less than
             // MAX_BLOCK_SIGOPS; we still consider this an invalid rather than
             // merely non-standard transaction.
-            if (context.SigOpsCost > this.ConsensusOptions.MaxBlockSigopsCost)
+            if (context.SigOpsCost > this.ConsensusOptions.MaxStandardTxSigopsCost)
             {
                 this.logger.LogTrace("(-)[FAIL_TOO_MANY_SIGOPS]");
                 context.State.Fail(MempoolErrors.TooManySigops).Throw();

--- a/src/Stratis.Bitcoin.Features.PoA/PoAConsensusOptions.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/PoAConsensusOptions.cs
@@ -9,8 +9,9 @@ namespace Stratis.Bitcoin.Features.PoA
             uint maxBlockBaseSize,
             int maxStandardVersion,
             int maxStandardTxWeight,
-            int maxBlockSigopsCost)
-                : base(maxBlockBaseSize, maxStandardVersion, maxStandardTxWeight, maxBlockSigopsCost)
+            int maxBlockSigopsCost,
+            int maxStandardTxSigopsCost)
+                : base(maxBlockBaseSize, maxStandardVersion, maxStandardTxWeight, maxBlockSigopsCost, maxStandardTxSigopsCost)
         {
         }
     }

--- a/src/Stratis.Bitcoin.Features.PoA/PoANetwork.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/PoANetwork.cs
@@ -86,7 +86,8 @@ namespace Stratis.Bitcoin.Features.PoA
                 maxBlockBaseSize: 1_000_000,
                 maxStandardVersion: 2,
                 maxStandardTxWeight: 100_000,
-                maxBlockSigopsCost: 20_000
+                maxBlockSigopsCost: 20_000,
+                maxStandardTxSigopsCost: 20_000 / 5
             );
 
             var buriedDeployments = new BuriedDeploymentsArray

--- a/src/Stratis.Bitcoin.Networks/StratisMain.cs
+++ b/src/Stratis.Bitcoin.Networks/StratisMain.cs
@@ -65,6 +65,7 @@ namespace Stratis.Bitcoin.Networks
                 maxStandardVersion: 2,
                 maxStandardTxWeight: 100_000,
                 maxBlockSigopsCost: 20_000,
+                maxStandardTxSigopsCost: 20_000 / 5,
                 provenHeadersActivationHeight: 20_000_000 // TODO: Set it to the real value once it is known.
             );
 

--- a/src/Stratis.Bitcoin.Networks/StratisRegTest.cs
+++ b/src/Stratis.Bitcoin.Networks/StratisRegTest.cs
@@ -33,7 +33,7 @@ namespace Stratis.Bitcoin.Networks
             this.GenesisBits = 0x1e0fffff;
             this.GenesisVersion = 1;
             this.GenesisReward = Money.Zero;
-            
+
             Block genesisBlock = CreateStratisGenesisBlock(consensusFactory, this.GenesisTime, this.GenesisNonce, this.GenesisBits, this.GenesisVersion, this.GenesisReward);
 
             genesisBlock.Header.Time = 1494909211;
@@ -48,6 +48,7 @@ namespace Stratis.Bitcoin.Networks
                 maxStandardVersion: 2,
                 maxStandardTxWeight: 100_000,
                 maxBlockSigopsCost: 20_000,
+                maxStandardTxSigopsCost: 20_000 / 5,
                 provenHeadersActivationHeight: 10_000_000 // TODO: Set it to the real value once it is known.
             );
 

--- a/src/Stratis.Bitcoin.Networks/StratisTest.cs
+++ b/src/Stratis.Bitcoin.Networks/StratisTest.cs
@@ -39,7 +39,7 @@ namespace Stratis.Bitcoin.Networks
             this.GenesisReward = Money.Zero;
 
             Block genesisBlock = CreateStratisGenesisBlock(consensusFactory, this.GenesisTime, this.GenesisNonce, this.GenesisBits, this.GenesisVersion, this.GenesisReward);
-            
+
             genesisBlock.Header.Time = 1493909211;
             genesisBlock.Header.Nonce = 2433759;
             genesisBlock.Header.Bits = powLimit;
@@ -52,6 +52,7 @@ namespace Stratis.Bitcoin.Networks
                 maxStandardVersion: 2,
                 maxStandardTxWeight: 100_000,
                 maxBlockSigopsCost: 20_000,
+                maxStandardTxSigopsCost: 20_000 / 5,
                 provenHeadersActivationHeight: 10_000_000 // TODO: Set it to the real value once it is known.
             );
 
@@ -127,8 +128,8 @@ namespace Stratis.Bitcoin.Networks
             this.SeedNodes = new List<NetworkAddress>
             {
                 new NetworkAddress(IPAddress.Parse("51.140.231.125"), this.DefaultPort), // danger cloud node
-                new NetworkAddress(IPAddress.Parse("13.70.81.5"), 3389), // beard cloud node  
-                new NetworkAddress(IPAddress.Parse("191.235.85.131"), 3389), // fassa cloud node  
+                new NetworkAddress(IPAddress.Parse("13.70.81.5"), 3389), // beard cloud node
+                new NetworkAddress(IPAddress.Parse("191.235.85.131"), 3389), // fassa cloud node
                 new NetworkAddress(IPAddress.Parse("52.232.58.52"), 26178), // neurosploit public node
             };
 

--- a/src/Stratis.SmartContracts.Networks/SmartContractPosRegTest.cs
+++ b/src/Stratis.SmartContracts.Networks/SmartContractPosRegTest.cs
@@ -37,6 +37,7 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Networks
                 maxStandardVersion: 2,
                 maxStandardTxWeight: 100_000,
                 maxBlockSigopsCost: 20_000,
+                maxStandardTxSigopsCost: 20_000 / 5,
                 provenHeadersActivationHeight: 10_000_000 // TODO: Set it to the real value once it is known.
             );
 

--- a/src/Stratis.SmartContracts.Networks/SmartContractPosTest.cs
+++ b/src/Stratis.SmartContracts.Networks/SmartContractPosTest.cs
@@ -37,6 +37,7 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Networks
                 maxStandardVersion: 2,
                 maxStandardTxWeight: 100_000,
                 maxBlockSigopsCost: 20_000,
+                maxStandardTxSigopsCost: 20_000 / 5,
                 provenHeadersActivationHeight: 10_000_000 // TODO: Set it to the real value once it is known.
             );
 

--- a/src/Stratis.SmartContracts.Networks/SmartContractsPoARegTest.cs
+++ b/src/Stratis.SmartContracts.Networks/SmartContractsPoARegTest.cs
@@ -37,7 +37,8 @@ namespace Stratis.SmartContracts.Networks
                 maxBlockBaseSize: 1_000_000,
                 maxStandardVersion: 2,
                 maxStandardTxWeight: 100_000,
-                maxBlockSigopsCost: 20_000
+                maxBlockSigopsCost: 20_000,
+                maxStandardTxSigopsCost: 20_000 / 5
             );
 
             var buriedDeployments = new BuriedDeploymentsArray

--- a/src/Stratis.SmartContracts.Networks/SmartContractsRegTest.cs
+++ b/src/Stratis.SmartContracts.Networks/SmartContractsRegTest.cs
@@ -40,6 +40,7 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Networks
                 maxStandardVersion: 2,
                 maxStandardTxWeight: 100_000,
                 maxBlockSigopsCost: 20_000,
+                maxStandardTxSigopsCost: 20_000 / 5,
                 provenHeadersActivationHeight: 10_000_000 // TODO: Set it to the real value once it is known.
             );
 

--- a/src/Stratis.SmartContracts.Networks/SmartContractsTest.cs
+++ b/src/Stratis.SmartContracts.Networks/SmartContractsTest.cs
@@ -38,6 +38,7 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Networks
                 maxStandardVersion: 2,
                 maxStandardTxWeight: 100_000,
                 maxBlockSigopsCost: 20_000,
+                maxStandardTxSigopsCost: 20_000 / 5,
                 provenHeadersActivationHeight: 10_000_000 // TODO: Set it to the real value once it is known.
             );
 


### PR DESCRIPTION
Added maxStandardTxSigopsCost ConsensusOptions property to fix #2470 