### PR TITLE
[SC] Add return value to receipt

### DIFF
--- a/src/Stratis.Bitcoin.Features.SmartContracts.Tests/Controllers/SmartContractWalletControllerTest.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts.Tests/Controllers/SmartContractWalletControllerTest.cs
@@ -92,7 +92,7 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Tests.Controllers
             this.walletManager.Setup(w => w.GetAccounts(walletName)).Returns(new List<HdAccount> {account});
 
             this.receiptRepository.Setup(x => x.Retrieve(It.IsAny<uint256>()))
-                .Returns(new Receipt(null, 0, new Log[0], null, null, null, uint160.Zero, true, null));
+                .Returns(new Receipt(null, 0, new Log[0], null, null, null, uint160.Zero, true, null, null));
             this.callDataSerializer.Setup(x => x.Deserialize(It.IsAny<byte[]>()))
                 .Returns(Result.Ok(new ContractTxData(0, 0, (Gas) 0, new uint160(0), null, null)));
 

--- a/src/Stratis.Bitcoin.Features.SmartContracts.Tests/Receipts/PersistentReceiptRepositoryTests.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts.Tests/Receipts/PersistentReceiptRepositoryTests.cs
@@ -36,7 +36,7 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Tests.Receipts
             };
             var log2 = new Log(new uint160(12345), topics2, data2);
 
-            var receipt = new Receipt(new uint256(1234), 12345, new Log[] { log1, log2 }, new uint256(12345), new uint160(25), new uint160(24), new uint160(23), true, "SomeExceptionString") { BlockHash = new uint256(1234) };
+            var receipt = new Receipt(new uint256(1234), 12345, new Log[] { log1, log2 }, new uint256(12345), new uint160(25), new uint160(24), new uint160(23), true, "SomeResult", "SomeExceptionString") { BlockHash = new uint256(1234) };
             this.db.Store(new Receipt[] { receipt });
             Receipt retrievedReceipt = this.db.Retrieve(receipt.TransactionHash);
             ReceiptSerializationTest.TestStorageReceiptEquality(receipt, retrievedReceipt);

--- a/src/Stratis.Bitcoin.Features.SmartContracts.Tests/Receipts/ReceiptSerializationTest.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts.Tests/Receipts/ReceiptSerializationTest.cs
@@ -46,13 +46,13 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Tests.Receipts
 
             var receipt = new Receipt(new uint256(1234), 12345, new Log[] { log1, log2 });
             TestConsensusSerialize(receipt);
-            receipt = new Receipt(receipt.PostState, receipt.GasUsed, receipt.Logs, new uint256(12345), new uint160(25), new uint160(24), new uint160(23), true, null) { BlockHash = new uint256(1234) };
+            receipt = new Receipt(receipt.PostState, receipt.GasUsed, receipt.Logs, new uint256(12345), new uint160(25), new uint160(24), new uint160(23), true, null, null) { BlockHash = new uint256(1234) };
             TestStorageSerialize(receipt);
 
             // Test cases where either the sender or contract is null - AKA CALL vs CREATE
-            receipt = new Receipt(receipt.PostState, receipt.GasUsed, receipt.Logs, new uint256(12345), new uint160(25), new uint160(24), null, true, "Test Error Message") { BlockHash = new uint256(1234) };
+            receipt = new Receipt(receipt.PostState, receipt.GasUsed, receipt.Logs, new uint256(12345), new uint160(25), new uint160(24), null, true, "Test Result", "Test Error Message") { BlockHash = new uint256(1234) };
             TestStorageSerialize(receipt);
-            receipt = new Receipt(receipt.PostState, receipt.GasUsed, receipt.Logs, new uint256(12345), new uint160(25), null, new uint160(23), true, "Test Error Message 2") { BlockHash = new uint256(1234) };
+            receipt = new Receipt(receipt.PostState, receipt.GasUsed, receipt.Logs, new uint256(12345), new uint160(25), null, new uint160(23), true, "Test Result 2", "Test Error Message 2") { BlockHash = new uint256(1234) };
             TestStorageSerialize(receipt);
         }
 

--- a/src/Stratis.Bitcoin.Features.SmartContracts/Rules/SmartContractCoinViewRuleLogic.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts/Rules/SmartContractCoinViewRuleLogic.cs
@@ -13,6 +13,7 @@ using Stratis.SmartContracts.Core;
 using Stratis.SmartContracts.Core.Receipts;
 using Stratis.SmartContracts.Core.State;
 using Stratis.SmartContracts.Core.Util;
