### PR TITLE
Changed Default log lovel to Information for API appsettings

### DIFF
--- a/src/Stratis.Bitcoin.Features.Api/appsettings.json
+++ b/src/Stratis.Bitcoin.Features.Api/appsettings.json
@@ -2,7 +2,7 @@
   "Logging": {
     "IncludeScopes": false,
     "LogLevel": {
-      "Default": "Debug",
+      "Default": "Information",
       "System": "Information",
       "Microsoft": "Information"
     }


### PR DESCRIPTION
Changed this because when I create an exe, this appsettings is distributed the package and as a result, debug statements show up in the console.