### PR TITLE
[Consensus] Remove unused ICoinView parameter

### DIFF
--- a/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/LoadCoinviewRule.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/LoadCoinviewRule.cs
@@ -27,7 +27,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Rules.CommonRules
             // unless the coinview treashold is reached.
             this.Logger.LogTrace("Saving coinview changes.");
             var utxoRuleContext = context as UtxoRuleContext;
-            await this.PowParent.UtxoSet.SaveChangesAsync(utxoRuleContext.UnspentOutputSet.GetCoins(this.PowParent.UtxoSet), null, oldBlockHash, nextBlockHash, height).ConfigureAwait(false);
+            await this.PowParent.UtxoSet.SaveChangesAsync(utxoRuleContext.UnspentOutputSet.GetCoins(), null, oldBlockHash, nextBlockHash, height).ConfigureAwait(false);
 
             // Use the default flush condition to decide if flush is required (currently set to every 60 seconds)
             if (this.PowParent.UtxoSet is CachedCoinView cachedCoinView)

--- a/src/Stratis.Bitcoin.Features.Consensus/UnspentOutputSet.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/UnspentOutputSet.cs
@@ -76,7 +76,7 @@ namespace Stratis.Bitcoin.Features.Consensus
             }
         }
 
-        public IList<UnspentOutputs> GetCoins(ICoinView utxo)
+        public IList<UnspentOutputs> GetCoins()
         {
             return this.unspents.Select(u => u.Value).ToList();
         }


### PR DESCRIPTION
Trivial change - removes a variable that is not being used and makes the API for dealing with an UnspentOutputSet a little nicer