### PR TITLE
Fix unhandled miner exception

### DIFF
--- a/src/Stratis.Bitcoin.Features.Miner/Staking/PosMinting.cs
+++ b/src/Stratis.Bitcoin.Features.Miner/Staking/PosMinting.cs
@@ -308,6 +308,14 @@ namespace Stratis.Bitcoin.Features.Miner.Staking
                     this.logger.LogDebug("Consensus error exception occurred in miner loop: {0}", cee.ToString());
                     this.rpcGetStakingInfoModel.Errors = cee.Message;
                 }
+                catch (ConsensusException ce)
+                {
+                    // All consensus exceptions should be ignored. It means that the miner
+                    // run into problems while constructing block or verifying it
+                    // but it should not halted the staking operation.
+                    this.logger.LogDebug("Consensus exception occurred in miner loop: {0}", ce.ToString());
+                    this.rpcGetStakingInfoModel.Errors = ce.Message;
+                }
                 catch (Exception ex)
                 {
                     this.logger.LogError("Exception: {0}", ex);

--- a/src/Stratis.Bitcoin.IntegrationTests/MinerTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/MinerTests.cs
@@ -399,7 +399,7 @@ namespace Stratis.Bitcoin.IntegrationTests
                 }
 
                 var error = Assert.Throws<ConsensusException>(() => TestHelper.MineBlocks(miner, 1));
-                Assert.True(error.Message == ConsensusErrors.BadBlockSigOps.Message);
+                Assert.True(error.Message == ConsensusErrors.BadBlockSigOps.ToString());
 
                 TestHelper.WaitLoop(() => TestHelper.IsNodeSynced(miner));
 
@@ -494,7 +494,7 @@ namespace Stratis.Bitcoin.IntegrationTests
                 miner.FullNode.NodeService<ITxMempool>().AddUnchecked(duplicateCoinbase.GetHash(), txMempoolEntry);
 
                 var error = Assert.Throws<ConsensusException>(() => TestHelper.MineBlocks(miner, 1));
-                Assert.True(error.Message == ConsensusErrors.BadMultipleCoinbase.Message);
+                Assert.True(error.Message == ConsensusErrors.BadMultipleCoinbase.ToString());
 
                 TestHelper.WaitLoop(() => TestHelper.IsNodeSynced(miner));
 

--- a/src/Stratis.Bitcoin/Consensus/ConsensusManager.cs
+++ b/src/Stratis.Bitcoin/Consensus/ConsensusManager.cs
@@ -294,7 +294,7 @@ namespace Stratis.Bitcoin.Consensus
 
                     this.logger.LogError("Miner produced an invalid block, partial validation failed: {0}", validationContext.Error.Message);
                     this.logger.LogTrace("(-)[PARTIAL_VALIDATION_FAILED]");
-                    throw new ConsensusException(validationContext.Error.Message);
+                    throw new ConsensusException(validationContext.Error.ToString());
                 }
             }
 


### PR DESCRIPTION
Fix issue
```
Stratis.Bitcoin.Consensus.ConsensusException: input missing/spent
   at Stratis.Bitcoin.Consensus.ConsensusManager.BlockMinedAsync(Block block) in C:\Users\fullnodedan\Documents\Github\StratisBitcoinFullNode\src\Stratis.Bitcoin\Consensus\ConsensusManager.cs:line 281
   at Stratis.Bitcoin.Features.Miner.Staking.PosMinting.CheckStakeAsync(Block block, ChainedHeader chainTip) in C:\Users\fullnodedan\Documents\Github\StratisBitcoinFullNode\src\Stratis.Bitcoin.Features.Miner\Staking\PosMinting.cs:line 490
   at Stratis.Bitcoin.Features.Miner.Staking.PosMinting.GenerateBlocksAsync(WalletSecret walletSecret, CancellationToken cancellationToken) in C:\Users\fullnodedan\Documents\Github\StratisBitcoinFullNode\src\Stratis.Bitcoin.Features.Miner\Staking\PosMinting.cs:line 408
   at Stratis.Bitcoin.Features.Miner.Staking.PosMinting.<>c__DisplayClass38_0.<<Stake>b__0>d.MoveNext() in C:\Users\fullnodedan\Documents\Github\StratisBitcoinFullNode\src\Stratis.Bitcoin.Features.Miner\Staking\PosMinting.cs:line 288
[2018-12-11 18:44:18.7424 62] INFO: Stratis.Bitcoin.Utilities.AsyncLoop+<>c__DisplayClass16_0+<<StartAsync>b__0>d.MoveNext PosMining.Stake stopping.
[2018-12-11 18:44:18.7424 62] FATAL: Stratis.Bitcoin.Utilities.AsyncLoop+<>c__DisplayClass16_0+<<StartAsync>b__0>d.MoveNext PosMining.Stake threw an unhandled exception
[2018-12-11 18:44:18.7424 62] ERROR: Stratis.Bitcoin.Utilities.AsyncLoop+<>c__DisplayClass16_0+<<StartAsync>b__0>d.MoveNext PosMining.Stake threw an unhandled exception: Stratis.Bitcoin.Consensus.ConsensusException: input missing/spent
   at Stratis.Bitcoin.Consensus.ConsensusManager.BlockMinedAsync(Block block) in C:\Users\fullnodedan\Documents\Github\StratisBitcoinFullNode\src\Stratis.Bitcoin\Consensus\ConsensusManager.cs:line 281
   at Stratis.Bitcoin.Features.Miner.Staking.PosMinting.CheckStakeAsync(Block block, ChainedHeader chainTip) in C:\Users\fullnodedan\Documents\Github\StratisBitcoinFullNode\src\Stratis.Bitcoin.Features.Miner\Staking\PosMinting.cs:line 490
   at Stratis.Bitcoin.Features.Miner.Staking.PosMinting.GenerateBlocksAsync(WalletSecret walletSecret, CancellationToken cancellationToken) in C:\Users\fullnodedan\Documents\Github\StratisBitcoinFullNode\src\Stratis.Bitcoin.Features.Miner\Staking\PosMinting.cs:line 408
   at Stratis.Bitcoin.Features.Miner.Staking.PosMinting.<>c__DisplayClass38_0.<<Stake>b__0>d.MoveNext() in C:\Users\fullnodedan\Documents\Github\StratisBitcoinFullNode\src\Stratis.Bitcoin.Features.Miner\Staking\PosMinting.cs:line 288
--- End of stack trace from previous location where exception was thrown ---
   at Stratis.Bitcoin.Utilities.AsyncLoop.<>c__DisplayClass16_0.<<StartAsync>b__0>d.MoveNext() in C:\Users\fullnodedan\Documents\Github\StratisBitcoinFullNode\src\Stratis.Bitcoin\Utilities\AsyncLoop.cs:line 140
```