### PR TITLE
PH BlockStoreSignaled (#2589)

### DIFF
--- a/src/Stratis.Bitcoin.Features.BlockStore/BlockStoreSignaled.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/BlockStoreSignaled.cs
@@ -221,13 +221,13 @@ namespace Stratis.Bitcoin.Features.BlockStore
                 return;
             }
 
-            // Announce the blocks to each of the peers.
-            List<BlockStoreBehavior> behaviours = peers.Select(s => s.Behavior<BlockStoreBehavior>())
-                .Where(b => b != null).ToList();
+            // Announces the headers to peers using the appropriate behavior (BlockStoreBehavior or behaviors that inherits from it).
+            List<BlockStoreBehavior> behaviors = peers.Select(peer => peer.Behavior<BlockStoreBehavior>())
+                .Where(behavior => behavior != null).ToList();
 
-            this.logger.LogTrace("{0} blocks will be sent to {1} peers.", batch.Count, behaviours.Count);
-            foreach (BlockStoreBehavior behaviour in behaviours)
-                await behaviour.AnnounceBlocksAsync(batch).ConfigureAwait(false);
+            this.logger.LogTrace("{0} blocks will be sent to {1} peers.", batch.Count, behaviors.Count);
+            foreach (BlockStoreBehavior behavior in behaviors)
+                await behavior.AnnounceBlocksAsync(batch).ConfigureAwait(false);
         }
 
         /// <inheritdoc />

--- a/src/Stratis.Bitcoin.Features.BlockStore/BlockStoreSignaled.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/BlockStoreSignaled.cs
@@ -25,7 +25,7 @@ namespace Stratis.Bitcoin.Features.BlockStore
         private readonly IConnectionManager connection;
 
         /// <summary>Instance logger.</summary>
-        private readonly ILogger logger;
+        protected readonly ILogger logger;
 
         /// <summary>Global application life cycle control - triggers when application shuts down.</summary>
         private readonly INodeLifetime nodeLifetime;
@@ -85,7 +85,7 @@ namespace Stratis.Bitcoin.Features.BlockStore
             this.logger.LogTrace("Block hash is '{0}'.", chainedHeader.HashBlock);
 
             // Ensure the block is written to disk before relaying.
-            this.blockStoreQueue.AddToPending(blockPair);
+            this.AddBlockToQueue(blockPair);
 
             if (this.initialBlockDownloadState.IsInitialBlockDownload())
             {
@@ -95,6 +95,16 @@ namespace Stratis.Bitcoin.Features.BlockStore
 
             this.logger.LogTrace("Block header '{0}' added to the announce queue.", chainedHeader);
             this.blocksToAnnounce.Enqueue(chainedHeader);
+        }
+
+        /// <summary>
+        /// Adds the block to queue.
+        /// Ensures the block is written to disk before relaying to peers.
+        /// </summary>
+        /// <param name="blockPair">The block pair.</param>
+        protected virtual void AddBlockToQueue(ChainedHeaderBlock blockPair)
+        {
+            this.blockStoreQueue.AddToPending(blockPair);
         }
 
         /// <summary>

--- a/src/Stratis.Bitcoin.Features.BlockStore/ProvenHeadersBlockStoreSignaled.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/ProvenHeadersBlockStoreSignaled.cs
@@ -1,8 +1,11 @@
-﻿using Microsoft.Extensions.Logging;
+﻿using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Extensions.Logging;
 using NBitcoin;
 using Stratis.Bitcoin.Base;
 using Stratis.Bitcoin.Connection;
 using Stratis.Bitcoin.Interfaces;
+using Stratis.Bitcoin.P2P.Peer;
 using Stratis.Bitcoin.Primitives;
 using Stratis.Bitcoin.Utilities;
 
@@ -46,17 +49,23 @@ namespace Stratis.Bitcoin.Features.BlockStore
             base.AddBlockToQueue(blockPair);
 
             int blockHeight = blockPair.ChainedHeader.Height;
-            PosBlock block = blockPair.Block as PosBlock;
-            if (block != null && this.AreProvenHeadersActivated(blockHeight))
+            if (this.AreProvenHeadersActivated(blockHeight))
             {
                 uint256 blockHash = blockPair.Block.Header.GetHash();
+
+                if (blockPair.ChainedHeader.Header is ProvenBlockHeader phHeader)
+                {
+                    return;//TODo
+                }
 
                 ProvenBlockHeader provenHeader = this.provenBlockHeaderStore.GetAsync(blockPair.ChainedHeader.Height).GetAwaiter().GetResult();
                 // Proven Header not found? create it now.
                 if (provenHeader == null)
                 {
                     logger.LogTrace("Proven Header at height {0} NOT found.", blockHeight);
-                    CreateAndStoreProvenHeader(blockHeight, block);
+                    CreateAndStoreProvenHeader(blockHeight, (PosBlock)blockPair.Block);
+
+                    blockPair.ChainedHeader.Header ==
                 }
                 else
                 {
@@ -68,10 +77,7 @@ namespace Stratis.Bitcoin.Features.BlockStore
                     }
                     else
                     {
-                        logger.LogTrace("Proven Header at height {0} found but hashes don't match, updating the stored Proven Header.", blockHeight);
-
-                        //TODO: does AddToPendingBatch manage itself the removal of a PH at the same height? I doubt, need to investigate
-                        CreateAndStoreProvenHeader(blockHeight, block);
+                        throw new BlockStoreException("TODO");
                     }
                 }
             }

