### PR TITLE
[SC] Fix boundaries of Stratis.SmartContracts.Core

### DIFF
--- a/src/Stratis.Bitcoin.Features.SmartContracts.Tests/AddressTests.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts.Tests/AddressTests.cs
@@ -3,6 +3,7 @@ using NBitcoin;
 using Stratis.Bitcoin.Features.SmartContracts.Networks;
 using Stratis.SmartContracts;
 using Stratis.SmartContracts.Core;
+using Stratis.SmartContracts.Executor.Reflection;
 using Xunit;
 
 namespace Stratis.Bitcoin.Features.SmartContracts.Tests

--- a/src/Stratis.Bitcoin.Features.SmartContracts.Tests/AuctionTests.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts.Tests/AuctionTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using Stratis.Bitcoin.Features.SmartContracts.Networks;
 using Stratis.SmartContracts;
 using Stratis.SmartContracts.Core;
+using Stratis.SmartContracts.Executor.Reflection;
 using Stratis.SmartContracts.Executor.Reflection.Serialization;
 using Xunit;
 

--- a/src/Stratis.Bitcoin.Features.SmartContracts.Tests/ContractLogHolderTests.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts.Tests/ContractLogHolderTests.cs
@@ -6,6 +6,7 @@ using Stratis.Bitcoin.Features.SmartContracts.Networks;
 using Stratis.SmartContracts;
 using Stratis.SmartContracts.Core;
 using Stratis.SmartContracts.Core.Receipts;
+using Stratis.SmartContracts.Executor.Reflection;
 using Stratis.SmartContracts.Executor.Reflection.ContractLogging;
 using Stratis.SmartContracts.Executor.Reflection.Serialization;
 using Xunit;

--- a/src/Stratis.Bitcoin.Features.SmartContracts.Tests/ContractPrimitiveSerializerTests.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts.Tests/ContractPrimitiveSerializerTests.cs
@@ -5,6 +5,7 @@ using Newtonsoft.Json;
 using Stratis.Bitcoin.Features.SmartContracts.Networks;
 using Stratis.SmartContracts;
 using Stratis.SmartContracts.Core;
+using Stratis.SmartContracts.Executor.Reflection;
 using Stratis.SmartContracts.Executor.Reflection.Exceptions;
 using Stratis.SmartContracts.Executor.Reflection.Serialization;
 using Xunit;

--- a/src/Stratis.Bitcoin.Features.SmartContracts.Tests/MethodParameterByteSerializerTests.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts.Tests/MethodParameterByteSerializerTests.cs
@@ -5,6 +5,7 @@ using System.Text;
 using NBitcoin;
 using Stratis.Bitcoin.Features.SmartContracts.Networks;
 using Stratis.SmartContracts.Core;
+using Stratis.SmartContracts.Executor.Reflection;
 using Stratis.SmartContracts.Executor.Reflection.Serialization;
 using Xunit;
 

--- a/src/Stratis.Bitcoin.Features.SmartContracts.Tests/MethodParameterStringSerializerTests.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts.Tests/MethodParameterStringSerializerTests.cs
@@ -6,6 +6,7 @@ using NBitcoin;
 using Stratis.Bitcoin.Features.SmartContracts.Networks;
 using Stratis.SmartContracts;
 using Stratis.SmartContracts.Core;
+using Stratis.SmartContracts.Executor.Reflection;
 using Stratis.SmartContracts.Executor.Reflection.Serialization;
 using Xunit;
 

