### PR TITLE
[Integration Tests] Remove defaulted DateTimeProvider override for Pos Runners

### DIFF
--- a/src/Stratis.Bitcoin.IntegrationTests.Common/EnvironmentMockUpHelpers/CoreNode.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests.Common/EnvironmentMockUpHelpers/CoreNode.cs
@@ -10,7 +10,6 @@ using Moq;
 using NBitcoin;
 using NBitcoin.DataEncoders;
 using NBitcoin.Protocol;
-using Stratis.Bitcoin.Base;
 using Stratis.Bitcoin.Configuration;
 using Stratis.Bitcoin.Configuration.Logging;
 using Stratis.Bitcoin.Configuration.Settings;
@@ -60,6 +59,7 @@ namespace Stratis.Bitcoin.IntegrationTests.Common.EnvironmentMockUpHelpers
         private Func<ChainedHeaderBlock, bool> builderInterceptor;
         private bool builderNotInIBD;
         private bool builderNoValidation;
+        private bool builderOverrideDateTimeProvider;
         private bool builderWithDummyWallet;
         private bool builderWithWallet;
         private string builderWalletName;
@@ -125,6 +125,23 @@ namespace Stratis.Bitcoin.IntegrationTests.Common.EnvironmentMockUpHelpers
             return this;
         }
 
