### PR TITLE
Tests for consensusmanager (#1937)

### DIFF
--- a/src/Stratis.Bitcoin.Tests/Consensus/ConsensusManagerTests.cs
+++ b/src/Stratis.Bitcoin.Tests/Consensus/ConsensusManagerTests.cs
@@ -606,6 +606,7 @@ namespace Stratis.Bitcoin.Tests.Consensus
                 });
 
             Assert.Throws<Bitcoin.Consensus.ConsensusException>(() => builder.ConsensusManager.BlockMinedAsync(additionalHeaders.Block).GetAwaiter().GetResult());
+            Assert.Equal(builder.InitialChainTip, builder.ConsensusManager.Tip);
         }
 
         [Fact]
@@ -627,6 +628,7 @@ namespace Stratis.Bitcoin.Tests.Consensus
                 });
 
             Assert.Throws<Bitcoin.Consensus.ConsensusException>(() => builder.ConsensusManager.BlockMinedAsync(additionalHeaders.Block).GetAwaiter().GetResult());
+            Assert.Equal(builder.InitialChainTip, builder.ConsensusManager.Tip);
         }
 
         [Fact]
@@ -679,6 +681,7 @@ namespace Stratis.Bitcoin.Tests.Consensus
                 });
 
             Assert.Throws<Bitcoin.Consensus.ConsensusException>(() => builder.ConsensusManager.BlockMinedAsync(additionalHeaders.Block).GetAwaiter().GetResult());
+            Assert.Equal(builder.InitialChainTip, builder.ConsensusManager.Tip);
         }
 
 

--- a/src/Stratis.Bitcoin.Tests/Consensus/ConsensusManagerTests.cs
+++ b/src/Stratis.Bitcoin.Tests/Consensus/ConsensusManagerTests.cs
@@ -1,10 +1,13 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Tasks;
 using Moq;
 using NBitcoin;
+using NBitcoin.Crypto;
 using Stratis.Bitcoin.Consensus.Validators;
 using Stratis.Bitcoin.P2P.Peer;
+using Stratis.Bitcoin.Primitives;
+using Stratis.Bitcoin.Tests.Common;
 using Xunit;
 
 namespace Stratis.Bitcoin.Tests.Consensus
@@ -71,6 +74,7 @@ namespace Stratis.Bitcoin.Tests.Consensus
             Assert.True(builder.ConsensusManager.PeerIsKnown(peer.Object.Connection.Id));
             Assert.Equal(200 * 2, builder.ConsensusManager.GetExpectedBlockDataBytes());
             var blockSize = builder.ConsensusManager.GetExpectedBlockSizes();
+
             // expect only first two blocks.
             var expectedBlocks = headerTree.Take(2).Select(h => h.GetHash()).ToList();
             AssertBlockSizes(blockSize, expectedBlocks, 500);
@@ -95,6 +99,7 @@ namespace Stratis.Bitcoin.Tests.Consensus
             Assert.True(builder.ConsensusManager.PeerIsKnown(peer.Object.Connection.Id));
             Assert.Equal(200 * 5, builder.ConsensusManager.GetExpectedBlockDataBytes());
             var blockSize = builder.ConsensusManager.GetExpectedBlockSizes();
+
             // expect only first five blocks.
             var expectedBlocks = headerTree.Take(5).Select(h => h.GetHash()).ToList();
             AssertBlockSizes(blockSize, expectedBlocks, 200);
@@ -140,7 +145,7 @@ namespace Stratis.Bitcoin.Tests.Consensus
         }
 
         [Fact]
-        public void HeadersPresented_ProcessDownloadedBlock_PartialValidationCalledWhenBlockImmediatelyAfterTip()
+        public void ProcessDownloadedBlock_PartialValidationCalledWhenBlockImmediatelyAfterTip()
         {
             var contextBuilder = new TestContextBuilder().WithInitialChain(10).UseCheckpoints(false);
             TestContext builder = contextBuilder.Build();
@@ -155,12 +160,12 @@ namespace Stratis.Bitcoin.Tests.Consensus
 
             Assert.NotNull(builder.blockPullerBlockDownloadCallback);
             builder.blockPullerBlockDownloadCallback(additionalHeaders.HashBlock, additionalHeaders.Block, peer.Object.Connection.Id);
-            
+
             builder.PartialValidator.Verify(p => p.StartPartialValidation(It.IsAny<ChainedHeader>(), It.IsAny<Block>(), It.IsAny<OnPartialValidationCompletedAsyncCallback>()), Times.Exactly(1));
         }
 
         [Fact]
-        public void HeadersPresented_ProcessDownloadedBlock_PartialValidationNotCalledWhenBlockNotImmediatelyAfterTip()
+        public void ProcessDownloadedBlock_PartialValidationNotCalledWhenBlockNotImmediatelyAfterTip()
         {
             var contextBuilder = new TestContextBuilder().WithInitialChain(10).UseCheckpoints(false);
             TestContext builder = contextBuilder.Build();
@@ -178,6 +183,247 @@ namespace Stratis.Bitcoin.Tests.Consensus
 
             builder.PartialValidator.Verify(p => p.StartPartialValidation(It.IsAny<ChainedHeader>(), It.IsAny<Block>(), It.IsAny<OnPartialValidationCompletedAsyncCallback>()), Times.Exactly(0));
         }
