### PR TITLE
[SC Integration Tests] [Dont Merge] Remove ClassFixtures

### DIFF
--- a/src/Stratis.SmartContracts.IntegrationTests/PoA/ContractExecutionFailureTests.cs
+++ b/src/Stratis.SmartContracts.IntegrationTests/PoA/ContractExecutionFailureTests.cs
@@ -18,18 +18,20 @@ using Xunit;
 
 namespace Stratis.SmartContracts.IntegrationTests.PoA
 {
-    public class ContractExecutionFailureTests : IClassFixture<PoAMockChainFixture>
+    public class ContractExecutionFailureTests : IDisposable
     {
         private readonly PoAMockChain mockChain;
+        private readonly PoAMockChainFixture mockChainFixture;
         private readonly MockChainNode node1;
         private readonly MockChainNode node2;
 
         private readonly IAddressGenerator addressGenerator;
         private readonly ISenderRetriever senderRetriever;
 
-        public ContractExecutionFailureTests(PoAMockChainFixture fixture)
+        public ContractExecutionFailureTests()
         {
-            this.mockChain = fixture.Chain;
+            this.mockChainFixture = new PoAMockChainFixture();
+            this.mockChain = this.mockChainFixture.Chain;
             this.node1 = this.mockChain.Nodes[0];
             this.node2 = this.mockChain.Nodes[1];
             this.addressGenerator = new AddressGenerator();
@@ -579,6 +581,11 @@ namespace Stratis.SmartContracts.IntegrationTests.PoA
             Assert.Equal(this.node1.MinerAddress.Address, receipt.From);
             Assert.StartsWith("Stratis.SmartContracts.SmartContractAssertException", receipt.Error);
             Assert.Equal(preResponse.NewContractAddress, receipt.To);
+        }
+
+        public void Dispose()
+        {
+            this.mockChainFixture.Dispose();
         }
     }
 }

--- a/src/Stratis.SmartContracts.IntegrationTests/PoA/ContractInternalTransferTests.cs
+++ b/src/Stratis.SmartContracts.IntegrationTests/PoA/ContractInternalTransferTests.cs
@@ -11,18 +11,20 @@ using Xunit;
 
 namespace Stratis.SmartContracts.IntegrationTests.PoA
 {
-    public class ContractInternalTransferTests : IClassFixture<PoAMockChainFixture>
+    public class ContractInternalTransferTests : IDisposable
     {
         private readonly PoAMockChain mockChain;
+        private readonly PoAMockChainFixture mockChainFixture;
         private readonly MockChainNode node1;
         private readonly MockChainNode node2;
 
         private readonly IAddressGenerator addressGenerator;
         private readonly ISenderRetriever senderRetriever;
 
-        public ContractInternalTransferTests(PoAMockChainFixture fixture)
+        public ContractInternalTransferTests()
         {
-            this.mockChain = fixture.Chain;
+            this.mockChainFixture = new PoAMockChainFixture();
+            this.mockChain = this.mockChainFixture.Chain;
             this.node1 = this.mockChain.Nodes[0];
             this.node2 = this.mockChain.Nodes[1];
 
@@ -484,6 +486,11 @@ namespace Stratis.SmartContracts.IntegrationTests.PoA
 
             // Balance should be the same as the initial amount
             Assert.True((new Money(amount, MoneyUnit.BTC) == new Money(savedUlong, MoneyUnit.Satoshi)));
+        }
+
+        public void Dispose()
+        {
+            this.mockChainFixture.Dispose();
         }
     }
 }

--- a/src/Stratis.SmartContracts.IntegrationTests/PoW/ContractExecutionFailureTests.cs
+++ b/src/Stratis.SmartContracts.IntegrationTests/PoW/ContractExecutionFailureTests.cs
@@ -18,18 +18,20 @@ using Xunit;
 
 namespace Stratis.SmartContracts.IntegrationTests.PoW
 {
-    public class ContractExecutionFailureTests : IClassFixture<PoWMockChainFixture>
+    public class ContractExecutionFailureTests : IDisposable
     {
         private readonly PoWMockChain mockChain;
+        private readonly PoWMockChainFixture mockChainFixture;
         private readonly MockChainNode node1;
         private readonly MockChainNode node2;
 
         private readonly IAddressGenerator addressGenerator;
         private readonly ISenderRetriever senderRetriever;
 
-        public ContractExecutionFailureTests(PoWMockChainFixture fixture)
+        public ContractExecutionFailureTests()
         {
-            this.mockChain = fixture.Chain;
+            this.mockChainFixture = new PoWMockChainFixture();
+            this.mockChain = this.mockChainFixture.Chain;
             this.node1 = this.mockChain.Nodes[0];
             this.node2 = this.mockChain.Nodes[1];
             this.addressGenerator = new AddressGenerator();
@@ -698,6 +700,11 @@ namespace Stratis.SmartContracts.IntegrationTests.PoW
             Assert.Equal(this.node1.MinerAddress.Address, receipt.From);
             Assert.StartsWith("Execution ran out of gas.", receipt.Error);
             Assert.Equal(preResponse.NewContractAddress, receipt.To);
+        }
+
+        public void Dispose()
+        {
+            this.mockChainFixture.Dispose();
         }
     }
 }

