### PR TITLE
[SC] Display history with empty block numbers first

### DIFF
--- a/src/Stratis.Bitcoin.Features.SmartContracts/Wallet/SmartContractWalletController.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts/Wallet/SmartContractWalletController.cs
@@ -202,7 +202,7 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Wallet
                     }
                 }
 
-                return this.Json(transactionItems.OrderByDescending(x=>x.BlockHeight));
+                return this.Json(transactionItems.OrderByDescending(x => x.BlockHeight ?? Int32.MaxValue));
             }
             catch (Exception e)
             {

--- a/src/Stratis.Bitcoin.Features.SmartContracts/Wallet/SmartContractWalletController.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts/Wallet/SmartContractWalletController.cs
@@ -202,7 +202,7 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Wallet
                     }
                 }
 
-                return this.Json(transactionItems.OrderByDescending(x => x.BlockHeight ?? Int32.MaxValue));
+                return this.Json(transactionItems.OrderByDescending(x => x.BlockHeight ?? Int32.MaxValue).ThenBy(x => x.Hash.ToString()));
             }
             catch (Exception e)
             {


### PR DESCRIPTION
Also adds secondary ordering by txhash, so that multiple histories in the same block still appear in logical order.

Closes #2775.