### PR TITLE
Fix the calculation of sigOps cost when mining a block

### DIFF
--- a/src/Stratis.Bitcoin.Features.Miner/BlockDefinition.cs
+++ b/src/Stratis.Bitcoin.Features.Miner/BlockDefinition.cs
@@ -376,7 +376,7 @@ namespace Stratis.Bitcoin.Features.Miner
 
                 long packageSize = iter.SizeWithAncestors;
                 Money packageFees = iter.ModFeesWithAncestors;
-                long packageSigOpsCost = iter.SizeWithAncestors;
+                long packageSigOpsCost = iter.SigOpCostWithAncestors;
                 if (fUsingModified)
                 {
                     packageSize = modit.SizeWithAncestors;


### PR DESCRIPTION
Fixes https://github.com/stratisproject/StratisBitcoinFullNode/issues/2590

So before, when checking whether the size of transactions to be included in a block wouldn't exceed the max sigOps, we looked at the **size** of the trnsactions, rather than at the number of sigOps.
This is now fixed.