+
+        [Fact]
+        public void BlockDownloaded_CallbackRegisteredForHash_UnknownHeader_BlockNotExpected_ThrowsInvalidOperationException()
+        {
+            var contextBuilder = new TestContextBuilder().WithInitialChain(10).UseCheckpoints(false);
+            TestContext builder = contextBuilder.Build();
+
+            builder.ConsensusManager.InitializeAsync(builder.InitialChainTip).GetAwaiter().GetResult();
+
+            var additionalHeaders = builder.ExtendAChain(1, builder.InitialChainTip);
+            var headerTree = builder.ChainedHeaderToList(additionalHeaders, 1);
+            var peer = builder.GetNetworkPeerWithConnection();
+
+            var result = builder.ConsensusManager.HeadersPresented(peer.Object, headerTree, true);
+
+            var callbackCalled = false;
+            var callback = new Bitcoin.Consensus.OnBlockDownloadedCallback(d => { callbackCalled = true; });
+
+            // setup the callback
+            builder.ConsensusManager.SetupCallbackByBlocksRequestedHash(additionalHeaders.HashBlock, callback);
+
+            Assert.NotNull(builder.blockPullerBlockDownloadCallback);
+            // call the blockdownloaded method from the blockpuller with a random header
+            Assert.Throws<InvalidOperationException>(() => builder.blockPullerBlockDownloadCallback(new uint256(29836872365), null, peer.Object.Connection.Id));
+
+            // expect the setup callback is not called.
+            Assert.False(callbackCalled);
+        }
+
+        [Fact]
+        public void BlockDownloaded_CallbackRegisteredForHash_KnownHeader_BlockExpected_CallbackNotRegistered_CallbackNotCalled()
+        {
+            var contextBuilder = new TestContextBuilder().WithInitialChain(10).UseCheckpoints(false);
+            TestContext builder = contextBuilder.Build();
+
+            builder.ConsensusManager.InitializeAsync(builder.InitialChainTip).GetAwaiter().GetResult();
+
+            var additionalHeaders = builder.ExtendAChain(1, builder.InitialChainTip);
+            var headerTree = builder.ChainedHeaderToList(additionalHeaders, 1);
+            var peer = builder.GetNetworkPeerWithConnection();
+
+            var result = builder.ConsensusManager.HeadersPresented(peer.Object, headerTree, true);
+
+            var additionalHeaders2 = builder.ExtendAChain(1, additionalHeaders);
+            builder.ConsensusManager.AddExpectedBlockSize(additionalHeaders2.HashBlock, additionalHeaders2.Block.BlockSize.Value);
+
+            var callbackCalled = false;
+            var callback = new Bitcoin.Consensus.OnBlockDownloadedCallback(d => { callbackCalled = true; });
+
+            // setup the callback
+            builder.ConsensusManager.SetupCallbackByBlocksRequestedHash(additionalHeaders.HashBlock, callback);
+
+            Assert.NotNull(builder.blockPullerBlockDownloadCallback);
+            // call the blockdownloaded method from the blockpuller with a random header
+            builder.blockPullerBlockDownloadCallback(additionalHeaders2.HashBlock, null, peer.Object.Connection.Id);
+
+            // expect the setup callback is not called.
+            Assert.False(callbackCalled);
+        }
+
+        [Fact]
+        public void BlockDownloaded_CallbackRegisteredForHash_KnownHeader_NotBlockExpected_ThrowsInvalidOperationException()
+        {
+            var contextBuilder = new TestContextBuilder().WithInitialChain(10).UseCheckpoints(false);
+            TestContext builder = contextBuilder.Build();
+
+            builder.ConsensusManager.InitializeAsync(builder.InitialChainTip).GetAwaiter().GetResult();
+
+            var additionalHeaders = builder.ExtendAChain(1, builder.InitialChainTip);
+            var headerTree = builder.ChainedHeaderToList(additionalHeaders, 1);
+            var peer = builder.GetNetworkPeerWithConnection();
+
+
+            // todo: either load and clear or not load at all.
+            var result = builder.ConsensusManager.HeadersPresented(peer.Object, headerTree, true);
+            builder.ConsensusManager.ClearExpectedBlockSizes();
+
+            var callbackCalled = false;
+            var callback = new Bitcoin.Consensus.OnBlockDownloadedCallback(d => { callbackCalled = true; });
+
+            // setup the callback
+            builder.ConsensusManager.SetupCallbackByBlocksRequestedHash(additionalHeaders.HashBlock, callback);
+
+            Assert.NotNull(builder.blockPullerBlockDownloadCallback);
+            // call the blockdownloaded method from the blockpuller with a random header
+            Assert.Throws<InvalidOperationException>(() => builder.blockPullerBlockDownloadCallback(additionalHeaders.HashBlock, null, peer.Object.Connection.Id));
+
+            // expect the setup callback is not called.
+            Assert.False(callbackCalled);
+        }
+
+        [Fact]
+        public void BlockDownloaded_CallbackRegisteredForHash_KnownHeader_BlockExpected_CallbackRegistered_CallbackCalled()
+        {
+            var contextBuilder = new TestContextBuilder().WithInitialChain(10).UseCheckpoints(false);
+            TestContext builder = contextBuilder.Build();
+
+            builder.ConsensusManager.InitializeAsync(builder.InitialChainTip).GetAwaiter().GetResult();
+
+            var additionalHeaders = builder.ExtendAChain(1, builder.InitialChainTip);
+            var headerTree = builder.ChainedHeaderToList(additionalHeaders, 1);
+            var peer = builder.GetNetworkPeerWithConnection();
+
+            var result = builder.ConsensusManager.HeadersPresented(peer.Object, headerTree, true);
+
+            var callbackCalled = false;
+            var callback = new Bitcoin.Consensus.OnBlockDownloadedCallback(d => { callbackCalled = true; });
+
+            // setup the callback
+            builder.ConsensusManager.SetupCallbackByBlocksRequestedHash(additionalHeaders.HashBlock, callback);
+
+            Assert.NotNull(builder.blockPullerBlockDownloadCallback);
+            // call the blockdownloaded method from the blockpuller with a random header
+            builder.blockPullerBlockDownloadCallback(additionalHeaders.HashBlock, additionalHeaders.Block, peer.Object.Connection.Id);
+
+            // expect the setup callback is not called.
+            Assert.True(callbackCalled);
+        }
+
+        [Fact]
+        public void BlockDownloaded_KnownHeader_BlockIntegrityInvalidated_BansPeer_DoesNotCallCallback()
+        {
+            var contextBuilder = new TestContextBuilder(KnownNetworks.StratisMain).WithInitialChain(10).UseCheckpoints(false);
+            TestContext builder = contextBuilder.Build();
+
+            builder.ConsensusManager.InitializeAsync(builder.InitialChainTip).GetAwaiter().GetResult();
+
+            var additionalHeaders = builder.ExtendAChain(1, builder.InitialChainTip);
+            var headerTree = builder.ChainedHeaderToList(additionalHeaders, 1);
+            var peer = builder.GetNetworkPeerWithConnection();
+
+            var result = builder.ConsensusManager.HeadersPresented(peer.Object, headerTree, true);
+
+            var callbackCalled = false;
+            var callback = new Bitcoin.Consensus.OnBlockDownloadedCallback(d => { callbackCalled = true; });
+
+            // setup the callback
+            builder.ConsensusManager.SetupCallbackByBlocksRequestedHash(additionalHeaders.HashBlock, callback);
+
+            Assert.NotNull(builder.blockPullerBlockDownloadCallback);
+
+            // setup validation to fail.
+            builder.IntegrityValidator.Setup(i => i.VerifyBlockIntegrity(additionalHeaders, additionalHeaders.Block))
+                .Returns(new Bitcoin.Consensus.ValidationContext()
+                {
+                    BanDurationSeconds = 3000,
+                    Error = Bitcoin.Consensus.ConsensusErrors.BadBlockSignature
+                });
+
+            builder.blockPullerBlockDownloadCallback(additionalHeaders.HashBlock, additionalHeaders.Block, peer.Object.Connection.Id);
+
+            // expect the setup callback is not called.
+            Assert.False(callbackCalled);
+            builder.AssertPeerBanned(peer.Object);
+            builder.AssertExpectedBlockSizesEmpty();
+        }
+
+        [Fact]
+        public void BlockDownloaded_ExpectedBlockDataBytesCalculatedCorrectly()
+        {
+            var contextBuilder = new TestContextBuilder().WithInitialChain(10).UseCheckpoints(false);
+            TestContext builder = contextBuilder.Build();
+
+            builder.ConsensusManager.InitializeAsync(builder.InitialChainTip).GetAwaiter().GetResult();
+
+            builder.SetupAverageBlockSize(100);
+            var additionalHeaders = builder.ExtendAChain(1, builder.InitialChainTip, avgBlockSize: 100);
+            var headerTree = builder.ChainedHeaderToList(additionalHeaders, 1);
+            var peer = builder.GetNetworkPeerWithConnection();
+
+            var result = builder.ConsensusManager.HeadersPresented(peer.Object, headerTree, true);
+
+            Assert.NotNull(builder.blockPullerBlockDownloadCallback);
+
+            builder.ConsensusManager.SetExpectedBlockDataBytes(1000);
+
+            var callback1Called = false;
+            var callback2Called = false;
+            var callback1 = new Bitcoin.Consensus.OnBlockDownloadedCallback(d => { callback1Called = true; });
+            var callback2 = new Bitcoin.Consensus.OnBlockDownloadedCallback(d => { callback2Called = true; });
+
+            builder.ConsensusManager.SetupCallbackByBlocksRequestedHash(additionalHeaders.HashBlock, callback1, callback2);
+
+            builder.blockPullerBlockDownloadCallback(additionalHeaders.HashBlock, additionalHeaders.Block, peer.Object.Connection.Id);
+
+
+            Assert.False(builder.ConsensusManager.CallbacksByBlocksRequestedHashContainsKeyForHash(additionalHeaders.HashBlock));
+            Assert.Equal(900, builder.ConsensusManager.GetExpectedBlockDataBytes());
+            builder.AssertExpectedBlockSizesEmpty();
+            Assert.True(callback1Called);
+            Assert.True(callback2Called);
+        }
+
+        [Fact]
+        public void BlockDownloaded_NullBlock_CallsCallbacks()
+        {
+            var contextBuilder = new TestContextBuilder().WithInitialChain(10).UseCheckpoints(false);
+            TestContext builder = contextBuilder.Build();
+
+            builder.ConsensusManager.InitializeAsync(builder.InitialChainTip).GetAwaiter().GetResult();
+
+            var additionalHeaders = builder.ExtendAChain(2, builder.InitialChainTip);
+            var headerTree = builder.ChainedHeaderToList(additionalHeaders, 2);
+            var peer = builder.GetNetworkPeerWithConnection();
+
+            var result = builder.ConsensusManager.HeadersPresented(peer.Object, headerTree, true);
+
+            Assert.NotNull(builder.blockPullerBlockDownloadCallback);
+
+            builder.ConsensusManager.SetExpectedBlockDataBytes(1000);
+
+            var callback1Called = false;
+            var callback2Called = false;
+            var callback3Called = false;
+            ChainedHeaderBlock calledWith1 = null;
+            ChainedHeaderBlock calledWith2 = null;
+            ChainedHeaderBlock calledWith3 = null;
+            var callback1 = new Bitcoin.Consensus.OnBlockDownloadedCallback(d => { callback1Called = true; calledWith1 = d; });
+            var callback2 = new Bitcoin.Consensus.OnBlockDownloadedCallback(d => { callback2Called = true; calledWith2 = d; });
+            var callback3 = new Bitcoin.Consensus.OnBlockDownloadedCallback(d => { callback3Called = true; calledWith3 = d; });
+
+            builder.ConsensusManager.SetupCallbackByBlocksRequestedHash(additionalHeaders.HashBlock, callback1, callback2);
+            builder.ConsensusManager.SetupCallbackByBlocksRequestedHash(additionalHeaders.Previous.HashBlock, callback3);
+
+            // call for both blocks.
+            builder.blockPullerBlockDownloadCallback(additionalHeaders.Previous.HashBlock, null, peer.Object.Connection.Id);
+            builder.blockPullerBlockDownloadCallback(additionalHeaders.HashBlock, null, peer.Object.Connection.Id);
+
+            Assert.False(builder.ConsensusManager.CallbacksByBlocksRequestedHashContainsKeyForHash(additionalHeaders.HashBlock));
+            Assert.False(builder.ConsensusManager.CallbacksByBlocksRequestedHashContainsKeyForHash(additionalHeaders.Previous.HashBlock));
+
+            builder.AssertExpectedBlockSizesEmpty();
+
+            Assert.True(callback1Called);
+            Assert.True(callback2Called);
+            Assert.True(callback3Called);
+            Assert.Null(calledWith1);
+            Assert.Null(calledWith2);
+            Assert.Null(calledWith3);
+        }
+
 
         private static void AssertBlockSizes(Dictionary<uint256, long> blockSize, List<uint256> expectedBlocks, int expectedSize)
         {

--- a/src/Stratis.Bitcoin.Tests/Consensus/ConsensusManagerTests.cs
+++ b/src/Stratis.Bitcoin.Tests/Consensus/ConsensusManagerTests.cs
@@ -1,24 +1,114 @@
-﻿using System.Threading.Tasks;
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Moq;
 using NBitcoin;
+using Stratis.Bitcoin.P2P.Peer;
 using Xunit;
 
 namespace Stratis.Bitcoin.Tests.Consensus
 {
     public class ConsensusManagerTests
     {
+
+        // https://github.com/stratisproject/StratisBitcoinFullNode/issues/1937
+
         [Fact(Skip = "To be finished")]
         public void BlockMined_PartialValidationOnly_Succeeded_Consensus_TipUpdated()
         {
             TestContext builder = new TestContextBuilder().WithInitialChain(10).BuildOnly();
             ChainedHeader chainTip = builder.InitialChainTip;
 
-            builder.ConsensusRulesEngine.Setup(c => c.GetBlockHashAsync()).Returns(Task.FromResult(chainTip.HashBlock));
+            // builder.ConsensusRulesEngine.Setup(c => c.GetBlockHashAsync()).Returns(Task.FromResult(chainTip.HashBlock));
+            builder.coinView.UpdateTipHash(chainTip.Header.GetHash());
             builder.ConsensusManager.InitializeAsync(chainTip).GetAwaiter().GetResult();
 
             var minedBlock = builder.CreateBlock(chainTip);
             var result = builder.ConsensusManager.BlockMinedAsync(minedBlock).GetAwaiter().GetResult();
-            Assert.NotNull(result);
-            Assert.Equal(minedBlock.GetHash(), builder.ConsensusManager.Tip.HashBlock);
+            Xunit.Assert.NotNull(result);
+            Xunit.Assert.Equal(minedBlock.GetHash(), builder.ConsensusManager.Tip.HashBlock);
+        }
+
+
+        [Fact]
+        public void HeadersPresented_NewHeaders_ProducesExpectedBlocks()
+        {
+            var contextBuilder = new TestContextBuilder().WithInitialChain(10);
+            TestContext builder = contextBuilder.Build();
+
+            builder.SetupAverageBlockSize(200);
+            builder.ChainState.Setup(c => c.BlockStoreTip)
+                .Returns(builder.InitialChainTip);
+            builder.ConsensusManager.InitializeAsync(builder.InitialChainTip).GetAwaiter().GetResult();
+
+            var additionalHeaders = builder.ExtendAChain(10, builder.InitialChainTip);
+            var headerTree = builder.ChainedHeaderToList(additionalHeaders, 10);
+            var peer = builder.GetNetworkPeerWithConnection();
+
+            var result = builder.ConsensusManager.HeadersPresented(peer.Object, headerTree, true);
+
+            Assert.True(builder.ConsensusManager.PeerIsKnown(peer.Object.Connection.Id));
+            Assert.Equal(200 * 10, builder.ConsensusManager.GetExpectedBlockDataBytes());
+            var blockSize = builder.ConsensusManager.GetExpectedBlockSizes();
+            var expectedBlocks = headerTree.Select(h => h.GetHash()).ToList();
+            AssertBlockSizes(blockSize, expectedBlocks, 200);            
+        }
+
+        [Fact(Skip = "test scenario failing. code not doing what is expected.")]
+        public void HeadersPresented_NewHeaders_BlocksMaxUnconsumedBlockssDatBytes_LimitsDownloadedBlocks()
+        {
+            var contextBuilder = new TestContextBuilder().UseCheckpoints(false).WithInitialChain(10);
+            TestContext builder = contextBuilder.Build();
+
+            builder.SetupAverageBlockSize(200);
+            builder.ConsensusManager.SetMaxUnconsumedBlocksDataBytes(1000);
+
+            builder.ChainState.Setup(c => c.BlockStoreTip)
+               .Returns(builder.InitialChainTip);
+            builder.ConsensusManager.InitializeAsync(builder.InitialChainTip).GetAwaiter().GetResult();
+
+            var additionalHeaders = builder.ExtendAChain(3, builder.InitialChainTip, avgBlockSize: 500);
+            var headerTree = builder.ChainedHeaderToList(additionalHeaders, 3);
+            var peer = builder.GetNetworkPeerWithConnection();
+
+            var result = builder.ConsensusManager.HeadersPresented(peer.Object, headerTree, true);
+
+            Assert.True(builder.ConsensusManager.PeerIsKnown(peer.Object.Connection.Id));
+            Assert.Equal(200 * 2, builder.ConsensusManager.GetExpectedBlockDataBytes());
+            var blockSize = builder.ConsensusManager.GetExpectedBlockSizes();
+            // expect only first two blocks.
+            var expectedBlocks = headerTree.Take(2).Select(h => h.GetHash()).ToList();
+            AssertBlockSizes(blockSize, expectedBlocks, 500);
+        }
+
+        [Fact]
+        public void HeadersPresented_DownloadHeaders_ReturnsCorrectHeaderResult()
+        {
+            var contextBuilder = new TestContextBuilder().WithInitialChain(10);
+            TestContext builder = contextBuilder.Build();
+            
+            builder.ChainState.Setup(c => c.BlockStoreTip)
+                .Returns(builder.InitialChainTip);
+            builder.ConsensusManager.InitializeAsync(builder.InitialChainTip).GetAwaiter().GetResult();
+
+            var additionalHeaders = builder.ExtendAChain(10, builder.InitialChainTip);
+            var headerTree = builder.ChainedHeaderToList(additionalHeaders, 10);
+            var peer = builder.GetNetworkPeerWithConnection();
+
+            var result = builder.ConsensusManager.HeadersPresented(peer.Object, headerTree, true);
+            
+            Assert.Equal(headerTree.Last().GetHash(), result.Consumed.Header.GetHash());
+            Assert.Equal(headerTree.First().GetHash(), result.DownloadFrom.Header.GetHash());
+            Assert.Equal(headerTree.Last().GetHash(), result.DownloadTo.Header.GetHash());
+        }
+
+        private static void AssertBlockSizes(Dictionary<uint256, long> blockSize, List<uint256> expectedBlocks, int expectedSize)
+        {            
+            foreach (var hash in expectedBlocks)
+            {
+                // checks it exists and is 200 at the same time.
+                Assert.Equal(expectedSize, blockSize[hash]);
+            }
         }
     }
 }

--- a/src/Stratis.Bitcoin.Tests/Consensus/ConsensusManagerTests.cs
+++ b/src/Stratis.Bitcoin.Tests/Consensus/ConsensusManagerTests.cs
@@ -10,7 +10,6 @@ namespace Stratis.Bitcoin.Tests.Consensus
 {
     public class ConsensusManagerTests
     {
-
         // https://github.com/stratisproject/StratisBitcoinFullNode/issues/1937
 
         [Fact(Skip = "To be finished")]
@@ -37,8 +36,6 @@ namespace Stratis.Bitcoin.Tests.Consensus
             TestContext builder = contextBuilder.Build();
 
             builder.SetupAverageBlockSize(200);
-            builder.ChainState.Setup(c => c.BlockStoreTip)
-                .Returns(builder.InitialChainTip);
             builder.ConsensusManager.InitializeAsync(builder.InitialChainTip).GetAwaiter().GetResult();
 
             var additionalHeaders = builder.ExtendAChain(10, builder.InitialChainTip);
@@ -51,20 +48,17 @@ namespace Stratis.Bitcoin.Tests.Consensus
             Assert.Equal(200 * 10, builder.ConsensusManager.GetExpectedBlockDataBytes());
             var blockSize = builder.ConsensusManager.GetExpectedBlockSizes();
             var expectedBlocks = headerTree.Select(h => h.GetHash()).ToList();
-            AssertBlockSizes(blockSize, expectedBlocks, 200);            
+            AssertBlockSizes(blockSize, expectedBlocks, 200);
         }
 
-        [Fact(Skip = "test scenario failing. code not doing what is expected.")]
-        public void HeadersPresented_NewHeaders_BlocksMaxUnconsumedBlockssDatBytes_LimitsDownloadedBlocks()
+        [Fact(Skip = "Does not work. Needs to been reviewed if possible to fix or test case is incorrect.")]
+        public void HeadersPresented_NewHeaders_BlockSizeTotalHigherThanMaxUnconsumedBlocksDataBytes_UnexpectedlyBiggerBlocksThanAverage_LimitsDownloadedBlocks()
         {
             var contextBuilder = new TestContextBuilder().UseCheckpoints(false).WithInitialChain(10);
             TestContext builder = contextBuilder.Build();
 
             builder.SetupAverageBlockSize(200);
             builder.ConsensusManager.SetMaxUnconsumedBlocksDataBytes(1000);
-
-            builder.ChainState.Setup(c => c.BlockStoreTip)
-               .Returns(builder.InitialChainTip);
             builder.ConsensusManager.InitializeAsync(builder.InitialChainTip).GetAwaiter().GetResult();
 
             var additionalHeaders = builder.ExtendAChain(3, builder.InitialChainTip, avgBlockSize: 500);
@@ -82,13 +76,35 @@ namespace Stratis.Bitcoin.Tests.Consensus
         }
 
         [Fact]
+        public void HeadersPresented_NewHeaders_BlockSizeTotalHigherThanMaxUnconsumedBlocksDataBytes_LimitsDownloadedBlocks()
+        {
+            var contextBuilder = new TestContextBuilder().UseCheckpoints(false).WithInitialChain(10);
+            TestContext builder = contextBuilder.Build();
+
+            builder.SetupAverageBlockSize(200);
+            builder.ConsensusManager.SetMaxUnconsumedBlocksDataBytes(1000);
+            builder.ConsensusManager.InitializeAsync(builder.InitialChainTip).GetAwaiter().GetResult();
+
+            var additionalHeaders = builder.ExtendAChain(10, builder.InitialChainTip, avgBlockSize: 200);
+            var headerTree = builder.ChainedHeaderToList(additionalHeaders, 10);
+            var peer = builder.GetNetworkPeerWithConnection();
+
+            var result = builder.ConsensusManager.HeadersPresented(peer.Object, headerTree, true);
+
+            Assert.True(builder.ConsensusManager.PeerIsKnown(peer.Object.Connection.Id));
+            Assert.Equal(200 * 5, builder.ConsensusManager.GetExpectedBlockDataBytes());
+            var blockSize = builder.ConsensusManager.GetExpectedBlockSizes();
+            // expect only first five blocks.
+            var expectedBlocks = headerTree.Take(5).Select(h => h.GetHash()).ToList();
+            AssertBlockSizes(blockSize, expectedBlocks, 200);
+        }
+
+        [Fact]
         public void HeadersPresented_DownloadHeaders_ReturnsCorrectHeaderResult()
         {
             var contextBuilder = new TestContextBuilder().WithInitialChain(10);
             TestContext builder = contextBuilder.Build();
-            
-            builder.ChainState.Setup(c => c.BlockStoreTip)
-                .Returns(builder.InitialChainTip);
+
             builder.ConsensusManager.InitializeAsync(builder.InitialChainTip).GetAwaiter().GetResult();
 
             var additionalHeaders = builder.ExtendAChain(10, builder.InitialChainTip);
@@ -96,17 +112,37 @@ namespace Stratis.Bitcoin.Tests.Consensus
             var peer = builder.GetNetworkPeerWithConnection();
 
             var result = builder.ConsensusManager.HeadersPresented(peer.Object, headerTree, true);
-            
+
+            Assert.Equal(headerTree.Last().GetHash(), result.Consumed.Header.GetHash());
+            Assert.Equal(headerTree.First().GetHash(), result.DownloadFrom.Header.GetHash());
+            Assert.Equal(headerTree.Last().GetHash(), result.DownloadTo.Header.GetHash());
+        }
+
+        [Fact]
+        public void HeadersPresented_NoTriggerDownload_ReturnsCorrectHeaderResult()
+        {
+            var contextBuilder = new TestContextBuilder().WithInitialChain(10);
+            TestContext builder = contextBuilder.Build();
+
+            builder.ConsensusManager.InitializeAsync(builder.InitialChainTip).GetAwaiter().GetResult();
+
+            var additionalHeaders = builder.ExtendAChain(10, builder.InitialChainTip);
+            var headerTree = builder.ChainedHeaderToList(additionalHeaders, 10);
+            var peer = builder.GetNetworkPeerWithConnection();
+
+            var result = builder.ConsensusManager.HeadersPresented(peer.Object, headerTree, false);
+
+            builder.VerifyNoBlocksAskedToBlockPuller();
             Assert.Equal(headerTree.Last().GetHash(), result.Consumed.Header.GetHash());
             Assert.Equal(headerTree.First().GetHash(), result.DownloadFrom.Header.GetHash());
             Assert.Equal(headerTree.Last().GetHash(), result.DownloadTo.Header.GetHash());
         }
 
         private static void AssertBlockSizes(Dictionary<uint256, long> blockSize, List<uint256> expectedBlocks, int expectedSize)
-        {            
+        {
             foreach (var hash in expectedBlocks)
             {
-                // checks it exists and is 200 at the same time.
+                // checks it exists and is expectedsize at the same time.
                 Assert.Equal(expectedSize, blockSize[hash]);
             }
         }

--- a/src/Stratis.Bitcoin.Tests/Consensus/ConsensusTestContext.cs
+++ b/src/Stratis.Bitcoin.Tests/Consensus/ConsensusTestContext.cs
@@ -1,7 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net.Sockets;
 using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using Moq;
 using NBitcoin;
 using Stratis.Bitcoin.Base;
@@ -12,10 +15,16 @@ using Stratis.Bitcoin.Configuration.Logging;
 using Stratis.Bitcoin.Configuration.Settings;
 using Stratis.Bitcoin.Connection;
 using Stratis.Bitcoin.Consensus;
+using Stratis.Bitcoin.Consensus.Rules;
 using Stratis.Bitcoin.Consensus.Validators;
+using Stratis.Bitcoin.Features.Consensus;
 using Stratis.Bitcoin.Features.Consensus.CoinViews;
 using Stratis.Bitcoin.Features.Consensus.Rules;
+using Stratis.Bitcoin.Features.Consensus.Rules.CommonRules;
 using Stratis.Bitcoin.Interfaces;
+using Stratis.Bitcoin.P2P;
+using Stratis.Bitcoin.P2P.Peer;
+using Stratis.Bitcoin.P2P.Protocol.Payloads;
 using Stratis.Bitcoin.Signals;
 using Stratis.Bitcoin.Tests.Common;
 using Stratis.Bitcoin.Utilities;
@@ -30,12 +39,21 @@ namespace Stratis.Bitcoin.Tests.Consensus
 
         public Network Network = KnownNetworks.RegTest;
 
-        public Mock<IChainState> ChainState = new Mock<IChainState>();
+        // public Mock<IChainState> ChainState = new Mock<IChainState>();
         internal ChainedHeaderTree ChainedHeaderTree;
-        public Mock<ICheckpoints> Checkpoints = new Mock<ICheckpoints>();
-        public ConsensusSettings ConsensusSettings = new ConsensusSettings(new NodeSettings(KnownNetworks.RegTest));
-        public IConsensusManager ConsensusManager;
-        public readonly Mock<IConsensusRuleEngine> ConsensusRulesEngine = new Mock<IConsensusRuleEngine>();
+
+        // private Mock<IFinalizedBlockInfo> finalizedBlockInfo;
+        // private Mock<INodeStats> nodeStats;
+        private INodeStats nodeStats;
+        private Mock<IInitialBlockDownloadState> ibd;
+        private Mock<IBlockPuller> blockPuller;
+        private Mock<IBlockStore> blockStore;
+        // public Mock<ICheckpoints> Checkpoints = new Mock<ICheckpoints>();
+        // private ICheckpoints checkpoints;
+        private Mock<ICheckpoints> checkpoints = new Mock<ICheckpoints>();
+
+        public TestConsensusManager ConsensusManager;
+        // public readonly Mock<IConsensusRuleEngine> ConsensusRulesEngine = new Mock<IConsensusRuleEngine>();
         public Mock<IFinalizedBlockInfoRepository> FinalizedBlockMock = new Mock<IFinalizedBlockInfoRepository>();
 
         public readonly Mock<IInitialBlockDownloadState> ibdState = new Mock<IInitialBlockDownloadState>();
@@ -43,37 +61,147 @@ namespace Stratis.Bitcoin.Tests.Consensus
         public Mock<IIntegrityValidator> IntegrityValidator = new Mock<IIntegrityValidator>();
         public readonly IPartialValidator PartialValidation;
         public readonly IFullValidator FullValidation;
-        public readonly Mock<IPeerBanning> PeerBanning = new Mock<IPeerBanning>();
+        // public readonly Mock<IPeerBanning> PeerBanning = new Mock<IPeerBanning>();
+        private IPeerBanning peerBanning;
+        private IConnectionManager connectionManager;
 
         private static int nonceValue;
-        public Mock<ISignals> Signals = new Mock<ISignals>();
+
+        // public Mock<ISignals> Signals = new Mock<ISignals>();
+        private ConcurrentChain chain;
+        // private ExtendedLoggerFactory extendedLoggerFactory;
+        private DateTimeProvider dateTimeProvider;
+        private InvalidBlockHashStore hashStore;
+        private NodeSettings nodeSettings;
+        private ILoggerFactory loggerFactory;
+        private IRuleRegistration ruleRegistration;
+
+        // todo: merge
+        public ConsensusSettings ConsensusSettings = new ConsensusSettings(new NodeSettings(KnownNetworks.RegTest));
+        private ConsensusSettings consensusSettings;
+        private INetworkPeerFactory networkPeerFactory;
+        public Mock<IChainState> ChainState;
+
+        private readonly IConsensusRuleEngine consensusRules;
+        public readonly TestInMemoryCoinView coinView;
+        // private readonly IConsensusRuleEngine powConsensusRulesEngine;
+        private NodeDeployments deployments;
+        private ISelfEndpointTracker selfEndpointTracker;
+        private INodeLifetime nodeLifetime;
 
         public TestContext()
         {
-            var chain = new ConcurrentChain(this.Network);
-            var extendedLoggerFactory = new ExtendedLoggerFactory();
-            var dateTimeProvider = new DateTimeProvider();
-            var hashStore = new InvalidBlockHashStore(dateTimeProvider);
-            var powConsensusRulesEngine = new PowConsensusRuleEngine(this.Network, extendedLoggerFactory, dateTimeProvider, chain,
-                new NodeDeployments(this.Network, chain), this.ConsensusSettings, this.Checkpoints.Object, new Mock<ICoinView>().Object,
-                this.ChainState.Object, hashStore, new NodeStats(dateTimeProvider));
+            this.chain = new ConcurrentChain(this.Network);
+            // this.extendedLoggerFactory = new ExtendedLoggerFactory();
+            this.dateTimeProvider = new DateTimeProvider();
+            this.hashStore = new InvalidBlockHashStore(this.dateTimeProvider);
 
-            this.PartialValidation = new PartialValidator(powConsensusRulesEngine, extendedLoggerFactory);
-            this.FullValidation = new FullValidator(powConsensusRulesEngine, extendedLoggerFactory);
+            // todo:merge
+            //  new Mock<ICoinView>().Object
+            this.coinView = new TestInMemoryCoinView(this.chain.Tip.HashBlock);
             this.HeaderValidator = new Mock<IHeaderValidator>();
             this.HeaderValidator.Setup(hv => hv.ValidateHeader(It.IsAny<ChainedHeader>())).Returns(new ValidationContext());
+            
+            this.nodeLifetime = new NodeLifetime();            
+            // this.nodeStats = new Mock<INodeStats>();
+            this.ibd = new Mock<IInitialBlockDownloadState>();
+            this.blockPuller = new Mock<IBlockPuller>();
+            this.blockStore = new Mock<IBlockStore>();
+            // this.checkpoints = new Checkpoints();
+            this.checkpoints = new Mock<ICheckpoints>();
+            // this.chainState = new ChainState();
+            this.ChainState = new Mock<IChainState>();
+            this.nodeStats = new NodeStats(this.dateTimeProvider);
 
+
+            string[] param = new string[] { };
+            this.nodeSettings = new NodeSettings(this.Network, args: param);
+
+
+            // if (loggerFactory == null)
+            this.loggerFactory = this.nodeSettings.LoggerFactory;
+            // if (dateTimeProvider == null)
+            //     dateTimeProvider = DateTimeProvider.Default;
+
+            this.selfEndpointTracker = new SelfEndpointTracker(this.loggerFactory);
             this.ChainedHeaderTree = new ChainedHeaderTree(
-                this.Network,
-                extendedLoggerFactory,
-                this.HeaderValidator.Object,
-                this.Checkpoints.Object,
-                this.ChainState.Object,
-                this.FinalizedBlockMock.Object,
-                this.ConsensusSettings,
-                hashStore);
+              this.Network,
+              this.loggerFactory,
+              this.HeaderValidator.Object,
+              // this.Checkpoints.Object,
+              this.checkpoints.Object,
+              // this.ChainState.Object,
+              this.ChainState.Object,
+              this.FinalizedBlockMock.Object,
+              this.ConsensusSettings,
+              this.hashStore);
 
-            this.ConsensusManager = CreateConsensusManager();
+            this.Network.Consensus.Options = new ConsensusOptions();
+
+            this.ruleRegistration = new FullNodeBuilderConsensusExtension.PowConsensusRulesRegistration();
+            this.ruleRegistration.RegisterRules(this.Network.Consensus);
+
+            // Dont check PoW of a header in this test.
+            this.Network.Consensus.HeaderValidationRules.RemoveAll(x => x.GetType() == typeof(CheckDifficultyPowRule));
+
+            this.consensusSettings = new ConsensusSettings(this.nodeSettings);
+
+            // if (chain == null)
+            //     chain = new ConcurrentChain(network);
+
+            // inMemoryCoinView = new InMemoryCoinView(chain.Tip.HashBlock);
+
+            this.networkPeerFactory = new NetworkPeerFactory(this.Network,
+                this.dateTimeProvider,
+                this.loggerFactory, new PayloadProvider().DiscoverPayloads(),
+                this.selfEndpointTracker,
+                this.ibd.Object,
+                new ConnectionManagerSettings());
+
+            var peerAddressManager = new PeerAddressManager(DateTimeProvider.Default, this.nodeSettings.DataFolder, this.loggerFactory, this.selfEndpointTracker);
+            var peerDiscovery = new PeerDiscovery(new AsyncLoopFactory(this.loggerFactory), this.loggerFactory, this.Network, this.networkPeerFactory, this.nodeLifetime, this.nodeSettings, peerAddressManager);
+            var connectionSettings = new ConnectionManagerSettings(this.nodeSettings);            
+            
+            this.connectionManager = new ConnectionManager(this.dateTimeProvider, this.loggerFactory, this.Network, this.networkPeerFactory, this.nodeSettings,
+                this.nodeLifetime, new NetworkPeerConnectionParameters(), peerAddressManager, new IPeerConnector[] { },
+                peerDiscovery, this.selfEndpointTracker, connectionSettings, new VersionProvider(), this.nodeStats);
+
+
+            // this.chainState = new ChainState();
+
+
+            // todo: merge
+
+            this.deployments = new NodeDeployments(this.Network, this.chain);
+
+            // this.powConsensusRulesEngine = new PowConsensusRuleEngine(this.Network, this.extendedLoggerFactory, this.dateTimeProvider, this.chain,
+            //     new NodeDeployments(this.Network, this.chain), this.ConsensusSettings, this.Checkpoints.Object, this.coinView,
+            //     this.ChainState.Object, this.hashStore, new NodeStats(this.dateTimeProvider));
+
+            this.consensusRules = new PowConsensusRuleEngine(this.Network, this.loggerFactory, this.dateTimeProvider, this.chain, this.deployments, this.ConsensusSettings,
+                     this.checkpoints.Object, this.coinView, this.ChainState.Object, this.hashStore, this.nodeStats);
+
+            this.consensusRules.Register();
+            // this.powConsensusRulesEngine.Register();
+
+            // new HeaderValidator(this.consensusRules, this.loggerFactory)
+            var tree = new ChainedHeaderTree(this.Network, this.loggerFactory, this.HeaderValidator.Object , this.checkpoints.Object,
+                this.ChainState.Object, this.FinalizedBlockMock.Object, this.consensusSettings, this.hashStore);
+
+
+            // new PartialValidator(powConsensusRulesEngine, loggerFactory)
+            // new FullValidator(powConsensusRulesEngine, loggerFactory)
+
+
+            this.PartialValidation = new PartialValidator(this.consensusRules, this.loggerFactory);
+            this.FullValidation = new FullValidator(this.consensusRules, this.loggerFactory);
+            this.peerBanning = new PeerBanning(this.connectionManager, this.loggerFactory, this.dateTimeProvider, peerAddressManager);
+
+            this.ConsensusManager = new TestConsensusManager(tree, this.Network, this.loggerFactory, this.ChainState.Object, new IntegrityValidator(this.consensusRules, this.loggerFactory),
+                this.PartialValidation, this.FullValidation, this.consensusRules,
+                this.FinalizedBlockMock.Object, new Stratis.Bitcoin.Signals.Signals(), this.peerBanning, this.ibd.Object, this.chain,
+                this.blockPuller.Object, this.blockStore.Object, this.connectionManager, this.nodeStats, this.nodeLifetime);
+
         }
 
         public Block CreateBlock(ChainedHeader previous)
@@ -91,12 +219,11 @@ namespace Stratis.Bitcoin.Tests.Consensus
             return block;
         }
 
-        private IConsensusManager CreateConsensusManager()
-        {
-            this.ConsensusManager = ConsensusManagerHelper.CreateConsensusManager(this.Network);
-
-            return this.ConsensusManager;
-        }
+        // private IConsensusManager CreateConsensusManager()
+        // {
+        //     this.ConsensusManager = ConsensusManagerHelper.CreateConsensusManager(this.Network);
+        //     return this.ConsensusManager;
+        // }
 
         internal Target ChangeDifficulty(ChainedHeader header, int difficultyAdjustmentDivisor)
         {
@@ -116,16 +243,16 @@ namespace Stratis.Bitcoin.Tests.Consensus
             foreach (CheckpointFixture checkpoint in checkpoints.OrderBy(h => h.Height))
             {
                 var checkpointInfo = new CheckpointInfo(checkpoint.Header.GetHash());
-                this.Checkpoints
+                this.checkpoints
                     .Setup(c => c.GetCheckpoint(checkpoint.Height))
                     .Returns(checkpointInfo);
             }
 
-            this.Checkpoints
+            this.checkpoints
                 .Setup(c => c.GetCheckpoint(It.IsNotIn(checkpoints.Select(h => h.Height))))
                 .Returns((CheckpointInfo)null);
 
-            this.Checkpoints
+            this.checkpoints
                 .Setup(c => c.GetLastCheckpointHeight())
                 .Returns(checkpoints.OrderBy(h => h.Height).Last().Height);
         }
@@ -135,7 +262,8 @@ namespace Stratis.Bitcoin.Tests.Consensus
             ChainedHeader chainedHeader = null,
             int difficultyAdjustmentDivisor = 1,
             bool assignBlocks = true,
-            ValidationState? validationState = null)
+            ValidationState? validationState = null, 
+            int? avgBlockSize = null)
         {
             if (difficultyAdjustmentDivisor == 0)
                 throw new ArgumentException("Divisor cannot be 0");
@@ -158,6 +286,30 @@ namespace Stratis.Bitcoin.Tests.Consensus
                 {
                     Block block = this.Network.Consensus.ConsensusFactory.CreateBlock();
                     block.GetSerializedSize();
+
+                    if (avgBlockSize.HasValue)
+                    {                        
+                        var transaction = new Transaction();
+                        transaction.Outputs.Add(new TxOut(new Money(10000000000), new Script()));
+                        block.Transactions.Add(transaction);
+
+                        int blockWeight = block.GetSerializedSize();
+
+                        int requiredScriptWeight = avgBlockSize.Value - blockWeight - 2;
+                        block.Transactions[0].Outputs.Clear();
+                        // generate nonsense script with required bytes to reach required weight.
+                        Script script = Script.FromBytesUnsafe(new string('A', requiredScriptWeight).Select(c => (byte)c).ToArray());
+                        transaction.Outputs.Add(new TxOut(new Money(10000000000), script));
+
+                        block.GetSerializedSize();
+
+                        if (block.BlockSize != avgBlockSize.Value)
+                        {
+                            throw new Exception("Unable to generate block with expected size.");
+                        }
+                    }
+
+
                     newHeader.Block = block;
                 }
 
@@ -197,6 +349,25 @@ namespace Stratis.Bitcoin.Tests.Consensus
 
             return (connectNewHeadersResult.DownloadTo == null)
                    && (connectNewHeadersResult.DownloadFrom == null);
+        }
+
+        internal void SetupAverageBlockSize(int amount)
+        {
+            this.blockPuller.Setup(b => b.GetAverageBlockSizeBytes())
+                .Returns(amount);            
+        }
+
+
+        internal Mock<INetworkPeer> GetNetworkPeerWithConnection()
+        {
+            var networkPeer = new Mock<INetworkPeer>();
+
+            var connection = new NetworkPeerConnection(this.Network, networkPeer.Object, new TcpClient(), 0, (message, token) => Task.CompletedTask,
+            this.dateTimeProvider, this.loggerFactory, new PayloadProvider().DiscoverPayloads());
+            networkPeer.Setup(n => n.Connection)
+                .Returns(connection);
+
+            return networkPeer;
         }
 
         /// <summary>

