### PR TITLE
[Mempool] Adjustments to mempool tests

### DIFF
--- a/src/Stratis.Bitcoin.Features.MemoryPool.Tests/MempoolValidatorTest.cs
+++ b/src/Stratis.Bitcoin.Features.MemoryPool.Tests/MempoolValidatorTest.cs
@@ -24,42 +24,8 @@ namespace Stratis.Bitcoin.Features.MemoryPool.Tests
         {
         }
 
-        [Fact(Skip = "Awaiting fix for issue #2474")]
-        public async void CheckFinalTransaction_WithStandardLockTimeAndValidTxTime_ReturnsTrueAsync()
-        {
-            string dataDir = GetTestDirectoryPath(this);
-
-            // Run mempool tests on mainnet so that RequireStandard flag is set in the mempool settings.
-            Network network = KnownNetworks.Main;
-            var minerSecret = new BitcoinSecret(new Key(), network);
-            ITestChainContext context = await TestChainFactory.CreateAsync(network, minerSecret.PubKey.Hash.ScriptPubKey, dataDir);
-            IMempoolValidator validator = context.MempoolValidator;
-            Assert.NotNull(validator);
-
-            var destSecret = new BitcoinSecret(new Key(), network);
-            Transaction tx = network.CreateTransaction();
-            tx.AddInput(new TxIn(new OutPoint(context.SrcTxs[0].GetHash(), 0), PayToPubkeyHashTemplate.Instance.GenerateScriptPubKey(minerSecret.PubKey)));
-
-            tx.Inputs.First().Sequence = new Sequence(Sequence.SEQUENCE_LOCKTIME_DISABLE_FLAG);
-
-            tx.AddOutput(new TxOut(new Money(Money.Coins(1)), destSecret.PubKeyHash));
-
-            // Set the nLockTime to an arbitrary low block number so that the locktime has elapsed.
-            tx.LockTime = new LockTime(1);
-
-            // Set the transaction time to a recent value.
-            tx.Time = context.SrcTxs.Last().Time + 100;
-
-            tx.Sign(network, minerSecret, false);
-
-            var state = new MempoolValidationState(false);
-
-            bool isSuccess = await validator.AcceptToMemoryPool(state, tx);
-            Assert.True(isSuccess, "Transaction with nLockTime in the past and valid transaction time should have been accepted.");
-        }
-
-        [Fact(Skip = "Awaiting fix for issue #2474")]
-        public async void CheckFinalTransaction_WithNoLockTimeAndValidTxTime_ReturnsTrueAsync()
+        [Fact]
+        public async void CheckFinalTransaction_WithElapsedLockTime_ReturnsTrueAsync()
         {
             string dataDir = GetTestDirectoryPath(this);
 
@@ -80,55 +46,14 @@ namespace Stratis.Bitcoin.Features.MemoryPool.Tests
 
             // Do not set an nLockTime for this test.
 
-            // Set the transaction time to a recent value.
-            tx.Time = context.SrcTxs.Last().Time + 100;
+            // Non-PoS chains do not have the concept of a transaction time, so do not set that.
 
             tx.Sign(network, minerSecret, false);
 
             var state = new MempoolValidationState(false);
 
             bool isSuccess = await validator.AcceptToMemoryPool(state, tx);
-            Assert.True(isSuccess, "Transaction with no nLockTime and a valid transaction time should have been accepted.");
-        }
-
-        [Fact(Skip = "Awaiting fix for issue #2474")]
-        public async void CheckFinalTransaction_WithStandardLockTimeAndExpiredTxTime_FailsAsync()
-        {
-            string dataDir = GetTestDirectoryPath(this);
-
-            // Run mempool tests on mainnet so that RequireStandard flag is set in the mempool settings.
-            Network network = KnownNetworks.Main;
-            var minerSecret = new BitcoinSecret(new Key(), network);
-            ITestChainContext context = await TestChainFactory.CreateAsync(network, minerSecret.PubKey.Hash.ScriptPubKey, dataDir);
-            IMempoolValidator validator = context.MempoolValidator;
-            Assert.NotNull(validator);
-
-            var destSecret = new BitcoinSecret(new Key(), network);
-            Transaction tx = network.CreateTransaction();
-            tx.AddInput(new TxIn(new OutPoint(context.SrcTxs[0].GetHash(), 0), PayToPubkeyHashTemplate.Instance.GenerateScriptPubKey(minerSecret.PubKey)));
-
-            tx.Inputs.First().Sequence = new Sequence(Sequence.SEQUENCE_LOCKTIME_DISABLE_FLAG);
-
-            tx.AddOutput(new TxOut(new Money(Money.Coins(1)), destSecret.PubKeyHash));
-
-            // Set the nLockTime to an arbitrary low block number so that the locktime has elapsed.
-            tx.LockTime = new LockTime(1);
-
-            // Set the transaction time to an old value.
-            tx.Time = context.SrcTxs.First().Time - 100;
-
-            tx.Sign(network, minerSecret, false);
-
-            var state = new MempoolValidationState(false);
-
-            bool isSuccess = await validator.AcceptToMemoryPool(state, tx);
-            Assert.False(isSuccess, "Transaction with nLockTime in the past and valid transaction time should have been accepted.");
-        }
-
-        [Fact(Skip = "Awaiting fix for issue #2474")]
-        public void CheckFinalTransaction_WithNoLockTimeLockTimeAndExpiredTxTime_Fails()
-        {
-            // TODO: Implement test
+            Assert.True(isSuccess, "Transaction with elapsed nLockTime should have been accepted.");
         }
 
         [Fact(Skip = "Not implemented yet.")]
