### PR TITLE
Mempool default values improved

### DIFF
--- a/src/Stratis.Bitcoin.Features.MemoryPool/MempoolValidator.cs
+++ b/src/Stratis.Bitcoin.Features.MemoryPool/MempoolValidator.cs
@@ -84,7 +84,7 @@ namespace Stratis.Bitcoin.Features.MemoryPool
         /// Default for -limitancestorsize, maximum kilobytes of tx + all in-mempool ancestors.
         /// </summary>
         /// <seealso cref = "MempoolSettings" />
-        public const int DefaultAncestorSizeLimit = 101;
+        public const int DefaultAncestorSizeLimit = 1000;
 
         /// <summary>
         /// Default for -limitdescendantcount, max number of in-mempool descendants.
@@ -96,7 +96,7 @@ namespace Stratis.Bitcoin.Features.MemoryPool
         /// Default for -limitdescendantsize, maximum kilobytes of in-mempool descendants.
         /// </summary>
         /// <seealso cref = "MempoolSettings" />
-        public const int DefaultDescendantSizeLimit = 101;
+        public const int DefaultDescendantSizeLimit = 1000;
 
         /// <summary>
         /// Default for -mempoolexpiry, expiration time for mempool transactions in hours.


### PR DESCRIPTION
Previous values of 101 kb are kind of nonsensical when maximum tx size is 100kb, at least this gives us some room to move. 

I'm wondering where these values came from though - Bitcoin Core and other clients don't enforce a limit, I think we should follow suit provided there are no known attack vectors

See https://github.com/bitcoin/bitcoin/blob/ed12fd83ca7999a896350197533de5e9202bc2fe/src/txmempool.cpp#L656