--- a/src/Stratis.Bitcoin.Tests/Consensus/ConsensusTestContext.cs
+++ b/src/Stratis.Bitcoin.Tests/Consensus/ConsensusTestContext.cs
@@ -47,8 +47,8 @@ namespace Stratis.Bitcoin.Tests.Consensus
         // private Mock<INodeStats> nodeStats;
         private INodeStats nodeStats;
         private Mock<IInitialBlockDownloadState> ibd;
-        private Mock<IBlockPuller> blockPuller;
-        private Mock<IBlockStore> blockStore;
+        public readonly Mock<IBlockPuller> BlockPuller;
+        public readonly Mock<IBlockStore> BlockStore;
         // public Mock<ICheckpoints> Checkpoints = new Mock<ICheckpoints>();
         // private ICheckpoints checkpoints;
         private Mock<ICheckpoints> checkpoints = new Mock<ICheckpoints>();
@@ -115,11 +115,11 @@ namespace Stratis.Bitcoin.Tests.Consensus
             this.nodeLifetime = new NodeLifetime();
             // this.nodeStats = new Mock<INodeStats>();
             this.ibd = new Mock<IInitialBlockDownloadState>();
-            this.blockPuller = new Mock<IBlockPuller>();
+            this.BlockPuller = new Mock<IBlockPuller>();
 
