### PR TITLE
Ability to access private CHT members in tests

### DIFF
--- a/src/Stratis.Bitcoin.Features.PoA.IntegrationTests.Common/PoANodeRunner.cs
+++ b/src/Stratis.Bitcoin.Features.PoA.IntegrationTests.Common/PoANodeRunner.cs
@@ -35,6 +35,7 @@ namespace Stratis.Bitcoin.Features.PoA.IntegrationTests.Common
                 .UseApi()
                 .AddRPC()
                 .MockIBD()
+                .UseTestChainedHeaderTree()
                 .ReplaceTimeProvider(this.timeProvider)
                 .AddFastMiningCapability()
                 .Build();

--- a/src/Stratis.Bitcoin.IntegrationTests.Common/EnvironmentMockUpHelpers/NodeBuilder.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests.Common/EnvironmentMockUpHelpers/NodeBuilder.cs
@@ -135,6 +135,7 @@ namespace Stratis.Bitcoin.IntegrationTests.Common.EnvironmentMockUpHelpers
                .AddMining()
                .UseWallet()
                .AddRPC()
+               .UseTestChainedHeaderTree()
                .MockIBD());
 
             return CreateCustomNode(callback, network, ProtocolVersion.PROTOCOL_VERSION, configParameters: configParameters);

--- a/src/Stratis.Bitcoin.IntegrationTests.Common/EnvironmentMockUpHelpers/TestChainedHeaderTree.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests.Common/EnvironmentMockUpHelpers/TestChainedHeaderTree.cs
@@ -1,0 +1,34 @@
+﻿using System.Collections.Generic;
+using System.Reflection;
+using Microsoft.Extensions.Logging;
+using NBitcoin;
+using Stratis.Bitcoin.Base;
+using Stratis.Bitcoin.Configuration.Settings;
+using Stratis.Bitcoin.Consensus;
+using Stratis.Bitcoin.Consensus.Validators;
+
+namespace Stratis.Bitcoin.IntegrationTests.Common.EnvironmentMockUpHelpers
+{
+    /// <summary>Test-only implementation of <see cref="TestChainedHeaderTree"/> that exposes inner structures.</summary>
+    public class TestChainedHeaderTree : ChainedHeaderTree
+    {
+        public TestChainedHeaderTree(
+            Network network,
+            ILoggerFactory loggerFactory,
+            IHeaderValidator headerValidator,
+            ICheckpoints checkpoints,
+            IChainState chainState,
+            IFinalizedBlockInfoRepository finalizedBlockInfo,
+            ConsensusSettings consensusSettings,
+            IInvalidBlockHashStore invalidHashesStore) : base(network, loggerFactory, headerValidator, checkpoints,
+                chainState, finalizedBlockInfo, consensusSettings, invalidHashesStore)
+        {
+        }
+
+        public Dictionary<uint256, HashSet<int>> PeerIdsByTipHash => typeof(ChainedHeaderTree).GetField("peerIdsByTipHash", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(this) as Dictionary<uint256, HashSet<int>>;
+
+        public Dictionary<int, uint256> PeerTipsByPeerId => typeof(ChainedHeaderTree).GetField("peerTipsByPeerId", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(this) as Dictionary<int, uint256>;
+
+        public Dictionary<uint256, ChainedHeader> ChainedHeadersByHash => typeof(ChainedHeaderTree).GetField("chainedHeadersByHash", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(this) as Dictionary<uint256, ChainedHeader>;
+    }
+}

--- a/src/Stratis.Bitcoin.IntegrationTests.Common/Runners/StratisBitcoinPosRunner.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests.Common/Runners/StratisBitcoinPosRunner.cs
@@ -35,6 +35,7 @@ namespace Stratis.Bitcoin.IntegrationTests.Common.Runners
                 .AddPowPosMining()
                 .AddRPC()
                 .UseApi()
+                .UseTestChainedHeaderTree()
                 .MockIBD();
 
             if (this.OverrideDateTimeProvider)
@@ -75,6 +76,7 @@ namespace Stratis.Bitcoin.IntegrationTests.Common.Runners
                                 .AddPowPosMining()
                                 .AddRPC()
                                 .MockIBD()
+                                .UseTestChainedHeaderTree()
                                 .Build();
 
             return fullNode;

--- a/src/Stratis.Bitcoin.IntegrationTests.Common/Runners/StratisBitcoinPowRunner.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests.Common/Runners/StratisBitcoinPowRunner.cs
@@ -40,6 +40,7 @@ namespace Stratis.Bitcoin.IntegrationTests.Common.Runners
                             .UseWallet()
                             .AddRPC()
                             .UseApi()
+                            .UseTestChainedHeaderTree()
                             .MockIBD();
 
             if (this.InterceptorDisconnect != null)

--- a/src/Stratis.Bitcoin.IntegrationTests/Compatibility/StratisXTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/Compatibility/StratisXTests.cs
@@ -140,6 +140,7 @@ namespace Stratis.Bitcoin.IntegrationTests.Compatibility
                     .UseWallet()
                     .AddPowPosMining()
                     .AddRPC()
+                    .UseTestChainedHeaderTree()
                     .MockIBD());
 
                 CoreNode stratisNode = builder.CreateCustomNode(callback, network, protocolVersion: ProtocolVersion.ALT_PROTOCOL_VERSION).WithWallet().Start();

--- a/src/Stratis.Bitcoin.IntegrationTests/ProofOfStakeSteps.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/ProofOfStakeSteps.cs
@@ -68,6 +68,7 @@ namespace Stratis.Bitcoin.IntegrationTests
                 .AddPowPosMining()
                 .AddRPC()
                 .MockIBD()
+                .UseTestChainedHeaderTree()
                 .OverrideDateTimeProviderFor<MiningFeature>());
 
             this.PremineNodeWithCoins = this.nodeBuilder.CreateCustomNode(callback, new StratisRegTest(), ProtocolVersion.PROTOCOL_VERSION, configParameters: configParameters);

--- a/src/Stratis.Bitcoin.IntegrationTests/Wallet/ColdWalletTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/Wallet/ColdWalletTests.cs
@@ -87,6 +87,7 @@ namespace Stratis.Bitcoin.IntegrationTests.Wallet
                  .AddPowPosMining()
                  .AddRPC()
                  .UseApi()
+                 .UseTestChainedHeaderTree()
                  .MockIBD();
             });
 

