### PR TITLE
Added custom path for KeyTool

### DIFF
--- a/src/Stratis.Bitcoin.Features.PoA.Tests/SlotsManagerTests.cs
+++ b/src/Stratis.Bitcoin.Features.PoA.Tests/SlotsManagerTests.cs
@@ -54,7 +54,7 @@ namespace Stratis.Bitcoin.Features.PoA.Tests
         [Fact]
         public void GetMiningTimestamp()
         {
-            var tool = new KeyTool(null);
+            var tool = new KeyTool(new DataFolder(string.Empty));
             Key key = tool.GeneratePrivateKey();
             this.network = new TestPoANetwork(new List<PubKey>() { tool.GeneratePrivateKey().PubKey, key.PubKey, tool.GeneratePrivateKey().PubKey});
 

--- a/src/Stratis.Bitcoin.Features.PoA/KeyTool.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/KeyTool.cs
@@ -1,6 +1,7 @@
 ﻿using System.IO;
 using NBitcoin;
 using Stratis.Bitcoin.Configuration;
+using Stratis.Bitcoin.Utilities;
 
 namespace Stratis.Bitcoin.Features.PoA
 {
@@ -8,11 +9,16 @@ namespace Stratis.Bitcoin.Features.PoA
     {
         public const string KeyFileDefaultName = "federationKey.dat";
 
-        private readonly DataFolder dataFolder;
+        private readonly string path;
 
         public KeyTool(DataFolder dataFolder)
         {
-            this.dataFolder = dataFolder;
+            this.path = dataFolder.RootPath;
+        }
+
+        public KeyTool(string path)
+        {
+            this.path = path;
         }
 
         /// <summary>Generates a new private key.</summary>
@@ -27,7 +33,7 @@ namespace Stratis.Bitcoin.Features.PoA
         /// <summary>Gets the default path for private key saving and loading.</summary>
         public string GetPrivateKeySavePath()
         {
-            string path = Path.Combine(this.dataFolder.RootPath, KeyTool.KeyFileDefaultName);
+            string path = Path.Combine(this.path, KeyTool.KeyFileDefaultName);
 
             return path;
         }


### PR DESCRIPTION
It'd be nice to be able to just use a path for the tool.

Also, generating the mining keys on the fly is not great UX, because there are too many steps between mining key generation and miners actually mining.

An idea we had is to generate the federationKey.dat file at the same time as the 
federation members generate the signing key. 
Then everyone share their keys and the networks are created. 
Finally, miners can start the federation member sidechain node by specifying the path to the federationKey.dat file.

@noescape00 @monsieurleberre 