+        /// <summary>
+        /// Overrides the node's date time provider with one where the current date time starts 2018-01-01.
+        /// <para>
+        /// This is primarily used where we want to mine coins in the past used for staking.
+        /// </para>
+        /// </summary>
+        /// <returns>This node.</returns>
+        public CoreNode OverrideDateTimeProvider()
+        {
+            this.builderOverrideDateTimeProvider = true;
+            return this;
+        }
+
+        /// <summary>
+        /// This does not create a physical wallet but only sets the miner secret on the node.
+        /// </summary>
+        /// <returns>This node.</returns>
         public CoreNode WithDummyWallet()
         {
             this.builderWithDummyWallet = true;
@@ -179,6 +196,8 @@ namespace Stratis.Bitcoin.IntegrationTests.Common.EnvironmentMockUpHelpers
         {
             lock (this.lockObject)
             {
+                this.runner.OverrideDateTimeProvider = this.builderOverrideDateTimeProvider;
+
                 if (this.builderInterceptor != null)
                     this.runner.Interceptor = this.builderInterceptor;
 

--- a/src/Stratis.Bitcoin.IntegrationTests.Common/EnvironmentMockUpHelpers/InitialBlockDownloadStateMock.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests.Common/EnvironmentMockUpHelpers/InitialBlockDownloadStateMock.cs
@@ -3,7 +3,6 @@ using NBitcoin;
 using Stratis.Bitcoin.Base;
 using Stratis.Bitcoin.Configuration.Settings;
 using Stratis.Bitcoin.Consensus;
-using Stratis.Bitcoin.Features.Consensus;
 using Stratis.Bitcoin.Interfaces;
 using Stratis.Bitcoin.Utilities;
 

--- a/src/Stratis.Bitcoin.IntegrationTests.Common/Extensions/FullNodeTestBuilderExtension.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests.Common/Extensions/FullNodeTestBuilderExtension.cs
@@ -14,7 +14,7 @@ namespace Stratis.Bitcoin.IntegrationTests.Common
         /// Substitute the <see cref="IDateTimeProvider"/> for a given feature.
         /// </summary>
         /// <typeparam name="T">The feature to substitute the provider for.</typeparam>
-        public static IFullNodeBuilder SubstituteDateTimeProviderFor<T>(this IFullNodeBuilder fullNodeBuilder)
+        public static IFullNodeBuilder OverrideDateTimeProviderFor<T>(this IFullNodeBuilder fullNodeBuilder)
         {
             fullNodeBuilder.ConfigureFeature(features =>
             {

--- a/src/Stratis.Bitcoin.IntegrationTests.Common/Runners/NodeRunner.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests.Common/Runners/NodeRunner.cs
@@ -19,6 +19,7 @@ namespace Stratis.Bitcoin.IntegrationTests.Common.Runners
         public FullNode FullNode { get; set; }
         public Func<ChainedHeaderBlock, bool> Interceptor { get; internal set; }
         public Network Network { set; get; }
+        public bool OverrideDateTimeProvider { get; internal set; }
 
         protected NodeRunner(string dataDir)
         {

--- a/src/Stratis.Bitcoin.IntegrationTests.Common/Runners/StratisBitcoinPosRunner.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests.Common/Runners/StratisBitcoinPosRunner.cs
@@ -33,8 +33,10 @@ namespace Stratis.Bitcoin.IntegrationTests.Common.Runners
                 .AddPowPosMining()
                 .AddRPC()
                 .UseApi()
-                .MockIBD()
-                .SubstituteDateTimeProviderFor<MiningFeature>();
+                .MockIBD();
+
+            if (this.OverrideDateTimeProvider)
+                builder.OverrideDateTimeProviderFor<MiningFeature>();
 
             if (this.Interceptor != null)
                 builder = builder.InterceptBlockDisconnected(this.Interceptor);

--- a/src/Stratis.Bitcoin.IntegrationTests.Common/Runners/StratisSmartContractPosNode.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests.Common/Runners/StratisSmartContractPosNode.cs
@@ -35,7 +35,7 @@ namespace Stratis.Bitcoin.IntegrationTests.Common.Runners
                 .UseSmartContractPosPowMining()
                 .UseReflectionExecutor()
                 .MockIBD()
-                .SubstituteDateTimeProviderFor<MiningFeature>()
+                .OverrideDateTimeProviderFor<MiningFeature>()
                 .Build();
         }
 

--- a/src/Stratis.Bitcoin.IntegrationTests/ConsensusManagerInterceptorTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/ConsensusManagerInterceptorTests.cs
@@ -17,9 +17,9 @@ namespace Stratis.Bitcoin.IntegrationTests
         {
             using (var builder = NodeBuilder.Create(this))
             {
-                var minerA = builder.CreateStratisPosNode(new StratisRegTest()).NotInIBD().OverrideDateTimeProvider().WithWallet();
-                var minerB = builder.CreateStratisPosNode(new StratisRegTest()).NotInIBD().OverrideDateTimeProvider().NoValidation().WithWallet();
-                var minerC = builder.CreateStratisPosNode(new StratisRegTest()).NotInIBD().OverrideDateTimeProvider().WithWallet();
+                var minerA = builder.CreateStratisPosNode(new StratisRegTest()).NotInIBD().OverrideDateTimeProvider().WithDummyWallet();
+                var minerB = builder.CreateStratisPosNode(new StratisRegTest()).NotInIBD().OverrideDateTimeProvider().NoValidation().WithDummyWallet();
+                var minerC = builder.CreateStratisPosNode(new StratisRegTest()).NotInIBD().OverrideDateTimeProvider().WithDummyWallet();
 
                 // Configure the interceptor to disconnect a node after a certain block has been disconnected (rewound).
                 bool interceptor(ChainedHeaderBlock chainedHeaderBlock)

--- a/src/Stratis.Bitcoin.IntegrationTests/ConsensusManagerInterceptorTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/ConsensusManagerInterceptorTests.cs
@@ -17,9 +17,9 @@ namespace Stratis.Bitcoin.IntegrationTests
         {
             using (var builder = NodeBuilder.Create(this))
             {
-                var minerA = builder.CreateStratisPosNode(new StratisRegTest()).NotInIBD().WithWallet();
-                var minerB = builder.CreateStratisPosNode(new StratisRegTest()).NotInIBD().NoValidation().WithWallet();
-                var minerC = builder.CreateStratisPosNode(new StratisRegTest()).NotInIBD().WithWallet();
+                var minerA = builder.CreateStratisPosNode(new StratisRegTest()).NotInIBD().OverrideDateTimeProvider().WithWallet();
+                var minerB = builder.CreateStratisPosNode(new StratisRegTest()).NotInIBD().OverrideDateTimeProvider().NoValidation().WithWallet();
+                var minerC = builder.CreateStratisPosNode(new StratisRegTest()).NotInIBD().OverrideDateTimeProvider().WithWallet();
 
                 // Configure the interceptor to disconnect a node after a certain block has been disconnected (rewound).
                 bool interceptor(ChainedHeaderBlock chainedHeaderBlock)

--- a/src/Stratis.Bitcoin.IntegrationTests/ConsensusManagerTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/ConsensusManagerTests.cs
@@ -107,8 +107,8 @@ namespace Stratis.Bitcoin.IntegrationTests
         {
             using (NodeBuilder builder = NodeBuilder.Create(this))
             {
-                var minerA = builder.CreateStratisPosNode(this.posNetwork).NotInIBD().WithWallet().Start();
-                var minerB = builder.CreateStratisPosNode(this.posNetwork).NotInIBD().WithWallet().Start();
+                var minerA = builder.CreateStratisPosNode(this.posNetwork).NotInIBD().WithDummyWallet().Start();
+                var minerB = builder.CreateStratisPosNode(this.posNetwork).NotInIBD().WithDummyWallet().Start();
                 var syncer = builder.CreateStratisPosNode(this.posNetwork).NotInIBD().Start();
 
                 // MinerA mines to height 10.
@@ -155,9 +155,10 @@ namespace Stratis.Bitcoin.IntegrationTests
             {
                 var network = new StratisConsensusOptionsOverrideTest();
 
-                var minerA = builder.CreateStratisPosNode(network).NotInIBD().WithWallet().Start();
-                var minerB = builder.CreateStratisPosNode(network).NotInIBD().Start();
-                var syncer = builder.CreateStratisPosNode(network).NotInIBD().Start();
+                // MinerA requires an physical wallet to stake with.
+                var minerA = builder.CreateStratisPosNode(network).NotInIBD().OverrideDateTimeProvider().WithWallet().Start();
+                var minerB = builder.CreateStratisPosNode(network).NotInIBD().OverrideDateTimeProvider().Start();
+                var syncer = builder.CreateStratisPosNode(network).NotInIBD().OverrideDateTimeProvider().Start();
 
                 // MinerA mines to height 55.
                 TestHelper.MineBlocks(minerA, 55);
@@ -215,8 +216,8 @@ namespace Stratis.Bitcoin.IntegrationTests
             {
                 var network = new StratisMaxReorgOverrideTest();
 
-                var minerA = builder.CreateStratisPosNode(network).NotInIBD().WithWallet().Start();
-                var minerB = builder.CreateStratisPosNode(network).NotInIBD().WithWallet().Start();
+                var minerA = builder.CreateStratisPosNode(network).NotInIBD().WithDummyWallet().Start();
+                var minerB = builder.CreateStratisPosNode(network).NotInIBD().WithDummyWallet().Start();
                 var syncer = builder.CreateStratisPosNode(network).NotInIBD().Start();
 
                 // MinerA mines to height 20.
@@ -262,8 +263,8 @@ namespace Stratis.Bitcoin.IntegrationTests
         {
             using (NodeBuilder builder = NodeBuilder.Create(this))
             {
-                var minerA = builder.CreateStratisPowNode(this.powNetwork).NotInIBD().WithWallet().Start();
-                var minerB = builder.CreateStratisPowNode(this.powNetwork).NotInIBD().WithWallet().Start();
+                var minerA = builder.CreateStratisPowNode(this.powNetwork).NotInIBD().WithDummyWallet().Start();
+                var minerB = builder.CreateStratisPowNode(this.powNetwork).NotInIBD().WithDummyWallet().Start();
                 var syncer = builder.CreateStratisPowNode(this.powNetwork).NotInIBD().Start();
 
                 // MinerA mines to height 10.
@@ -310,8 +311,8 @@ namespace Stratis.Bitcoin.IntegrationTests
             {
                 var syncerNetwork = new StratisOverrideRegTest();
 
-                var minerA = builder.CreateStratisPosNode(this.posNetwork).NotInIBD().WithWallet().Start();
-                var minerB = builder.CreateStratisPosNode(this.posNetwork).NotInIBD().WithWallet().Start();
+                var minerA = builder.CreateStratisPosNode(this.posNetwork).NotInIBD().WithDummyWallet().Start();
+                var minerB = builder.CreateStratisPosNode(this.posNetwork).NotInIBD().WithDummyWallet().Start();
                 var syncer = builder.CreateStratisPosNode(syncerNetwork).NotInIBD().Start();
 
                 // MinerA mines to height 10.
@@ -360,8 +361,8 @@ namespace Stratis.Bitcoin.IntegrationTests
             {
                 var syncerNetwork = new BitcoinOverrideRegTest();
 
-                var minerA = builder.CreateStratisPowNode(this.powNetwork).NotInIBD().WithWallet().Start();
-                var minerB = builder.CreateStratisPowNode(this.powNetwork).NotInIBD().WithWallet().Start();
+                var minerA = builder.CreateStratisPowNode(this.powNetwork).NotInIBD().WithDummyWallet().Start();
+                var minerB = builder.CreateStratisPowNode(this.powNetwork).NotInIBD().WithDummyWallet().Start();
                 var syncer = builder.CreateStratisPowNode(syncerNetwork).NotInIBD().Start();
 
                 // MinerA mines to height 10.
@@ -406,7 +407,7 @@ namespace Stratis.Bitcoin.IntegrationTests
             {
                 var syncerNetwork = new StratisOverrideRegTest();
 
-                var minerA = builder.CreateStratisPosNode(this.posNetwork).NotInIBD().WithWallet().Start();
+                var minerA = builder.CreateStratisPosNode(this.posNetwork).NotInIBD().WithDummyWallet().Start();
                 var syncer = builder.CreateStratisPosNode(syncerNetwork).NotInIBD().Start();
 
                 // Miner A mines to height 11.

--- a/src/Stratis.Bitcoin.IntegrationTests/NodeSyncTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/NodeSyncTests.cs
@@ -218,10 +218,10 @@ namespace Stratis.Bitcoin.IntegrationTests
                 var stratisRegTest = new StratisRegTest();
 
                 // This represents local node.
-                CoreNode stratisMinerLocal = builder.CreateStratisPosNode(stratisRegTest).NotInIBD().WithDummyWallet().Start();
+                CoreNode stratisMinerLocal = builder.CreateStratisPosNode(stratisRegTest).NotInIBD().OverrideDateTimeProvider().WithDummyWallet().Start();
 
                 // This represents remote, which blocks are received by local node using its puller.
-                CoreNode stratisMinerRemote = builder.CreateStratisPosNode(stratisRegTest).NotInIBD().WithDummyWallet().Start();
+                CoreNode stratisMinerRemote = builder.CreateStratisPosNode(stratisRegTest).NotInIBD().OverrideDateTimeProvider().WithDummyWallet().Start();
 
                 // Let's mine block Ap and Bp.
                 TestHelper.MineBlocks(stratisMinerRemote, 2);

--- a/src/Stratis.Bitcoin.IntegrationTests/ProofOfStakeSteps.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/ProofOfStakeSteps.cs
@@ -68,7 +68,7 @@ namespace Stratis.Bitcoin.IntegrationTests
                 .AddPowPosMining()
                 .AddRPC()
                 .MockIBD()
-                .SubstituteDateTimeProviderFor<MiningFeature>());
+                .OverrideDateTimeProviderFor<MiningFeature>());
 
             this.PremineNodeWithCoins = this.nodeBuilder.CreateCustomNode(callback, new StratisRegTest(), ProtocolVersion.PROTOCOL_VERSION, configParameters: configParameters);
             this.PremineNodeWithCoins.NotInIBD().WithWallet().Start();

--- a/src/XUnitRetry/DelayedMessageBus.cs
+++ b/src/XUnitRetry/DelayedMessageBus.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Diagnostics;
 using Xunit.Abstractions;
 using Xunit.Sdk;
 
@@ -18,10 +19,11 @@ namespace Xunit
             this.innerBus = innerBus;
         }
 
+        [DebuggerStepThrough]
         public bool QueueMessage(IMessageSinkMessage message)
         {
-            lock (messages)
-                messages.Add(message);
+            lock (this.messages)
+                this.messages.Add(message);
 
             // No way to ask the inner bus if they want to cancel without sending them the message, so
             // we just go ahead and continue always.
@@ -30,8 +32,8 @@ namespace Xunit
 
         public void Dispose()
         {
-            foreach (var message in messages)
-                innerBus.QueueMessage(message);
+            foreach (IMessageSinkMessage message in this.messages)
+                this.innerBus.QueueMessage(message);
         }
     }
 }


### PR DESCRIPTION
We only really need to override the default DTP with integration tests where coins are staked. On occasion with the reorg tests the internal time of `GenerateCoinsFastDateTimeProvider` gets too far into the future and block creation fails for other tests as the transaction's time isn't valid anymore. 

This is because `GenerateCoinsFastDateTimeProvider` is subbed to `BlockConnected`, so every time a block is reconnected from a reorg, the DTP's internal clock also advances, which is incorrect.