### PR TITLE
Fixed CanAuthWithCookieFile for non-Windows environments

### DIFF
--- a/src/Stratis.Bitcoin.IntegrationTests/RPC/RpcBitcoinMutableTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/RPC/RpcBitcoinMutableTests.cs
@@ -375,8 +375,11 @@ namespace Stratis.Bitcoin.IntegrationTests.RPC
                 node.Restart();
                 rpcClient = node.CreateRPCClient();
                 rpcClient.GetBlockCount();
-                Assert.Throws<ArgumentException>(() => new RPCClient("cookiefile=Data\\invalid.cookie", new Uri("http://localhost/"), this.regTest));
-                Assert.Throws<FileNotFoundException>(() => new RPCClient("cookiefile=Data\\not_found.cookie", new Uri("http://localhost/"), this.regTest));
+
+                string invalidCookiePath = Path.Combine("Data","invalid.cookie");
+                string notFoundCookiePath = Path.Combine("Data", "not_found.cookie");
+                Assert.Throws<ArgumentException>(() => new RPCClient($"cookiefile={invalidCookiePath}", new Uri("http://localhost/"), this.regTest));
+                Assert.Throws<FileNotFoundException>(() => new RPCClient($"cookiefile={notFoundCookiePath}", new Uri("http://localhost/"), this.regTest));
 
                 rpcClient = new RPCClient("bla:bla", null as Uri, this.regTest);
                 Assert.Equal("http://127.0.0.1:" + this.regTest.RPCPort + "/", rpcClient.Address.AbsoluteUri);


### PR DESCRIPTION
Quite self-explanatory but in a nutshell, to be truly cross platform, we need to use Path.Combine when creating paths.