### PR TITLE
Fix for "PHBS can serve reorged headers"

### DIFF
--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/ProvenBlockHeaders/ProvenBlockHeaderRepositoryTests.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/ProvenBlockHeaders/ProvenBlockHeaderRepositoryTests.cs
@@ -132,34 +132,6 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.ProvenBlockHeaders
         }
 
         [Fact]
-        public async Task GetAsync_Reads_MultipleProvenBlockHeadersAsync()
-        {
-            string folder = CreateTestDir(this);
-
-            PosBlock posBlock = CreatePosBlockMock();
-            ProvenBlockHeader header1 = CreateNewProvenBlockHeaderMock(posBlock);
-            ProvenBlockHeader header2 = CreateNewProvenBlockHeaderMock(posBlock);
-
-            using (var engine = new DBreezeEngine(folder))
-            {
-                DBreeze.Transactions.Transaction txn = engine.GetTransaction();
-                txn.Insert<byte[], ProvenBlockHeader>(ProvenBlockHeaderTable, 1.ToBytes(), header1);
-                txn.Insert<byte[], ProvenBlockHeader>(ProvenBlockHeaderTable, 2.ToBytes(), header2);
-                txn.Commit();
-            }
-
-            // Query the repository for the item that was inserted in the above code.
-            using (ProvenBlockHeaderRepository repo = this.SetupRepository(this.Network, folder))
-            {
-                List<ProvenBlockHeader> headersOut = await repo.GetAsync(1, 2).ConfigureAwait(false);
-
-                headersOut.Count.Should().Be(2);
-                headersOut.First().GetHash().Should().Be(header1.GetHash());
-                headersOut.Last().GetHash().Should().Be(header2.GetHash());
-            }
-        }
-
-        [Fact]
         public async Task GetAsync_WithWrongBlockHeightReturnsNullAsync()
         {
             string folder = CreateTestDir(this);

--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/ProvenBlockHeaders/ProvenBlockHeaderStoreTests.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/ProvenBlockHeaders/ProvenBlockHeaderStoreTests.cs
@@ -41,24 +41,6 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.ProvenBlockHeaders
         }
 
         [Fact]
-        public async Task GetAsync_Get_Items_From_StoreAsync()
-        {
-            var tip = this.BuildChainWithProvenHeaders(3);
-
-            SortedDictionary<int, ProvenBlockHeader> headers = this.ConvertToDictionaryOfProvenHeaders(tip);
-            await this.provenBlockHeaderRepository.PutAsync(headers, new HashHeightPair(tip.HashBlock, tip.Height)).ConfigureAwait(false);
-
-            // Load saved headers.
-            using (IProvenBlockHeaderStore store = this.SetupStore())
-            {
-                var outHeaders = await store.GetAsync(0, tip.Height).ConfigureAwait(false);
-
-                Assert.Equal(tip.Height, outHeaders.Count);
-            }
-        }
-
-
-        [Fact]
         public async Task AddToPending_Adds_To_CacheAsync()
         {
             // Initialise store.
@@ -77,8 +59,8 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.ProvenBlockHeaders
             outHeader.GetHash().Should().Be(inHeader.GetHash());
 
             // Check if it has been saved to disk.  It shouldn't as the asyncLoopFactory() would not have been called yet.
-            var outHeaderRepo = await this.provenBlockHeaderRepository.GetAsync(1, 1).ConfigureAwait(false);
-            outHeaderRepo.FirstOrDefault().Should().BeNull();
+            var outHeaderRepo = await this.provenBlockHeaderRepository.GetAsync(1).ConfigureAwait(false);
+            outHeaderRepo.Should().BeNull();
         }
 
 
@@ -133,8 +115,8 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.ProvenBlockHeaders
             cacheCount.Should().Be(2_000);
 
             // Check if it has been saved to disk.  It shouldn't as the asyncLoopFactory() would not have been called yet.
-            var outHeaderRepo = await this.provenBlockHeaderRepository.GetAsync(1, 1).ConfigureAwait(false);
-            outHeaderRepo.FirstOrDefault().Should().BeNull();
+            var outHeaderRepo = await this.provenBlockHeaderRepository.GetAsync(1).ConfigureAwait(false);
+            outHeaderRepo.Should().BeNull();
         }
 
         [Fact]
@@ -176,93 +158,6 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.ProvenBlockHeaders
             // Check items in cache - should now be empty.
             cacheCount = this.provenBlockHeaderStore.PendingBatch.GetMemberValue("Count");
             cacheCount.Should().Be(0);