--- a/src/Stratis.SmartContracts.IntegrationTests/PoW/ContractInternalTransferTests.cs
+++ b/src/Stratis.SmartContracts.IntegrationTests/PoW/ContractInternalTransferTests.cs
@@ -15,18 +15,20 @@ using Xunit;
 
 namespace Stratis.SmartContracts.IntegrationTests.PoW
 {
-    public class ContractInternalTransferTests : IClassFixture<PoWMockChainFixture>
+    public class ContractInternalTransferTests : IDisposable
     {
         private readonly PoWMockChain mockChain;
+        private readonly PoWMockChainFixture mockChainFixture;
         private readonly MockChainNode node1;
         private readonly MockChainNode node2;
 
         private readonly IAddressGenerator addressGenerator;
         private readonly ISenderRetriever senderRetriever;
 
-        public ContractInternalTransferTests(PoWMockChainFixture fixture)
+        public ContractInternalTransferTests()
         {
-            this.mockChain = fixture.Chain;
+            this.mockChainFixture = new PoWMockChainFixture();
+            this.mockChain = this.mockChainFixture.Chain;
             this.node1 = this.mockChain.Nodes[0];
             this.node2 = this.mockChain.Nodes[1];
 
@@ -642,6 +644,11 @@ namespace Stratis.SmartContracts.IntegrationTests.PoW
 
             // Balance should be the same as the initial amount
             Assert.True((new Money(amount, MoneyUnit.BTC) == new Money(savedUlong, MoneyUnit.Satoshi)));
+        }
+
+        public void Dispose()
+        {
+            this.mockChainFixture.Dispose();
         }
     }
 }

--- a/src/Stratis.SmartContracts.IntegrationTests/PoW/ContractParameterSerializationTests.cs
+++ b/src/Stratis.SmartContracts.IntegrationTests/PoW/ContractParameterSerializationTests.cs
@@ -13,17 +13,19 @@ using Xunit;
 
 namespace Stratis.SmartContracts.IntegrationTests.PoW
 {
-    public class ContractParameterSerializationTests : IClassFixture<PoWMockChainFixture>
+    public class ContractParameterSerializationTests : IDisposable
     {
         private readonly PoWMockChain mockChain;
+        private readonly PoWMockChainFixture mockChainFixture;
         private readonly MockChainNode node1;
         private readonly MockChainNode node2;
 
         private readonly IContractPrimitiveSerializer serializer;
 
-        public ContractParameterSerializationTests(PoWMockChainFixture fixture)
+        public ContractParameterSerializationTests()
         {
-            this.mockChain = fixture.Chain;
+            this.mockChainFixture = new PoWMockChainFixture();
+            this.mockChain = this.mockChainFixture.Chain;
             this.node1 = this.mockChain.Nodes[0];
             this.node2 = this.mockChain.Nodes[1];
             this.serializer = new ContractPrimitiveSerializer(this.node1.CoreNode.FullNode.Network);
@@ -322,6 +324,11 @@ namespace Stratis.SmartContracts.IntegrationTests.PoW
             Assert.Equal(this.node1.MinerAddress.Address, receipt.From);
             Assert.Null(receipt.To);
             Assert.Null(receipt.Error);
+        }
+
+        public void Dispose()
+        {
+            this.mockChainFixture.Dispose();
         }
     }
 }

--- a/src/Stratis.SmartContracts.IntegrationTests/PoW/SmartContractMemoryPoolTests.cs
+++ b/src/Stratis.SmartContracts.IntegrationTests/PoW/SmartContractMemoryPoolTests.cs
@@ -4,7 +4,6 @@ using NBitcoin;
 using Stratis.Bitcoin.Features.SmartContracts;
 using Stratis.Bitcoin.Features.SmartContracts.ReflectionExecutor.Consensus.Rules;
 using Stratis.Bitcoin.IntegrationTests.Common;
-using Stratis.Bitcoin.IntegrationTests.Common.EnvironmentMockUpHelpers;
 using Stratis.SmartContracts.Core;
 using Stratis.SmartContracts.Core.State;
 using Stratis.SmartContracts.Executor.Reflection;


### PR DESCRIPTION
Hey @codingupastorm @rowandh check out this PR.

I have removed the IClassFixtures from the tests that are constantly failing and implemented a disposable when each test exits so that the node builder and its nodes get shut down properly.

I noticed that when the class fixtures are used, we only start the nodes once and re-use them throughout ALL the tests. This to me can be problematic as in an ideal scenario we want the tests to run contained, i.e. start nodes, run test, close nodes, start test, run test, close nodes etc.

However, when I did this loads of tests started failing due to the wallet not having spendable balances, asserts not being right etc.

This now leads me to believe that perhaps the tests were asserting values etc with that in mind? I..e possibly picking up values from other tests?

Have a look for yourself and see what ya think :)