--- a/src/Stratis.Bitcoin/Consensus/ChainedHeaderTree.cs
+++ b/src/Stratis.Bitcoin/Consensus/ChainedHeaderTree.cs
@@ -154,7 +154,7 @@ namespace Stratis.Bitcoin.Consensus
     }
 
     /// <inheritdoc />
-    public sealed class ChainedHeaderTree : IChainedHeaderTree
+    public class ChainedHeaderTree : IChainedHeaderTree
     {
         private readonly Network network;
         private readonly IHeaderValidator headerValidator;

--- a/src/Stratis.SmartContracts.Tests.Common/StratisSmartContractNode.cs
+++ b/src/Stratis.SmartContracts.Tests.Common/StratisSmartContractNode.cs
@@ -36,6 +36,7 @@ namespace Stratis.SmartContracts.Tests.Common
                 .UseSmartContractPowMining()
                 .UseReflectionExecutor()
                 .MockIBD()
+                .UseTestChainedHeaderTree()
                 .Build();
         }
     }

--- a/src/Stratis.SmartContracts.Tests.Common/StratisSmartContractPosNode.cs
+++ b/src/Stratis.SmartContracts.Tests.Common/StratisSmartContractPosNode.cs
@@ -37,6 +37,7 @@ namespace Stratis.SmartContracts.Tests.Common
                 .UseSmartContractPosPowMining()
                 .UseReflectionExecutor()
                 .MockIBD()
+                .UseTestChainedHeaderTree()
                 .OverrideDateTimeProviderFor<MiningFeature>()
                 .Build();
         }


### PR DESCRIPTION
Usage:

```
var testCHT = stratisNode1.FullNode.NodeService<TestChainedHeaderTree>();

Dictionary<uint256, ChainedHeader> chainedHeadersByHash = testCHT.ChainedHeadersByHash;
Dictionary<uint256, HashSet<int>> peerIdsByTipHash = testCHT.PeerIdsByTipHash;
Dictionary<int, uint256> peerTipsByPeerId = testCHT.PeerTipsByPeerId;
```