### PR TITLE
Added scripts to compile the StratisD to one single executable 🤯

### DIFF
--- a/Scripts/linux-x64.package.sh
+++ b/Scripts/linux-x64.package.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+dotnet_runtime="linux-x64"
+warp_runtime="linux-x64"
+configuration="release"
+git_commit=$(git log --format=%h --abbrev=7 -n 1)
+publish_directory="../src/Stratis.StratisD/bin/${configuration}/netcoreapp2.1/${dotnet_runtime}/publish"
+download_directory="/tmp"
+warp="${warp_runtime}.warp-packer"
+project_path="../src/Stratis.StratisD/Stratis.StratisD.csproj"
+
+echo warp is ${warp}
+echo "Download directory is:" $download_directory
+echo "Publish directory is: " $publish_directory
+echo "Download file is " ${download_directory}/${warp}
+echo "Current directory is:" $PWD 
+echo "Git commit to build:" $git_commit
+
+echo "Downloading warp..."
+curl -L -o ${download_directory}/${warp} "https://github.com/stratisproject/warp/releases/download/v0.2.1/${warp}"
+
+if [ -f "${download_directory}/${warp}" ]; then
+   echo "Warp packer downloaded succesfully."
+else
+   echo "Warp packer didn't download successfully."
+fi
+
+echo "Building the full node..."
+dotnet --info
+dotnet publish $project_path -c $configuration -v m -r $dotnet_runtime 
+
+echo "List of files to package:" 
+ls $publish_directory
+
+echo "Packaging the daemon..."
+chmod +x "${download_directory}/${warp}"
+"${download_directory}/./${warp}" --arch $warp_runtime --input_dir $publish_directory --exec Stratis.StratisD --output ${publish_directory}/Stratis-$git_commit
+
+echo "Done."

--- a/Scripts/osx-x64.package.sh
+++ b/Scripts/osx-x64.package.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+dotnet_runtime="osx-x64"
+warp_runtime="macos-x64"
+configuration="release"
+git_commit=$(git log --format=%h --abbrev=7 -n 1)
+publish_directory="../src/Stratis.StratisD/bin/${configuration}/netcoreapp2.1/${dotnet_runtime}/publish"
+download_directory="/tmp"
+warp="${warp_runtime}.warp-packer"
+project_path="../src/Stratis.StratisD/Stratis.StratisD.csproj"
+
+echo warp is ${warp}
+echo "Download directory is:" $download_directory
+echo "Publish directory is: " $publish_directory
+echo "Download file is " ${download_directory}/${warp}
+echo "Current directory is:" $PWD 
+echo "Git commit to build:" $git_commit
+
+echo "Downloading warp..."
+curl -L -o ${download_directory}/${warp} "https://github.com/stratisproject/warp/releases/download/v0.2.1/${warp}"
+
+if [ -f "${download_directory}/${warp}" ]; then
+   echo "Warp packer downloaded succesfully."
+else
+   echo "Warp packer didn't download successfully."
+fi
+
+echo "Building the full node..."
+dotnet --info
+dotnet publish $project_path -c $configuration -v m -r $dotnet_runtime 
+
+echo "List of files to package:" 
+ls $publish_directory
+
+echo "Packaging the daemon..."
+chmod +x "${download_directory}/${warp}"
+"${download_directory}/./${warp}" --arch $warp_runtime --input_dir $publish_directory --exec Stratis.StratisD --output ${publish_directory}/Stratis-$git_commit
+
+echo "Done."

--- a/Scripts/windows-x64.package.ps1
+++ b/Scripts/windows-x64.package.ps1
@@ -1,0 +1,36 @@
+$configuration="release"
+$runtime="win-x64"
+$git_commit=(git log --format=%h --abbrev=7 -n 1)
+$publish_directory="..\src\Stratis.StratisD\bin\$configuration\netcoreapp2.1\$runtime\publish"
+$download_directory=$env:temp
+$warp="$download_directory\windows-x64.warp-packer.exe"
+$project_path="..\src\Stratis.StratisD\Stratis.StratisD.csproj"
+
+Write-Host "Download directory is $download_directory" -foregroundcolor "Magenta"
+Write-Host "Current directory is $PWD" -foregroundcolor "Magenta"
+Write-Host "Git commit to build: $git_commit" -foregroundcolor "Magenta"
+
+Write-Host "Downloading warp..." -foregroundcolor "Magenta"
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+Invoke-WebRequest https://github.com/stratisproject/warp/releases/download/v0.2.1/windows-x64.warp-packer.exe -O $download_directory\windows-x64.warp-packer.exe
+
+If(Get-ChildItem $warp)
+{
+    Write-Host "Warp downloaded succesfully." -foregroundcolor "Magenta"
+
+    $size=((Get-Item "$warp").Length)
+    Write-Host "Size is $size" -foregroundcolor "Magenta"
+}
+
+Write-Host "Building the full node..." -foregroundcolor "Magenta"
+dotnet --info
+dotnet publish $project_path -c $configuration -v m -r $runtime 
+
+Write-Host "List of files to package:" -foregroundcolor "Magenta"
+Get-ChildItem -Path $publish_directory
+
+Write-Host "Packaging the daemon..." -foregroundcolor "Magenta"
+& $warp --arch windows-x64 --input_dir $publish_directory --exec Stratis.StratisD.exe --output $publish_directory\Stratis-$git_commit.exe
+
+Write-Host "Done." -foregroundcolor "green"
+Read-Host "Press ENTER"


### PR DESCRIPTION
Does what it says on the tin.
Use at will. 
The name of the file output contains the git commit of the code contained in the executable, e.g Stratis-a51d85c.exe.
To run testnet, just do `Stratis-a51d85c.exe -tesnet` in a command line.