### PR TITLE
Fix issue: Additional fedpeg folder created

### DIFF
--- a/src/Stratis.Bitcoin.Features.SmartContracts/PoA/SmartContractPoABlockDefinition.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts/PoA/SmartContractPoABlockDefinition.cs
@@ -25,14 +25,16 @@ namespace Stratis.Bitcoin.Features.SmartContracts.PoA
             ICoinView coinView,
             IConsensusManager consensusManager,
             IDateTimeProvider dateTimeProvider,
-            IContractExecutorFactory executorFactory, 
+            IContractExecutorFactory executorFactory,
             ILoggerFactory loggerFactory,
-            ITxMempool mempool, 
+            ITxMempool mempool,
             MempoolSchedulerLock mempoolLock,
             Network network,
             ISenderRetriever senderRetriever,
-            IStateRepositoryRoot stateRoot) 
-            : base(blockBufferGenerator, coinView, consensusManager, dateTimeProvider, executorFactory, loggerFactory, mempool, mempoolLock, new MinerSettings(NodeSettings.Default(network)), network, senderRetriever, stateRoot)
+            IStateRepositoryRoot stateRoot,
+            NodeSettings nodeSettings)
+            : base(blockBufferGenerator, coinView, consensusManager, dateTimeProvider, executorFactory, loggerFactory, mempool,
+                mempoolLock, new MinerSettings(nodeSettings), network, senderRetriever, stateRoot)
         {
             // TODO: Fix gross MinerSettings injection ^^
         }


### PR DESCRIPTION
First step to fix: https://github.com/stratisproject/FederatedSidechains/issues/237

After this PR is merged we will need to create new nuget packages, update them on federation sidechains projects, then update `SmartContractPoABlockDefinition.cs` since constructor was changed and we need to pass nodeSettings to base constructor. 