+using Stratis.SmartContracts.Executor.Reflection.Serialization;
 
 namespace Stratis.Bitcoin.Features.SmartContracts.Rules
 {
@@ -159,6 +160,7 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Rules
                 result.To,
                 result.NewContractAddress,
                 !result.Revert,
+                result.Return?.ToString(),
                 result.ErrorMessage
             )
             {

--- a/src/Stratis.SmartContracts.Core/Receipts/Receipt.cs
+++ b/src/Stratis.SmartContracts.Core/Receipts/Receipt.cs
@@ -70,6 +70,11 @@ namespace Stratis.SmartContracts.Core.Receipts
         public bool Success { get; }
 
         /// <summary>
+        /// The result of the execution, serialized as a string.
+        /// </summary>
+        public string Result { get; }
+
+        /// <summary>
         /// If execution didn't complete successfully, the error will be stored here. 
         /// Could be an exception that occurred inside a contract or a message (e.g. method not found.)
         /// </summary>
@@ -80,17 +85,17 @@ namespace Stratis.SmartContracts.Core.Receipts
         /// <summary>
         /// Creates receipt with both consensus and storage fields and generates bloom.
         /// </summary>
-        public Receipt(
-            uint256 postState,
+        public Receipt(uint256 postState,
             ulong gasUsed,
             Log[] logs,
             uint256 transactionHash,
-            uint160 from, 
-            uint160 to, 
+            uint160 from,
+            uint160 to,
             uint160 newContractAddress,
             bool success,
+            string result,
             string errorMessage) 
-            : this(postState, gasUsed, logs, BuildBloom(logs), transactionHash, null, from, to, newContractAddress, success, errorMessage)
+            : this(postState, gasUsed, logs, BuildBloom(logs), transactionHash, null, from, to, newContractAddress, success, result, errorMessage)
         { }
 
         /// <summary>
@@ -100,7 +105,7 @@ namespace Stratis.SmartContracts.Core.Receipts
             uint256 postState,
             ulong gasUsed,
             Log[] logs)
-            : this(postState, gasUsed, logs, BuildBloom(logs), null, null, null, null, null, false, null)
+            : this(postState, gasUsed, logs, BuildBloom(logs), null, null, null, null, null, false, null, null)
         { }
 
         /// <summary>
@@ -111,11 +116,10 @@ namespace Stratis.SmartContracts.Core.Receipts
             ulong gasUsed,
             Log[] logs,
             Bloom bloom) 
-            : this(postState, gasUsed, logs, bloom, null, null, null, null, null, false, null)
+            : this(postState, gasUsed, logs, bloom, null, null, null, null, null, false, null, null)
         { }
 
-        private Receipt(
-            uint256 postState,
+        private Receipt(uint256 postState,
             ulong gasUsed,
             Log[] logs,
             Bloom bloom,
@@ -125,6 +129,7 @@ namespace Stratis.SmartContracts.Core.Receipts
             uint160 to,
             uint160 newContractAddress,
             bool success,
+            string result,
             string errorMessage)
         {
             this.PostState = postState;
@@ -137,6 +142,7 @@ namespace Stratis.SmartContracts.Core.Receipts
             this.To = to;
             this.NewContractAddress = newContractAddress;
             this.Success = success;
+            this.Result = result;
             this.ErrorMessage = errorMessage;
         }
 
@@ -225,7 +231,8 @@ namespace Stratis.SmartContracts.Core.Receipts
                 innerList[7].RLPData != null ? new uint160(innerList[7].RLPData) : null,
                 innerList[8].RLPData != null ? new uint160(innerList[8].RLPData) : null,
                 BitConverter.ToBoolean(innerList[9].RLPData),
-                innerList[10].RLPData != null ? Encoding.UTF8.GetString(innerList[10].RLPData) : null
+                innerList[10].RLPData != null ? Encoding.UTF8.GetString(innerList[10].RLPData) : null,
+                innerList[11].RLPData != null ? Encoding.UTF8.GetString(innerList[11].RLPData) : null
             );
 
             return receipt;
@@ -249,6 +256,7 @@ namespace Stratis.SmartContracts.Core.Receipts
                 RLP.EncodeElement(this.To?.ToBytes()),
                 RLP.EncodeElement(this.NewContractAddress?.ToBytes()),
                 RLP.EncodeElement(BitConverter.GetBytes(this.Success)),
+                RLP.EncodeElement(Encoding.UTF8.GetBytes(this.Result ?? "")),
                 RLP.EncodeElement(Encoding.UTF8.GetBytes(this.ErrorMessage ?? ""))
             );
         }


### PR DESCRIPTION
Serializes return value using `ToString()`, which does not work for all types. Can be improved in the future as this is not part of consensus.