### PR TITLE
Changed wallet logs to include immature coins in balance

### DIFF
--- a/src/Stratis.Bitcoin.Features.Wallet/WalletFeature.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/WalletFeature.cs
@@ -131,8 +131,13 @@ namespace Stratis.Bitcoin.Features.Wallet
 
                 foreach (string walletName in walletNames)
                 {
-                    IEnumerable<UnspentOutputReference> items = this.walletManager.GetSpendableTransactionsInWallet(walletName, 1);
-                    log.AppendLine("Wallet: " + (walletName + ",").PadRight(LoggingConfiguration.ColumnLength) + " Confirmed balance: " + new Money(items.Sum(s => s.Transaction.Amount)).ToString());
+                    foreach (HdAccount account in this.walletManager.GetAccounts(walletName))
+                    {
+                        AccountBalance accountBalance = this.walletManager.GetBalances(walletName, account.Name).Single();
+                        log.AppendLine("Wallet: " + (walletName + ",").PadRight(LoggingConfiguration.ColumnLength) 
+                                                  + (" Confirmed balance: " + accountBalance.AmountConfirmed.ToString()).PadRight(LoggingConfiguration.ColumnLength + 20)
+                                                  + " Unconfirmed balance: " + accountBalance.AmountUnconfirmed.ToString());
+                    }
                 }
             }
         }


### PR DESCRIPTION
Previously, this log would show coins that are spendable only but then immature coins wouldn't be included.
since it's supposed to show the balance of confirmed coins, immature coins should also included.
I've also added the unconfirmed balances.

It looks like this now:
![image](https://user-images.githubusercontent.com/1867877/47308810-9b766c00-d62a-11e8-8886-79a05aaa7f04.png)
