### PR TITLE
Consensus manager reorg bug

### DIFF
--- a/src/NBitcoin/ChainedHeader.cs
+++ b/src/NBitcoin/ChainedHeader.cs
@@ -92,7 +92,7 @@ namespace NBitcoin
         /// <summary>
         /// An indicator that the current instance of <see cref="ChainedHeader"/> has been disconnected from the previous instance.
         /// </summary>
-        public bool IsConnected
+        public bool IsReferenceConnected
         {
             get { return this.Previous.Next.Any(c => ReferenceEquals(c, this)); }
         }

--- a/src/NBitcoin/ChainedHeader.cs
+++ b/src/NBitcoin/ChainedHeader.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using NBitcoin.BouncyCastle.Math;
 
 namespace NBitcoin
@@ -87,6 +88,14 @@ namespace NBitcoin
 
         /// <inheritdoc cref="ValidationState" />
         public ValidationState BlockValidationState { get; set; }
+
+        /// <summary>
+        /// An indicator that the current instance of <see cref="ChainedHeader"/> has been disconnected from the previous instance.
+        /// </summary>
+        public bool IsConnected
+        {
+            get { return this.Previous.Next.Any(c => ReferenceEquals(c, this)); }
+        }
 
         /// <summary>
         /// Block represented by this header is assumed to be valid and only subset of validation rules should be applied to it.

--- a/src/Stratis.Bitcoin.IntegrationTests/Compatibility/StratisXTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/Compatibility/StratisXTests.cs
@@ -2,6 +2,7 @@
 using System.Runtime.InteropServices;
 using System.Threading;
 using NBitcoin;
+using NBitcoin.Protocol;
 using Stratis.Bitcoin.Builder;
 using Stratis.Bitcoin.Features.BlockStore;
 using Stratis.Bitcoin.Features.Consensus;
@@ -22,8 +23,8 @@ namespace Stratis.Bitcoin.IntegrationTests.Compatibility
         /// Tests whether a quantity of blocks mined on SBFN are
         /// correctly synced to a stratisX node.
         /// </summary>
-        [Fact]
-        public void SBFNMinesBlocksXSyncs()
+        [Fact(Skip = "Takes a long time to run with SBFN making blocks. Need to investigate why.")]
+        public void SBFNMinesBlocks_XSyncs()
         {
             if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
@@ -41,19 +42,52 @@ namespace Stratis.Bitcoin.IntegrationTests.Compatibility
                 RPCClient stratisXRpc = stratisXNode.CreateRPCClient();
                 RPCClient stratisNodeRpc = stratisNode.CreateRPCClient();
 
-                // TODO: Need to troubleshoot why TestHelper.Connect() does not work here, possibly unsupported RPC method.
-                stratisXRpc.AddNode(stratisNode.Endpoint, false);
+                // TODO: Need to troubleshoot why TestHelper.Connect() does not work here, possibly unsupported RPC method (it seems that addnode does not work for X).
                 stratisNodeRpc.AddNode(stratisXNode.Endpoint, false);
 
                 // TODO: Similarly, the 'generate' RPC call is problematic on X. Possibly returning an unexpected JSON format.
                 TestHelper.MineBlocks(stratisNode, 10);
 
-                // As we are not actually sending transactions, it does not
-                // matter that the datetime provider is substituted for this
-                // test. The blocks get accepted by X despite getting generated
-                // very rapidly.
+                // As we are not actually sending transactions, it does not matter that the datetime provider is substituted
+                // for this test. The blocks get accepted by X despite getting generated very rapidly.
                 var cancellationToken = new CancellationTokenSource(TimeSpan.FromMinutes(1)).Token;
-                TestHelper.WaitLoop(() => stratisNode.CreateRPCClient().GetBestBlockHash() == stratisXNode.CreateRPCClient().GetBestBlockHash(), cancellationToken: cancellationToken);
+
+                TestHelper.WaitLoop(() => stratisNodeRpc.GetBlockCount() >= 10, cancellationToken: cancellationToken);
+                TestHelper.WaitLoop(() => stratisNodeRpc.GetBestBlockHash() == stratisXRpc.GetBestBlockHash(), cancellationToken: cancellationToken);
+            }
+        }
+
+        /// <summary>
+        /// Tests whether a quantity of blocks mined on X are
+        /// correctly synced to an SBFN node.
+        /// </summary>
+        [Fact]
+        public void XMinesBlocks_SBFNSyncs()
+        {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                // TODO: Add the necessary executables for Linux & OSX
+                return;
+            }
+
+            using (NodeBuilder builder = NodeBuilder.Create(this))
+            {
+                var network = new StratisRegTest();
+
+                CoreNode stratisXNode = builder.CreateStratisXNode(version: "2.0.0.5").Start();
+                CoreNode stratisNode = builder.CreateStratisPosNode(network).WithWallet().Start();
+
+                RPCClient stratisXRpc = stratisXNode.CreateRPCClient();
+                RPCClient stratisNodeRpc = stratisNode.CreateRPCClient();
+
+                stratisNodeRpc.AddNode(stratisXNode.Endpoint, false);
+
+                stratisXRpc.SendCommand(RPCOperations.generate, 10);
+
+                var cancellationToken = new CancellationTokenSource(TimeSpan.FromMinutes(1)).Token;
+
+                TestHelper.WaitLoop(() => stratisXRpc.GetBlockCount() >= 10, cancellationToken: cancellationToken);
+                TestHelper.WaitLoop(() => stratisXRpc.GetBestBlockHash() == stratisNodeRpc.GetBestBlockHash(), cancellationToken: cancellationToken);
             }
         }
 
