### PR TITLE
[RPC] Properly handle optional parameters for getnewaddress

### DIFF
--- a/src/Stratis.Bitcoin.Features.Wallet/WalletRPCController.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/WalletRPCController.cs
@@ -127,11 +127,22 @@ namespace Stratis.Bitcoin.Features.Wallet
         /// RPC method that gets a new address for receiving payments.
         /// Uses the first wallet and account.
         /// </summary>
+        /// <param name="account">Parameter is deprecated.</param>
+        /// <param name="addressType">Address type, currently only 'legacy' is supported.</param>
         /// <returns>The new address.</returns>
         [ActionName("getnewaddress")]
         [ActionDescription("Returns a new wallet address for receiving payments.")]
-        public NewAddressModel GetNewAddress()
+        public NewAddressModel GetNewAddress(string account, string addressType)
         {
+            if (!string.IsNullOrEmpty(account))
+                throw new RPCServerException(RPCErrorCode.RPC_METHOD_DEPRECATED, "Use of 'account' parameter has been deprecated");
+
+            if (!string.IsNullOrEmpty(addressType))
+            {
+                // Currently segwit and bech32 addresses are not supported.
+                if (!addressType.Equals("legacy", StringComparison.InvariantCultureIgnoreCase))
+                    throw new RPCServerException(RPCErrorCode.RPC_METHOD_NOT_FOUND, "Only address type 'legacy' is currently supported.");
+            }
             HdAddress hdAddress = this.walletManager.GetUnusedAddress(this.GetAccount());
             string base58Address = hdAddress.Address;
             

--- a/src/Stratis.Bitcoin.IntegrationTests/API/ApiSteps.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/API/ApiSteps.cs
@@ -439,7 +439,7 @@ namespace Stratis.Bitcoin.IntegrationTests.API
             commands.Should().Contain(x => x.Command == "startstaking <walletname> <walletpassword>");
             commands.Should().Contain(x => x.Command == "getstakinginfo [<isjsonformat>]");
             commands.Should().Contain(x => x.Command == "sendtoaddress <address> <amount> <commenttx> <commentdest>");
-            commands.Should().Contain(x => x.Command == "getnewaddress");
+            commands.Should().Contain(x => x.Command == "getnewaddress <account> <addresstype>");
             commands.Should().Contain(x => x.Command == "sendrawtransaction <hex>");
             commands.Should().Contain(x => x.Command == "decoderawtransaction <hex>");
             commands.Should().Contain(x => x.Command == "getblock <blockhash> [<isjsonformat>]");

--- a/src/Stratis.Bitcoin.IntegrationTests/RPC/RPCTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/RPC/RPCTests.cs
@@ -231,8 +231,25 @@ namespace Stratis.Bitcoin.IntegrationTests.RPC
         [Fact]
         public void GetNewAddress()
         {
+            // Try creating with default parameters.
             BitcoinAddress address = this.rpcTestFixture.RpcClient.GetNewAddress();
             Assert.NotNull(address);
+
+            // Try creating with optional parameters.
+            address = BitcoinAddress.Create(this.rpcTestFixture.RpcClient.SendCommand(RPCOperations.getnewaddress, new[] { string.Empty, "legacy" }).ResultString, this.rpcTestFixture.RpcClient.Network);
+            Assert.NotNull(address);
+        }
+
+        [Fact]
+        public void TestGetNewAddressWithUnsupportedAddressTypeThrowsRpcException()
+        {
+            Assert.Throws<RPCException>(() => this.rpcTestFixture.RpcClient.SendCommand(RPCOperations.getnewaddress, new[] { string.Empty, "bech32" }));
+        }
+
+        [Fact]
+        public void TestGetNewAddressWithAccountParameterThrowsRpcException()
+        {
+            Assert.Throws<RPCException>(() => this.rpcTestFixture.RpcClient.SendCommand(RPCOperations.getnewaddress, new[] { "account1", "legacy" }));
         }
 
         // TODO: implement the RPC methods used below


### PR DESCRIPTION
There are some optional parameters we were ignoring in previous implementation. Throw exceptions when they are not well formed.

Bitcoin core docs https://bitcoincore.org/en/doc/0.16.0/rpc/wallet/getnewaddress/

Related to https://github.com/MetacoSA/NBitcoin/pull/413 