-            this.blockPuller.Setup(b => b.Initialize(It.IsAny<BlockPuller.OnBlockDownloadedCallback>()))
+            this.BlockPuller.Setup(b => b.Initialize(It.IsAny<BlockPuller.OnBlockDownloadedCallback>()))
                 .Callback<BlockPuller.OnBlockDownloadedCallback>((d) => { this.blockPullerBlockDownloadCallback = d; });
-            this.blockStore = new Mock<IBlockStore>();
+            this.BlockStore = new Mock<IBlockStore>();
             // this.checkpoints = new Checkpoints();
             this.checkpoints = new Mock<ICheckpoints>();
             // this.chainState = new ChainState();
@@ -222,7 +222,7 @@ namespace Stratis.Bitcoin.Tests.Consensus
             this.ConsensusManager = new TestConsensusManager(tree, this.Network, this.loggerFactory, this.ChainState.Object, this.IntegrityValidator.Object,
                 this.PartialValidator.Object, this.FullValidator.Object, this.consensusRules,
                 this.FinalizedBlockMock.Object, new Stratis.Bitcoin.Signals.Signals(), this.peerBanning, this.ibd.Object, this.chain,
-                this.blockPuller.Object, this.blockStore.Object, this.connectionManager, this.nodeStats, this.nodeLifetime);
+                this.BlockPuller.Object, this.BlockStore.Object, this.connectionManager, this.nodeStats, this.nodeLifetime);
         }
 
         public Block CreateBlock(ChainedHeader previous)