--- a/src/Stratis.Bitcoin.Features.SmartContracts.Tests/ObserverTests.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts.Tests/ObserverTests.cs
@@ -125,7 +125,7 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Tests
             var network = new SmartContractsRegTest();
             var serializer = new ContractPrimitiveSerializer(network);
             this.state = new SmartContractState(
-                new Stratis.SmartContracts.Core.Block(1, TestAddress),
+                new Stratis.SmartContracts.Block(1, TestAddress),
                 new Message(TestAddress, TestAddress, 0),
                 new PersistentState(new MeteredPersistenceStrategy(this.repository, this.gasMeter, new BasicKeyEncodingStrategy()),
                     context.Serializer, TestAddress.ToUint160()),

--- a/src/Stratis.Bitcoin.Features.SmartContracts.Tests/ReflectionVirtualMachineTests.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts.Tests/ReflectionVirtualMachineTests.cs
@@ -11,7 +11,6 @@ using Stratis.SmartContracts.Executor.Reflection.ContractLogging;
 using Xunit;
 using Block = Stratis.SmartContracts.Block;
 using InternalHashHelper = Stratis.SmartContracts.Core.Hashing.InternalHashHelper;
-using Message = Stratis.SmartContracts.Core.Message;
 
 namespace Stratis.Bitcoin.Features.SmartContracts.Tests
 {

--- a/src/Stratis.Bitcoin.Features.SmartContracts.Tests/ReflectionVirtualMachineTests.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts.Tests/ReflectionVirtualMachineTests.cs
@@ -10,7 +10,6 @@ using Stratis.SmartContracts.Executor.Reflection.Compilation;
 using Stratis.SmartContracts.Executor.Reflection.ContractLogging;
 using Xunit;
 using Block = Stratis.SmartContracts.Block;
-using InternalHashHelper = Stratis.SmartContracts.Core.Hashing.InternalHashHelper;
 
 namespace Stratis.Bitcoin.Features.SmartContracts.Tests
 {

--- a/src/Stratis.Bitcoin.Features.SmartContracts.Tests/ReflectionVirtualMachineTests.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts.Tests/ReflectionVirtualMachineTests.cs
@@ -9,7 +9,7 @@ using Stratis.SmartContracts.Executor.Reflection;
 using Stratis.SmartContracts.Executor.Reflection.Compilation;
 using Stratis.SmartContracts.Executor.Reflection.ContractLogging;
 using Xunit;
-using Block = Stratis.SmartContracts.Core.Block;
+using Block = Stratis.SmartContracts.Block;
 using InternalHashHelper = Stratis.SmartContracts.Core.Hashing.InternalHashHelper;
 using Message = Stratis.SmartContracts.Core.Message;
 

--- a/src/Stratis.Bitcoin.Features.SmartContracts/Models/ReceiptResponse.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts/Models/ReceiptResponse.cs
@@ -2,6 +2,7 @@
 using NBitcoin;
 using Stratis.SmartContracts.Core;
 using Stratis.SmartContracts.Core.Receipts;
+using Stratis.SmartContracts.Executor.Reflection;
 
 namespace Stratis.Bitcoin.Features.SmartContracts.Models
 {

--- a/src/Stratis.SmartContracts.Core/Extensions.cs
+++ b/src/Stratis.SmartContracts.Core/Extensions.cs
@@ -26,42 +26,7 @@ namespace Stratis.SmartContracts.Core
             return bytes;
         }
 
-        public static uint160 ToUint160(this Address address)
-        {
-            return new uint160(address.ToBytes());
-        }
-
-        public static uint160 ToUint160(this string base58Address, Network network)
-        {
-            return new uint160(new BitcoinPubKeyAddress(base58Address, network).Hash.ToBytes());
-        }
-
-        public static Address ToAddress(this uint160 address)
-        {
-            return Address.Create(address.ToBytes());
-        }
-
-        public static Address ToAddress(this string address, Network network)
-        {
-            return Address.Create(address.ToUint160(network).ToBytes());
-        }
-
-        public static Address ToAddress(this byte[] bytes)
-        {
-            if (bytes.Length != Address.Width)
-                throw new ArgumentOutOfRangeException(nameof(bytes), "Address must be 20 bytes wide");
-
-            return Address.Create(bytes);
-        }
-
-        public static Address HexToAddress(this string hexString)
-        {
-            // uint160 only parses a big-endian hex string
-            var result = HexStringToBytes(hexString);
-            return Address.Create(result);
-        }
-
-        private static byte[] HexStringToBytes(string val)
+        public static byte[] HexStringToBytes(string val)
         {
             if (val.StartsWith("0x", StringComparison.OrdinalIgnoreCase))
                 val = val.Substring(2);
@@ -73,11 +38,6 @@ namespace Stratis.SmartContracts.Core
                 ret[i / 2] = byte.Parse(hexChars, System.Globalization.NumberStyles.HexNumber);
             }
             return ret;
-        }
-
-        public static string ToBase58Address(this uint160 address, Network network)
-        {
-            return new BitcoinPubKeyAddress(new KeyId(address), network).ToString();
         }
 
         public static Money GetFee(this Transaction transaction, UnspentOutputSet inputs)

--- a/src/Stratis.SmartContracts.Core/Hashing/HashHelper.cs
+++ b/src/Stratis.SmartContracts.Core/Hashing/HashHelper.cs
@@ -19,20 +19,4 @@ namespace Stratis.SmartContracts.Core.Hashing
             return Keccak.ComputeBytes(input).GetBytes();
         }
     }
