### PR TITLE
[RPC] Handle paytopubkey tx type

### DIFF
--- a/src/NBitcoin/Script.cs
+++ b/src/NBitcoin/Script.cs
@@ -935,6 +935,9 @@ namespace NBitcoin
         /// <returns></returns>
         public TxDestination GetDestination(Network network)
         {
+            PubKey pubKeyParams = PayToPubkeyTemplate.Instance.ExtractScriptPubKeyParameters(this);
+            if (pubKeyParams != null)
+                return pubKeyParams.Hash;
             KeyId pubKeyHashParams = PayToPubkeyHashTemplate.Instance.ExtractScriptPubKeyParameters(this);
             if(pubKeyHashParams != null)
                 return pubKeyHashParams;


### PR DESCRIPTION
Fixes #2748 (hopefully)

Also see #2731

The root issue is that NBitcoin did not seem to have a `TxDestination` for P2PK transactions. While these are not often used any more, the coinstake transactions in each block tend to be of this type. So when trying to decode them no address information was getting returned.

This is quite a low level change and I am not 100% sure it is correct. It does however decode the coinstake destination into the address I'd expect, per the block explorer.

Example Stratis transaction hex:

```01000000506ee65b0135c59cb8bf34d98590efe61fc94290c07a8b048b893199b71f7ee7b9aa6422200100000049483045022100b28977b2e530fd2466b6cc4b35276ae158a1e9975c862c8a6e9af9b2db292b0902201b5ddcf93944d23a45ec50ec4410d228ef331d00a4c3602bf0e95f49279c383a01ffffffff020000000000000000001c339aeb70000000232102a961c743372b3b79e4c6a1c2917fecbcf351158e4b01fde729bb70f308cd34f4ac00000000```

-> resulting address for Vout 1:

```"TPcVgKfg2wHgABG3U5Rim7hKfk8mQPDWAH"```

Compared with block explorer:

https://chainz.cryptoid.info/strat-test/tx.dws?10ebe9c14f0a2bacfd361642597b6ab359db7224c61ecb61e239539a583725ab.htm