### PR TITLE
[SC] Shared CoinViewRule logic

### DIFF
--- a/src/Stratis.Bitcoin.Features.SmartContracts/PoA/Rules/SmartContractPoACoinviewRule.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts/PoA/Rules/SmartContractPoACoinviewRule.cs
@@ -9,23 +9,14 @@ namespace Stratis.Bitcoin.Features.SmartContracts.PoA.Rules
 {
     public class SmartContractPoACoinviewRule : PoACoinviewRule
     {
-        private readonly SmartContractCoinViewRuleLogic logic;
-
-        public SmartContractPoACoinviewRule()
-        {
-            this.logic = new SmartContractCoinViewRuleLogic();
-        }
+        private SmartContractCoinViewRuleLogic logic;
 
         /// <inheritdoc />
         public override void Initialize()
         {
             base.Initialize();
 
-            this.logic.Parent = this.Parent;
-            this.logic.ClearGeneratedTransaction();
-            this.logic.ResetRefundCounter();
-            this.logic.ContractCoinviewRule = (ISmartContractCoinviewRule)this.Parent;
-
+            this.logic = new SmartContractCoinViewRuleLogic(this.Parent);
         }
 
         /// <inheritdoc />

--- a/src/Stratis.Bitcoin.Features.SmartContracts/PoA/Rules/SmartContractPoACoinviewRule.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts/PoA/Rules/SmartContractPoACoinviewRule.cs
@@ -1,81 +1,42 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using Microsoft.Extensions.Logging;
+﻿using System.Threading.Tasks;
 using NBitcoin;
 using Stratis.Bitcoin.Base.Deployments;
-using Stratis.Bitcoin.Consensus;
 using Stratis.Bitcoin.Consensus.Rules;
-using Stratis.Bitcoin.Features.Consensus;
-using Stratis.Bitcoin.Features.Consensus.Rules;
-using Stratis.Bitcoin.Features.Consensus.Rules.CommonRules;
 using Stratis.Bitcoin.Features.PoA.ConsensusRules;
-using Stratis.SmartContracts.Core;
-using Stratis.SmartContracts.Core.Receipts;
-using Stratis.SmartContracts.Core.State;
-using Stratis.SmartContracts.Core.Util;
+using Stratis.Bitcoin.Features.SmartContracts.Rules;
 
 namespace Stratis.Bitcoin.Features.SmartContracts.PoA.Rules
 {
     public class SmartContractPoACoinviewRule : PoACoinviewRule
     {
-        protected List<Transaction> blockTxsProcessed;
-        protected Transaction generatedTransaction;
-        protected IList<Receipt> receipts;
-        protected uint refundCounter;
-        protected IStateRepositoryRoot mutableStateRepository;
+        private readonly SmartContractCoinViewRuleLogic logic;
 
-        protected ISmartContractCoinviewRule ContractCoinviewRule { get; private set; }
+        public SmartContractPoACoinviewRule()
+        {
+            this.logic = new SmartContractCoinViewRuleLogic();
+        }
 
         /// <inheritdoc />
         public override void Initialize()
         {
             base.Initialize();
 
-            this.generatedTransaction = null;
-            this.refundCounter = 1;
-            this.ContractCoinviewRule = (ISmartContractCoinviewRule)this.Parent;
+            this.logic.ClearGeneratedTransaction();
+            this.logic.ResetRefundCounter();
+            this.logic.ContractCoinviewRule = (ISmartContractCoinviewRule)this.Parent;
+
         }
 
         /// <inheritdoc />
         public override async Task RunAsync(RuleContext context)
         {
-            this.blockTxsProcessed = new List<Transaction>();
-            this.receipts = new List<Receipt>();
-            this.refundCounter = 1;
-            NBitcoin.Block block = context.ValidationContext.BlockToValidate;
-
-            // Get a IStateRepositoryRoot we can alter without affecting the injected one which is used elsewhere.
-            byte[] blockRoot = ((ISmartContractBlockHeader)context.ValidationContext.ChainedHeaderToValidate.Previous.Header).HashStateRoot.ToBytes();
-            this.mutableStateRepository = this.ContractCoinviewRule.OriginalStateRoot.GetSnapshotTo(blockRoot);
-
-            await base.RunAsync(context);
-
-            if (new uint256(this.mutableStateRepository.Root) != ((ISmartContractBlockHeader)block.Header).HashStateRoot)
-                SmartContractConsensusErrors.UnequalStateRoots.Throw();
-
-            ValidateAndStoreReceipts(((ISmartContractBlockHeader)block.Header).ReceiptRoot);
-
-            // Push to underlying database
-            this.mutableStateRepository.Commit();
-
-            // Update the globally injected state so all services receive the updates.
-            this.ContractCoinviewRule.OriginalStateRoot.SyncToRoot(this.mutableStateRepository.Root);
+            await this.logic.RunAsync(base.RunAsync, context);
         }
 
         /// <inheritdoc/>
         protected override bool CheckInput(Transaction tx, int inputIndexCopy, TxOut txout, PrecomputedTransactionData txData, TxIn input, DeploymentFlags flags)
         {
-            if (txout.ScriptPubKey.IsSmartContractExec() || txout.ScriptPubKey.IsSmartContractInternalCall())
-            {
-                return input.ScriptSig.IsSmartContractSpend();
-            }
-
-            var checker = new TransactionChecker(tx, inputIndexCopy, txout.Value, txData);
-            var ctx = new ScriptEvaluationContext(this.Parent.Network);
-            ctx.ScriptVerify = flags.ScriptFlags;
-            return ctx.VerifyScript(input.ScriptSig, txout.ScriptPubKey, checker);
+            return this.logic.CheckInput(base.CheckInput, tx, inputIndexCopy, txout, txData, input, flags);
         }
 
         /// <summary>
@@ -84,146 +45,7 @@ namespace Stratis.Bitcoin.Features.SmartContracts.PoA.Rules
         /// <inheritdoc/>
         public override void UpdateCoinView(RuleContext context, Transaction transaction)
         {
-            if (this.generatedTransaction != null)
-            {
-                ValidateGeneratedTransaction(transaction);
-                base.UpdateUTXOSet(context, transaction);
-                this.blockTxsProcessed.Add(transaction);
-                return;
-            }
-
-            // If we are here, was definitely submitted by someone
-            ValidateSubmittedTransaction(transaction);
-
-            TxOut smartContractTxOut = transaction.Outputs.FirstOrDefault(txOut => txOut.ScriptPubKey.IsSmartContractExec());
-            if (smartContractTxOut == null)
-            {
-                // Someone submitted a standard transaction - no smart contract opcodes.
-                base.UpdateUTXOSet(context, transaction);
-                this.blockTxsProcessed.Add(transaction);
-                return;
-            }
-
-            // Someone submitted a smart contract transaction.
-            ExecuteContractTransaction(context, transaction);
-
-            base.UpdateUTXOSet(context, transaction);
-            this.blockTxsProcessed.Add(transaction);
-        }
-
-        /// <summary>
-        /// Validates that any condensing transaction matches the transaction generated during execution
-        /// </summary>
-        /// <param name="transaction"></param>
-        protected void ValidateGeneratedTransaction(Transaction transaction)
-        {
-            if (this.generatedTransaction.GetHash() != transaction.GetHash())
-                SmartContractConsensusErrors.UnequalCondensingTx.Throw();
-
-            this.generatedTransaction = null;
-
-            return;
-        }
-
-        /// <summary>
-        /// Validates that a submitted transacction doesn't contain illegal operations
-        /// </summary>
-        /// <param name="transaction"></param>
-        protected void ValidateSubmittedTransaction(Transaction transaction)
-        {
-            if (transaction.Inputs.Any(x => x.ScriptSig.IsSmartContractSpend()))
-                SmartContractConsensusErrors.UserOpSpend.Throw();
-
-            if (transaction.Outputs.Any(x => x.ScriptPubKey.IsSmartContractInternalCall()))
-                SmartContractConsensusErrors.UserInternalCall.Throw();
-        }
-
-        /// <summary>
-        /// Executes the smart contract part of a transaction
-        /// </summary>
-        protected void ExecuteContractTransaction(RuleContext context, Transaction transaction)
-        {
-            IContractTransactionContext txContext = GetSmartContractTransactionContext(context, transaction);
-            IContractExecutor executor = this.ContractCoinviewRule.ExecutorFactory.CreateExecutor(this.mutableStateRepository, txContext);
-
-            IContractExecutionResult result = executor.Execute(txContext);
-
-            var receipt = new Receipt(
-                new uint256(this.mutableStateRepository.Root),
-                result.GasConsumed,
-                result.Logs.ToArray(),
-                txContext.TransactionHash,
-                txContext.Sender,
-                result.To,
-                result.NewContractAddress,
-                !result.Revert,
-                result.ErrorMessage
-            )
-            {
-                BlockHash = context.ValidationContext.BlockToValidate.GetHash()
-            };
-
-            this.receipts.Add(receipt);
-
-            ValidateRefunds(result.Refund, context.ValidationContext.BlockToValidate.Transactions[0]);
-
-            if (result.InternalTransaction != null)
-                this.generatedTransaction = result.InternalTransaction;
-        }
-
-        /// <summary>
-        /// Retrieves the context object to be given to the contract executor.
-        /// </summary>
-        private IContractTransactionContext GetSmartContractTransactionContext(RuleContext context, Transaction transaction)
-        {
-            ulong blockHeight = Convert.ToUInt64(context.ValidationContext.ChainedHeaderToValidate.Height);
-
-            GetSenderResult getSenderResult = this.ContractCoinviewRule.SenderRetriever.GetSender(transaction, ((PowConsensusRuleEngine)this.Parent).UtxoSet, this.blockTxsProcessed);
-
-            if (!getSenderResult.Success)
-                throw new ConsensusErrorException(new ConsensusError("sc-consensusvalidator-executecontracttransaction-sender", getSenderResult.Error));
-
-            Script coinbaseScriptPubKey = context.ValidationContext.BlockToValidate.Transactions[0].Outputs[0].ScriptPubKey;
-
-            GetSenderResult getCoinbaseResult = this.ContractCoinviewRule.SenderRetriever.GetAddressFromScript(coinbaseScriptPubKey);
-
-            uint160 coinbaseAddress = (getCoinbaseResult.Success) ? getCoinbaseResult.Sender : uint160.Zero;
-
-            Money mempoolFee = transaction.GetFee(((UtxoRuleContext)context).UnspentOutputSet);
-
-            return new ContractTransactionContext(blockHeight, coinbaseAddress, mempoolFee, getSenderResult.Sender, transaction);
-        }
-
-        /// <summary>
-        /// Throws a consensus exception if the receipt roots don't match.
-        /// </summary>
-        private void ValidateAndStoreReceipts(uint256 receiptRoot)
-        {
-            List<uint256> leaves = this.receipts.Select(x => x.GetHash()).ToList();
-            bool mutated = false; // TODO: Do we need this?
-            uint256 expectedReceiptRoot = BlockMerkleRootRule.ComputeMerkleRoot(leaves, out mutated);
-
-            if (receiptRoot != expectedReceiptRoot)
-                SmartContractConsensusErrors.UnequalReceiptRoots.Throw();
-
-            // TODO: Could also check for equality of logsBloom?
-
-            this.ContractCoinviewRule.ReceiptRepository.Store(this.receipts);
-            this.receipts.Clear();
-        }
-
-        /// <summary>
-        /// Throws a consensus exception if the gas refund inside the block is different to what this node calculated during execution.
-        /// </summary>
-        private void ValidateRefunds(TxOut refund, Transaction coinbaseTransaction)
-        {
-            TxOut refundToMatch = coinbaseTransaction.Outputs[this.refundCounter];
-            if (refund.Value != refundToMatch.Value || refund.ScriptPubKey != refundToMatch.ScriptPubKey)
-            {
-                SmartContractConsensusErrors.UnequalRefundAmounts.Throw();
-            }
-
-            this.refundCounter++;
+            this.logic.UpdateCoinView(base.UpdateUTXOSet, context, transaction);
         }
     }
 }

--- a/src/Stratis.Bitcoin.Features.SmartContracts/PoA/Rules/SmartContractPoACoinviewRule.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts/PoA/Rules/SmartContractPoACoinviewRule.cs
@@ -21,6 +21,7 @@ namespace Stratis.Bitcoin.Features.SmartContracts.PoA.Rules
         {
             base.Initialize();
 
+            this.logic.Parent = this.Parent;
             this.logic.ClearGeneratedTransaction();
             this.logic.ResetRefundCounter();
             this.logic.ContractCoinviewRule = (ISmartContractCoinviewRule)this.Parent;

--- a/src/Stratis.Bitcoin.Features.SmartContracts/Rules/SmartContractCoinViewRuleLogic.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts/Rules/SmartContractCoinViewRuleLogic.cs
@@ -19,7 +19,7 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Rules
     /// <summary>
     /// Abstraction for shared SC coinview rule logic.
     /// </summary>
-    public sealed class SmartContractCoinViewRuleLogic
+    internal sealed class SmartContractCoinViewRuleLogic
     {
         private readonly List<Transaction> blockTxsProcessed;
         private Transaction generatedTransaction;

--- a/src/Stratis.Bitcoin.Features.SmartContracts/Rules/SmartContractCoinViewRuleLogic.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts/Rules/SmartContractCoinViewRuleLogic.cs
@@ -238,12 +238,12 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Rules
             this.ClearGeneratedTransaction();
         }
 
-        public void ResetRefundCounter()
+        private void ResetRefundCounter()
         {
             this.refundCounter = 1;
         }
 
-        public void ClearGeneratedTransaction()
+        private void ClearGeneratedTransaction()
         {
             this.generatedTransaction = null;
         }

--- a/src/Stratis.Bitcoin.Features.SmartContracts/Rules/SmartContractCoinViewRuleLogic.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts/Rules/SmartContractCoinViewRuleLogic.cs
@@ -103,7 +103,7 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Rules
         /// Validates that any condensing transaction matches the transaction generated during execution
         /// </summary>
         /// <param name="transaction"></param>
-        private void ValidateGeneratedTransaction(Transaction transaction)
+        public void ValidateGeneratedTransaction(Transaction transaction)
         {
             if (this.generatedTransaction.GetHash() != transaction.GetHash())
                 SmartContractConsensusErrors.UnequalCondensingTx.Throw();
@@ -117,7 +117,7 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Rules
         /// Validates that a submitted transacction doesn't contain illegal operations
         /// </summary>
         /// <param name="transaction"></param>
-        protected void ValidateSubmittedTransaction(Transaction transaction)
+        public void ValidateSubmittedTransaction(Transaction transaction)
         {
             if (transaction.Inputs.Any(x => x.ScriptSig.IsSmartContractSpend()))
                 SmartContractConsensusErrors.UserOpSpend.Throw();
@@ -143,7 +143,7 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Rules
         /// <summary>
         /// Executes the smart contract part of a transaction
         /// </summary>
-        protected void ExecuteContractTransaction(RuleContext context, Transaction transaction)
+        public void ExecuteContractTransaction(RuleContext context, Transaction transaction)
         {
             IContractTransactionContext txContext = GetSmartContractTransactionContext(context, transaction);
             IContractExecutor executor = this.ContractCoinviewRule.ExecutorFactory.CreateExecutor(this.mutableStateRepository, txContext);
@@ -179,7 +179,7 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Rules
         /// <summary>
         /// Retrieves the context object to be given to the contract executor.
         /// </summary>
-        private IContractTransactionContext GetSmartContractTransactionContext(RuleContext context, Transaction transaction)
+        public IContractTransactionContext GetSmartContractTransactionContext(RuleContext context, Transaction transaction)
         {
             ulong blockHeight = Convert.ToUInt64(context.ValidationContext.ChainedHeaderToValidate.Height);
 
@@ -202,7 +202,7 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Rules
         /// <summary>
         /// Throws a consensus exception if the receipt roots don't match.
         /// </summary>
-        private void ValidateAndStoreReceipts(uint256 receiptRoot)
+        public void ValidateAndStoreReceipts(uint256 receiptRoot)
         {
             List<uint256> leaves = this.receipts.Select(x => x.GetHash()).ToList();
             bool mutated = false; // TODO: Do we need this?

--- a/src/Stratis.Bitcoin.Features.SmartContracts/Rules/SmartContractCoinViewRuleLogic.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts/Rules/SmartContractCoinViewRuleLogic.cs
@@ -17,7 +17,8 @@ using Stratis.SmartContracts.Core.Util;
 namespace Stratis.Bitcoin.Features.SmartContracts.Rules
 {
     /// <summary>
-    /// Abstraction for shared SC coinview rule logic.
+    /// Abstraction for shared SC coinview rule logic. 
+    /// TODO: Long-term solution requires refactoring of the FN CoinViewRule implementation.
     /// </summary>
     internal sealed class SmartContractCoinViewRuleLogic
     {

--- a/src/Stratis.Bitcoin.Features.SmartContracts/Rules/SmartContractCoinViewRuleLogic.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts/Rules/SmartContractCoinViewRuleLogic.cs
@@ -172,7 +172,9 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Rules
             }
 
             if (result.InternalTransaction != null)
+            {
                 this.generatedTransaction = result.InternalTransaction;
+            }
         }
 
         /// <summary>

--- a/src/Stratis.Bitcoin.Features.SmartContracts/Rules/SmartContractCoinViewRuleLogic.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts/Rules/SmartContractCoinViewRuleLogic.cs
@@ -1,0 +1,231 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using NBitcoin;
+using Stratis.Bitcoin.Base.Deployments;
+using Stratis.Bitcoin.Consensus;
+using Stratis.Bitcoin.Consensus.Rules;
+using Stratis.Bitcoin.Features.Consensus;
+using Stratis.Bitcoin.Features.Consensus.Rules;
+using Stratis.Bitcoin.Features.Consensus.Rules.CommonRules;
+using Stratis.SmartContracts.Core;
+using Stratis.SmartContracts.Core.Receipts;
+using Stratis.SmartContracts.Core.State;
+using Stratis.SmartContracts.Core.Util;
+
+namespace Stratis.Bitcoin.Features.SmartContracts.Rules
+{
+    /// <summary>
+    /// Abstraction for shared SC coinview rule logic.
+    /// </summary>
+    public sealed class SmartContractCoinViewRuleLogic
+    {
+        protected List<Transaction> blockTxsProcessed;
+        protected Transaction generatedTransaction;
+        protected IList<Receipt> receipts;
+        protected uint refundCounter;
+        protected IStateRepositoryRoot mutableStateRepository;
+
+        public ISmartContractCoinviewRule ContractCoinviewRule { get; set; }
+
+   
+        public async Task RunAsync(Func<RuleContext, Task> baseRunAsync, RuleContext context)
+        {
+            this.blockTxsProcessed = new List<Transaction>();
+            this.receipts = new List<Receipt>();
+            this.refundCounter = 1;
+            NBitcoin.Block block = context.ValidationContext.BlockToValidate;
+
+            // Get a IStateRepositoryRoot we can alter without affecting the injected one which is used elsewhere.
+            byte[] blockRoot = ((ISmartContractBlockHeader)context.ValidationContext.ChainedHeaderToValidate.Previous.Header).HashStateRoot.ToBytes();
+            this.mutableStateRepository = this.ContractCoinviewRule.OriginalStateRoot.GetSnapshotTo(blockRoot);
+
+            await baseRunAsync(context);
+
+            if (new uint256(this.mutableStateRepository.Root) != ((ISmartContractBlockHeader)block.Header).HashStateRoot)
+                SmartContractConsensusErrors.UnequalStateRoots.Throw();
+
+            ValidateAndStoreReceipts(((ISmartContractBlockHeader)block.Header).ReceiptRoot);
+
+            // Push to underlying database
+            this.mutableStateRepository.Commit();
+
+            // Update the globally injected state so all services receive the updates.
+            this.ContractCoinviewRule.OriginalStateRoot.SyncToRoot(this.mutableStateRepository.Root);
+        }
+
+        /// <summary>
+        /// Executes contracts as necessary and updates the coinview / UTXOset after execution.
+        /// </summary>
+        /// <inheritdoc/>
+        public void UpdateCoinView(Action<RuleContext, Transaction> baseUpdateUTXOSet, RuleContext context, Transaction transaction)
+        {
+            if (this.generatedTransaction != null)
+            {
+                ValidateGeneratedTransaction(transaction);
+                baseUpdateUTXOSet(context, transaction);
+                this.blockTxsProcessed.Add(transaction);
+                return;
+            }
+
+            // If we are here, was definitely submitted by someone
+            ValidateSubmittedTransaction(transaction);
+
+            TxOut smartContractTxOut = transaction.Outputs.FirstOrDefault(txOut => SmartContractScript.IsSmartContractExec(txOut.ScriptPubKey));
+            if (smartContractTxOut == null)
+            {
+                // Someone submitted a standard transaction - no smart contract opcodes.
+                baseUpdateUTXOSet(context, transaction);
+                this.blockTxsProcessed.Add(transaction);
+                return;
+            }
+
+            // Someone submitted a smart contract transaction.
+            ExecuteContractTransaction(context, transaction);
+
+            baseUpdateUTXOSet(context, transaction);
+            this.blockTxsProcessed.Add(transaction);
+        }
+
+        /// <summary>
+        /// Validates that any condensing transaction matches the transaction generated during execution
+        /// </summary>
+        /// <param name="transaction"></param>
+        private void ValidateGeneratedTransaction(Transaction transaction)
+        {
+            if (this.generatedTransaction.GetHash() != transaction.GetHash())
+                SmartContractConsensusErrors.UnequalCondensingTx.Throw();
+
+            this.generatedTransaction = null;
+
+            return;
+        }
+
+        /// <summary>
+        /// Validates that a submitted transacction doesn't contain illegal operations
+        /// </summary>
+        /// <param name="transaction"></param>
+        protected void ValidateSubmittedTransaction(Transaction transaction)
+        {
+            if (transaction.Inputs.Any(x => x.ScriptSig.IsSmartContractSpend()))
+                SmartContractConsensusErrors.UserOpSpend.Throw();
+
+            if (transaction.Outputs.Any(x => x.ScriptPubKey.IsSmartContractInternalCall()))
+                SmartContractConsensusErrors.UserInternalCall.Throw();
+        }
+
+        /// <summary>
+        /// Throws a consensus exception if the gas refund inside the block is different to what this node calculated during execution.
+        /// </summary>
+        public void ValidateRefunds(TxOut refund, Transaction coinbaseTransaction)
+        {
+            TxOut refundToMatch = coinbaseTransaction.Outputs[this.refundCounter];
+            if (refund.Value != refundToMatch.Value || refund.ScriptPubKey != refundToMatch.ScriptPubKey)
+            {
+                SmartContractConsensusErrors.UnequalRefundAmounts.Throw();
+            }
+
+            this.refundCounter++;
+        }
+
+        /// <summary>
+        /// Executes the smart contract part of a transaction
+        /// </summary>
+        protected void ExecuteContractTransaction(RuleContext context, Transaction transaction)
+        {
+            IContractTransactionContext txContext = GetSmartContractTransactionContext(context, transaction);
+            IContractExecutor executor = this.ContractCoinviewRule.ExecutorFactory.CreateExecutor(this.mutableStateRepository, txContext);
+
+            IContractExecutionResult result = executor.Execute(txContext);
+
+            var receipt = new Receipt(
+                new uint256(this.mutableStateRepository.Root),
+                result.GasConsumed,
+                result.Logs.ToArray(),
+                txContext.TransactionHash,
+                txContext.Sender,
+                result.To,
+                result.NewContractAddress,
+                !result.Revert,
+                result.ErrorMessage
+            )
+            {
+                BlockHash = context.ValidationContext.BlockToValidate.GetHash()
+            };
+
+            this.receipts.Add(receipt);
+
+            ValidateRefunds(result.Refund, context.ValidationContext.BlockToValidate.Transactions[0]);
+
+            if (result.InternalTransaction != null)
+                this.generatedTransaction = result.InternalTransaction;
+        }
+
+        /// <summary>
+        /// Retrieves the context object to be given to the contract executor.
+        /// </summary>
+        private IContractTransactionContext GetSmartContractTransactionContext(RuleContext context, Transaction transaction)
+        {
+            ulong blockHeight = Convert.ToUInt64(context.ValidationContext.ChainedHeaderToValidate.Height);
+
+            GetSenderResult getSenderResult = this.ContractCoinviewRule.SenderRetriever.GetSender(transaction, ((PowConsensusRuleEngine)this.Parent).UtxoSet, this.blockTxsProcessed);
+
+            if (!getSenderResult.Success)
+                throw new ConsensusErrorException(new ConsensusError("sc-consensusvalidator-executecontracttransaction-sender", getSenderResult.Error));
+
+            Script coinbaseScriptPubKey = context.ValidationContext.BlockToValidate.Transactions[0].Outputs[0].ScriptPubKey;
+
+            GetSenderResult getCoinbaseResult = this.ContractCoinviewRule.SenderRetriever.GetAddressFromScript(coinbaseScriptPubKey);
+
+            uint160 coinbaseAddress = (getCoinbaseResult.Success) ? getCoinbaseResult.Sender : uint160.Zero;
+
+            Money mempoolFee = transaction.GetFee(((UtxoRuleContext)context).UnspentOutputSet);
+
+            return new ContractTransactionContext(blockHeight, coinbaseAddress, mempoolFee, getSenderResult.Sender, transaction);
+        }
+
+        /// <summary>
+        /// Throws a consensus exception if the receipt roots don't match.
+        /// </summary>
+        private void ValidateAndStoreReceipts(uint256 receiptRoot)
+        {
+            List<uint256> leaves = this.receipts.Select(x => x.GetHash()).ToList();
+            bool mutated = false; // TODO: Do we need this?
+            uint256 expectedReceiptRoot = BlockMerkleRootRule.ComputeMerkleRoot(leaves, out mutated);
+
+            if (receiptRoot != expectedReceiptRoot)
+                SmartContractConsensusErrors.UnequalReceiptRoots.Throw();
+
+            // TODO: Could also check for equality of logsBloom?
+
+            this.ContractCoinviewRule.ReceiptRepository.Store(this.receipts);
+            this.receipts.Clear();
+        }
+
+        public bool CheckInput(Func<Transaction, int, TxOut, PrecomputedTransactionData, TxIn, DeploymentFlags, bool> baseCheckInput, Transaction tx, int inputIndexCopy, TxOut txout, PrecomputedTransactionData txData, TxIn input, DeploymentFlags flags)
+        {
+            if (txout.ScriptPubKey.IsSmartContractExec() || txout.ScriptPubKey.IsSmartContractInternalCall())
+            {
+                return input.ScriptSig.IsSmartContractSpend();
+            }
+
+            return baseCheckInput(tx, inputIndexCopy, txout, txData, input, flags);
+        }
+
+        public bool IsProtocolTransaction(Transaction transaction)
+        {
+            return transaction.IsCoinBase || transaction.IsCoinStake;
+        }
+
+        public void ResetRefundCounter()
+        {
+            this.refundCounter = 1;
+        }
+
+        public void ClearGeneratedTransaction()
+        {
+            this.generatedTransaction = null;
+        }
+    }
+}

--- a/src/Stratis.Bitcoin.Features.SmartContracts/Rules/SmartContractCoinViewRuleLogic.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts/Rules/SmartContractCoinViewRuleLogic.cs
@@ -29,7 +29,8 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Rules
 
         public ISmartContractCoinviewRule ContractCoinviewRule { get; set; }
 
-   
+        public ConsensusRuleEngine Parent { get; set; }
+
         public async Task RunAsync(Func<RuleContext, Task> baseRunAsync, RuleContext context)
         {
             this.blockTxsProcessed = new List<Transaction>();

--- a/src/Stratis.Bitcoin.Features.SmartContracts/Rules/SmartContractCoinViewRuleLogic.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts/Rules/SmartContractCoinViewRuleLogic.cs
@@ -34,7 +34,6 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Rules
             this.blockTxsProcessed = new List<Transaction>();
             this.receipts = new List<Receipt>();
             this.ContractCoinviewRule = (ISmartContractCoinviewRule)this.Parent;
-
         }
 
         public ISmartContractCoinviewRule ContractCoinviewRule { get; }

--- a/src/Stratis.Bitcoin.Features.SmartContracts/Rules/SmartContractCoinviewRule.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts/Rules/SmartContractCoinviewRule.cs
@@ -10,6 +10,7 @@ using Stratis.Bitcoin.Consensus.Rules;
 using Stratis.Bitcoin.Features.Consensus;
 using Stratis.Bitcoin.Features.Consensus.Rules;
 using Stratis.Bitcoin.Features.Consensus.Rules.CommonRules;
+using Stratis.Bitcoin.Utilities;
 using Stratis.SmartContracts.Core;
 using Stratis.SmartContracts.Core.Receipts;
 using Stratis.SmartContracts.Core.State;
@@ -84,6 +85,12 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Rules
                 this.Logger.LogTrace("(-)[BAD_COINBASE_AMOUNT]");
                 ConsensusErrors.BadCoinbaseAmount.Throw();
             }
+        }
+
+        /// <inheritdoc/>
+        public override void CheckMaturity(UnspentOutputs coins, int spendHeight)
+        {
+            base.CheckCoinbaseMaturity(coins, spendHeight);
         }
 
         /// <inheritdoc />

--- a/src/Stratis.Bitcoin.Features.SmartContracts/Rules/SmartContractCoinviewRule.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts/Rules/SmartContractCoinviewRule.cs
@@ -10,7 +10,6 @@ using Stratis.Bitcoin.Consensus.Rules;
 using Stratis.Bitcoin.Features.Consensus;
 using Stratis.Bitcoin.Features.Consensus.Rules;
 using Stratis.Bitcoin.Features.Consensus.Rules.CommonRules;
-using Stratis.Bitcoin.Utilities;
 using Stratis.SmartContracts.Core;
 using Stratis.SmartContracts.Core.Receipts;
 using Stratis.SmartContracts.Core.State;
@@ -85,12 +84,6 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Rules
                 this.Logger.LogTrace("(-)[BAD_COINBASE_AMOUNT]");
                 ConsensusErrors.BadCoinbaseAmount.Throw();
             }
-        }
-
-        /// <inheritdoc/>
-        public override void CheckMaturity(UnspentOutputs coins, int spendHeight)
-        {
-            base.CheckCoinbaseMaturity(coins, spendHeight);
         }
 
         /// <inheritdoc />

--- a/src/Stratis.Bitcoin.Features.SmartContracts/Rules/SmartContractCoinviewRule.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts/Rules/SmartContractCoinviewRule.cs
@@ -66,17 +66,14 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Rules
         }
 
         /// <inheritdoc/>
-        protected override bool CheckInput(Transaction tx, int inputIndexCopy, TxOut txout,PrecomputedTransactionData txData, TxIn input, DeploymentFlags flags)
+        protected override bool CheckInput(Transaction tx, int inputIndexCopy, TxOut txout, PrecomputedTransactionData txData, TxIn input, DeploymentFlags flags)
         {
             if (txout.ScriptPubKey.IsSmartContractExec() || txout.ScriptPubKey.IsSmartContractInternalCall())
             {
                 return input.ScriptSig.IsSmartContractSpend();
             }
 
-            var checker = new TransactionChecker(tx, inputIndexCopy, txout.Value, txData);
-            var ctx = new ScriptEvaluationContext(this.Parent.Network);
-            ctx.ScriptVerify = flags.ScriptFlags;
-            return ctx.VerifyScript(input.ScriptSig, txout.ScriptPubKey, checker);
+            return base.CheckInput(tx, inputIndexCopy, txout, txData, input, flags);
         }
 
         /// <inheritdoc/>

--- a/src/Stratis.Bitcoin.Features.SmartContracts/Rules/SmartContractCoinviewRule.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts/Rules/SmartContractCoinviewRule.cs
@@ -1,20 +1,12 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using NBitcoin;
 using Stratis.Bitcoin.Base.Deployments;
 using Stratis.Bitcoin.Consensus;
 using Stratis.Bitcoin.Consensus.Rules;
-using Stratis.Bitcoin.Features.Consensus;
-using Stratis.Bitcoin.Features.Consensus.Rules;
 using Stratis.Bitcoin.Features.Consensus.Rules.CommonRules;
 using Stratis.Bitcoin.Utilities;
-using Stratis.SmartContracts.Core;
-using Stratis.SmartContracts.Core.Receipts;
-using Stratis.SmartContracts.Core.State;
-using Stratis.SmartContracts.Core.Util;
 
 namespace Stratis.Bitcoin.Features.SmartContracts.Rules
 {
@@ -23,57 +15,26 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Rules
     {
         protected List<Transaction> blockTxsProcessed;
         protected Transaction generatedTransaction;
-        protected IList<Receipt> receipts;
         protected uint refundCounter;
-        protected IStateRepositoryRoot mutableStateRepository;
-
-        protected ISmartContractCoinviewRule ContractCoinviewRule { get; private set; }
+        private SmartContractCoinViewRuleLogic logic;
 
         /// <inheritdoc />
         public override void Initialize()
         {
             base.Initialize();
-
-            this.generatedTransaction = null;
-            this.refundCounter = 1;
-            this.ContractCoinviewRule = (ISmartContractCoinviewRule)this.Parent;
+            this.logic = new SmartContractCoinViewRuleLogic(this.Parent);
         }
 
         /// <inheritdoc />
         public override async Task RunAsync(RuleContext context)
         {
-            this.blockTxsProcessed = new List<Transaction>();
-            this.receipts = new List<Receipt>();
-            this.refundCounter = 1;
-            NBitcoin.Block block = context.ValidationContext.BlockToValidate;
-            
-            // Get a IStateRepositoryRoot we can alter without affecting the injected one which is used elsewhere.
-            byte[] blockRoot = ((ISmartContractBlockHeader)context.ValidationContext.ChainedHeaderToValidate.Previous.Header).HashStateRoot.ToBytes();
-            this.mutableStateRepository = this.ContractCoinviewRule.OriginalStateRoot.GetSnapshotTo(blockRoot);
-
-            await base.RunAsync(context);
-
-            if (new uint256(this.mutableStateRepository.Root) != ((ISmartContractBlockHeader)block.Header).HashStateRoot)
-                SmartContractConsensusErrors.UnequalStateRoots.Throw();
-
-            ValidateAndStoreReceipts(((ISmartContractBlockHeader)block.Header).ReceiptRoot);
-
-            // Push to underlying database
-            this.mutableStateRepository.Commit();
-
-            // Update the globally injected state so all services receive the updates.
-            this.ContractCoinviewRule.OriginalStateRoot.SyncToRoot(this.mutableStateRepository.Root);
+            await this.logic.RunAsync(base.RunAsync, context);
         }
 
         /// <inheritdoc/>
         protected override bool CheckInput(Transaction tx, int inputIndexCopy, TxOut txout, PrecomputedTransactionData txData, TxIn input, DeploymentFlags flags)
         {
-            if (txout.ScriptPubKey.IsSmartContractExec() || txout.ScriptPubKey.IsSmartContractInternalCall())
-            {
-                return input.ScriptSig.IsSmartContractSpend();
-            }
-
-            return base.CheckInput(tx, inputIndexCopy, txout, txData, input, flags);
+            return this.logic.CheckInput(base.CheckInput, tx, inputIndexCopy, txout, txData, input, flags);
         }
 
         /// <inheritdoc/>
@@ -109,31 +70,7 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Rules
         /// <inheritdoc/>
         public override void UpdateCoinView(RuleContext context, Transaction transaction)
         {
-            if (this.generatedTransaction != null)
-            {
-                ValidateGeneratedTransaction(transaction);
-                base.UpdateUTXOSet(context, transaction);
-                this.blockTxsProcessed.Add(transaction);
-                return;
-            }
-
-            // If we are here, was definitely submitted by someone
-            ValidateSubmittedTransaction(transaction);
-
-            TxOut smartContractTxOut = transaction.Outputs.FirstOrDefault(txOut => txOut.ScriptPubKey.IsSmartContractExec());
-            if (smartContractTxOut == null)
-            {
-                // Someone submitted a standard transaction - no smart contract opcodes.
-                base.UpdateUTXOSet(context, transaction);
-                this.blockTxsProcessed.Add(transaction);
-                return;
-            }
-
-            // Someone submitted a smart contract transaction.
-            ExecuteContractTransaction(context, transaction);
-
-            base.UpdateUTXOSet(context, transaction);
-            this.blockTxsProcessed.Add(transaction);
+            this.logic.UpdateCoinView(base.UpdateUTXOSet, context, transaction);
         }
 
         /// <summary>
@@ -142,12 +79,7 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Rules
         /// <param name="transaction"></param>
         protected void ValidateGeneratedTransaction(Transaction transaction)
         {
-            if (this.generatedTransaction.GetHash() != transaction.GetHash())
-                SmartContractConsensusErrors.UnequalCondensingTx.Throw();
-
-            this.generatedTransaction = null;
-
-            return;
+            this.logic.ValidateGeneratedTransaction(transaction);
         }
 
         /// <summary>
@@ -156,11 +88,7 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Rules
         /// <param name="transaction"></param>
         protected void ValidateSubmittedTransaction(Transaction transaction)
         {
-            if (transaction.Inputs.Any(x => x.ScriptSig.IsSmartContractSpend()))
-                SmartContractConsensusErrors.UserOpSpend.Throw();
-
-            if (transaction.Outputs.Any(x => x.ScriptPubKey.IsSmartContractInternalCall()))
-                SmartContractConsensusErrors.UserInternalCall.Throw();
+            this.logic.ValidateSubmittedTransaction(transaction);
         }
 
         /// <summary>
@@ -168,93 +96,13 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Rules
         /// </summary>
         protected void ExecuteContractTransaction(RuleContext context, Transaction transaction)
         {
-            IContractTransactionContext txContext = GetSmartContractTransactionContext(context, transaction);
-            IContractExecutor executor = this.ContractCoinviewRule.ExecutorFactory.CreateExecutor(this.mutableStateRepository, txContext);
-
-            IContractExecutionResult result = executor.Execute(txContext);
-
-            var receipt = new Receipt(
-                new uint256(this.mutableStateRepository.Root),
-                result.GasConsumed,
-                result.Logs.ToArray(),
-                txContext.TransactionHash,
-                txContext.Sender,
-                result.To,
-                result.NewContractAddress,
-                !result.Revert,
-                result.ErrorMessage
-            )
-            {
-                BlockHash = context.ValidationContext.BlockToValidate.GetHash()
-            };
-
-            this.receipts.Add(receipt);
-
-            // Refund can be null when all gas is consumed
-            if (result.Refund != null)
-                ValidateRefunds(result.Refund, context.ValidationContext.BlockToValidate.Transactions[0]);
-
-            if (result.InternalTransaction != null)
-                this.generatedTransaction = result.InternalTransaction;
-        }
-
-        /// <summary>
-        /// Retrieves the context object to be given to the contract executor.
-        /// </summary>
-        private IContractTransactionContext GetSmartContractTransactionContext(RuleContext context, Transaction transaction)
-        {
-            ulong blockHeight = Convert.ToUInt64(context.ValidationContext.ChainedHeaderToValidate.Height);
-
-            GetSenderResult getSenderResult = this.ContractCoinviewRule.SenderRetriever.GetSender(transaction, ((PowConsensusRuleEngine)this.Parent).UtxoSet, this.blockTxsProcessed);
-
-            if (!getSenderResult.Success)
-                throw new ConsensusErrorException(new ConsensusError("sc-consensusvalidator-executecontracttransaction-sender", getSenderResult.Error));
-
-            Script coinbaseScriptPubKey = context.ValidationContext.BlockToValidate.Transactions[0].Outputs[0].ScriptPubKey;
-            GetSenderResult getCoinbaseResult = this.ContractCoinviewRule.SenderRetriever.GetAddressFromScript(coinbaseScriptPubKey);
-            uint160 coinbaseAddress = (getCoinbaseResult.Success) ? getCoinbaseResult.Sender : uint160.Zero;
-
-            Money mempoolFee = transaction.GetFee(((UtxoRuleContext)context).UnspentOutputSet);
-
-            return new ContractTransactionContext(blockHeight, coinbaseAddress, mempoolFee, getSenderResult.Sender, transaction);
-        }
-
-        /// <summary>
-        /// Throws a consensus exception if the receipt roots don't match.
-        /// </summary>
-        private void ValidateAndStoreReceipts(uint256 receiptRoot)
-        {
-            List<uint256> leaves = this.receipts.Select(x => x.GetHash()).ToList();
-            bool mutated = false; // TODO: Do we need this?
-            uint256 expectedReceiptRoot = BlockMerkleRootRule.ComputeMerkleRoot(leaves, out mutated);
-
-            if (receiptRoot != expectedReceiptRoot)
-                SmartContractConsensusErrors.UnequalReceiptRoots.Throw();
-
-            // TODO: Could also check for equality of logsBloom?
-
-            this.ContractCoinviewRule.ReceiptRepository.Store(this.receipts);
-            this.receipts.Clear();
-        }
-
-        /// <summary>
-        /// Throws a consensus exception if the gas refund inside the block is different to what this node calculated during execution.
-        /// </summary>
-        private void ValidateRefunds(TxOut refund, Transaction coinbaseTransaction)
-        {
-            TxOut refundToMatch = coinbaseTransaction.Outputs[this.refundCounter];
-            if (refund.Value != refundToMatch.Value || refund.ScriptPubKey != refundToMatch.ScriptPubKey)
-            {
-                SmartContractConsensusErrors.UnequalRefundAmounts.Throw();
-            }
-
-            this.refundCounter++;
+            this.logic.ExecuteContractTransaction(context, transaction);
         }
 
         /// <inheritdoc/>
         protected override bool IsProtocolTransaction(Transaction transaction)
         {
-            return transaction.IsCoinBase || transaction.IsCoinStake;
+            return this.logic.IsProtocolTransaction(transaction);
         }
     }
 }


### PR DESCRIPTION
Separates logic shared between SC base and PoA CoinViewRule implementations. PoS is different (and inherits from ScCoinViewRule), so I left it untouched. Goal is to prevent bugs like #2755 in the short term. Ideal long-term solution requires refactoring of the FN CoinViewRule implementation, which is not in the immediate plan.

Closes #2755.