### PR TITLE
Wallet: skip processing of transactions with 0 in output

### DIFF
--- a/src/Stratis.Bitcoin.Features.Wallet/WalletManager.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/WalletManager.cs
@@ -872,8 +872,8 @@ namespace Stratis.Bitcoin.Features.Wallet
 
             lock (this.lockObject)
             {
-                // Check the outputs.
-                foreach (TxOut utxo in transaction.Outputs)
+                // Check the outputs, ignoring the ones with a 0 amount.
+                foreach (TxOut utxo in transaction.Outputs.Where(o => o.Value != Money.Zero))
                 {
                     // Check if the outputs contain one of our addresses.
                     if (this.scriptToAddressLookup.TryGetValue(utxo.ScriptPubKey, out HdAddress _))


### PR DESCRIPTION
Closes https://github.com/stratisproject/StratisBitcoinFullNode/issues/2518

This will leave out from processing in the wallet:
- poa mining transactions
- coinbase transactions in pos
- first coinstake output

where we know we're not gonna save anything to the wallet.
This will also improve performance a bit.
