### PR TITLE
[Mempool] AttachedPeer can be null when relaying.

### DIFF
--- a/src/Stratis.Bitcoin.Features.MemoryPool/MempoolBehavior.cs
+++ b/src/Stratis.Bitcoin.Features.MemoryPool/MempoolBehavior.cs
@@ -314,7 +314,7 @@ namespace Stratis.Bitcoin.Features.MemoryPool
                     this.logger.LogInformation("Transaction ID '{0}' inventory sent in violation of protocol peer '{1}'.", inv.Hash, peer.RemoteSocketEndpoint);
                     continue;
                 }
-   
+
                 send.Inventory.Add(new InventoryVector(peer.AddSupportedOptions(InventoryType.MSG_TX), inv.Hash));
             }
 
@@ -487,6 +487,12 @@ namespace Stratis.Bitcoin.Features.MemoryPool
             IEnumerable<MempoolBehavior> behaviours = peers.Select(s => s.Behavior<MempoolBehavior>());
             foreach (MempoolBehavior mempoolBehavior in behaviours)
             {
+                if (mempoolBehavior?.AttachedPeer == null)
+                {
+                    this.logger.LogTrace("Peer is null, skipped.");
+                    continue;
+                }
+
                 this.logger.LogTrace("Attempting to relaying transaction ID '{0}' to peer '{1}'.", hash, mempoolBehavior?.AttachedPeer.RemoteSocketEndpoint);
                 if (mempoolBehavior?.AttachedPeer.PeerVersion.Relay ?? false)
                 {

--- a/src/Stratis.Bitcoin.Features.MemoryPool/MempoolBehavior.cs
+++ b/src/Stratis.Bitcoin.Features.MemoryPool/MempoolBehavior.cs
@@ -487,14 +487,17 @@ namespace Stratis.Bitcoin.Features.MemoryPool
             IEnumerable<MempoolBehavior> behaviours = peers.Select(s => s.Behavior<MempoolBehavior>());
             foreach (MempoolBehavior mempoolBehavior in behaviours)
             {
-                if (mempoolBehavior?.AttachedPeer == null)
+                var peer = mempoolBehavior?.AttachedPeer;
+
+                if (peer == null)
                 {
                     this.logger.LogTrace("Peer is null, skipped.");
                     continue;
                 }
 
-                this.logger.LogTrace("Attempting to relaying transaction ID '{0}' to peer '{1}'.", hash, mempoolBehavior?.AttachedPeer.RemoteSocketEndpoint);
-                if (mempoolBehavior?.AttachedPeer.PeerVersion.Relay ?? false)
+                this.logger.LogTrace("Attempting to relaying transaction ID '{0}' to peer '{1}'.", hash, peer.RemoteSocketEndpoint);
+
+                if (peer.PeerVersion.Relay)
                 {
                     mempoolBehavior.AddTransactionToSend(hash);
                     this.logger.LogTrace("Added transaction ID '{0}' to send inventory of peer '{1}'.", hash, mempoolBehavior?.AttachedPeer.RemoteSocketEndpoint);

--- a/src/Stratis.Bitcoin.Features.MemoryPool/MempoolBehavior.cs
+++ b/src/Stratis.Bitcoin.Features.MemoryPool/MempoolBehavior.cs
@@ -500,11 +500,11 @@ namespace Stratis.Bitcoin.Features.MemoryPool
                 if (peer.PeerVersion.Relay)
                 {
                     mempoolBehavior.AddTransactionToSend(hash);
-                    this.logger.LogTrace("Added transaction ID '{0}' to send inventory of peer '{1}'.", hash, mempoolBehavior?.AttachedPeer.RemoteSocketEndpoint);
+                    this.logger.LogTrace("Added transaction ID '{0}' to send inventory of peer '{1}'.", hash, peer.RemoteSocketEndpoint);
                 }
                 else
                 {
-                    this.logger.LogTrace("Peer '{0}' does not support 'Relay', skipped.", mempoolBehavior?.AttachedPeer.RemoteSocketEndpoint);
+                    this.logger.LogTrace("Peer '{0}' does not support 'Relay', skipped.", peer.RemoteSocketEndpoint);
                 }
             }
         }


### PR DESCRIPTION
This is to see if this fixes the timeout in integration tests as this test fails to complete:

`MempoolReceiveFromManyNodes`