@@ -65,7 +99,7 @@ namespace Stratis.Bitcoin.IntegrationTests.Compatibility
         /// <remarks>Takes a while to run as block generation cannot
         /// be sped up for this test.</remarks>
         [Fact(Skip = "Awaiting fix for issue #2468")]
-        public void SBFNMinesTransactionAndXSyncs()
+        public void SBFNMinesTransaction_XSyncs()
         {
             // TODO: Currently fails due to issue #2468 (coinbase
             // reward on stratisX cannot be >4. No fees are allowed)
@@ -93,7 +127,7 @@ namespace Stratis.Bitcoin.IntegrationTests.Compatibility
                     .AddRPC()
                     .MockIBD());
 
-                CoreNode stratisNode = builder.CreateCustomNode(callback, network).WithWallet().Start();
+                CoreNode stratisNode = builder.CreateCustomNode(callback, network, protocolVersion: ProtocolVersion.ALT_PROTOCOL_VERSION).WithWallet().Start();
 
                 RPCClient stratisXRpc = stratisXNode.CreateRPCClient();
                 RPCClient stratisNodeRpc = stratisNode.CreateRPCClient();
@@ -127,9 +161,211 @@ namespace Stratis.Bitcoin.IntegrationTests.Compatibility
                 // We expect that X will sync correctly.
                 TestHelper.WaitLoop(() => stratisNodeRpc.GetBestBlockHash() == stratisXRpc.GetBestBlockHash(), cancellationToken: shortCancellationToken);
 
-                // Sanity check - mempools should both be empty.
+                // Sanity check - mempools should both become empty.
                 TestHelper.WaitLoop(() => stratisNodeRpc.GetRawMempool().Length == 0, cancellationToken: shortCancellationToken);
                 TestHelper.WaitLoop(() => stratisXRpc.GetRawMempool().Length == 0, cancellationToken: shortCancellationToken);
