### PR TITLE
Size formatting

### DIFF
--- a/src/Stratis.Bitcoin.Features.Wallet/WalletFeature.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/WalletFeature.cs
@@ -134,7 +134,7 @@ namespace Stratis.Bitcoin.Features.Wallet
                     foreach (HdAccount account in this.walletManager.GetAccounts(walletName))
                     {
                         AccountBalance accountBalance = this.walletManager.GetBalances(walletName, account.Name).Single();
-                        log.AppendLine("Wallet: " + (walletName + ",").PadRight(LoggingConfiguration.ColumnLength) 
+                        log.AppendLine(($"{walletName}/{account.Name}" + ",").PadRight(LoggingConfiguration.ColumnLength + 10) 
                                                   + (" Confirmed balance: " + accountBalance.AmountConfirmed.ToString()).PadRight(LoggingConfiguration.ColumnLength + 20)
                                                   + " Unconfirmed balance: " + accountBalance.AmountUnconfirmed.ToString());
                     }

--- a/src/Stratis.Bitcoin/Consensus/ConsensusManager.cs
+++ b/src/Stratis.Bitcoin/Consensus/ConsensusManager.cs
@@ -1209,10 +1209,10 @@ namespace Stratis.Bitcoin.Consensus
 
             lock (this.peerLock)
             {
-                string unconsumedBlocks = this.formatBigNumber(this.chainedHeaderTree.UnconsumedBlocksCount);
+                string unconsumedBlocks = this.FormatBigNumber(this.chainedHeaderTree.UnconsumedBlocksCount);
 
-                string unconsumedBytes = this.formatBigNumber(this.chainedHeaderTree.UnconsumedBlocksDataBytes);
-                string maxUnconsumedBytes = this.formatBigNumber(MaxUnconsumedBlocksDataBytes);
+                string unconsumedBytes = this.FormatBigNumber(this.chainedHeaderTree.UnconsumedBlocksDataBytes);
+                string maxUnconsumedBytes = this.FormatBigNumber(MaxUnconsumedBlocksDataBytes);
 
                 double filledPercentage = Math.Round((this.chainedHeaderTree.UnconsumedBlocksDataBytes / (double)MaxUnconsumedBlocksDataBytes) * 100, 2);
 
@@ -1221,17 +1221,10 @@ namespace Stratis.Bitcoin.Consensus
         }
 
         /// <summary>Formats the big number.</summary>
-        /// <remarks><c>123456789</c> => <c>123 456 789</c></remarks>
-        private string formatBigNumber(long number)
+        /// <remarks><c>123456789</c> => <c>123,456,789</c></remarks>
+        private string FormatBigNumber(long number)
         {
-            string temp = number.ToString("N").Replace(',', ' ');
-
-            int index = temp.IndexOf(".00");
-
-            if (index != -1)
-                temp = temp.Substring(0, index);
-
-            return temp;
+            return $"{number:#,##0}";
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
1. 
Changed the size of consumed blocks in the console from
```
Unconsumed blocks: -126 -- (-50 633 / 209 715 200 bytes). Cache is filled by: -0.02%
```
to
```
Unconsumed blocks: -126 -- (-50,633 / 209,715,200 bytes). Cache is filled by: -0.02%
```
because space is not a proper separator for thousands.

2. 
Changed the balance of wallets in the console from
```
 ======Wallets======
Wallet: newWallet, Confirmed balance: 1000.00000000        Unconfirmed balance: 0.00000000
Wallet: newWallet, Confirmed balance: 0.00000000           Unconfirmed balance: 0.00000000
Wallet: myRecoveredWallet, Confirmed balance: 500.77550400         Unconfirmed balance: 0.00000000
```
to
```
 ======Wallets======
newWallet/account 0,           Confirmed balance: 1000.00000000        Unconfirmed balance: 0.00000000
newWallet/account 1,           Confirmed balance: 0.00000000           Unconfirmed balance: 0.00000000
myRecoveredWallet/account 0,   Confirmed balance: 500.77550400         Unconfirmed balance: 0.00000000
```
because multiple accounts were appearing to be the same wallet, twice.