### PR TITLE
Remove the callback when a downloaded block headers is not found

### DIFF
--- a/src/Stratis.Bitcoin/Consensus/ConsensusManager.cs
+++ b/src/Stratis.Bitcoin/Consensus/ConsensusManager.cs
@@ -953,8 +953,7 @@ namespace Stratis.Bitcoin.Consensus
                     {
                         lock (this.blockRequestedLock)
                         {
-                            if (this.callbacksByBlocksRequestedHash.TryGetValue(blockHash, out List<OnBlockDownloadedCallback> _))
-                                this.callbacksByBlocksRequestedHash.Remove(blockHash);
+                            this.callbacksByBlocksRequestedHash.Remove(blockHash);
                         }
 
                         this.logger.LogTrace("(-)[CHAINED_HEADER_NOT_FOUND]");

--- a/src/Stratis.Bitcoin/Consensus/ConsensusManager.cs
+++ b/src/Stratis.Bitcoin/Consensus/ConsensusManager.cs
@@ -951,6 +951,12 @@ namespace Stratis.Bitcoin.Consensus
 
                     if (chainedHeader == null)
                     {
+                        lock (this.blockRequestedLock)
+                        {
+                            if (this.callbacksByBlocksRequestedHash.TryGetValue(blockHash, out List<OnBlockDownloadedCallback> _))
+                                this.callbacksByBlocksRequestedHash.Remove(blockHash);
+                        }
+
                         this.logger.LogTrace("(-)[CHAINED_HEADER_NOT_FOUND]");
                         return;
                     }


### PR DESCRIPTION
This should resolve #2580 