-        }
-
-        [Fact]
-        public async Task GetAsync_Add_Items_Greater_Than_Max_Size_Cache_Stays_Below_Max_SizeAsync()
-        {
-            // Initialise store.
-            await this.provenBlockHeaderStore.InitializeAsync(BuildChainWithProvenHeaders(1)).ConfigureAwait(false);
-
-            var inHeaders = new SortedDictionary<int, ProvenBlockHeader>();
-
-            // Add maximum cache count items headers.
-            for (int i = 0; i < 10; i++)
-                inHeaders.Add(i, CreateNewProvenBlockHeaderMock());
-
-            long maxSize = 500;
-
-            // Reduce the MaxMemoryCacheSizeInBytes size for test.
-            FieldInfo field = typeof(MemorySizeCache<int, ProvenBlockHeader>).GetField("maxSize", BindingFlags.NonPublic | BindingFlags.Instance);
-            field.SetValue(this.provenBlockHeaderStore.Cache, maxSize);
-
-            // Add items to the repository.
-            await this.provenBlockHeaderRepository.PutAsync(inHeaders,
-                new HashHeightPair(inHeaders.LastOrDefault().Value.GetHash(), inHeaders.Count - 1)).ConfigureAwait(false);
-
-            // Asking for headers will check the cache store.  If the header is not in the cache store, then it will check the repository and add the cache store.
-            var outHeaders = await this.provenBlockHeaderStore.GetAsync(0, inHeaders.Count - 1).ConfigureAwait(false);
-
-            this.provenBlockHeaderStore.Cache.TotalSize.Should().BeLessThan(maxSize);
-        }
-
-        [Fact]
-        public async Task GetAsync_Headers_Should_Be_In_Consecutive_OrderAsync()
-        {
-            var inItems = new List<ProvenBlockHeader>();
-
-            ProvenBlockHeader provenHeaderMock;
-
-            await this.provenBlockHeaderStore.InitializeAsync(this.BuildChainWithProvenHeaders(1)).ConfigureAwait(false);
-            uint nonceIndex = 1; // a random index to change the header hash.
-
-            // Save items 0 - 9 to disk.
-            for (int i = 0; i < 10; i++)
-            {
-                provenHeaderMock = CreateNewProvenBlockHeaderMock();
-                provenHeaderMock.Nonce = ++nonceIndex;
-                this.provenBlockHeaderStore.AddToPendingBatch(provenHeaderMock, new HashHeightPair(provenHeaderMock.GetHash(), i));
-                inItems.Add(provenHeaderMock);
-            }
-
-            // Save to disk and cache is cleared.
-            this.provenBlockHeaderStore.InvokeMethod("SaveAsync");
-
-            // When pendingTipHashHeight is null we can safely say the items were saved to the repository, based on the above SaveAsync.
-            WaitLoop(() =>
-            {
-                var tipHashHeight = this.provenBlockHeaderStore.GetMemberValue("TipHashHeight") as HashHeightPair;
-                return tipHashHeight.Height == 9;
-            });
-
-            // Clear cache.
-            for (int i = 0; i < 10; i++)
-            {
-                this.provenBlockHeaderStore.Cache.Remove(i);
-            }
-
-            // Add item 4 to cache
-            var provenHeaderMock1 = CreateNewProvenBlockHeaderMock();
-            provenHeaderMock1.Nonce = ++nonceIndex;
-            this.provenBlockHeaderStore.AddToPendingBatch(provenHeaderMock1, new HashHeightPair(provenHeaderMock1.GetHash(), 4));
-            inItems[4] = provenHeaderMock1;
-
-            // Add item 6 to cache.
-            var provenHeaderMock2 = CreateNewProvenBlockHeaderMock();
-            provenHeaderMock2.Nonce = ++nonceIndex;
-            this.provenBlockHeaderStore.AddToPendingBatch(provenHeaderMock2, new HashHeightPair(provenHeaderMock2.GetHash(), 6));
-            inItems[6] = provenHeaderMock2;
-
-            // Load the items and make sure in sequence.
-            var outItems = await this.provenBlockHeaderStore.GetAsync(0, 9).ConfigureAwait(false);
-
-            outItems.Count.Should().Be(10);
-
-            // Items 4 and 6 were added to pending cache and have the same block hash.
-            for (int i = 0; i < 10; i++)
-            {
-                outItems[i].GetHash().Should().Be(inItems[i].GetHash());
-            }
         }
 
         // Commented out because those tests test incorrect logic in PH store.

--- a/src/Stratis.Bitcoin.Features.Consensus/ProvenBlockHeaders/ProvenBlockHeaderStore.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/ProvenBlockHeaders/ProvenBlockHeaderStore.cs
@@ -20,7 +20,8 @@ namespace Stratis.Bitcoin.Features.Consensus.ProvenBlockHeaders
     /// The pending batch is saved to the database and cleared every minute.
     /// </para>
     /// <para>
-    /// Items in the pending batch are also saved to the least recently used <see cref="MemorySizeCache{int, ProvenBlockHeader}"/>. Where the memory size is limited by <see cref="MemoryCacheSizeLimitInBytes"/>.
+    /// Items in the pending batch are also saved to the least recently used <see cref="MemorySizeCache{int, ProvenBlockHeader}"/>.
+    /// Where the memory size is limited by <see cref="MemoryCacheSizeLimitInBytes"/>.
     /// </para>
     /// <para>
     /// When new <see cref="ProvenBlockHeader"/> items are saved to the database - in case <see cref="IProvenBlockHeaderRepository"/> contains headers that