@@ -374,14 +374,14 @@ namespace Stratis.Bitcoin.Tests.Consensus
 
         internal void SetupAverageBlockSize(int amount)
         {
-            this.blockPuller.Setup(b => b.GetAverageBlockSizeBytes())
+            this.BlockPuller.Setup(b => b.GetAverageBlockSizeBytes())
                 .Returns(amount);
         }
 
 
         internal void VerifyNoBlocksAskedToBlockPuller()
         {
-            this.blockPuller.Verify(b => b.RequestBlocksDownload(It.IsAny<List<ChainedHeader>>(), It.IsAny<bool>()), Times.Exactly(0));
+            this.BlockPuller.Verify(b => b.RequestBlocksDownload(It.IsAny<List<ChainedHeader>>(), It.IsAny<bool>()), Times.Exactly(0));
         }
 
         internal void AssertPeerBanned(INetworkPeer peer)

--- a/src/Stratis.Bitcoin.Tests/Consensus/ConsensusTestContext.cs
+++ b/src/Stratis.Bitcoin.Tests/Consensus/ConsensusTestContext.cs
@@ -93,7 +93,7 @@ namespace Stratis.Bitcoin.Tests.Consensus
 
         private PeerAddressManager peerAddressManager;
 
-        public TestContext() : this( KnownNetworks.RegTest)
+        public TestContext() : this(KnownNetworks.RegTest)
         {
         }
 