@@ -149,12 +74,6 @@ namespace Stratis.Bitcoin.Features.MemoryPool.Tests
         public void CheckSequenceLocks_WithExistingLockPointAndChainWihtNoPrevAndExpiredBlockTime_Fails()
         {
             // TODO: Test case - the lock point MinTime exceeds 0
-        }
-
-        [Fact(Skip = "Not implemented yet.")]
-        public void CheckSequenceLocks_WithExistingLockPointAndBadHeight_Fails()
-        {
-            // TODO: Test case - lock point height exceeds chain height
         }
 
         [Fact(Skip = "Not implemented yet.")]
@@ -184,7 +103,7 @@ namespace Stratis.Bitcoin.Features.MemoryPool.Tests
         }
 
         [Fact]
-        public async Task AcceptToMemoryPool_WithValidP2PKHTxn_IsSuccessfullAsync()
+        public async Task AcceptToMemoryPool_WithValidP2PKHTxn_IsSuccessfulAsync()
         {
             string dataDir = GetTestDirectoryPath(this);
 
@@ -212,7 +131,7 @@ namespace Stratis.Bitcoin.Features.MemoryPool.Tests
         /// </summary>
         /// <seealso cref="https://www.codeproject.com/Articles/835098/NBitcoin-Build-Them-All"/>
         [Fact]
-        public async Task AcceptToMemoryPool_WithMultiInOutValidTxns_IsSuccessfullAsync()
+        public async Task AcceptToMemoryPool_WithMultiInOutValidTxns_IsSuccessfulAsync()
         {
             string dataDir = GetTestDirectoryPath(this);
 
@@ -276,7 +195,7 @@ namespace Stratis.Bitcoin.Features.MemoryPool.Tests
         /// </summary>
         /// <seealso cref="https://www.codeproject.com/Articles/835098/NBitcoin-Build-Them-All"/>
         [Fact]
-        public async Task AcceptToMemoryPool_WithMultiSigValidTxns_IsSuccessfullAsync()
+        public async Task AcceptToMemoryPool_WithMultiSigValidTxns_IsSuccessfulAsync()
         {
             string dataDir = GetTestDirectoryPath(this);
 
@@ -344,7 +263,7 @@ namespace Stratis.Bitcoin.Features.MemoryPool.Tests
         /// </summary>
         /// <seealso cref="https://www.codeproject.com/Articles/835098/NBitcoin-Build-Them-All"/>
         [Fact]
-        public async Task AcceptToMemoryPool_WithP2SHValidTxns_IsSuccessfullAsync()
+        public async Task AcceptToMemoryPool_WithP2SHValidTxns_IsSuccessfulAsync()
         {
             string dataDir = GetTestDirectoryPath(this);
 
@@ -404,7 +323,7 @@ namespace Stratis.Bitcoin.Features.MemoryPool.Tests
         /// Validate P2WPKH transaction in memory pool.
         /// </summary>
         [Fact]
-        public async Task AcceptToMemoryPool_WithP2WPKHValidTxns_IsSuccessfullAsync()
+        public async Task AcceptToMemoryPool_WithP2WPKHValidTxns_IsSuccessfulAsync()
         {
             string dataDir = GetTestDirectoryPath(this);
 
@@ -435,7 +354,7 @@ namespace Stratis.Bitcoin.Features.MemoryPool.Tests
         /// Validate P2WSH transaction in memory pool.
         /// </summary>
         [Fact]
-        public async Task AcceptToMemoryPool_WithP2WSHValidTxns_IsSuccessfullAsync()
+        public async Task AcceptToMemoryPool_WithP2WSHValidTxns_IsSuccessfulAsync()
         {
             string dataDir = GetTestDirectoryPath(this);
 
@@ -466,7 +385,7 @@ namespace Stratis.Bitcoin.Features.MemoryPool.Tests
         /// Validate SegWit transaction in memory pool.
         /// </summary>
         [Fact]
-        public async Task AcceptToMemoryPool_WithSegWitValidTxns_IsSuccessfullAsync()
+        public async Task AcceptToMemoryPool_WithSegWitValidTxns_IsSuccessfulAsync()
         {
             string dataDir = GetTestDirectoryPath(this);
 

--- a/src/Stratis.Bitcoin.IntegrationTests/Mempool/MemoryPoolTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/Mempool/MemoryPoolTests.cs
@@ -449,6 +449,85 @@ namespace Stratis.Bitcoin.IntegrationTests.Mempool
         }
 
         [Fact]
+        public void Mempool_SendPosTransaction_WithElapsedLockTime_ShouldBeAcceptedByMempool()
+        {
+            // See CheckFinalTransaction_WithElapsedLockTime_ReturnsTrueAsync for the 'unit test' version
+            
+            var network = KnownNetworks.StratisRegTest;
+
+            using (NodeBuilder builder = NodeBuilder.Create(this))
+            {
+                CoreNode stratisSender = builder.CreateStratisPosNode(network).WithWallet().Start();
+
+                int maturity = (int)network.Consensus.CoinbaseMaturity;
+                TestHelper.MineBlocks(stratisSender, maturity + 5);
+
+                // Send coins to the receiver.
+                var context = WalletTests.CreateContext(network, new WalletAccountReference(WalletName, Account), Password, new Key().PubKey.GetAddress(network).ScriptPubKey, Money.COIN * 100, FeeType.Medium, 1);
+
+                Transaction trx = stratisSender.FullNode.WalletTransactionHandler().BuildTransaction(context);
+
+                // Treat the locktime as absolute, not relative.
+                trx.Inputs.First().Sequence = new Sequence(Sequence.SEQUENCE_LOCKTIME_DISABLE_FLAG);
+                
+                // Set the nLockTime to be behind the current tip so that locktime has elapsed.
+                trx.LockTime = new LockTime(stratisSender.FullNode.Chain.Height - 1);
+
+                // Sign trx again after changing the nLockTime.
+                trx = context.TransactionBuilder.SignTransaction(trx);
+
+                // Enable standard policy relay.
+                stratisSender.FullNode.NodeService<MempoolSettings>().RequireStandard = true;
+
+                var broadcaster = stratisSender.FullNode.NodeService<IBroadcasterManager>();
+
+                broadcaster.BroadcastTransactionAsync(trx);
+                
+                TestHelper.WaitLoop(() => stratisSender.CreateRPCClient().GetRawMempool().Length == 1);
+            }
+        }
+        
+        [Fact]
+        public void Mempool_SendPosTransaction_WithFutureLockTime_ShouldBeRejectedByMempool()
+        {
+            // See AcceptToMemoryPool_TxFinalCannotMine_ReturnsFalseAsync for the 'unit test' version
+            
+            var network = KnownNetworks.StratisRegTest;
+
+            using (NodeBuilder builder = NodeBuilder.Create(this))
+            {
+                CoreNode stratisSender = builder.CreateStratisPosNode(network).WithWallet().Start();
+
+                int maturity = (int)network.Consensus.CoinbaseMaturity;
+                TestHelper.MineBlocks(stratisSender, maturity + 5);
+
+                // Send coins to the receiver.
+                var context = WalletTests.CreateContext(network, new WalletAccountReference(WalletName, Account), Password, new Key().PubKey.GetAddress(network).ScriptPubKey, Money.COIN * 100, FeeType.Medium, 1);
+
+                Transaction trx = stratisSender.FullNode.WalletTransactionHandler().BuildTransaction(context);
+
+                // Treat the locktime as absolute, not relative.
+                trx.Inputs.First().Sequence = new Sequence(Sequence.SEQUENCE_LOCKTIME_DISABLE_FLAG);
+                
+                // Set the nLockTime to be ahead of the current tip so that locktime has not elapsed.
+                trx.LockTime = new LockTime(stratisSender.FullNode.Chain.Height + 1);
+
+                // Sign trx again after changing the nLockTime.
+                trx = context.TransactionBuilder.SignTransaction(trx);
+
+                // Enable standard policy relay.
+                stratisSender.FullNode.NodeService<MempoolSettings>().RequireStandard = true;
+
+                var broadcaster = stratisSender.FullNode.NodeService<IBroadcasterManager>();
+
+                broadcaster.BroadcastTransactionAsync(trx).GetAwaiter().GetResult();
+                var entry = broadcaster.GetTransaction(trx.GetHash());
+
+                Assert.Equal("non-final", entry.ErrorMessage);
+            }
+        }
+        
+        [Fact]
         public void Mempool_SendOversizeTransaction_ShouldRejectByMempool()
         {
             var network = KnownNetworks.StratisRegTest;


### PR DESCRIPTION
Some tests were marked as requiring #2474 before they could be completed.

However, transaction rejection for transactions newer than the future drift time is already separately tested in the integration tests. It is not entirely clear what was meant by 'expired transaction times' in some of the unimplemented test names, so these have been removed.

Positive and negative integration tests for non-relative locktimes have also been added.