--- a/src/Stratis.Bitcoin.Features.BlockStore/ProvenHeadersBlockStoreSignaled.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/ProvenHeadersBlockStoreSignaled.cs
@@ -1,0 +1,94 @@
+﻿using Microsoft.Extensions.Logging;
+using NBitcoin;
+using Stratis.Bitcoin.Base;
+using Stratis.Bitcoin.Connection;
+using Stratis.Bitcoin.Interfaces;
+using Stratis.Bitcoin.Primitives;
+using Stratis.Bitcoin.Utilities;
+
+namespace Stratis.Bitcoin.Features.BlockStore
+{
+    public class ProvenHeadersBlockStoreSignaled : BlockStoreSignaled
+    {
+        private readonly Network network;
+        private readonly IProvenBlockHeaderStore provenBlockHeaderStore;
+
+        public ProvenHeadersBlockStoreSignaled(
+            Network network,
+            IBlockStoreQueue blockStoreQueue,
+            ConcurrentChain chain,
+            StoreSettings storeSettings,
+            IChainState chainState,
+            IConnectionManager connection,
+            INodeLifetime nodeLifetime,
+            ILoggerFactory loggerFactory,
+            IInitialBlockDownloadState initialBlockDownloadState,
+            IProvenBlockHeaderStore provenBlockHeaderStore)
+            : base(blockStoreQueue, chain, storeSettings, chainState, connection, nodeLifetime, loggerFactory, initialBlockDownloadState)
+        {
+            this.network = Guard.NotNull(network, nameof(network));
+            this.provenBlockHeaderStore = Guard.NotNull(provenBlockHeaderStore, nameof(provenBlockHeaderStore));
+        }
+
+        private bool AreProvenHeadersActivated(int blockHeight)
+        {
+            if (this.network.Consensus.Options is PosConsensusOptions options)
+            {
+                return blockHeight >= options.ProvenHeadersActivationHeight;
+            }
+
+            return false;
+        }
+
+        /// <inheritdoc />
+        protected override void AddBlockToQueue(ChainedHeaderBlock blockPair)
+        {
+            base.AddBlockToQueue(blockPair);
+
+            int blockHeight = blockPair.ChainedHeader.Height;
+            PosBlock block = blockPair.Block as PosBlock;
+            if (block != null && this.AreProvenHeadersActivated(blockHeight))
+            {
+                uint256 blockHash = blockPair.Block.Header.GetHash();
+
+                ProvenBlockHeader provenHeader = this.provenBlockHeaderStore.GetAsync(blockPair.ChainedHeader.Height).GetAwaiter().GetResult();
+                // Proven Header not found? create it now.
+                if (provenHeader == null)
+                {
+                    logger.LogTrace("Proven Header at height {0} NOT found.", blockHeight);
+                    CreateAndStoreProvenHeader(blockHeight, block);
+                }
+                else
+                {
+                    // If the Proven Header is the right one, then it's OK and we can return without doing anything.
+                    uint256 provenHeaderHash = provenHeader.GetHash();
+                    if (provenHeaderHash == blockHash)
+                    {
+                        logger.LogTrace("Proven Header {0} found.", blockHash);
+                    }
+                    else
+                    {
+                        logger.LogTrace("Proven Header at height {0} found but hashes don't match, updating the stored Proven Header.", blockHeight);
+
+                        //TODO: does AddToPendingBatch manage itself the removal of a PH at the same height? I doubt, need to investigate
+                        CreateAndStoreProvenHeader(blockHeight, block);
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Creates the and store a <see cref="ProvenBlockHeader"/>.
+        /// </summary>
+        /// <param name="blockHeight">Height of the block used to generate its Proven Header.</param>
+        /// <param name="block">Block used to generate its Proven Header.</param>
+        private void CreateAndStoreProvenHeader(int blockHeight, PosBlock block)
+        {
+            ProvenBlockHeader newProvenHeader = ((PosConsensusFactory)this.network.Consensus.ConsensusFactory).CreateProvenBlockHeader(block);
+
+            uint256 provenHeaderHash = newProvenHeader.GetHash();
+            logger.LogTrace("Creating Proven Header at height {0} with hash {1} and adding to the store.", blockHeight, provenHeaderHash);
+            this.provenBlockHeaderStore.AddToPendingBatch(newProvenHeader, new HashHeightPair(provenHeaderHash, blockHeight));
+        }
+    }
+}

--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/ProvenBlockHeaders/ProvenBlockHeaderRepositoryTests.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/ProvenBlockHeaders/ProvenBlockHeaderRepositoryTests.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.Logging;
 using Moq;
 using NBitcoin;
 using Stratis.Bitcoin.Features.Consensus.ProvenBlockHeaders;
+using Stratis.Bitcoin.Interfaces;
 using Stratis.Bitcoin.Tests.Common;
 using Stratis.Bitcoin.Tests.Common.Logging;
 using Stratis.Bitcoin.Utilities;

--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/ProvenBlockHeaders/ProvenBlockHeaderStoreTests.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/ProvenBlockHeaders/ProvenBlockHeaderStoreTests.cs
@@ -10,6 +10,7 @@ using Moq;
 using NBitcoin;
 using Stratis.Bitcoin.Consensus;
 using Stratis.Bitcoin.Features.Consensus.ProvenBlockHeaders;
+using Stratis.Bitcoin.Interfaces;
 using Stratis.Bitcoin.Tests.Common;
 using Stratis.Bitcoin.Tests.Common.Logging;
 using Stratis.Bitcoin.Utilities;

--- a/src/Stratis.Bitcoin.Features.Consensus/ProvenBlockHeaders/ProvenBlockHeaderRepository.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/ProvenBlockHeaders/ProvenBlockHeaderRepository.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -8,6 +7,7 @@ using DBreeze.DataTypes;
 using DBreeze.Utils;
 using Microsoft.Extensions.Logging;
 using NBitcoin;
+using Stratis.Bitcoin.Interfaces;
 using Stratis.Bitcoin.Utilities;
 
 namespace Stratis.Bitcoin.Features.Consensus.ProvenBlockHeaders

--- a/src/Stratis.Bitcoin.Features.Consensus/ProvenBlockHeaders/ProvenBlockHeaderStore.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/ProvenBlockHeaders/ProvenBlockHeaderStore.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using NBitcoin;
 using Stratis.Bitcoin.Features.Consensus.CoinViews;
+using Stratis.Bitcoin.Interfaces;
 using Stratis.Bitcoin.Utilities;
 
 namespace Stratis.Bitcoin.Features.Consensus.ProvenBlockHeaders
@@ -280,7 +281,7 @@ namespace Stratis.Bitcoin.Features.Consensus.ProvenBlockHeaders
         /// <inheritdoc />
         public void AddToPendingBatch(ProvenBlockHeader provenBlockHeader, HashHeightPair newTip)
         {
-            lock(this.lockObject)
+            lock (this.lockObject)
             {
                 this.PendingBatch.Add(newTip.Height, provenBlockHeader);
 

--- a/src/Stratis.Bitcoin/Interfaces/IProvenBlockHeaderProvider.cs
+++ b/src/Stratis.Bitcoin/Interfaces/IProvenBlockHeaderProvider.cs
@@ -4,7 +4,7 @@ using System.Threading.Tasks;
 using NBitcoin;
 using Stratis.Bitcoin.Utilities;
 
-namespace Stratis.Bitcoin.Features.Consensus.ProvenBlockHeaders
+namespace Stratis.Bitcoin.Interfaces
 {
     /// <summary>
     /// Interface <see cref="ProvenBlockHeader"/> provider.

--- a/src/Stratis.Bitcoin/Interfaces/IProvenBlockHeaderRepository.cs
+++ b/src/Stratis.Bitcoin/Interfaces/IProvenBlockHeaderRepository.cs
@@ -4,7 +4,7 @@ using System.Threading.Tasks;
 using NBitcoin;
 using Stratis.Bitcoin.Utilities;
 
-namespace Stratis.Bitcoin.Features.Consensus.ProvenBlockHeaders
+namespace Stratis.Bitcoin.Interfaces
 {
     /// <summary>
     /// Interface to insert and retrieve <see cref="ProvenBlockHeader"/> items from the database repository.

--- a/src/Stratis.Bitcoin/Interfaces/IProvenBlockHeaderStore.cs
+++ b/src/Stratis.Bitcoin/Interfaces/IProvenBlockHeaderStore.cs
@@ -3,7 +3,7 @@ using System.Threading.Tasks;
 using NBitcoin;
 using Stratis.Bitcoin.Utilities;
 
-namespace Stratis.Bitcoin.Features.Consensus.ProvenBlockHeaders
+namespace Stratis.Bitcoin.Interfaces
 {
     /// <summary>
     /// Cache layer for <see cref="ProvenBlockHeaderStore"/>s.


### PR DESCRIPTION
Implemented as per #2589 requirements

Actually it's not yet complete because it isn't clear what to do once a ProvenHeader is created because the arguments passed, are then used to announce the blocks and so if a header is a legacy header this wouldn't work.
Moreover the eventual assignment
//blockPair.Block.Header = blockPair.ChainedHeader.Header = createdProvenHeader;
can't actually be done because both those property setters aren't accessible and I'm not sure is a good idea to set them public or have a way to change it once a block has been instantiated

as a final note it seems we want to get rid of whitelisted legacy nodes so the creation shouldn't be needed (all nodes should talk using proven header)