@@ -305,7 +305,11 @@ namespace Stratis.Bitcoin.Tests.Consensus
 
                 if (assignBlocks)
                 {
-                    Block block = this.Network.Consensus.ConsensusFactory.CreateBlock();
+                    Block block = this.Network.Consensus.ConsensusFactory.CreateBlock();                    
+                    block.Header.Bits = header.Bits;
+                    block.Header.HashPrevBlock = header.HashPrevBlock;
+                    block.Header.Nonce = header.Nonce;
+
                     block.GetSerializedSize();
 
                     if (avgBlockSize.HasValue)
@@ -412,6 +416,9 @@ namespace Stratis.Bitcoin.Tests.Consensus
             networkPeer.Setup(n => n.RemoteSocketPort)
                 .Returns(9999);
 
+            networkPeer.Setup(n => n.RemoteSocketEndpoint)
+                .Returns(new System.Net.IPEndPoint(IPAddress.Loopback.EnsureIPv6(), 9999));
+
             networkPeer.Setup(n => n.State)
                 .Returns(NetworkPeerState.Connected);
 
@@ -420,7 +427,7 @@ namespace Stratis.Bitcoin.Tests.Consensus
                 .Returns(behavior.Object);
 
             this.peerAddressManager.AddPeer(networkPeer.Object.PeerEndPoint, networkPeer.Object.PeerEndPoint.Address);
-            this.connectionManager.AddConnectedPeer(networkPeer.Object);            
+            this.connectionManager.AddConnectedPeer(networkPeer.Object);
 
             return networkPeer;
         }

--- a/src/Stratis.Bitcoin.Tests/Consensus/ConsensusTestContext.cs
+++ b/src/Stratis.Bitcoin.Tests/Consensus/ConsensusTestContext.cs
@@ -295,7 +295,7 @@ namespace Stratis.Bitcoin.Tests.Consensus
 
                         int blockWeight = block.GetSerializedSize();
 
-                        int requiredScriptWeight = avgBlockSize.Value - blockWeight - 2;
+                        int requiredScriptWeight = avgBlockSize.Value - blockWeight;
                         block.Transactions[0].Outputs.Clear();
                         // generate nonsense script with required bytes to reach required weight.
                         Script script = Script.FromBytesUnsafe(new string('A', requiredScriptWeight).Select(c => (byte)c).ToArray());
@@ -355,6 +355,12 @@ namespace Stratis.Bitcoin.Tests.Consensus
         {
             this.blockPuller.Setup(b => b.GetAverageBlockSizeBytes())
                 .Returns(amount);            
+        }
+
+
+        internal void VerifyNoBlocksAskedToBlockPuller()
+        {
+            this.blockPuller.Verify(b => b.RequestBlocksDownload(It.IsAny<List<ChainedHeader>>(), It.IsAny<bool>()), Times.Exactly(0));
         }
 
 

--- a/src/Stratis.Bitcoin.Tests/Consensus/ConsensusTestContextBuilder.cs
+++ b/src/Stratis.Bitcoin.Tests/Consensus/ConsensusTestContextBuilder.cs
@@ -29,7 +29,10 @@ namespace Stratis.Bitcoin.Tests.Consensus
         internal TestContext Build()
         {
             if (this.testContext.InitialChainTip != null)
+            {
+                this.testContext.coinView.UpdateTipHash(this.testContext.InitialChainTip.Header.GetHash());
                 this.testContext.ChainedHeaderTree.Initialize(this.testContext.InitialChainTip);
+            }
 
             return this.testContext;
         }

--- a/src/Stratis.Bitcoin.Tests/Consensus/ConsensusTestContextBuilder.cs
+++ b/src/Stratis.Bitcoin.Tests/Consensus/ConsensusTestContextBuilder.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using NBitcoin;
 
 namespace Stratis.Bitcoin.Tests.Consensus
 {
@@ -9,6 +10,11 @@ namespace Stratis.Bitcoin.Tests.Consensus
         public TestContextBuilder()
         {
             this.testContext = new TestContext();
+        }
+
+        public TestContextBuilder(Network network)
+        {
+            this.testContext = new TestContext(network);
         }
 
         internal TestContextBuilder WithInitialChain(int initialChainSize, bool assignBlocks = true)

--- a/src/Stratis.Bitcoin.Tests/Consensus/ConsensusTestContextBuilder.cs
+++ b/src/Stratis.Bitcoin.Tests/Consensus/ConsensusTestContextBuilder.cs
@@ -12,11 +12,6 @@ namespace Stratis.Bitcoin.Tests.Consensus
             this.testContext = new TestContext();
         }
 
-        public TestContextBuilder(Network network)
-        {
-            this.testContext = new TestContext(network);
-        }
-
         internal TestContextBuilder WithInitialChain(int initialChainSize, bool assignBlocks = true)
         {
             if (initialChainSize < 0)

--- a/src/Stratis.Bitcoin.Tests/Consensus/ConsensusTestContextBuilder.cs
+++ b/src/Stratis.Bitcoin.Tests/Consensus/ConsensusTestContextBuilder.cs
@@ -32,6 +32,9 @@ namespace Stratis.Bitcoin.Tests.Consensus
             {
                 this.testContext.coinView.UpdateTipHash(this.testContext.InitialChainTip.Header.GetHash());
                 this.testContext.ChainedHeaderTree.Initialize(this.testContext.InitialChainTip);
+
+                this.testContext.ChainState.Setup(c => c.BlockStoreTip)
+                    .Returns(this.testContext.InitialChainTip);
             }
 
             return this.testContext;

--- a/src/Stratis.Bitcoin.Tests/Consensus/TestConsensusManager.cs
+++ b/src/Stratis.Bitcoin.Tests/Consensus/TestConsensusManager.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using Microsoft.Extensions.Logging;
+using Moq;
 using NBitcoin;
 using Stratis.Bitcoin.Base;
 using Stratis.Bitcoin.BlockPulling;
@@ -53,6 +55,11 @@ namespace Stratis.Bitcoin.Tests.Consensus
             return base.ExpectedBlockDataBytes;
         }
 
+        public void SetExpectedBlockDataBytes(long val)
+        {
+            base.ExpectedBlockDataBytes = val;
+        }
+
         public Dictionary<uint256, long> GetExpectedBlockSizes()
         {
             return base.ExpectedBlockSizes;
@@ -63,6 +70,31 @@ namespace Stratis.Bitcoin.Tests.Consensus
             base.MaxUnconsumedBlocksDataBytes = newSize;
         }
 
+        public void SetupCallbackByBlocksRequestedHash(uint256 hash, params OnBlockDownloadedCallback[] callbacks)
+        {
+            if (base.CallbacksByBlocksRequestedHash.ContainsKey(hash))
+            {
+                base.CallbacksByBlocksRequestedHash[hash] = callbacks.ToList();
+            }
+            else
+            {
+                base.CallbacksByBlocksRequestedHash.Add(hash, callbacks.ToList());
+            }
+        }
 
+        public bool CallbacksByBlocksRequestedHashContainsKeyForHash(uint256 hash)
+        {
+            return base.CallbacksByBlocksRequestedHash.ContainsKey(hash);
+        }
+
+        public void AddExpectedBlockSize(uint256 key, long size)
+        {
+            base.ExpectedBlockSizes.Add(key, size);
+        }
+
+        public void ClearExpectedBlockSizes()
+        {
+            base.ExpectedBlockSizes.Clear();
+        }
     }
 }

--- a/src/Stratis.Bitcoin.Tests/Consensus/TestConsensusManager.cs
+++ b/src/Stratis.Bitcoin.Tests/Consensus/TestConsensusManager.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.Extensions.Logging;
+using NBitcoin;
+using Stratis.Bitcoin.Base;
+using Stratis.Bitcoin.BlockPulling;
+using Stratis.Bitcoin.Connection;
+using Stratis.Bitcoin.Consensus;
+using Stratis.Bitcoin.Consensus.Validators;
+using Stratis.Bitcoin.Interfaces;
+using Stratis.Bitcoin.Signals;
+using Stratis.Bitcoin.Utilities;
+
+namespace Stratis.Bitcoin.Tests.Consensus
+{
+    public class TestConsensusManager : ConsensusManager
+    {
+        public TestConsensusManager(
+            IChainedHeaderTree chainedHeaderTree,
+            Network network,
+            ILoggerFactory loggerFactory,
+            IChainState chainState,
+            IIntegrityValidator integrityValidator,
+            IPartialValidator partialValidator,
+            IFullValidator fullValidator,
+            IConsensusRuleEngine consensusRules,
+            IFinalizedBlockInfoRepository finalizedBlockInfo,
+            ISignals signals,
+            IPeerBanning peerBanning,
+            IInitialBlockDownloadState ibdState,
+            ConcurrentChain chain,
+            IBlockPuller blockPuller,
+            IBlockStore blockStore,
+            IConnectionManager connectionManager,
+            INodeStats nodeStats,
+            INodeLifetime nodeLifetime) : base 
+            (chainedHeaderTree, network, loggerFactory, chainState, integrityValidator, partialValidator, fullValidator, 
+                consensusRules, finalizedBlockInfo, signals, peerBanning, ibdState, chain, blockPuller, blockStore, connectionManager, nodeStats, nodeLifetime)
+        {
+
+        }
+
+
+        public bool PeerIsKnown(int peerId)
+        {
+            return base.PeersByPeerId.ContainsKey(peerId);
+        }
+
+
+        public long GetExpectedBlockDataBytes()
+        {
+            return base.ExpectedBlockDataBytes;
+        }
+
+        public Dictionary<uint256, long> GetExpectedBlockSizes()
+        {
+            return base.ExpectedBlockSizes;
+        }
+
+        public void SetMaxUnconsumedBlocksDataBytes(long newSize)
+        {
+            base.MaxUnconsumedBlocksDataBytes = newSize;
+        }
+
+
+    }
+}

--- a/src/Stratis.Bitcoin.Tests/Consensus/TestInMemoryCoinView.cs
+++ b/src/Stratis.Bitcoin.Tests/Consensus/TestInMemoryCoinView.cs
@@ -66,7 +66,7 @@ namespace Stratis.Bitcoin.Tests.Consensus
         }
 
         /// <inheritdoc />
