### PR TITLE
Node is failing to synchronise after a reorg fix

### DIFF
--- a/src/Stratis.Bitcoin/Consensus/ConsensusManager.cs
+++ b/src/Stratis.Bitcoin/Consensus/ConsensusManager.cs
@@ -543,6 +543,17 @@ namespace Stratis.Bitcoin.Consensus
 
             if (connectBlockResult.Succeeded)
             {
+                // Mark disconnected blocks as not available.
+                // This is needed in case of large reorgs when we disconnect more than CHT.KeepBlockDataForLastBlocks blocks.
+                // In case we disconnect more than that we would expect some of disconnected blocks to be in memory and some in store,
+                // but those that are in store are reorged.
+                // Removing block data will result in redownloading blocks next time node would like to reconnect this chain.
+                foreach (ChainedHeaderBlock disconnectedBlock in disconnectedBlocks)
+                {
+                    disconnectedBlock.ChainedHeader.Block = null;
+                    disconnectedBlock.ChainedHeader.BlockDataAvailability = BlockDataAvailabilityState.HeaderOnly;
+                }
+
                 this.logger.LogTrace("(-)[SUCCEEDED]:'{0}'", connectBlockResult);
                 return connectBlockResult;
             }


### PR DESCRIPTION
Related to #2595

I think the bug appears under following scenario:
We connect chain A because it's better.
We advance some blocks on A and remove block data from CHT that is > 100 blocks behind. Block availability for those is still BlockAvailable because it's in block store.

We rewind more than 100 blocks and and connect chain B. But we still think that blocks from chain A are available in memory or store.
Now A is better again.
We try to connect it but we don't find blocks because we have them marked as available but they are reorged away from BS.

ps
I'm not 100% if this is the right fix, we need to test this PR on internal network. 