### PR TITLE
Error in PosConsensusFeature.InitializeAsync #2846

### DIFF
--- a/src/Stratis.Bitcoin.Features.Consensus/PosConsensusFeature.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/PosConsensusFeature.cs
@@ -70,7 +70,7 @@ namespace Stratis.Bitcoin.Features.Consensus
             NetworkPeerConnectionParameters connectionParameters = this.connectionManager.Parameters;
 
             // Replace CMB.
-            bool oldCMBRemoved = connectionParameters.TemplateBehaviors.Remove(connectionParameters.TemplateBehaviors.Single(x => x is ConsensusManagerBehavior));
+            bool oldCMBRemoved = connectionParameters.TemplateBehaviors.Remove(connectionParameters.TemplateBehaviors.FirstOrDefault(x => x is ConsensusManagerBehavior));
             Guard.Assert(oldCMBRemoved);
             connectionParameters.TemplateBehaviors.Add(new ProvenHeadersConsensusManagerBehavior(this.chain, this.initialBlockDownloadState, this.consensusManager, this.peerBanning, this.loggerFactory, this.network, this.chainState, this.checkpoints, this.provenBlockHeaderStore, this.connectionManagerSettings));
 

--- a/src/Stratis.Bitcoin.Features.Consensus/PosConsensusFeature.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/PosConsensusFeature.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.Logging;
 using NBitcoin;
 using Stratis.Bitcoin.Base;
 using Stratis.Bitcoin.Base.Deployments;
+using Stratis.Bitcoin.Builder.Feature;
 using Stratis.Bitcoin.Configuration.Settings;
 using Stratis.Bitcoin.Connection;
 using Stratis.Bitcoin.Consensus;
@@ -69,9 +70,14 @@ namespace Stratis.Bitcoin.Features.Consensus
         {
             NetworkPeerConnectionParameters connectionParameters = this.connectionManager.Parameters;
 
-            // Replace CMB.
-            bool oldCMBRemoved = connectionParameters.TemplateBehaviors.Remove(connectionParameters.TemplateBehaviors.FirstOrDefault(x => x is ConsensusManagerBehavior));
-            Guard.Assert(oldCMBRemoved);
+            var defaultConsensusManagerBehavior = connectionParameters.TemplateBehaviors.FirstOrDefault(behavior => behavior is ConsensusManagerBehavior);
+            if (defaultConsensusManagerBehavior == null)
+            {
+                throw new MissingServiceException(typeof(ConsensusManagerBehavior), "Missing expected ConsensusManagerBehavior.");
+            }
+
+            // Replace default ConsensusManagerBehavior with ProvenHeadersConsensusManagerBehavior
+            connectionParameters.TemplateBehaviors.Remove(defaultConsensusManagerBehavior);
             connectionParameters.TemplateBehaviors.Add(new ProvenHeadersConsensusManagerBehavior(this.chain, this.initialBlockDownloadState, this.consensusManager, this.peerBanning, this.loggerFactory, this.network, this.chainState, this.checkpoints, this.provenBlockHeaderStore, this.connectionManagerSettings));
 
             return Task.CompletedTask;

--- a/src/Stratis.Bitcoin.Features.PoA/PoAFeature.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/PoAFeature.cs
@@ -67,7 +67,7 @@ namespace Stratis.Bitcoin.Features.PoA
         public override Task InitializeAsync()
         {
             NetworkPeerConnectionParameters connectionParameters = this.connectionManager.Parameters;
-            bool oldCMBRemoved = connectionParameters.TemplateBehaviors.Remove(connectionParameters.TemplateBehaviors.Single(x => x is ConsensusManagerBehavior));
+            bool oldCMBRemoved = connectionParameters.TemplateBehaviors.Remove(connectionParameters.TemplateBehaviors.FirstOrDefault(x => x is ConsensusManagerBehavior));
             Guard.Assert(oldCMBRemoved);
 
             connectionParameters.TemplateBehaviors.Add(new PoAConsensusManagerBehavior(this.chain, this.initialBlockDownloadState, this.consensusManager, this.peerBanning, this.loggerFactory));

--- a/src/Stratis.Bitcoin.Features.PoA/PoAFeature.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/PoAFeature.cs
@@ -67,9 +67,15 @@ namespace Stratis.Bitcoin.Features.PoA
         public override Task InitializeAsync()
         {
             NetworkPeerConnectionParameters connectionParameters = this.connectionManager.Parameters;
-            bool oldCMBRemoved = connectionParameters.TemplateBehaviors.Remove(connectionParameters.TemplateBehaviors.FirstOrDefault(x => x is ConsensusManagerBehavior));
-            Guard.Assert(oldCMBRemoved);
 
+            var defaultConsensusManagerBehavior = connectionParameters.TemplateBehaviors.FirstOrDefault(behavior => behavior is ConsensusManagerBehavior);
+            if (defaultConsensusManagerBehavior == null)
+            {
+                throw new MissingServiceException(typeof(ConsensusManagerBehavior), "Missing expected ConsensusManagerBehavior.");
+            }
+
+            // Replace default ConsensusManagerBehavior with ProvenHeadersConsensusManagerBehavior
+            connectionParameters.TemplateBehaviors.Remove(defaultConsensusManagerBehavior);
             connectionParameters.TemplateBehaviors.Add(new PoAConsensusManagerBehavior(this.chain, this.initialBlockDownloadState, this.consensusManager, this.peerBanning, this.loggerFactory));
 
             this.federationManager.Initialize();


### PR DESCRIPTION
about #2846 
this fixes the exception message itself (triggers the guard) but the reason why this exception was rised ins't clear yet.
This can be merged as it is, the problem probably should be fixed on the sidechain repo