-        public Task SaveChangesAsync(IEnumerable<UnspentOutputs> unspentOutputs, IEnumerable<TxOut[]> originalOutputs, uint256 oldBlockHash, uint256 nextBlockHash, List<RewindData> rewindDataList = null)
+        public Task SaveChangesAsync(IList<UnspentOutputs> unspentOutputs, IEnumerable<TxOut[]> originalOutputs, uint256 oldBlockHash, uint256 nextBlockHash, List<RewindData> rewindDataList = null)
         {
             Guard.NotNull(oldBlockHash, nameof(oldBlockHash));
             Guard.NotNull(nextBlockHash, nameof(nextBlockHash));
@@ -100,7 +100,7 @@ namespace Stratis.Bitcoin.Tests.Consensus
         }
 
         /// <inheritdoc />
-        public Task<uint256> Rewind()
+        public Task<uint256> RewindAsync()
         {
             throw new NotImplementedException();
         }

--- a/src/Stratis.Bitcoin.Tests/Consensus/TestInMemoryCoinView.cs
+++ b/src/Stratis.Bitcoin.Tests/Consensus/TestInMemoryCoinView.cs
@@ -1,0 +1,108 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using NBitcoin;
+using Stratis.Bitcoin.Features.Consensus.CoinViews;
+using Stratis.Bitcoin.Utilities;
+using ReaderWriterLock = NBitcoin.ReaderWriterLock;
+
+namespace Stratis.Bitcoin.Tests.Consensus
+{
+    /// <summary>
+    /// Coinview that holds all information in the memory, which is used in tests.
+    /// </summary>
+    /// <remarks>Rewinding is not supported in this implementation.</remarks>
+    public class TestInMemoryCoinView : ICoinView
+    {
+        /// <summary>Lock object to protect access to <see cref="unspents"/> and <see cref="tipHash"/>.</summary>
+        private readonly ReaderWriterLock lockobj = new ReaderWriterLock();
+
+        /// <summary>Information about unspent outputs mapped by transaction IDs the outputs belong to.</summary>
+        /// <remarks>All access to this object has to be protected by <see cref="lockobj"/>.</remarks>
+        private readonly Dictionary<uint256, UnspentOutputs> unspents = new Dictionary<uint256, UnspentOutputs>();
+
+        /// <summary>Hash of the block header which is the tip of the coinview.</summary>
+        /// <remarks>All access to this object has to be protected by <see cref="lockobj"/>.</remarks>
+        private uint256 tipHash;
+
+        /// <summary>
+        /// Initializes an instance of the object.
+        /// </summary>
+        /// <param name="tipHash">Hash of the block headers of the tip of the coinview.</param>
+        public TestInMemoryCoinView(uint256 tipHash)
+        {
+            this.tipHash = tipHash;
+        }
+
+        /// <inheritdoc />
+        public Task<uint256> GetTipHashAsync(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return Task.FromResult(this.tipHash);
+        }
+
+        public void UpdateTipHash(uint256 tipHash)
+        {
+            this.tipHash = tipHash;
+        }
+
+        /// <inheritdoc />
+        public Task<FetchCoinsResponse> FetchCoinsAsync(uint256[] txIds, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            Guard.NotNull(txIds, nameof(txIds));
+
+            using (this.lockobj.LockRead())
+            {
+                var result = new UnspentOutputs[txIds.Length];
+                for (int i = 0; i < txIds.Length; i++)
+                {
+                    result[i] = this.unspents.TryGet(txIds[i]);
+                    if (result[i] != null)
+                        result[i] = result[i].Clone();
+                }
+
+                return Task.FromResult(new FetchCoinsResponse(result, this.tipHash));
+            }
+        }
+
+        /// <inheritdoc />
+        public Task SaveChangesAsync(IEnumerable<UnspentOutputs> unspentOutputs, IEnumerable<TxOut[]> originalOutputs, uint256 oldBlockHash, uint256 nextBlockHash, List<RewindData> rewindDataList = null)
+        {
+            Guard.NotNull(oldBlockHash, nameof(oldBlockHash));
+            Guard.NotNull(nextBlockHash, nameof(nextBlockHash));
+            Guard.NotNull(unspentOutputs, nameof(unspentOutputs));
+
+            using (this.lockobj.LockWrite())
+            {
+                if ((this.tipHash != null) && (oldBlockHash != this.tipHash))
+                    return Task.FromException(new InvalidOperationException("Invalid oldBlockHash"));
+
+                this.tipHash = nextBlockHash;
+                foreach (UnspentOutputs unspent in unspentOutputs)
+                {
+                    UnspentOutputs existing;
+                    if (this.unspents.TryGetValue(unspent.TransactionId, out existing))
+                    {
+                        existing.Spend(unspent);
+                    }
+                    else
+                    {
+                        existing = unspent.Clone();
+                        this.unspents.Add(unspent.TransactionId, existing);
+                    }
+
+                    if (existing.IsPrunable)
+                        this.unspents.Remove(unspent.TransactionId);
+                }
+            }
+
+            return Task.FromResult(true);
+        }
+
+        /// <inheritdoc />
+        public Task<uint256> Rewind()
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/Stratis.Bitcoin.Tests/Stratis.Bitcoin.Tests.csproj
+++ b/src/Stratis.Bitcoin.Tests/Stratis.Bitcoin.Tests.csproj
@@ -30,7 +30,6 @@
   <ItemGroup>
     <PackageReference Include="DBreeze" Version="1.89.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
-    <PackageReference Include="Moq.AutoMock" Version="1.2.0.111" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/src/Stratis.Bitcoin.Tests/Stratis.Bitcoin.Tests.csproj
+++ b/src/Stratis.Bitcoin.Tests/Stratis.Bitcoin.Tests.csproj
@@ -30,6 +30,7 @@
   <ItemGroup>
     <PackageReference Include="DBreeze" Version="1.89.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
+    <PackageReference Include="Moq.AutoMock" Version="1.2.0.111" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/src/Stratis.Bitcoin/Consensus/ConsensusManager.cs
+++ b/src/Stratis.Bitcoin/Consensus/ConsensusManager.cs
@@ -318,7 +318,6 @@ namespace Stratis.Bitcoin.Consensus
                 }
                 else
                     this.logger.LogDebug("Node is shutting down therefore underlying components won't be updated.");
-
             }
             else
                 this.logger.LogTrace("Peer {0} was already removed.", peerId);
@@ -407,7 +406,7 @@ namespace Stratis.Bitcoin.Consensus
                         chainedHeaderBlocksToValidate = this.chainedHeaderTree.PartialValidationSucceeded(chainedHeader, out fullValidationRequired);
                     }
 