-
-    /// <summary>
-    /// This gets injected into the contract to provide implementations for the hashing of data. 
-    /// </summary>
-    public class InternalHashHelper : IInternalHashHelper
-    {
-        /// <summary>
-        /// Returns a 32-byte Keccak256 hash of the given bytes.
-        /// </summary>
-        /// <param name="toHash"></param>
-        /// <returns></returns>
-        public byte[] Keccak256(byte[] toHash)
-        {
-            return HashHelper.Keccak256(toHash);
-        }
-    }
 }

--- a/src/Stratis.SmartContracts.Core/IContractExecutionResult.cs
+++ b/src/Stratis.SmartContracts.Core/IContractExecutionResult.cs
@@ -14,7 +14,7 @@ namespace Stratis.SmartContracts.Core
         /// <summary>
         /// The amount of gas units used through execution of the smart contract.
         /// </summary>
-        Gas GasConsumed { get; set; }
+        ulong GasConsumed { get; set; }
 
         /// <summary>
         /// If the execution created a new contract, its address will be stored here.

--- a/src/Stratis.SmartContracts.Core/Stratis.SmartContracts.Core.csproj
+++ b/src/Stratis.SmartContracts.Core/Stratis.SmartContracts.Core.csproj
@@ -23,7 +23,6 @@
     <ProjectReference Include="..\Stratis.Bitcoin\Stratis.Bitcoin.csproj" />
     <ProjectReference Include="..\Stratis.ModuleValidation.Net\Stratis.ModuleValidation.Net.csproj" />
     <ProjectReference Include="..\Stratis.SmartContracts.Core.Validation\Stratis.SmartContracts.Core.Validation.csproj" />
-    <ProjectReference Include="..\Stratis.SmartContracts\Stratis.SmartContracts.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Stratis.SmartContracts.Executor.Reflection/AddressExtensions.cs
+++ b/src/Stratis.SmartContracts.Executor.Reflection/AddressExtensions.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using NBitcoin;
+using Extensions = Stratis.SmartContracts.Core.Extensions;
+
+namespace Stratis.SmartContracts.Executor.Reflection
+{
+    public static class AddressExtensions
+    {
+        public static uint160 ToUint160(this Address address)
+        {
+            return new uint160(address.ToBytes());
+        }
+
+        public static uint160 ToUint160(this string base58Address, Network network)
+        {
+            return new uint160(new BitcoinPubKeyAddress(base58Address, network).Hash.ToBytes());
+        }
+
+        public static Address ToAddress(this uint160 address)
+        {
+            return Address.Create(address.ToBytes());
+        }
+
+        public static Address ToAddress(this string address, Network network)
+        {
+            return Address.Create(address.ToUint160(network).ToBytes());
+        }
+
+        public static Address ToAddress(this byte[] bytes)
+        {
+            if (bytes.Length != Address.Width)
+                throw new ArgumentOutOfRangeException(nameof(bytes), "Address must be 20 bytes wide");
+
+            return Address.Create(bytes);
+        }
+
+        public static Address HexToAddress(this string hexString)
+        {
+            // uint160 only parses a big-endian hex string
+            var result = Extensions.HexStringToBytes(hexString);
+            return Address.Create(result);
+        }
+
+        public static string ToBase58Address(this uint160 address, Network network)
+        {
+            return new BitcoinPubKeyAddress(new KeyId(address), network).ToString();
+        }
+    }
+}

--- a/src/Stratis.SmartContracts.Executor.Reflection/ContractExecutor.cs
+++ b/src/Stratis.SmartContracts.Executor.Reflection/ContractExecutor.cs
@@ -5,7 +5,6 @@ using Stratis.SmartContracts.Core;
 using Stratis.SmartContracts.Core.State;
 using Stratis.SmartContracts.Executor.Reflection.ResultProcessors;
 using Stratis.SmartContracts.Executor.Reflection.Serialization;
