### PR TITLE
[Coinview] Deduplicate coinview cache fetches for staking

### DIFF
--- a/src/Stratis.Bitcoin.Features.Miner/Staking/PosMinting.cs
+++ b/src/Stratis.Bitcoin.Features.Miner/Staking/PosMinting.cs
@@ -441,7 +441,7 @@ namespace Stratis.Bitcoin.Features.Miner.Staking
             List<UnspentOutputReference> spendableTransactions = this.walletManager
                 .GetSpendableTransactionsInWalletForStaking(walletSecret.WalletName, 1).ToList();
 
-            FetchCoinsResponse fetchedCoinSet = await this.coinView.FetchCoinsAsync(spendableTransactions.Select(t => t.Transaction.Id).ToArray(), cancellationToken).ConfigureAwait(false);
+            FetchCoinsResponse fetchedCoinSet = await this.coinView.FetchCoinsAsync(spendableTransactions.Select(t => t.Transaction.Id).Distinct().ToArray(), cancellationToken).ConfigureAwait(false);
 
             foreach (UnspentOutputReference outputReference in spendableTransactions)
             {


### PR DESCRIPTION
Fixes #2761

I examined other calls to `CachedCoinview.FetchCoinsAsync` and they all either use the CoinviewHelper (which internally utilises a HashSet) or only fetch one transaction at a time. This was the only apparent place where de-duplication needed to be done.