### PR TITLE
Make sure we send an inv message to downloaders needing more blocks.

### DIFF
--- a/src/Stratis.Bitcoin.Features.BlockStore/BlockStoreBehavior.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/BlockStoreBehavior.cs
@@ -264,9 +264,8 @@ namespace Stratis.Bitcoin.Features.BlockStore
             int count = inv.Inventory.Count;
             if (count > 0)
             {
-                ChainedHeader highestHeader = this.consensusManagerBehavior.BestSentHeader;
-
-                if (highestHeader?.Height < lastAddedChainedHeader.Height)
+                // If we reached the limmit size of inv, we need to tell the downloader to send another 'getblocks' message.
+                if (count == InvPayload.MaxGetBlocksInventorySize && lastAddedChainedHeader != null)
                 {
                     this.logger.LogTrace("Setting peer's last block sent to '{0}'.", lastAddedChainedHeader);
                     this.lastSentHeader = lastAddedChainedHeader;


### PR DESCRIPTION
Fixes #2570 .

The flow for nodes requesting blocks using `getblocks` (like stratisX) is the following:

node A `getblocks` (do you have these blocks?) ----> node B
node A <--------- `inv` (yeah I got these hashes) node B
node A `getdata` (I like that, send blocks to me) ----------> node B
node A <------- `block` node B
node A <------- `block` node B
node A <------- `block` node B
etc..
Then, the logic in X says that if node B has sent the max number of block hashes in the `inv` to node A, then node B needs to send one last `inv` containing the last block hash, to trigger A into sending another `getblocks`.

```
int nLimit = 500;
LogPrint("net", "getblocks %d to %s limit %d\n", (pindex ? pindex->nHeight : -1), hashStop.ToString(), nLimit);
for (; pindex; pindex = pindex->pnext)
{
	if (pindex->GetBlockHash() == hashStop)
	{
		LogPrint("net", "  getblocks stopping at %d %s\n", pindex->nHeight, pindex->GetBlockHash().ToString());
		break;
	}
	pfrom->PushInventory(CInv(MSG_BLOCK, pindex->GetBlockHash()));
	if (--nLimit <= 0)
	{
		// When this block is requested, we'll send an inv that'll make them
		// getblocks the next batch of inventory.
		LogPrint("net", "  getblocks stopping at limit %d %s\n", pindex->nHeight, pindex->GetBlockHash().ToString());
		pfrom->hashContinue = pindex->GetBlockHash();
		break;
	}
}
```

We didn't do that in the C# node so the logic has been replicated.