-using Block = Stratis.SmartContracts.Core.Block;
 
 namespace Stratis.SmartContracts.Executor.Reflection
 {

--- a/src/Stratis.SmartContracts.Executor.Reflection/SmartContractExecutionResult.cs
+++ b/src/Stratis.SmartContracts.Executor.Reflection/SmartContractExecutionResult.cs
@@ -26,7 +26,7 @@ namespace Stratis.SmartContracts.Executor.Reflection
         public ulong FutureRefund { get; set; }
 
         /// <inheritdoc/>
-        public Gas GasConsumed { get; set; }
+        public ulong GasConsumed { get; set; }
         
         /// <inheritdoc/>
         public object Return { get; set; }

--- a/src/Stratis.SmartContracts.IntegrationTests/MockChain/MockChainNode.cs
+++ b/src/Stratis.SmartContracts.IntegrationTests/MockChain/MockChainNode.cs
@@ -250,7 +250,7 @@ namespace Stratis.SmartContracts.IntegrationTests.MockChain
         /// <summary>
         /// Get the last block mined. AKA the current tip.
         /// </summary
-        public Block GetLastBlock()
+        public NBitcoin.Block GetLastBlock()
         {
             return this.blockStore.GetBlockAsync(this.CoreNode.FullNode.Chain.Tip.HashBlock).Result;
         }

--- a/src/Stratis.SmartContracts.IntegrationTests/PoW/ContractExecutionFailureTests.cs
+++ b/src/Stratis.SmartContracts.IntegrationTests/PoW/ContractExecutionFailureTests.cs
@@ -16,7 +16,6 @@ using Stratis.SmartContracts.Executor.Reflection.Serialization;
 using Stratis.SmartContracts.IntegrationTests.MockChain;
 using Stratis.SmartContracts.IntegrationTests.PoW.MockChain;
 using Xunit;
-using Block = NBitcoin.Block;
 
 namespace Stratis.SmartContracts.IntegrationTests.PoW
 {
@@ -99,7 +98,7 @@ namespace Stratis.SmartContracts.IntegrationTests.PoW
             BuildCreateContractTransactionResponse response = this.node1.SendCreateContractTransaction(bytes, amount);
             this.node2.WaitMempoolCount(1);
             this.node2.MineBlocks(1);
-            Block lastBlock = this.node1.GetLastBlock();
+            NBitcoin.Block lastBlock = this.node1.GetLastBlock();
 
             // Blocks progressed
             Assert.NotEqual(currentHash, lastBlock.GetHash());
@@ -147,7 +146,7 @@ namespace Stratis.SmartContracts.IntegrationTests.PoW
             BuildCreateContractTransactionResponse response = this.node1.SendCreateContractTransaction(compilationResult.Compilation, amount);
             this.node2.WaitMempoolCount(1);
             this.node2.MineBlocks(1);
-            Block lastBlock = this.node1.GetLastBlock();
+            NBitcoin.Block lastBlock = this.node1.GetLastBlock();
 
             // Blocks progressed
             Assert.NotEqual(currentHash, lastBlock.GetHash());
@@ -194,7 +193,7 @@ namespace Stratis.SmartContracts.IntegrationTests.PoW
             BuildCreateContractTransactionResponse response = this.node1.SendCreateContractTransaction(compilationResult.Compilation, amount);
             this.node2.WaitMempoolCount(1);
             this.node2.MineBlocks(1);
-            Block lastBlock = this.node1.GetLastBlock();
+            NBitcoin.Block lastBlock = this.node1.GetLastBlock();
 
             // Blocks progressed
             Assert.NotEqual(currentHash, lastBlock.GetHash());
@@ -254,7 +253,7 @@ namespace Stratis.SmartContracts.IntegrationTests.PoW
             BuildCallContractTransactionResponse response = this.node1.SendCallContractTransaction("Method", preResponse.NewContractAddress, amount);
             this.node2.WaitMempoolCount(1);
             this.node2.MineBlocks(1);
-            Block lastBlock = this.node1.GetLastBlock();
+            NBitcoin.Block lastBlock = this.node1.GetLastBlock();
 
             // Blocks progressed
             Assert.NotEqual(currentHash, lastBlock.GetHash());
@@ -307,7 +306,7 @@ namespace Stratis.SmartContracts.IntegrationTests.PoW
 
             this.node2.WaitMempoolCount(1);
             this.node2.MineBlocks(1);
-            Block lastBlock = this.node1.GetLastBlock();
+            NBitcoin.Block lastBlock = this.node1.GetLastBlock();
 
             // Blocks progressed
             Assert.NotEqual(currentHash, lastBlock.GetHash());
@@ -358,7 +357,7 @@ namespace Stratis.SmartContracts.IntegrationTests.PoW
             BuildCallContractTransactionResponse response = this.node1.SendCallContractTransaction("MethodThatDoesntExist", preResponse.NewContractAddress, amount);
             this.node2.WaitMempoolCount(1);
             this.node2.MineBlocks(1);
-            Block lastBlock = this.node1.GetLastBlock();
+            NBitcoin.Block lastBlock = this.node1.GetLastBlock();
 
             // Blocks progressed
             Assert.NotEqual(currentHash, lastBlock.GetHash());
@@ -409,7 +408,7 @@ namespace Stratis.SmartContracts.IntegrationTests.PoW
             BuildCallContractTransactionResponse response = this.node1.SendCallContractTransaction("CallMe", preResponse.NewContractAddress, amount);
             this.node2.WaitMempoolCount(1);
             this.node2.MineBlocks(1);
-            Block lastBlock = this.node1.GetLastBlock();
+            NBitcoin.Block lastBlock = this.node1.GetLastBlock();
 
             // Blocks progressed
             Assert.NotEqual(currentHash, lastBlock.GetHash());
@@ -461,7 +460,7 @@ namespace Stratis.SmartContracts.IntegrationTests.PoW
             BuildCreateContractTransactionResponse response = this.node1.SendCreateContractTransaction(compilationResult.Compilation, amount, parameters);
             this.node2.WaitMempoolCount(1);
             this.node2.MineBlocks(1);
-            Block lastBlock = this.node1.GetLastBlock();
+            NBitcoin.Block lastBlock = this.node1.GetLastBlock();
 
             // Blocks progressed
             Assert.NotEqual(currentHash, lastBlock.GetHash());
@@ -528,7 +527,7 @@ namespace Stratis.SmartContracts.IntegrationTests.PoW
             BuildCreateContractTransactionResponse response = this.node1.SendCreateContractTransaction(emptyModule, amount);
             this.node2.WaitMempoolCount(1);
             this.node2.MineBlocks(1);
-            Block lastBlock = this.node1.GetLastBlock();
+            NBitcoin.Block lastBlock = this.node1.GetLastBlock();
 
             // Blocks progressed
             Assert.NotEqual(currentHash, lastBlock.GetHash());
@@ -575,7 +574,7 @@ namespace Stratis.SmartContracts.IntegrationTests.PoW
             BuildCreateContractTransactionResponse response = this.node1.SendCreateContractTransaction(compilationResult.Compilation, amount, gasLimit: gasLimit);
             this.node2.WaitMempoolCount(1);
             this.node2.MineBlocks(1);
-            Block lastBlock = this.node1.GetLastBlock();
+            NBitcoin.Block  lastBlock = this.node1.GetLastBlock();
 
             // Blocks progressed
             Assert.NotEqual(currentHash, lastBlock.GetHash());
@@ -628,7 +627,7 @@ namespace Stratis.SmartContracts.IntegrationTests.PoW
             BuildCallContractTransactionResponse response = this.node1.SendCallContractTransaction(nameof(RecursiveLoopCall.Call), preResponse.NewContractAddress, amount, gasLimit: gasLimit);
             this.node2.WaitMempoolCount(1);
             this.node2.MineBlocks(1);
-            Block lastBlock = this.node1.GetLastBlock();
+            NBitcoin.Block lastBlock = this.node1.GetLastBlock();
 
             // Blocks progressed
             Assert.NotEqual(currentHash, lastBlock.GetHash());

--- a/src/Stratis.SmartContracts.IntegrationTests/PoW/ContractInternalTransferTests.cs
+++ b/src/Stratis.SmartContracts.IntegrationTests/PoW/ContractInternalTransferTests.cs
@@ -64,7 +64,7 @@ namespace Stratis.SmartContracts.IntegrationTests.PoW
             this.node2.WaitMempoolCount(1);
             this.node2.MineBlocks(1);
 
-            Block lastBlock = this.node1.GetLastBlock();
+            NBitcoin.Block lastBlock = this.node1.GetLastBlock();
 
             // Blocks progressed
             Assert.NotEqual(currentHash, lastBlock.GetHash());
@@ -133,7 +133,7 @@ namespace Stratis.SmartContracts.IntegrationTests.PoW
             this.node2.WaitMempoolCount(1);
             this.node2.MineBlocks(1);
 
-            Block lastBlock = this.node1.GetLastBlock();
+            NBitcoin.Block lastBlock = this.node1.GetLastBlock();
 
             // Blocks progressed
             Assert.NotEqual(currentHash, lastBlock.GetHash());
@@ -198,7 +198,7 @@ namespace Stratis.SmartContracts.IntegrationTests.PoW
             this.node2.WaitMempoolCount(1);
             this.node2.MineBlocks(1);
             Assert.NotNull(this.node1.GetCode(response.NewContractAddress));
-            Block lastBlock = this.node1.GetLastBlock();
+            NBitcoin.Block lastBlock = this.node1.GetLastBlock();
 
             // Blocks progressed
             Assert.NotEqual(currentHash, lastBlock.GetHash());
@@ -273,7 +273,7 @@ namespace Stratis.SmartContracts.IntegrationTests.PoW
             BuildCallContractTransactionResponse response = this.node1.SendCallContractTransaction(nameof(NestedCallsStarter.Start), preResponse.NewContractAddress, amount, parameters);
             this.node2.WaitMempoolCount(1);
             this.node2.MineBlocks(1);
-            Block lastBlock = this.node1.GetLastBlock();
+            NBitcoin.Block lastBlock = this.node1.GetLastBlock();
 
             // Blocks progressed
             Assert.NotEqual(currentHash, lastBlock.GetHash());
@@ -324,7 +324,7 @@ namespace Stratis.SmartContracts.IntegrationTests.PoW
             this.node1.WaitMempoolCount(1);
             this.node1.MineBlocks(1);
             Assert.NotNull(this.node1.GetCode(response.NewContractAddress));
-            Block lastBlock = this.node1.GetLastBlock();
+            NBitcoin.Block lastBlock = this.node1.GetLastBlock();
 
             // Storage from nested call succeeded
             Assert.NotNull(this.node1.GetStorageValue(response.NewContractAddress, "Caller"));
@@ -378,7 +378,7 @@ namespace Stratis.SmartContracts.IntegrationTests.PoW
             this.node2.WaitMempoolCount(1);
             this.node2.MineBlocks(1);
 
-            Block lastBlock = this.node1.GetLastBlock();
+            NBitcoin.Block lastBlock = this.node1.GetLastBlock();
 
             // Blocks progressed
             Assert.NotEqual(currentHash, lastBlock.GetHash());

--- a/src/Stratis.SmartContracts.IntegrationTests/PoW/ContractParameterSerializationTests.cs
+++ b/src/Stratis.SmartContracts.IntegrationTests/PoW/ContractParameterSerializationTests.cs
@@ -67,7 +67,7 @@ namespace Stratis.SmartContracts.IntegrationTests.PoW
             BuildCreateContractTransactionResponse response = this.node1.SendCreateContractTransaction(compilationResult.Compilation, amount, parameters);
             this.node2.WaitMempoolCount(1);
             this.node2.MineBlocks(1);
-            Block lastBlock = this.node1.GetLastBlock();
+            NBitcoin.Block lastBlock = this.node1.GetLastBlock();
 
             // Blocks progressed
             Assert.NotEqual(currentHash, lastBlock.GetHash());
@@ -162,7 +162,7 @@ namespace Stratis.SmartContracts.IntegrationTests.PoW
             BuildCallContractTransactionResponse response = this.node1.SendCallContractTransaction(nameof(CallWithAllParameters.Call), preResponse.NewContractAddress, amount, parameters);
             this.node2.WaitMempoolCount(1);
             this.node2.MineBlocks(1);
-            Block lastBlock = this.node1.GetLastBlock();
+            NBitcoin.Block lastBlock = this.node1.GetLastBlock();
 
             // Blocks progressed
             Assert.NotEqual(currentHash, lastBlock.GetHash());
@@ -228,7 +228,7 @@ namespace Stratis.SmartContracts.IntegrationTests.PoW
             BuildCreateContractTransactionResponse response = this.node1.SendCreateContractTransaction(compilationResult.Compilation, amount, parameters);
             this.node2.WaitMempoolCount(1);
             this.node2.MineBlocks(1);
-            Block lastBlock = this.node1.GetLastBlock();
+            NBitcoin.Block lastBlock = this.node1.GetLastBlock();
 
             // Blocks progressed
             Assert.NotEqual(currentHash, lastBlock.GetHash());
@@ -287,7 +287,7 @@ namespace Stratis.SmartContracts.IntegrationTests.PoW
             BuildCreateContractTransactionResponse response = this.node1.SendCreateContractTransaction(compilationResult.Compilation, amount, parameters);
             this.node2.WaitMempoolCount(1);
             this.node2.MineBlocks(1);
-            Block lastBlock = this.node1.GetLastBlock();
+            NBitcoin.Block lastBlock = this.node1.GetLastBlock();
 
             // Blocks progressed
             Assert.NotEqual(currentHash, lastBlock.GetHash());

--- a/src/Stratis.SmartContracts.Networks/SmartContractsPoARegTest.cs
+++ b/src/Stratis.SmartContracts.Networks/SmartContractsPoARegTest.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using NBitcoin;
 using NBitcoin.DataEncoders;
 using NBitcoin.Protocol;
@@ -29,7 +27,7 @@ namespace Stratis.SmartContracts.Networks
             this.GenesisVersion = 1;
             this.GenesisReward = Money.Zero;
 
-            Block genesisBlock = CreatePoAGenesisBlock(consensusFactory, this.GenesisTime, this.GenesisNonce, this.GenesisBits, this.GenesisVersion, this.GenesisReward);
+            NBitcoin.Block genesisBlock = CreatePoAGenesisBlock(consensusFactory, this.GenesisTime, this.GenesisNonce, this.GenesisBits, this.GenesisVersion, this.GenesisReward);
 
             this.Genesis = genesisBlock;
 

--- a/src/Stratis.SmartContracts.Token.Tests/StandardTokenTests.cs
+++ b/src/Stratis.SmartContracts.Token.Tests/StandardTokenTests.cs
@@ -2,6 +2,7 @@ using System;
 using Moq;
 using Stratis.Bitcoin.Features.SmartContracts.Networks;
 using Stratis.SmartContracts.Core;
+using Stratis.SmartContracts.Executor.Reflection;
 using Xunit;
 
 namespace Stratis.SmartContracts.Token.Tests

--- a/src/Stratis.SmartContracts/AssemblyInfo.cs
+++ b/src/Stratis.SmartContracts/AssemblyInfo.cs
@@ -5,6 +5,7 @@
 [assembly: InternalsVisibleTo("Stratis.SmartContracts.Backend")]
 [assembly: InternalsVisibleTo("Stratis.SmartContracts.Demo")]
 [assembly: InternalsVisibleTo("Stratis.SmartContracts.Compiler")]
+[assembly: InternalsVisibleTo("Stratis.SmartContracts.Executor.Reflection")]
 [assembly: InternalsVisibleTo("Stratis.Bitcoin.Features.SmartContracts")]
 [assembly: InternalsVisibleTo("Stratis.Bitcoin.Features.SmartContractsApi")]
 [assembly: InternalsVisibleTo("Stratis.Bitcoin.Features.SmartContracts.Tests")]

--- a/src/Stratis.SmartContracts/Block.cs
+++ b/src/Stratis.SmartContracts/Block.cs
@@ -1,4 +1,4 @@
-﻿namespace Stratis.SmartContracts.Core
+﻿namespace Stratis.SmartContracts
 {
     public struct Block : IBlock
     {

--- a/src/Stratis.SmartContracts/Message.cs
+++ b/src/Stratis.SmartContracts/Message.cs
@@ -1,4 +1,4 @@
-﻿namespace Stratis.SmartContracts.Core
+﻿namespace Stratis.SmartContracts
 {
     public sealed class Message : IMessage
     {


### PR DESCRIPTION
Removes all references to Stratis.SmartContracts (which is implementation-specific) from Stratis.SmartContracts.Core.