-                    this.logger.LogTrace("Full validation is{0} required.", fullValidationRequired ? "" : " NOT");
+                    this.logger.LogTrace("Full validation is{0} required.", fullValidationRequired ? string.Empty : " NOT");
 
                     if (fullValidationRequired)
                     {
@@ -1111,7 +1110,7 @@ namespace Stratis.Bitcoin.Consensus
                 long freeBytes = this.MaxUnconsumedBlocksDataBytes - this.chainedHeaderTree.UnconsumedBlocksDataBytes - this.ExpectedBlockDataBytes;
                 this.logger.LogTrace("{0} bytes worth of blocks is available for download.", freeBytes);
 
-                if (freeBytes <= ConsumptionThresholdBytes)
+                if (freeBytes <= this.ConsumptionThresholdBytes)
                 {
                     this.logger.LogTrace("(-)[THRESHOLD_NOT_MET]");
                     return;
@@ -1214,12 +1213,12 @@ namespace Stratis.Bitcoin.Consensus
 
             lock (this.peerLock)
             {
-                string unconsumedBlocks = this.formatBigNumber(this.chainedHeaderTree.UnconsumedBlocksCount);
+                string unconsumedBlocks = this.FormatBigNumber(this.chainedHeaderTree.UnconsumedBlocksCount);
 
-                string unconsumedBytes = this.formatBigNumber(this.chainedHeaderTree.UnconsumedBlocksDataBytes);
-                string maxUnconsumedBytes = this.formatBigNumber(MaxUnconsumedBlocksDataBytes);
+                string unconsumedBytes = this.FormatBigNumber(this.chainedHeaderTree.UnconsumedBlocksDataBytes);
+                string maxUnconsumedBytes = this.FormatBigNumber(this.MaxUnconsumedBlocksDataBytes);
 
-                double filledPercentage = Math.Round((this.chainedHeaderTree.UnconsumedBlocksDataBytes / (double)MaxUnconsumedBlocksDataBytes) * 100, 2);
+                double filledPercentage = Math.Round((this.chainedHeaderTree.UnconsumedBlocksDataBytes / (double)this.MaxUnconsumedBlocksDataBytes) * 100, 2);
 
                 log.AppendLine($"Unconsumed blocks: {unconsumedBlocks} -- ({unconsumedBytes} / {maxUnconsumedBytes} bytes). Cache is filled by: {filledPercentage}%");
             }
@@ -1227,7 +1226,7 @@ namespace Stratis.Bitcoin.Consensus
 
         /// <summary>Formats the big number.</summary>
         /// <remarks><c>123456789</c> => <c>123 456 789</c></remarks>
-        private string formatBigNumber(long number)
+        private string FormatBigNumber(long number)
         {
             string temp = number.ToString("N").Replace(',', ' ');
 

--- a/src/Stratis.Bitcoin/Consensus/ConsensusManager.cs
+++ b/src/Stratis.Bitcoin/Consensus/ConsensusManager.cs
@@ -112,6 +112,25 @@ namespace Stratis.Bitcoin.Consensus
             INodeStats nodeStats,
             INodeLifetime nodeLifetime)
         {
+            Guard.NotNull(chainedHeaderTree, nameof(chainedHeaderTree));
+            Guard.NotNull(network, nameof(network));
+            Guard.NotNull(loggerFactory, nameof(loggerFactory));
+            Guard.NotNull(chainState, nameof(chainState));
+            Guard.NotNull(integrityValidator, nameof(integrityValidator));
+            Guard.NotNull(partialValidator, nameof(partialValidator));
+            Guard.NotNull(fullValidator, nameof(fullValidator));
+            Guard.NotNull(consensusRules, nameof(consensusRules));
+            Guard.NotNull(finalizedBlockInfo, nameof(finalizedBlockInfo));
+            Guard.NotNull(signals, nameof(signals));
+            Guard.NotNull(peerBanning, nameof(peerBanning));
+            Guard.NotNull(ibdState, nameof(ibdState));
+            Guard.NotNull(chain, nameof(chain));
+            Guard.NotNull(blockPuller, nameof(blockPuller));
+            Guard.NotNull(blockStore, nameof(blockStore));
+            Guard.NotNull(connectionManager, nameof(connectionManager));
+            Guard.NotNull(nodeStats, nameof(nodeStats));
+            Guard.NotNull(nodeLifetime, nameof(nodeLifetime));
+
             this.network = network;
             this.chainState = chainState;
             this.integrityValidator = integrityValidator;
@@ -157,6 +176,8 @@ namespace Stratis.Bitcoin.Consensus
         /// </remarks>
         public async Task InitializeAsync(ChainedHeader chainTip)
         {
+            Guard.NotNull(chainTip, nameof(chainTip));
+
             // TODO: consensus store
             // We should consider creating a consensus store class that will internally contain
             // coinview and it will abstract the methods `RewindAsync()` `GetBlockHashAsync()`
@@ -193,6 +214,9 @@ namespace Stratis.Bitcoin.Consensus
         /// <inheritdoc />
         public ConnectNewHeadersResult HeadersPresented(INetworkPeer peer, List<BlockHeader> headers, bool triggerDownload = true)
         {
+            Guard.NotNull(peer, nameof(peer));
+            Guard.NotNull(headers, nameof(headers));
+
             ConnectNewHeadersResult connectNewHeadersResult;
 
             lock (this.peerLock)
@@ -1017,6 +1041,9 @@ namespace Stratis.Bitcoin.Consensus
         /// <inheritdoc />
         public async Task GetOrDownloadBlocksAsync(List<uint256> blockHashes, OnBlockDownloadedCallback onBlockDownloadedCallback)
         {
+            Guard.NotNull(blockHashes, nameof(blockHashes));
+            Guard.NotNull(onBlockDownloadedCallback, nameof(onBlockDownloadedCallback));
+
             var blocksToDownload = new List<ChainedHeader>();
 
             foreach (uint256 blockHash in blockHashes)
@@ -1049,6 +1076,8 @@ namespace Stratis.Bitcoin.Consensus
         /// <inheritdoc />
         public async Task<ChainedHeaderBlock> GetBlockDataAsync(uint256 blockHash)
         {
+            Guard.NotNull(blockHash, nameof(blockHash));
+
             ChainedHeaderBlock chainedHeaderBlock;
 
             lock (this.peerLock)

--- a/src/Stratis.Bitcoin/Consensus/ConsensusManager.cs
+++ b/src/Stratis.Bitcoin/Consensus/ConsensusManager.cs
@@ -65,7 +65,7 @@ namespace Stratis.Bitcoin.Consensus
         /// <inheritdoc />
         public IConsensusRuleEngine ConsensusRules { get; private set; }
 
-        private readonly Dictionary<uint256, List<OnBlockDownloadedCallback>> callbacksByBlocksRequestedHash;
+        protected readonly Dictionary<uint256, List<OnBlockDownloadedCallback>> CallbacksByBlocksRequestedHash;
 
         /// <summary>Peers mapped by their ID.</summary>
         /// <remarks>This object has to be protected by <see cref="peerLock"/>.</remarks>
@@ -101,7 +101,7 @@ namespace Stratis.Bitcoin.Consensus
             IPartialValidator partialValidator,
             IFullValidator fullValidator,
             IConsensusRuleEngine consensusRules,
-            IFinalizedBlockInfoRepository finalizedBlockInfo,            
+            IFinalizedBlockInfoRepository finalizedBlockInfo,
             ISignals signals,
             IPeerBanning peerBanning,
             IInitialBlockDownloadState ibdState,
@@ -135,7 +135,7 @@ namespace Stratis.Bitcoin.Consensus
             this.ExpectedBlockDataBytes = 0;
             this.ExpectedBlockSizes = new Dictionary<uint256, long>();
 
-            this.callbacksByBlocksRequestedHash = new Dictionary<uint256, List<OnBlockDownloadedCallback>>();
+            this.CallbacksByBlocksRequestedHash = new Dictionary<uint256, List<OnBlockDownloadedCallback>>();
             this.PeersByPeerId = new Dictionary<int, INetworkPeer>();
             this.toDownloadQueue = new Queue<BlockDownloadRequest>();
             this.performanceCounter = new ConsensusManagerPerformanceCounter();
@@ -861,7 +861,7 @@ namespace Stratis.Bitcoin.Consensus
         /// <summary>
         /// Request a list of block headers to download their respective blocks.
         /// If <paramref name="chainedHeaders"/> is not an array of consecutive headers it will be split to batches of consecutive header requests.
-        /// Callbacks of all entries are added to <see cref="callbacksByBlocksRequestedHash"/>. If a block header was already requested
+        /// Callbacks of all entries are added to <see cref="CallbacksByBlocksRequestedHash"/>. If a block header was already requested
         /// to download and not delivered yet, it will not be requested again, instead just it's callback will be called when the block arrives.
         /// </summary>
         /// <param name="chainedHeaders">Array of chained headers to download.</param>
@@ -877,12 +877,12 @@ namespace Stratis.Bitcoin.Consensus
             {
                 foreach (ChainedHeader chainedHeader in chainedHeaders)
                 {
-                    bool blockAlreadyAsked = this.callbacksByBlocksRequestedHash.TryGetValue(chainedHeader.HashBlock, out List<OnBlockDownloadedCallback> callbacks);
+                    bool blockAlreadyAsked = this.CallbacksByBlocksRequestedHash.TryGetValue(chainedHeader.HashBlock, out List<OnBlockDownloadedCallback> callbacks);
 
                     if (!blockAlreadyAsked)
                     {
                         callbacks = new List<OnBlockDownloadedCallback>();
-                        this.callbacksByBlocksRequestedHash.Add(chainedHeader.HashBlock, callbacks);
+                        this.CallbacksByBlocksRequestedHash.Add(chainedHeader.HashBlock, callbacks);
                     }
                     else
                     {
@@ -996,8 +996,8 @@ namespace Stratis.Bitcoin.Consensus
 
             lock (this.blockRequestedLock)
             {
-                if (this.callbacksByBlocksRequestedHash.TryGetValue(blockHash, out listOfCallbacks))
-                    this.callbacksByBlocksRequestedHash.Remove(blockHash);
+                if (this.CallbacksByBlocksRequestedHash.TryGetValue(blockHash, out listOfCallbacks))
+                    this.CallbacksByBlocksRequestedHash.Remove(blockHash);
             }
 
             if (listOfCallbacks != null)

--- a/src/Stratis.Bitcoin/Consensus/ConsensusManager.cs
+++ b/src/Stratis.Bitcoin/Consensus/ConsensusManager.cs
@@ -981,7 +981,7 @@ namespace Stratis.Bitcoin.Consensus
                     {
                         lock (this.blockRequestedLock)
                         {
-                            this.callbacksByBlocksRequestedHash.Remove(blockHash);
+                            this.CallbacksByBlocksRequestedHash.Remove(blockHash);
                         }
 
                         this.logger.LogTrace("(-)[CHAINED_HEADER_NOT_FOUND]");

--- a/src/Stratis.Bitcoin/Consensus/ConsensusManager.cs
+++ b/src/Stratis.Bitcoin/Consensus/ConsensusManager.cs
@@ -300,7 +300,7 @@ namespace Stratis.Bitcoin.Consensus
         /// <param name="peerId">The peer that was disconnected.</param>
         private void PeerDisconnectedLocked(int peerId)
         {
-            bool removed = this.peersByPeerId.Remove(peerId);
+            bool removed = this.PeersByPeerId.Remove(peerId);
 
             if (removed)
             {
@@ -425,7 +425,7 @@ namespace Stratis.Bitcoin.Consensus
                         {
                             foreach (int peerId in connectBlocksResult.PeersToBan)
                             {
-                                if (this.peersByPeerId.TryGetValue(peerId, out INetworkPeer peer))
+                                if (this.PeersByPeerId.TryGetValue(peerId, out INetworkPeer peer))
                                     peersToBan.Add(peer);
                             }
                         }

--- a/src/Stratis.Bitcoin/Consensus/ConsensusManager.cs
+++ b/src/Stratis.Bitcoin/Consensus/ConsensusManager.cs
@@ -230,6 +230,8 @@ namespace Stratis.Bitcoin.Consensus
         /// <inheritdoc />
         public async Task<ChainedHeader> BlockMinedAsync(Block block)
         {
+            Guard.NotNull(block, nameof(block));
+
             ValidationContext validationContext;
 
             using (await this.reorgLock.LockAsync().ConfigureAwait(false))


### PR DESCRIPTION
First set of tests for https://github.com/stratisproject/StratisBitcoinFullNode/issues/1937
These are the tests up to and including OnPartialValidationCompletedCallbackAsync

* refactored consensusmanager and consensustestcontext to what I needed for these tests. CreateConsensusManager was in the way quite a bit, I initially tried to rework the ConsensusManagerHelper with automock to easily setup the consensus manager and allow for some overrides but I needed too much of the consensustestcontext so merged that into the consensustestcontext.
* added a testconsensusmanager with some helper methods.
* added an inmemory test coin view to help with testability.

There are some differences from the initial task:

HeadersPresented
> Setup blockPuller.AverageBlockSize = 200 bytes. Checkpoints are disabled, max MaxUnconsumedBlocksDataBytes = 1000. Avg block size is 500. 3 headers are presented, 2 are asked for download. 1 item is in the ToDownloadQueue.
> Make sure that expectedBlockDataBytes equals to 200*2. Make sure that hashes of 2 asked for download headers are inside expectedBlockSized list. Make sure that peer that was supplied was added to peersByPeerId.

Original test does not pass but added with skip so you guys can have a look at it. As far as I can tell that is not going to be possible without downloading the block which is a requirement not to do that early:
- HeadersPresented_NewHeaders_BlockSizeTotalHigherThanMaxUnconsumedBlocksDataBytes_UnexpectedlyBiggerBlocksThanAverage_LimitsDownloadedBlocks

Instead added another test of what I think is right:
- HeadersPresented_NewHeaders_BlockSizeTotalHigherThanMaxUnconsumedBlocksDataBytes_LimitsDownloadedBlocks

BlockDownloaded
- Merged most peer ban tests together and just went with block integrity invalidated as from the code logic they were testing the same thing.

GetOrDownloadBlocks/BlockMined
- This was unit testable so went with that instead.