@@ -32,24 +33,15 @@ namespace Stratis.Bitcoin.Features.Consensus.ProvenBlockHeaders
     /// </remarks>
     public class ProvenBlockHeaderStore : IProvenBlockHeaderStore
     {
-        /// <summary>
-        /// Instance logger.
-        /// </summary>
         private readonly ILogger logger;
 
-        /// <summary>
-        /// Database repository storing <see cref="ProvenBlockHeader"/> items.
-        /// </summary>
+        /// <summary>Database repository storing <see cref="ProvenBlockHeader"/> items.</summary>
         private readonly IProvenBlockHeaderRepository provenBlockHeaderRepository;
 
-        /// <summary>
-        /// Performance counter to measure performance of the save and get operations.
-        /// </summary>
+        /// <summary>Performance counter to measure performance of the save and get operations.</summary>
         private readonly BackendPerformanceCounter performanceCounter;
 
-        /// <summary>
-        /// Latest snapshot performance counter to measure performance of the save and get operations.
-        /// </summary>
+        /// <summary>Latest snapshot performance counter to measure performance of the save and get operations.</summary>
         private BackendPerformanceSnapshot latestPerformanceSnapShot;
 
         /// <summary>
@@ -59,21 +51,15 @@ namespace Stratis.Bitcoin.Features.Consensus.ProvenBlockHeaders
 
         /// <summary>
         /// Pending - not yet saved to disk - <see cref="IProvenBlockHeaderStore"/> tip hash and height that the <see cref= "ProvenBlockHeader"/> belongs to.
-        /// <para>
-        /// All access to these items have to be protected by <see cref="lockObject" />
-        /// </para>
+        /// <para>All access to these items have to be protected by <see cref="lockObject" /></para>
         /// </summary>
         private HashHeightPair pendingTipHashHeight;
 
-        /// <summary>
-        /// A lock object that protects access to the <see cref="PendingBatch"/> and <see cref="pendingTipHashHeight"/>.
-        /// </summary>
+        /// <summary>A lock object that protects access to the <see cref="PendingBatch"/> and <see cref="pendingTipHashHeight"/>.</summary>
         private readonly object lockObject;
 
-        /// <summary>
-        /// Limit <see cref="Cache"/> size to 100MB.
-        /// </summary>
-        private readonly long MemoryCacheSizeLimitInBytes = 100 * 1024 * 1024;
+        /// <summary>Cache limit.</summary>
+        private readonly long MemoryCacheSizeLimitInBytes = 50 * 1024 * 1024;
 
         /// <summary>
         /// Cache of pending <see cref= "ProvenBlockHeader"/> items.
@@ -142,7 +128,7 @@ namespace Stratis.Bitcoin.Features.Consensus.ProvenBlockHeaders
                     // the repo tip.
                     for (int height = repoTip.Height - 1; height > 0; height--)
                     {
-                        var provenBlockHeader = await this.provenBlockHeaderRepository.GetAsync(height).ConfigureAwait(false);
+                        ProvenBlockHeader provenBlockHeader = await this.provenBlockHeaderRepository.GetAsync(height).ConfigureAwait(false);
 
                         tip = highestHeader.FindAncestorOrSelf(provenBlockHeader.GetHash());
                         if (tip != null)
@@ -155,7 +141,7 @@ namespace Stratis.Bitcoin.Features.Consensus.ProvenBlockHeaders
                     if (tip == null)
                     {
                         this.logger.LogTrace("[TIP_NOT_FOUND]:{0}", highestHeader);
-                        throw new ProvenBlockHeaderException(string.Format("{0} was not found in the store.", highestHeader));
+                        throw new ProvenBlockHeaderException($"{highestHeader} was not found in the store.");
                     }
                 }
                 else

--- a/src/Stratis.Bitcoin/Interfaces/IProvenBlockHeaderProvider.cs
+++ b/src/Stratis.Bitcoin/Interfaces/IProvenBlockHeaderProvider.cs
@@ -19,14 +19,6 @@ namespace Stratis.Bitcoin.Interfaces
         Task<ProvenBlockHeader> GetAsync(int blockHeight);
 
         /// <summary>
-        /// Retrieves <see cref="ProvenBlockHeader"/> items.
-        /// </summary>
-        /// <param name="fromBlockHeight"> Block height to start querying from.</param>
-        /// <param name="toBlockHeight"> Block height to stop querying to.</param>
-        /// <returns> A dictionary of <see cref="ProvenBlockHeader"/> items by block height key.</returns>
-        Task<List<ProvenBlockHeader>> GetAsync(int fromBlockHeight, int toBlockHeight);
-
-        /// <summary>
         /// Height of the block which is currently the tip of the <see cref="ProvenBlockHeader"/>.
         /// </summary>
         HashHeightPair TipHashHeight { get; }


### PR DESCRIPTION
GetAsync now looks into pending batch first. 

Also removed GetAsync overload from the codebase because it wasn't implemented properly and would ask repo for headers one by one. Also given that we don't use this method and don't plan to (mostly because we will keep PH always in memory like ChainedHeaders) it wasn't reasonable to fix it over removing it. 

Fix: #2873