+            }
+        }
+
+        [Fact]
+        public void XMinesTransaction_SBFNSyncs()
+        {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                // TODO: Add the necessary executables for Linux & OSX
+                return;
+            }
+
+            using (NodeBuilder builder = NodeBuilder.Create(this))
+            {
+                var network = new StratisRegTest();
+
+                CoreNode stratisXNode = builder.CreateStratisXNode(version: "2.0.0.5").Start();
+
+                var callback = new Action<IFullNodeBuilder>(build => build
+                    .UseBlockStore()
+                    .UsePosConsensus()
+                    .UseMempool()
+                    .UseWallet()
+                    .AddPowPosMining()
+                    .AddRPC());
+
+                CoreNode stratisNode = builder.CreateCustomNode(callback, network, protocolVersion: ProtocolVersion.ALT_PROTOCOL_VERSION).WithWallet().Start();
+
+                RPCClient stratisXRpc = stratisXNode.CreateRPCClient();
+                RPCClient stratisNodeRpc = stratisNode.CreateRPCClient();
+
+                stratisXRpc.AddNode(stratisNode.Endpoint, false);
+                stratisNodeRpc.AddNode(stratisXNode.Endpoint, false);
+
+                stratisXRpc.SendCommand(RPCOperations.generate, 11);
+
+                var shortCancellationToken = new CancellationTokenSource(TimeSpan.FromMinutes(1)).Token;
+
+                // Without this there seems to be a race condition between the blocks all getting generated and SBFN syncing high enough to fall through the getbestblockhash check.
+                TestHelper.WaitLoop(() => stratisXRpc.GetBlockCount() >= 11, cancellationToken: shortCancellationToken);
+                
+                TestHelper.WaitLoop(() => stratisNodeRpc.GetBestBlockHash() == stratisXRpc.GetBestBlockHash(), cancellationToken: shortCancellationToken);
+
+                // Send transaction to arbitrary address from X side.
+                var alice = new Key().GetBitcoinSecret(network);
+                var aliceAddress = alice.GetAddress();
+                stratisXRpc.SendCommand(RPCOperations.sendtoaddress, aliceAddress.ToString(), 1);
+
+                TestHelper.WaitLoop(() => stratisXRpc.GetRawMempool().Length == 1, cancellationToken: shortCancellationToken);
+
+                // Transaction should percolate through to SBFN's mempool.
+                TestHelper.WaitLoop(() => stratisNodeRpc.GetRawMempool().Length == 1, cancellationToken: shortCancellationToken);
+
+                // Now X must mine the block.
+                stratisXRpc.SendCommand(RPCOperations.generate, 1);
+                TestHelper.WaitLoop(() => stratisXRpc.GetBlockCount() >= 12, cancellationToken: shortCancellationToken);
+
+                // We expect that SBFN will sync correctly.
+                TestHelper.WaitLoop(() => stratisNodeRpc.GetBestBlockHash() == stratisXRpc.GetBestBlockHash(), cancellationToken: shortCancellationToken);
+
+                // Sanity check - mempools should both become empty.
+                TestHelper.WaitLoop(() => stratisNodeRpc.GetRawMempool().Length == 0, cancellationToken: shortCancellationToken);
+                TestHelper.WaitLoop(() => stratisXRpc.GetRawMempool().Length == 0, cancellationToken: shortCancellationToken);
+            }
+        }
+
+        /// <summary>
+        /// Construct a small network of 3 nodes, X1 - S2 -X3.
+        /// X1 generates sufficient blocks to get spendable coins.
+        /// X1 creates a transaction sending a coin to an arbitrary address.
+        /// S2 and X3 should get the transaction in their mempools.
+        /// </summary>
+        [Fact]
+        public void Transaction_CreatedByXNode_TraversesSBFN_ReachesSecondXNode()
+        {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                // TODO: Add the necessary executables for Linux & OSX
+                return;
+            }
+
+            using (NodeBuilder builder = NodeBuilder.Create(this))
+            {
+                var network = new StratisRegTest();
+
+                CoreNode xNode1 = builder.CreateStratisXNode(version: "2.0.0.5").Start();
+
+                var callback = new Action<IFullNodeBuilder>(build => build
+                    .UseBlockStore()
+                    .UsePosConsensus()
+                    .UseMempool()
+                    .UseWallet()
+                    .AddPowPosMining()
+                    .AddRPC());
+
+                CoreNode sbfnNode2 = builder.CreateCustomNode(callback, network, protocolVersion: ProtocolVersion.ALT_PROTOCOL_VERSION).WithWallet().Start();
+
+                CoreNode xNode3 = builder.CreateStratisXNode(version: "2.0.0.5").Start();
+
+                RPCClient xRpc1 = xNode1.CreateRPCClient();
+                RPCClient sbfnRpc2 = sbfnNode2.CreateRPCClient();
+                RPCClient xRpc3 = xNode3.CreateRPCClient();
+
+                // Connect the nodes linearly. X does not appear to respond properly to the addnode RPC so SBFN needs to initiate.
+                sbfnRpc2.AddNode(xNode1.Endpoint, false);
+                sbfnRpc2.AddNode(xNode3.Endpoint, false);
+
+                xRpc1.SendCommand(RPCOperations.generate, 11);
+
+                var shortCancellationToken = new CancellationTokenSource(TimeSpan.FromMinutes(1)).Token;
+
+                TestHelper.WaitLoop(() => xRpc1.GetBlockCount() >= 11, cancellationToken: shortCancellationToken);
+                
+                TestHelper.WaitLoop(() => xRpc1.GetBestBlockHash() == sbfnRpc2.GetBestBlockHash(), cancellationToken: shortCancellationToken);
+                TestHelper.WaitLoop(() => xRpc1.GetBestBlockHash() == xRpc3.GetBestBlockHash(), cancellationToken: shortCancellationToken);
+
+                // Send transaction to arbitrary address.
+                var alice = new Key().GetBitcoinSecret(network);
+                var aliceAddress = alice.GetAddress();
+                xRpc1.SendCommand(RPCOperations.sendtoaddress, aliceAddress.ToString(), 1);
+
+                TestHelper.WaitLoop(() => xRpc1.GetRawMempool().Length == 1, cancellationToken: shortCancellationToken);
+                TestHelper.WaitLoop(() => sbfnRpc2.GetRawMempool().Length == 1, cancellationToken: shortCancellationToken);
+                TestHelper.WaitLoop(() => xRpc3.GetRawMempool().Length == 1, cancellationToken: shortCancellationToken);
+            }
+        }
+
+        /// <summary>
+        /// Construct a small network of 3 nodes, X1 - S2 -X3.
+        /// X1 generates sufficient blocks to get spendable coins.
+        /// X1 creates a transaction sending a coin to an arbitrary address.
+        /// S2 and X3 should get the transaction in their mempools.
+        /// Now X1 mines a block.
+        /// S2 and X3 should sync to the new block height.
+        /// All mempools should be empty at the end.
+        /// </summary>
+        [Fact]
+        public void Transaction_TraversesNodes_AndIsMined_AndNodesSync()
+        {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                // TODO: Add the necessary executables for Linux & OSX
+                return;
+            }
+
+            using (NodeBuilder builder = NodeBuilder.Create(this))
+            {
+                var network = new StratisRegTest();
+
+                CoreNode xNode1 = builder.CreateStratisXNode(version: "2.0.0.5").Start();
+
+                var callback = new Action<IFullNodeBuilder>(build => build
+                    .UseBlockStore()
+                    .UsePosConsensus()
+                    .UseMempool()
+                    .UseWallet()
+                    .AddPowPosMining()
+                    .AddRPC());
+
+                CoreNode sbfnNode2 = builder
+                    .CreateCustomNode(callback, network, protocolVersion: ProtocolVersion.ALT_PROTOCOL_VERSION)
+                    .WithWallet().Start();
+
+                CoreNode xNode3 = builder.CreateStratisXNode(version: "2.0.0.5").Start();
+
+                RPCClient xRpc1 = xNode1.CreateRPCClient();
+                RPCClient sbfnRpc2 = sbfnNode2.CreateRPCClient();
+                RPCClient xRpc3 = xNode3.CreateRPCClient();
+
+                sbfnRpc2.AddNode(xNode1.Endpoint, false);
+                sbfnRpc2.AddNode(xNode3.Endpoint, false);
+
+                xRpc1.SendCommand(RPCOperations.generate, 11);
+
+                var shortCancellationToken = new CancellationTokenSource(TimeSpan.FromMinutes(1)).Token;
+
+                TestHelper.WaitLoop(() => xRpc1.GetBlockCount() >= 11, cancellationToken: shortCancellationToken);
+
+                TestHelper.WaitLoop(() => xRpc1.GetBestBlockHash() == sbfnRpc2.GetBestBlockHash(), cancellationToken: shortCancellationToken);
+                TestHelper.WaitLoop(() => xRpc1.GetBestBlockHash() == xRpc3.GetBestBlockHash(), cancellationToken: shortCancellationToken);
+
+                // Send transaction to arbitrary address.
+                var alice = new Key().GetBitcoinSecret(network);
+                var aliceAddress = alice.GetAddress();
+                xRpc1.SendCommand(RPCOperations.sendtoaddress, aliceAddress.ToString(), 1);
+
+                TestHelper.WaitLoop(() => xRpc1.GetRawMempool().Length == 1, cancellationToken: shortCancellationToken);
+                TestHelper.WaitLoop(() => sbfnRpc2.GetRawMempool().Length == 1, cancellationToken: shortCancellationToken);
+                TestHelper.WaitLoop(() => xRpc3.GetRawMempool().Length == 1, cancellationToken: shortCancellationToken);
+
+                // TODO: Until #2468 is fixed we need an X node to mine the block so it doesn't get rejected.
+                xRpc1.SendCommand(RPCOperations.generate, 1);
+                TestHelper.WaitLoop(() => xRpc1.GetBlockCount() >= 12, cancellationToken: shortCancellationToken);
+
+                // We expect that SBFN and the other X node will sync correctly.
+                TestHelper.WaitLoop(() => sbfnRpc2.GetBestBlockHash() == xRpc1.GetBestBlockHash(), cancellationToken: shortCancellationToken);
+                TestHelper.WaitLoop(() => xRpc3.GetBestBlockHash() == xRpc1.GetBestBlockHash(), cancellationToken: shortCancellationToken);
+
+                // Sanity check - mempools should all become empty.
+                TestHelper.WaitLoop(() => xRpc1.GetRawMempool().Length == 0, cancellationToken: shortCancellationToken);
+                TestHelper.WaitLoop(() => sbfnRpc2.GetRawMempool().Length == 0, cancellationToken: shortCancellationToken);
+                TestHelper.WaitLoop(() => xRpc3.GetRawMempool().Length == 0, cancellationToken: shortCancellationToken);
             }
         }
     }

--- a/src/Stratis.Bitcoin.Tests/Consensus/ConsensusTestContext.cs
+++ b/src/Stratis.Bitcoin.Tests/Consensus/ConsensusTestContext.cs
@@ -151,6 +151,7 @@ namespace Stratis.Bitcoin.Tests.Consensus
                                     : this.ChangeDifficulty(previousHeader, difficultyAdjustmentDivisor);
                 header.Nonce = (uint)Interlocked.Increment(ref nonceValue);
                 var newHeader = new ChainedHeader(header, header.GetHash(), previousHeader);
+                previousHeader.Next.Add(newHeader);
                 if (validationState.HasValue)
                     newHeader.BlockValidationState = validationState.Value;
 

--- a/src/Stratis.Bitcoin/Consensus/ChainedHeaderTree.cs
+++ b/src/Stratis.Bitcoin/Consensus/ChainedHeaderTree.cs
@@ -322,7 +322,7 @@ namespace Stratis.Bitcoin.Consensus
         {
             fullValidationRequired = false;
 
-            if (!chainedHeader.Previous.Next.Contains(chainedHeader))
+            if (!chainedHeader.IsConnected)
             {
                 this.logger.LogTrace("(-)[HEADER_DISCONNECTED]:false");
                 return null;
@@ -588,7 +588,7 @@ namespace Stratis.Bitcoin.Consensus
         /// <inheritdoc />
         public bool BlockDataDownloaded(ChainedHeader chainedHeader, Block block)
         {
-            if (!chainedHeader.Previous.Next.Contains(chainedHeader))
+            if (!chainedHeader.IsConnected)
             {
                 this.logger.LogTrace("(-)[HEADER_DISCONNECTED]:false");
                 return false;
@@ -611,7 +611,7 @@ namespace Stratis.Bitcoin.Consensus
             bool partialValidationRequired = chainedHeader.Previous.BlockValidationState == ValidationState.PartiallyValidated
                                           || chainedHeader.Previous.BlockValidationState == ValidationState.FullyValidated;
 
-            this.logger.LogTrace("[BLOCK_DOWNLOAD_PREVIOUS_STATE]{0}:{1}:{2}", nameof(chainedHeader.Previous), chainedHeader.Previous, chainedHeader.Previous.BlockValidationState);
+            this.logger.LogTrace("[BLOCK_DOWNLOAD_PREVIOUS_STATE]{0}:{1}", nameof(chainedHeader.Previous), chainedHeader.Previous);
 
             return partialValidationRequired;
         }

--- a/src/Stratis.Bitcoin/Consensus/ChainedHeaderTree.cs
+++ b/src/Stratis.Bitcoin/Consensus/ChainedHeaderTree.cs
@@ -611,7 +611,7 @@ namespace Stratis.Bitcoin.Consensus
             bool partialValidationRequired = chainedHeader.Previous.BlockValidationState == ValidationState.PartiallyValidated
                                           || chainedHeader.Previous.BlockValidationState == ValidationState.FullyValidated;
 
-            this.logger.LogTrace("[BLOCK_DOWNLOAD_PREVIOUS_STATE]{0}:{1}", nameof(chainedHeader.Previous), chainedHeader.Previous);
+            this.logger.LogTrace("[BLOCK_DOWNLOAD_PREVIOUS_STATE]{0}.{1}:{2}", nameof(chainedHeader), nameof(chainedHeader.Previous), chainedHeader.Previous);
 
             return partialValidationRequired;
         }

--- a/src/Stratis.Bitcoin/Consensus/ChainedHeaderTree.cs
+++ b/src/Stratis.Bitcoin/Consensus/ChainedHeaderTree.cs
@@ -322,7 +322,7 @@ namespace Stratis.Bitcoin.Consensus
         {
             fullValidationRequired = false;
 
-            if (!chainedHeader.IsConnected)
+            if (!chainedHeader.IsReferenceConnected)
             {
                 this.logger.LogTrace("(-)[HEADER_DISCONNECTED]:null");
                 return null;
@@ -588,7 +588,7 @@ namespace Stratis.Bitcoin.Consensus
         /// <inheritdoc />
         public bool BlockDataDownloaded(ChainedHeader chainedHeader, Block block)
         {
-            if (!chainedHeader.IsConnected)
+            if (!chainedHeader.IsReferenceConnected)
             {
                 this.logger.LogTrace("(-)[HEADER_DISCONNECTED]:false");
                 return false;

--- a/src/Stratis.Bitcoin/Consensus/ChainedHeaderTree.cs
+++ b/src/Stratis.Bitcoin/Consensus/ChainedHeaderTree.cs
@@ -318,6 +318,12 @@ namespace Stratis.Bitcoin.Consensus
         {
             fullValidationRequired = false;
 
+            if (!chainedHeader.Previous.Next.Contains(chainedHeader))
+            {
+                this.logger.LogTrace("(-)[HEADER_DISCONNECTED]:false");
+                return null;
+            }
+
             // Can happen in case peer was disconnected during the validation and it was the only peer claiming that header.
             if (!this.chainedHeadersByHash.ContainsKey(chainedHeader.HashBlock))
             {
@@ -574,6 +580,12 @@ namespace Stratis.Bitcoin.Consensus
         /// <inheritdoc />
         public bool BlockDataDownloaded(ChainedHeader chainedHeader, Block block)
         {
+            if (!chainedHeader.Previous.Next.Contains(chainedHeader))
+            {
+                this.logger.LogTrace("(-)[HEADER_DISCONNECTED]:false");
+                return false;
+            }
+
             if (chainedHeader.BlockValidationState == ValidationState.FullyValidated)
             {
                 this.logger.LogTrace("(-)[HEADER_FULLY_VALIDATED]:false");

--- a/src/Stratis.Bitcoin/Consensus/ChainedHeaderTree.cs
+++ b/src/Stratis.Bitcoin/Consensus/ChainedHeaderTree.cs
@@ -809,7 +809,7 @@ namespace Stratis.Bitcoin.Consensus
         private bool HeaderWasRequested(ChainedHeader chainedHeader)
         {
             return (chainedHeader.BlockDataAvailability == BlockDataAvailabilityState.BlockAvailable)
-                  || (chainedHeader.BlockDataAvailability == BlockDataAvailabilityState.BlockRequired);
+                || (chainedHeader.BlockDataAvailability == BlockDataAvailabilityState.BlockRequired);
         }
 
         /// <summary>
@@ -818,8 +818,9 @@ namespace Stratis.Bitcoin.Consensus
         /// </summary>
         private bool HeaderWasMarkedAsValidated(ChainedHeader chainedHeader)
         {
-            return chainedHeader.IsAssumedValid || (chainedHeader.BlockValidationState == ValidationState.PartiallyValidated)
-                  || (chainedHeader.BlockValidationState == ValidationState.FullyValidated);
+            return chainedHeader.IsAssumedValid
+                   || (chainedHeader.BlockValidationState == ValidationState.PartiallyValidated)
+                   || (chainedHeader.BlockValidationState == ValidationState.FullyValidated);
         }
 
         /// <summary>


### PR DESCRIPTION
When we handle ChanedHeaders we should assume that at any given moment a peer may get disconnected and the chain will be removed form the tree.

**Unhandled yet**
The problematic scenario is when we are in the middle of a big reorg and the only peer that claims this branch gets disconnected.
For example a reorg of 10 blocks and at block 5 the only peer claiming this branch is disconnected we will remove the entire branch of the reorg from the tree.


Two ways to fix it
1. We observe the branch was disconnected and try to reconnect
2. We place a temporary claim on a branch that is about to be connected, then this branch will not get removed on disconnect. 
