### PR TITLE
[Light Wallet] Fix Breeze node and introduce pruning

### DIFF
--- a/src/Stratis.Bitcoin.Features.BlockStore.Tests/BlockRepositoryTest.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore.Tests/BlockRepositoryTest.cs
@@ -4,7 +4,6 @@ using System.Threading.Tasks;
 using DBreeze;
 using DBreeze.DataTypes;
 using NBitcoin;
-using Stratis.Bitcoin.Configuration;
 using Stratis.Bitcoin.Tests.Common.Logging;
 using Stratis.Bitcoin.Utilities;
 using Xunit;
@@ -528,7 +527,7 @@ namespace Stratis.Bitcoin.Features.BlockStore.Tests
 
         private IBlockRepository SetupRepository(Network main, string dir)
         {
-            var repository = new BlockRepository(main, dir, this.LoggerFactory.Object, new StoreSettings(NodeSettings.Default(this.Network)));
+            var repository = new BlockRepository(main, dir, this.LoggerFactory.Object);
             repository.InitializeAsync().GetAwaiter().GetResult();
 
             return repository;

--- a/src/Stratis.Bitcoin.Features.BlockStore.Tests/BlockRepositoryTest.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore.Tests/BlockRepositoryTest.cs
@@ -527,7 +527,7 @@ namespace Stratis.Bitcoin.Features.BlockStore.Tests
 
         private IBlockRepository SetupRepository(Network main, string dir)
         {
-            var repository = new BlockRepository(main, dir, DateTimeProvider.Default, this.LoggerFactory.Object);
+            var repository = new BlockRepository(main, dir, this.LoggerFactory.Object);
             repository.InitializeAsync().GetAwaiter().GetResult();
 
             return repository;

--- a/src/Stratis.Bitcoin.Features.BlockStore.Tests/BlockRepositoryTest.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore.Tests/BlockRepositoryTest.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using DBreeze;
 using DBreeze.DataTypes;
 using NBitcoin;
+using Stratis.Bitcoin.Configuration;
 using Stratis.Bitcoin.Tests.Common.Logging;
 using Stratis.Bitcoin.Utilities;
 using Xunit;
@@ -527,7 +528,7 @@ namespace Stratis.Bitcoin.Features.BlockStore.Tests
 
         private IBlockRepository SetupRepository(Network main, string dir)
         {
-            var repository = new BlockRepository(main, dir, this.LoggerFactory.Object);
+            var repository = new BlockRepository(main, dir, this.LoggerFactory.Object, new StoreSettings(NodeSettings.Default(this.Network)));
             repository.InitializeAsync().GetAwaiter().GetResult();
 
             return repository;

--- a/src/Stratis.Bitcoin.Features.BlockStore/BlockRepository.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/BlockRepository.cs
@@ -22,14 +22,14 @@ namespace Stratis.Bitcoin.Features.BlockStore
         DBreezeEngine DBreeze { get; }
 
         /// <summary>
-        /// Delete blocks and their transactions.
+        /// Deletes blocks and indexes for transactions that belong to deleted blocks.
         /// <para>
         /// It should be noted that this does not delete the entries from disk (only the references are removed) and
         /// as such the file size remains the same.
         /// </para>
         /// </summary>
-        /// <param name="hashes">List of block hashes to be deleted.</param>
-        /// <returns>The awaited task.</returns>
+        /// <remarks>TODO: This will need to be revisited once DBreeze has been fixed or replaced with a solution that works.</remarks>
+        /// <param name="hashes">List of block hashes to be deleted.</param>        
         Task DeleteBlocksAsync(List<uint256> hashes);
 
         /// <summary>

--- a/src/Stratis.Bitcoin.Features.BlockStore/BlockRepository.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/BlockRepository.cs
@@ -91,7 +91,7 @@ namespace Stratis.Bitcoin.Features.BlockStore
 
         private readonly ILogger logger;
 
-        protected readonly Network network;
+        private readonly Network network;
 
         private static readonly byte[] RepositoryTipKey = new byte[0];
 

--- a/src/Stratis.Bitcoin.Features.BlockStore/BlockRepository.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/BlockRepository.cs
@@ -120,10 +120,13 @@ namespace Stratis.Bitcoin.Features.BlockStore
 
         private static readonly byte[] TxIndexKey = new byte[1];
 
+        /// <inheritdoc />
         public HashHeightPair PrunedTip { get; private set; }
 
+        /// <inheritdoc />
         public HashHeightPair TipHashAndHeight { get; private set; }
 
+        /// <inheritdoc />
         public bool TxIndex { get; private set; }
 
         public BlockRepository(Network network, DataFolder dataFolder, ILoggerFactory loggerFactory, StoreSettings storeSettings)

--- a/src/Stratis.Bitcoin.Features.BlockStore/BlockStoreFeature.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/BlockStoreFeature.cs
@@ -86,10 +86,13 @@ namespace Stratis.Bitcoin.Features.BlockStore
 
             if (highestBlock != null)
             {
-                string logString = $"BlockStore.Height: ".PadRight(LoggingConfiguration.ColumnLength + 1) + highestBlock.Height.ToString().PadRight(8) +
-                             $" BlockStore.Hash: ".PadRight(LoggingConfiguration.ColumnLength - 1) + highestBlock.HashBlock;
-
-                log.AppendLine(logString);
+                if (!this.storeSettings.Prune)
+                {
+                    var builder = new StringBuilder();
+                    builder.Append("BlockStore.Height: ".PadRight(LoggingConfiguration.ColumnLength + 1));
+                    builder.Append($" BlockStore.Hash: ".PadRight(LoggingConfiguration.ColumnLength - 1) + highestBlock.HashBlock);
+                    log.AppendLine(builder.ToString());
+                }
             }
         }
 
@@ -98,7 +101,7 @@ namespace Stratis.Bitcoin.Features.BlockStore
             if (this.storeSettings.Prune)
             {
                 this.logger.LogInformation("Pruning BlockStore...");
-                this.blockRepository.PruneDatabase(this.consensusManager.Tip).GetAwaiter().GetResult();
+                this.blockRepository.PruneDatabase(this.consensusManager.Tip, true).GetAwaiter().GetResult();
             }
 
             // Use ProvenHeadersBlockStoreBehavior for PoS Networks
@@ -131,7 +134,7 @@ namespace Stratis.Bitcoin.Features.BlockStore
             if (this.storeSettings.Prune)
             {
                 this.logger.LogInformation("Pruning BlockStore...");
-                this.blockRepository.PruneDatabase(this.consensusManager.Tip);
+                this.blockRepository.PruneDatabase(this.consensusManager.Tip, false);
             }
 
             this.logger.LogInformation("Stopping BlockStore.");

--- a/src/Stratis.Bitcoin.Features.BlockStore/BlockStoreFeature.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/BlockStoreFeature.cs
@@ -125,7 +125,7 @@ namespace Stratis.Bitcoin.Features.BlockStore
             if (this.storeSettings.Prune)
             {
                 this.logger.LogInformation("Pruning BlockStore...");
-                this.blockRepository.CompactBlockAndTransactionDatabase();
+                this.blockRepository.PruneBlockAndTransactionDatabase();
             }
 
             this.logger.LogInformation("Stopping BlockStore.");

--- a/src/Stratis.Bitcoin.Features.BlockStore/BlockStoreFeature.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/BlockStoreFeature.cs
@@ -122,13 +122,13 @@ namespace Stratis.Bitcoin.Features.BlockStore
         /// <inheritdoc />
         public override void Dispose()
         {
-            this.logger.LogInformation("Stopping BlockStore.");
-
             if (this.storeSettings.Prune)
             {
                 this.logger.LogInformation("Pruning BlockStore...");
                 this.blockRepository.CompactBlockAndTransactionDatabase();
             }
+
+            this.logger.LogInformation("Stopping BlockStore.");
 
             this.blockStoreSignaled.Dispose();
         }

--- a/src/Stratis.Bitcoin.Features.BlockStore/BlockStoreFeature.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/BlockStoreFeature.cs
@@ -86,17 +86,14 @@ namespace Stratis.Bitcoin.Features.BlockStore
 
             if (highestBlock != null)
             {
-                if (!this.storeSettings.PruningEnabled)
-                {
-                    var builder = new StringBuilder();
-                    builder.Append("BlockStore.Height: ".PadRight(LoggingConfiguration.ColumnLength + 1) + highestBlock.Height.ToString().PadRight(8));
-                    builder.Append(" BlockStore.Hash: ".PadRight(LoggingConfiguration.ColumnLength - 1) + highestBlock.HashBlock);
-                    log.AppendLine(builder.ToString());
-                }
+                var builder = new StringBuilder();
+                builder.Append("BlockStore.Height: ".PadRight(LoggingConfiguration.ColumnLength + 1) + highestBlock.Height.ToString().PadRight(8));
+                builder.Append(" BlockStore.Hash: ".PadRight(LoggingConfiguration.ColumnLength - 1) + highestBlock.HashBlock);
+                log.AppendLine(builder.ToString());
             }
         }
 
-        public override Task InitializeAsync()
+        public override async Task InitializeAsync()
         {
             this.prunedBlockRepository.InitializeAsync().GetAwaiter().GetResult();
 
@@ -109,7 +106,7 @@ namespace Stratis.Bitcoin.Features.BlockStore
                     throw new BlockStoreException($"The amount of blocks to prune [{this.storeSettings.AmountOfBlocksToKeep}] (blocks to keep) cannot be less than the node's max reorg length of {this.network.Consensus.MaxReorgLength}.");
 
                 this.logger.LogInformation("Pruning BlockStore...");
-                this.prunedBlockRepository.PruneAndCompactDatabase(this.chainState.BlockStoreTip, this.network, true).GetAwaiter().GetResult();
+                await this.prunedBlockRepository.PruneAndCompactDatabase(this.chainState.BlockStoreTip, this.network, true);
             }
 
             // Use ProvenHeadersBlockStoreBehavior for PoS Networks
@@ -134,7 +131,7 @@ namespace Stratis.Bitcoin.Features.BlockStore
 
             this.signals.SubscribeForBlocksConnected(this.blockStoreSignaled);
 
-            return Task.CompletedTask;
+            return;
         }
 
         /// <inheritdoc />

--- a/src/Stratis.Bitcoin.Features.BlockStore/BlockStoreFeature.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/BlockStoreFeature.cs
@@ -123,6 +123,7 @@ namespace Stratis.Bitcoin.Features.BlockStore
             }
 
             // Signal to peers that this node can serve blocks.
+            // TODO: Add NetworkLimited which is what BTC uses for pruned nodes.
             this.connectionManager.Parameters.Services = (this.storeSettings.PruningEnabled ? NetworkPeerServices.Nothing : NetworkPeerServices.Network);
 
             // Temporary measure to support asking witness data on BTC.

--- a/src/Stratis.Bitcoin.Features.BlockStore/BlockStoreFeature.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/BlockStoreFeature.cs
@@ -168,6 +168,7 @@ namespace Stratis.Bitcoin.Features.BlockStore
                     {
                         services.AddSingleton<IBlockStoreQueue, BlockStoreQueue>().AddSingleton<IBlockStore>(provider => provider.GetService<IBlockStoreQueue>());
                         services.AddSingleton<IBlockRepository, BlockRepository>();
+                        services.AddSingleton<IPrunedBlockRepository, PrunedBlockRepository>();
 
                         if (fullNodeBuilder.Network.Consensus.IsProofOfStake)
                             services.AddSingleton<BlockStoreSignaled, ProvenHeadersBlockStoreSignaled>();

--- a/src/Stratis.Bitcoin.Features.BlockStore/BlockStoreFeature.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/BlockStoreFeature.cs
@@ -95,6 +95,12 @@ namespace Stratis.Bitcoin.Features.BlockStore
 
         public override Task InitializeAsync()
         {
+            if (this.storeSettings.Prune)
+            {
+                this.logger.LogInformation("Pruning BlockStore...");
+                this.blockRepository.PruneDatabase(this.consensusManager.Tip).GetAwaiter().GetResult();
+            }
+
             // Use ProvenHeadersBlockStoreBehavior for PoS Networks
             if (this.network.Consensus.IsProofOfStake)
             {
@@ -125,7 +131,7 @@ namespace Stratis.Bitcoin.Features.BlockStore
             if (this.storeSettings.Prune)
             {
                 this.logger.LogInformation("Pruning BlockStore...");
-                this.blockRepository.PruneBlockAndTransactionDatabase();
+                this.blockRepository.PruneDatabase(this.consensusManager.Tip);
             }
 
             this.logger.LogInformation("Stopping BlockStore.");

--- a/src/Stratis.Bitcoin.Features.BlockStore/BlockStoreFeature.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/BlockStoreFeature.cs
@@ -95,9 +95,6 @@ namespace Stratis.Bitcoin.Features.BlockStore
 
         public override Task InitializeAsync()
         {
-            if (this.storeSettings.Prune)
-                this.blockRepository.CompactBlockDatabase();
-
             // Use ProvenHeadersBlockStoreBehavior for PoS Networks
             if (this.network.Consensus.IsProofOfStake)
             {
@@ -126,6 +123,12 @@ namespace Stratis.Bitcoin.Features.BlockStore
         public override void Dispose()
         {
             this.logger.LogInformation("Stopping BlockStore.");
+
+            if (this.storeSettings.Prune)
+            {
+                this.logger.LogInformation("Pruning BlockStore...");
+                this.blockRepository.CompactBlockAndTransactionDatabase();
+            }
 
             this.blockStoreSignaled.Dispose();
         }

--- a/src/Stratis.Bitcoin.Features.BlockStore/BlockStoreFeature.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/BlockStoreFeature.cs
@@ -46,6 +46,8 @@ namespace Stratis.Bitcoin.Features.BlockStore
 
         private readonly ICheckpoints checkpoints;
 
+        private readonly IBlockRepository blockRepository;
+
         public BlockStoreFeature(
             Network network,
             ConcurrentChain chain,
@@ -58,7 +60,8 @@ namespace Stratis.Bitcoin.Features.BlockStore
             IBlockStoreQueue blockStoreQueue,
             INodeStats nodeStats,
             IConsensusManager consensusManager,
-            ICheckpoints checkpoints)
+            ICheckpoints checkpoints,
+            IBlockRepository blockRepository)
         {
             this.network = network;
             this.chain = chain;
@@ -72,6 +75,7 @@ namespace Stratis.Bitcoin.Features.BlockStore
             this.chainState = chainState;
             this.consensusManager = consensusManager;
             this.checkpoints = checkpoints;
+            this.blockRepository = blockRepository;
 
             nodeStats.RegisterStats(this.AddInlineStats, StatsType.Inline, 900);
         }
@@ -91,6 +95,9 @@ namespace Stratis.Bitcoin.Features.BlockStore
 
         public override Task InitializeAsync()
         {
+            if (this.storeSettings.Prune)
+                this.blockRepository.CompactBlockDatabase();
+
             // Use ProvenHeadersBlockStoreBehavior for PoS Networks
             if (this.network.Consensus.IsProofOfStake)
             {

--- a/src/Stratis.Bitcoin.Features.BlockStore/BlockStoreFeature.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/BlockStoreFeature.cs
@@ -105,6 +105,9 @@ namespace Stratis.Bitcoin.Features.BlockStore
 
             if (this.storeSettings.Prune != 0)
             {
+                if (this.storeSettings.Prune < this.network.Consensus.MaxReorgLength)
+                    throw new BlockStoreException($"The amount of blocks to prune [{this.storeSettings.Prune}] (blocks to keep) cannot be less than the node's max reorg length of {this.network.Consensus.MaxReorgLength}.");
+
                 this.logger.LogInformation("Pruning BlockStore...");
                 this.prunedBlockRepository.PruneDatabase(this.chainState.BlockStoreTip, this.network, true).GetAwaiter().GetResult();
             }

--- a/src/Stratis.Bitcoin.Features.BlockStore/BlockStoreFeature.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/BlockStoreFeature.cs
@@ -46,7 +46,7 @@ namespace Stratis.Bitcoin.Features.BlockStore
 
         private readonly ICheckpoints checkpoints;
 
-        private readonly IBlockRepository blockRepository;
+        private readonly IPrunedBlockRepository prunedBlockRepository;
 
         public BlockStoreFeature(
             Network network,
@@ -61,7 +61,7 @@ namespace Stratis.Bitcoin.Features.BlockStore
             INodeStats nodeStats,
             IConsensusManager consensusManager,
             ICheckpoints checkpoints,
-            IBlockRepository blockRepository)
+            IPrunedBlockRepository prunedBlockRepository)
         {
             this.network = network;
             this.chain = chain;
@@ -75,7 +75,7 @@ namespace Stratis.Bitcoin.Features.BlockStore
             this.chainState = chainState;
             this.consensusManager = consensusManager;
             this.checkpoints = checkpoints;
-            this.blockRepository = blockRepository;
+            this.prunedBlockRepository = prunedBlockRepository;
 
             nodeStats.RegisterStats(this.AddInlineStats, StatsType.Inline, 900);
         }
@@ -101,7 +101,8 @@ namespace Stratis.Bitcoin.Features.BlockStore
             if (this.storeSettings.Prune)
             {
                 this.logger.LogInformation("Pruning BlockStore...");
-                this.blockRepository.PruneDatabase(this.consensusManager.Tip, true).GetAwaiter().GetResult();
+                this.prunedBlockRepository.InitializeAsync(this.network).GetAwaiter().GetResult();
+                this.prunedBlockRepository.PruneDatabase(this.consensusManager.Tip, true).GetAwaiter().GetResult();
             }
 
             // Use ProvenHeadersBlockStoreBehavior for PoS Networks
@@ -134,7 +135,7 @@ namespace Stratis.Bitcoin.Features.BlockStore
             if (this.storeSettings.Prune)
             {
                 this.logger.LogInformation("Pruning BlockStore...");
-                this.blockRepository.PruneDatabase(this.consensusManager.Tip, false);
+                this.prunedBlockRepository.PruneDatabase(this.consensusManager.Tip, false);
             }
 
             this.logger.LogInformation("Stopping BlockStore.");

--- a/src/Stratis.Bitcoin.Features.BlockStore/BlockStoreFeature.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/BlockStoreFeature.cs
@@ -109,7 +109,7 @@ namespace Stratis.Bitcoin.Features.BlockStore
                     throw new BlockStoreException($"The amount of blocks to prune [{this.storeSettings.AmountOfBlocksToKeep}] (blocks to keep) cannot be less than the node's max reorg length of {this.network.Consensus.MaxReorgLength}.");
 
                 this.logger.LogInformation("Pruning BlockStore...");
-                this.prunedBlockRepository.PruneDatabase(this.chainState.BlockStoreTip, this.network, true).GetAwaiter().GetResult();
+                this.prunedBlockRepository.PruneAndCompactDatabase(this.chainState.BlockStoreTip, this.network, true).GetAwaiter().GetResult();
             }
 
             // Use ProvenHeadersBlockStoreBehavior for PoS Networks
@@ -143,7 +143,7 @@ namespace Stratis.Bitcoin.Features.BlockStore
             if (this.storeSettings.PruningEnabled)
             {
                 this.logger.LogInformation("Pruning BlockStore...");
-                this.prunedBlockRepository.PruneDatabase(this.chainState.BlockStoreTip, this.network, false);
+                this.prunedBlockRepository.PruneAndCompactDatabase(this.chainState.BlockStoreTip, this.network, false);
             }
 
             this.logger.LogInformation("Stopping BlockStore.");

--- a/src/Stratis.Bitcoin.Features.BlockStore/BlockStoreFeature.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/BlockStoreFeature.cs
@@ -89,8 +89,8 @@ namespace Stratis.Bitcoin.Features.BlockStore
                 if (this.storeSettings.Prune == 0)
                 {
                     var builder = new StringBuilder();
-                    builder.Append("BlockStore.Height: ".PadRight(LoggingConfiguration.ColumnLength + 1));
-                    builder.Append($" BlockStore.Hash: ".PadRight(LoggingConfiguration.ColumnLength - 1) + highestBlock.HashBlock);
+                    builder.Append("BlockStore.Height: ".PadRight(LoggingConfiguration.ColumnLength + 1) + highestBlock.Height.ToString().PadRight(8));
+                    builder.Append(" BlockStore.Hash: ".PadRight(LoggingConfiguration.ColumnLength - 1) + highestBlock.HashBlock);
                     log.AppendLine(builder.ToString());
                 }
             }

--- a/src/Stratis.Bitcoin.Features.BlockStore/BlockStoreSignaled.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/BlockStoreSignaled.cs
@@ -65,11 +65,11 @@ namespace Stratis.Bitcoin.Features.BlockStore
 
         protected override void OnNextCore(ChainedHeaderBlock blockPair)
         {
-            if (this.storeSettings.Prune)
-            {
-                this.logger.LogTrace("(-)[PRUNE]");
-                return;
-            }
+            //if (this.storeSettings.Prune)
+            //{
+            //    this.logger.LogTrace("(-)[PRUNE]");
+            //    return;
+            //}
 
             ChainedHeader chainedHeader = blockPair.ChainedHeader;
             if (chainedHeader == null)

--- a/src/Stratis.Bitcoin.Features.BlockStore/BlockStoreSignaled.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/BlockStoreSignaled.cs
@@ -85,7 +85,7 @@ namespace Stratis.Bitcoin.Features.BlockStore
                 return;
             }
 
-            if (this.storeSettings.Prune != 0)
+            if (this.storeSettings.PruningEnabled)
             {
                 this.logger.LogTrace("(-)[PRUNE]");
                 return;

--- a/src/Stratis.Bitcoin.Features.BlockStore/BlockStoreSignaled.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/BlockStoreSignaled.cs
@@ -85,7 +85,7 @@ namespace Stratis.Bitcoin.Features.BlockStore
                 return;
             }
 
-            if (this.storeSettings.Prune)
+            if (this.storeSettings.Prune != 0)
             {
                 this.logger.LogTrace("(-)[PRUNE]");
                 return;

--- a/src/Stratis.Bitcoin.Features.BlockStore/BlockStoreSignaled.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/BlockStoreSignaled.cs
@@ -65,12 +65,6 @@ namespace Stratis.Bitcoin.Features.BlockStore
 
         protected override void OnNextCore(ChainedHeaderBlock blockPair)
         {
-            //if (this.storeSettings.Prune)
-            //{
-            //    this.logger.LogTrace("(-)[PRUNE]");
-            //    return;
-            //}
-
             ChainedHeader chainedHeader = blockPair.ChainedHeader;
             if (chainedHeader == null)
             {
@@ -88,6 +82,12 @@ namespace Stratis.Bitcoin.Features.BlockStore
             if (isIBD)
             {
                 this.logger.LogTrace("(-)[IBD]");
+                return;
+            }
+
+            if (this.storeSettings.Prune)
+            {
+                this.logger.LogTrace("(-)[PRUNE]");
                 return;
             }
 

--- a/src/Stratis.Bitcoin.Features.BlockStore/IPrunedBlockRepository.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/IPrunedBlockRepository.cs
@@ -12,18 +12,18 @@ namespace Stratis.Bitcoin.Features.BlockStore
         /// <summary>
         /// INitializes the pruned block repository.
         /// </summary>
-        /// <param name="network">The network the node is running on.</param>
         /// <returns>The awaited task.</returns>
-        Task InitializeAsync(Network network);
+        Task InitializeAsync();
 
         /// <summary>
         /// Compacts the block and transaction database by resaving the database file without
         /// all the deleted references.
         /// </summary>
         /// <param name="consensusTip">The current tip of consensus.</param>
+        /// <param name="network">The network the node is running on.</param>
         /// <param name="nodeInitializing">Indicates whether or not this method is called from node startup or not.</param>
         /// <returns>The awaited task.</returns>
-        Task PruneDatabase(ChainedHeader consensusTip, bool nodeInitializing);
+        Task PruneDatabase(ChainedHeader consensusTip, Network network, bool nodeInitializing);
 
         /// <summary> 
         /// The lowest block height that the repository has.

--- a/src/Stratis.Bitcoin.Features.BlockStore/IPrunedBlockRepository.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/IPrunedBlockRepository.cs
@@ -5,7 +5,7 @@ using Stratis.Bitcoin.Utilities;
 namespace Stratis.Bitcoin.Features.BlockStore
 {
     /// <summary>
-    /// Prunes the block store database by deleting blocks lower than a certain height.
+    /// Prunes and compacts the block store database by deleting blocks lower than a certain height and recreating the database file on disk.
     /// </summary>
     public interface IPrunedBlockRepository
     {
@@ -16,14 +16,19 @@ namespace Stratis.Bitcoin.Features.BlockStore
         Task InitializeAsync();
 
         /// <summary>
-        /// Compacts the block and transaction database by resaving the database file without
-        /// all the deleted references.
+        /// Prunes and compacts the block and transaction database.
+        /// <para>
+        /// The method first prunes by deleting blocks from the block store that are below the <see cref="StoreSettings.AmountOfBlocksToKeep"/> from the store tip.
+        /// </para>
+        /// <para>
+        /// Once this is done the database is compacted by resaving the database file without the deleted references, reducing the file size on disk.
+        /// </para>
         /// </summary>
-        /// <param name="consensusTip">The current tip of consensus.</param>
+        /// <param name="blockStoreTip">The current tip of the store.</param>
         /// <param name="network">The network the node is running on.</param>
         /// <param name="nodeInitializing">Indicates whether or not this method is called from node startup or not.</param>
         /// <returns>The awaited task.</returns>
-        Task PruneDatabase(ChainedHeader consensusTip, Network network, bool nodeInitializing);
+        Task PruneAndCompactDatabase(ChainedHeader blockStoreTip, Network network, bool nodeInitializing);
 
         /// <summary> 
         /// The lowest block height that the repository has.

--- a/src/Stratis.Bitcoin.Features.BlockStore/IPrunedBlockRepository.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/IPrunedBlockRepository.cs
@@ -12,7 +12,6 @@ namespace Stratis.Bitcoin.Features.BlockStore
         /// <summary>
         /// Initializes the pruned block repository.
         /// </summary>
-        /// <returns>The awaited task.</returns>
         Task InitializeAsync();
 
         /// <summary>
@@ -27,11 +26,10 @@ namespace Stratis.Bitcoin.Features.BlockStore
         /// <param name="blockStoreTip">The current tip of the store.</param>
         /// <param name="network">The network the node is running on.</param>
         /// <param name="nodeInitializing">Indicates whether or not this method is called from node startup or not.</param>
-        /// <returns>The awaited task.</returns>
         Task PruneAndCompactDatabase(ChainedHeader blockStoreTip, Network network, bool nodeInitializing);
 
         /// <summary> 
-        /// The lowest block height that the repository has.
+        /// The lowest block hash and height that the repository has.
         /// <para>
         /// This also indicated where the node has been pruned up to.
         /// </para>

--- a/src/Stratis.Bitcoin.Features.BlockStore/IPrunedBlockRepository.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/IPrunedBlockRepository.cs
@@ -1,0 +1,45 @@
+﻿using System.Threading.Tasks;
+using NBitcoin;
+using Stratis.Bitcoin.Utilities;
+
+namespace Stratis.Bitcoin.Features.BlockStore
+{
+    /// <summary>
+    /// Prunes the block store database by deleting blocks lower than a certain height.
+    /// </summary>
+    public interface IPrunedBlockRepository
+    {
+        /// <summary>
+        /// INitializes the pruned block repository.
+        /// </summary>
+        /// <param name="network">The network the node is running on.</param>
+        /// <returns>The awaited task.</returns>
+        Task InitializeAsync(Network network);
+
+        /// <summary>
+        /// Compacts the block and transaction database by resaving the database file without
+        /// all the deleted references.
+        /// </summary>
+        /// <param name="consensusTip">The current tip of consensus.</param>
+        /// <param name="nodeInitializing">Indicates whether or not this method is called from node startup or not.</param>
+        /// <returns>The awaited task.</returns>
+        Task PruneDatabase(ChainedHeader consensusTip, bool nodeInitializing);
+
+        /// <summary> 
+        /// The lowest block height that the repository has.
+        /// <para>
+        /// This also indicated where the node has been pruned up to.
+        /// </para>
+        /// </summary>
+        HashHeightPair PrunedTip { get; }
+
+        /// <summary>
+        /// Sets the pruned tip.
+        /// <para> 
+        /// It will be saved once the block database has been compacted on node initialization or shutdown.
+        /// </para>
+        /// </summary>
+        /// <param name="tip">The tip to set.</param>
+        void UpdatePrunedTip(ChainedHeader tip);
+    }
+}

--- a/src/Stratis.Bitcoin.Features.BlockStore/IPrunedBlockRepository.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/IPrunedBlockRepository.cs
@@ -10,7 +10,7 @@ namespace Stratis.Bitcoin.Features.BlockStore
     public interface IPrunedBlockRepository
     {
         /// <summary>
-        /// INitializes the pruned block repository.
+        /// Initializes the pruned block repository.
         /// </summary>
         /// <returns>The awaited task.</returns>
         Task InitializeAsync();

--- a/src/Stratis.Bitcoin.Features.BlockStore/PrunedBlockRepository.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/PrunedBlockRepository.cs
@@ -77,7 +77,7 @@ namespace Stratis.Bitcoin.Features.BlockStore
 
         private bool IsDatabasePruned()
         {
-            if (this.blockRepository.TipHashAndHeight.Height <= this.PrunedTip.Height + this.storeSettings.Prune)
+            if (this.blockRepository.TipHashAndHeight.Height <= this.PrunedTip.Height + this.storeSettings.AmountOfBlocksToKeep)
             {
                 this.logger.LogDebug("(-):true");
                 return true;
@@ -96,7 +96,7 @@ namespace Stratis.Bitcoin.Features.BlockStore
         /// <returns>The awaited task.</returns>
         private async Task PrepareDatabaseForCompactingAsync(ChainedHeader blockRepositoryTip)
         {
-            int upperHeight = this.blockRepository.TipHashAndHeight.Height - this.storeSettings.Prune;
+            int upperHeight = this.blockRepository.TipHashAndHeight.Height - this.storeSettings.AmountOfBlocksToKeep;
 
             var toDelete = new List<ChainedHeader>();
 

--- a/src/Stratis.Bitcoin.Features.BlockStore/PrunedBlockRepository.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/PrunedBlockRepository.cs
@@ -1,0 +1,179 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using DBreeze.DataTypes;
+using Microsoft.Extensions.Logging;
+using NBitcoin;
+using Stratis.Bitcoin.Utilities;
+
+namespace Stratis.Bitcoin.Features.BlockStore
+{
+    /// <inheritdoc />
+    public class PrunedBlockRepository : IPrunedBlockRepository
+    {
+        private readonly IBlockRepository blockRepository;
+        private readonly ILogger logger;
+        private static readonly byte[] prunedTipKey = new byte[2];
+        private readonly StoreSettings storeSettings;
+
+        /// <inheritdoc />
+        public HashHeightPair PrunedTip { get; private set; }
+
+        public PrunedBlockRepository(IBlockRepository blockRepository, ILoggerFactory loggerFactory, StoreSettings storeSettings)
+        {
+            this.blockRepository = blockRepository;
+            this.logger = loggerFactory.CreateLogger(this.GetType().FullName);
+            this.storeSettings = storeSettings;
+        }
+
+        /// <inheritdoc />
+        public Task InitializeAsync(Network network)
+        {
+            Block genesis = network.GetGenesis();
+
+            Task task = Task.Run(() =>
+            {
+                using (DBreeze.Transactions.Transaction transaction = this.blockRepository.DBreeze.GetTransaction())
+                {
+                    bool doCommit = false;
+
+                    if (this.storeSettings.Prune)
+                    {
+                        if (this.LoadPrunedTip(transaction) == null)
+                        {
+                            this.PrunedTip = new HashHeightPair(genesis.GetHash(), 0);
+                            transaction.Insert(BlockRepository.CommonTableName, prunedTipKey, this.PrunedTip);
+                            doCommit = true;
+                        }
+                    }
+
+                    if (doCommit) transaction.Commit();
+                }
+            });
+
+            return task;
+        }
+
+        /// <inheritdoc />
+        public async Task PruneDatabase(ChainedHeader consensusTip, bool nodeInitializing)
+        {
+            this.logger.LogInformation($"Pruning started.");
+
+            if (nodeInitializing)
+            {
+                if (IsDatabasePruned())
+                    return;
+
+                await this.PrepareDatabaseForPruningAsync(consensusTip);
+            }
+
+            this.CompactDataBase();
+
+            this.logger.LogInformation($"Pruning complete.");
+
+            return;
+        }
+
+        private bool IsDatabasePruned()
+        {
+            if (this.blockRepository.TipHashAndHeight.Height <= this.PrunedTip.Height + this.storeSettings.PruneBlockMargin)
+            {
+                this.logger.LogDebug("(-):true");
+                return true;
+            }
+            else
+            {
+                this.logger.LogDebug("(-):false");
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Compacts the block and transaction database by recreating the tables without the deleted references.
+        /// </summary>
+        /// <param name="consensusTip">The last fully validated block of the node.</param>
+        /// <returns>The awaited task.</returns>
+        private async Task PrepareDatabaseForPruningAsync(ChainedHeader consensusTip)
+        {
+            int upperHeight = this.blockRepository.TipHashAndHeight.Height - this.storeSettings.PruneBlockMargin;
+
+            var toDelete = new List<ChainedHeader>();
+
+            ChainedHeader startFromHeader = consensusTip.GetAncestor(upperHeight);
+            ChainedHeader endAtHeader = consensusTip.GetAncestor(this.PrunedTip.Height);
+
+            this.logger.LogInformation($"Pruning blocks from height {upperHeight} to {endAtHeader.Height}.");
+
+            while (startFromHeader.Previous != null && startFromHeader != endAtHeader)
+            {
+                toDelete.Add(startFromHeader);
+                startFromHeader = startFromHeader.Previous;
+            }
+
+            await this.blockRepository.DeleteBlocksAsync(toDelete.Select(cb => cb.HashBlock).ToList()).ConfigureAwait(false);
+
+            this.UpdatePrunedTip(consensusTip.GetAncestor(upperHeight));
+        }
+
+        private HashHeightPair LoadPrunedTip(DBreeze.Transactions.Transaction dbreezeTransaction)
+        {
+            if (this.PrunedTip == null)
+            {
+                dbreezeTransaction.ValuesLazyLoadingIsOn = false;
+
+                Row<byte[], HashHeightPair> row = dbreezeTransaction.Select<byte[], HashHeightPair>(BlockRepository.CommonTableName, prunedTipKey);
+                if (row.Exists)
+                    this.PrunedTip = row.Value;
+
+                dbreezeTransaction.ValuesLazyLoadingIsOn = true;
+            }
+
+            return this.PrunedTip;
+        }
+
+        /// <summary>
+        /// Compacts the block and transaction database by recreating the tables without the deleted references.
+        /// </summary>
+        private void CompactDataBase()
+        {
+            Task task = Task.Run(() =>
+            {
+                using (DBreeze.Transactions.Transaction dbreezeTransaction = this.blockRepository.DBreeze.GetTransaction())
+                {
+                    dbreezeTransaction.SynchronizeTables(BlockRepository.BlockTableName, BlockRepository.TransactionTableName);
+
+                    var tempBlocks = dbreezeTransaction.SelectDictionary<byte[], Block>(BlockRepository.BlockTableName);
+
+                    if (tempBlocks.Count != 0)
+                    {
+                        this.logger.LogInformation($"{tempBlocks.Count} blocks will be copied to the pruned table.");
+
+                        dbreezeTransaction.RemoveAllKeys(BlockRepository.BlockTableName, true);
+                        dbreezeTransaction.InsertDictionary(BlockRepository.BlockTableName, tempBlocks, false);
+
+                        var tempTransactions = dbreezeTransaction.SelectDictionary<byte[], Block>(BlockRepository.TransactionTableName);
+                        if (tempTransactions.Count != 0)
+                        {
+                            this.logger.LogInformation($"{tempTransactions.Count} transactions will be copied to the pruned table.");
+                            dbreezeTransaction.RemoveAllKeys(BlockRepository.TransactionTableName, true);
+                            dbreezeTransaction.InsertDictionary(BlockRepository.TransactionTableName, tempTransactions, false);
+                        }
+
+                        // Save the hash and height of where the node was pruned up to.
+                        dbreezeTransaction.Insert(BlockRepository.CommonTableName, prunedTipKey, this.PrunedTip);
+                    }
+
+                    dbreezeTransaction.Commit();
+                }
+
+                return Task.CompletedTask;
+            });
+        }
+
+        /// <inheritdoc />
+        public void UpdatePrunedTip(ChainedHeader tip)
+        {
+            this.PrunedTip = new HashHeightPair(tip);
+        }
+    }
+}

--- a/src/Stratis.Bitcoin.Features.BlockStore/PrunedBlockRepository.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/PrunedBlockRepository.cs
@@ -43,7 +43,7 @@ namespace Stratis.Bitcoin.Features.BlockStore
         }
 
         /// <inheritdoc />
-        public async Task PruneDatabase(ChainedHeader blockRepositoryTip, Network network, bool nodeInitializing)
+        public async Task PruneAndCompactDatabase(ChainedHeader blockRepositoryTip, Network network, bool nodeInitializing)
         {
             this.logger.LogInformation($"Pruning started.");
 

--- a/src/Stratis.Bitcoin.Features.BlockStore/PrunedBlockRepository.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/PrunedBlockRepository.cs
@@ -65,7 +65,7 @@ namespace Stratis.Bitcoin.Features.BlockStore
                 if (IsDatabasePruned())
                     return;
 
-                await this.PrepareDatabaseForCompactingAsync(blockRepositoryTip);
+                await this.PrepareDatabaseForCompactingAsync(blockRepositoryTip).ConfigureAwait(false);
             }
 
             this.CompactDataBase();
@@ -93,7 +93,6 @@ namespace Stratis.Bitcoin.Features.BlockStore
         /// Compacts the block and transaction database by recreating the tables without the deleted references.
         /// </summary>
         /// <param name="blockRepositoryTip">The last fully validated block of the node.</param>
-        /// <returns>The awaited task.</returns>
         private async Task PrepareDatabaseForCompactingAsync(ChainedHeader blockRepositoryTip)
         {
             int upperHeight = this.blockRepository.TipHashAndHeight.Height - this.storeSettings.AmountOfBlocksToKeep;

--- a/src/Stratis.Bitcoin.Features.BlockStore/StoreSettings.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/StoreSettings.cs
@@ -25,10 +25,7 @@ namespace Stratis.Bitcoin.Features.BlockStore
         public bool ReIndex { get; set; }
 
         /// <summary><c>true</c> to enable pruning to reduce storage requirements by enabling deleting of old blocks.</summary>
-        public bool Prune { get; set; }
-
-        /// <summary> The amount of blocks to keep from the block store's tip.</summary>
-        public int PruneBlockMargin { get; set; }
+        public int Prune { get; set; }
 
         /// <summary>The maximum amount of blocks the cache can contain.</summary>
         public int MaxCacheBlocksCount { get; set; }
@@ -45,13 +42,12 @@ namespace Stratis.Bitcoin.Features.BlockStore
 
             TextFileConfiguration config = nodeSettings.ConfigReader;
 
-            this.Prune = config.GetOrDefault<bool>("prune", false, this.logger);
-            this.PruneBlockMargin = config.GetOrDefault<int>("pruneblockmargin", 2880, this.logger);
+            this.Prune = config.GetOrDefault<int>("prune", 0, this.logger);
             this.TxIndex = config.GetOrDefault<bool>("txindex", false, this.logger);
             this.ReIndex = config.GetOrDefault<bool>("reindex", false, this.logger);
             this.MaxCacheBlocksCount = nodeSettings.ConfigReader.GetOrDefault("maxCacheBlocksCount", DefaultMaxCacheBlocksCount, this.logger);
 
-            if (this.Prune && this.TxIndex)
+            if (this.Prune != 0 && this.TxIndex)
                 throw new ConfigurationException("Prune mode is incompatible with -txindex");
         }
 
@@ -62,8 +58,7 @@ namespace Stratis.Bitcoin.Features.BlockStore
 
             builder.AppendLine($"-txindex=<0 or 1>              Enable to maintain a full transaction index.");
             builder.AppendLine($"-reindex=<0 or 1>              Rebuild chain state and block index from block data files on disk.");
-            builder.AppendLine($"-prune=<0 or 1>                Enable pruning to reduce storage requirements by enabling deleting of old blocks.");
-            builder.AppendLine($"-pruneblockmargin=<2880 +>     The amount of blocks to keep on disk.");
+            builder.AppendLine($"-prune=<amount of blocks>      Enable pruning to reduce storage requirements by enabling deleting of old blocks.");
             builder.AppendLine($"-maxCacheBlocksCount=<number>  The maximum amount of blocks the cache can contain. Default is {DefaultMaxCacheBlocksCount}.");
 
             NodeSettings.Default(network).Logger.LogInformation(builder.ToString());
@@ -82,9 +77,7 @@ namespace Stratis.Bitcoin.Features.BlockStore
             builder.AppendLine($"#Rebuild chain state and block index from block data files on disk.");
             builder.AppendLine($"#reindex=0");
             builder.AppendLine($"#Enable pruning to reduce storage requirements by enabling deleting of old blocks.");
-            builder.AppendLine($"#prune=0");
-            builder.AppendLine($"#The amount of blocks to keep on disk.");
-            builder.AppendLine($"#pruneblockmargin=2880");
+            builder.AppendLine($"#prune=2880");
             builder.AppendLine($"#The maximum amount of blocks the cache can contain. Default is {DefaultMaxCacheBlocksCount}");
             builder.AppendLine($"#maxCacheBlocksCount=300");
         }

--- a/src/Stratis.Bitcoin.Features.BlockStore/StoreSettings.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/StoreSettings.cs
@@ -62,7 +62,7 @@ namespace Stratis.Bitcoin.Features.BlockStore
             this.PruningEnabled = this.AmountOfBlocksToKeep != 0;
 
             if (this.PruningEnabled && this.AmountOfBlocksToKeep < this.GetMinPruningAmount())
-                throw new ConfigurationException($"Can't prune more than {this.GetMinPruningAmount()} blocks!");
+                throw new ConfigurationException($"The minimum amount of blocks to keep can't be less than {this.GetMinPruningAmount()}.");
 
             this.TxIndex = config.GetOrDefault<bool>("txindex", false, this.logger);
             this.ReIndex = config.GetOrDefault<bool>("reindex", false, this.logger);

--- a/src/Stratis.Bitcoin.Features.BlockStore/StoreSettings.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/StoreSettings.cs
@@ -27,6 +27,9 @@ namespace Stratis.Bitcoin.Features.BlockStore
         /// <summary><c>true</c> to enable pruning to reduce storage requirements by enabling deleting of old blocks.</summary>
         public bool Prune { get; set; }
 
+        /// <summary> The amount of blocks to keep from the block store's tip.</summary>
+        public int PruneBlockMargin { get; set; }
+
         /// <summary>The maximum amount of blocks the cache can contain.</summary>
         public int MaxCacheBlocksCount { get; set; }
 
@@ -43,6 +46,7 @@ namespace Stratis.Bitcoin.Features.BlockStore
             TextFileConfiguration config = nodeSettings.ConfigReader;
 
             this.Prune = config.GetOrDefault<bool>("prune", false, this.logger);
+            this.PruneBlockMargin = config.GetOrDefault<int>("pruneblockmargin", 2880, this.logger);
             this.TxIndex = config.GetOrDefault<bool>("txindex", false, this.logger);
             this.ReIndex = config.GetOrDefault<bool>("reindex", false, this.logger);
             this.MaxCacheBlocksCount = nodeSettings.ConfigReader.GetOrDefault("maxCacheBlocksCount", DefaultMaxCacheBlocksCount, this.logger);
@@ -56,10 +60,11 @@ namespace Stratis.Bitcoin.Features.BlockStore
         {
             var builder = new StringBuilder();
 
-            builder.AppendLine($"-txindex=<0 or 1>         Enable to maintain a full transaction index.");
-            builder.AppendLine($"-reindex=<0 or 1>         Rebuild chain state and block index from block data files on disk.");
-            builder.AppendLine($"-prune=<0 or 1>           Enable pruning to reduce storage requirements by enabling deleting of old blocks.");
-            builder.AppendLine($"-maxCacheBlocksCount=<number> The maximum amount of blocks the cache can contain. Default is {DefaultMaxCacheBlocksCount}.");
+            builder.AppendLine($"-txindex=<0 or 1>              Enable to maintain a full transaction index.");
+            builder.AppendLine($"-reindex=<0 or 1>              Rebuild chain state and block index from block data files on disk.");
+            builder.AppendLine($"-prune=<0 or 1>                Enable pruning to reduce storage requirements by enabling deleting of old blocks.");
+            builder.AppendLine($"-pruneblockmargin=<2880 +>     The amount of blocks to keep on disk.");
+            builder.AppendLine($"-maxCacheBlocksCount=<number>  The maximum amount of blocks the cache can contain. Default is {DefaultMaxCacheBlocksCount}.");
 
             NodeSettings.Default(network).Logger.LogInformation(builder.ToString());
         }
@@ -78,6 +83,8 @@ namespace Stratis.Bitcoin.Features.BlockStore
             builder.AppendLine($"#reindex=0");
             builder.AppendLine($"#Enable pruning to reduce storage requirements by enabling deleting of old blocks.");
             builder.AppendLine($"#prune=0");
+            builder.AppendLine($"#The amount of blocks to keep on disk.");
+            builder.AppendLine($"#pruneblockmargin=2880");
             builder.AppendLine($"#The maximum amount of blocks the cache can contain. Default is {DefaultMaxCacheBlocksCount}");
             builder.AppendLine($"#maxCacheBlocksCount=300");
         }

--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/TestChainFactory.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/TestChainFactory.cs
@@ -136,7 +136,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests
             testChainContext.PartialValidator = new PartialValidator(testChainContext.ConsensusRules, testChainContext.LoggerFactory);
             testChainContext.FullValidator = new FullValidator(testChainContext.ConsensusRules, testChainContext.LoggerFactory);
 
-            var blockRepository = new BlockRepository(testChainContext.Network, dataFolder, testChainContext.LoggerFactory);
+            var blockRepository = new BlockRepository(testChainContext.Network, dataFolder, testChainContext.LoggerFactory, new StoreSettings(testChainContext.NodeSettings));
 
             var blockStoreFlushCondition = new BlockStoreQueueFlushCondition(testChainContext.ChainState, testChainContext.InitialBlockDownloadState);
 

--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/TestChainFactory.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/TestChainFactory.cs
@@ -136,7 +136,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests
             testChainContext.PartialValidator = new PartialValidator(testChainContext.ConsensusRules, testChainContext.LoggerFactory);
             testChainContext.FullValidator = new FullValidator(testChainContext.ConsensusRules, testChainContext.LoggerFactory);
 
-            var blockRepository = new BlockRepository(testChainContext.Network, dataFolder, testChainContext.DateTimeProvider, testChainContext.LoggerFactory);
+            var blockRepository = new BlockRepository(testChainContext.Network, dataFolder, testChainContext.LoggerFactory);
 
             var blockStoreFlushCondition = new BlockStoreQueueFlushCondition(testChainContext.ChainState, testChainContext.InitialBlockDownloadState);
 

--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/TestChainFactory.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/TestChainFactory.cs
@@ -136,7 +136,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests
             testChainContext.PartialValidator = new PartialValidator(testChainContext.ConsensusRules, testChainContext.LoggerFactory);
             testChainContext.FullValidator = new FullValidator(testChainContext.ConsensusRules, testChainContext.LoggerFactory);
 
-            var blockRepository = new BlockRepository(testChainContext.Network, dataFolder, testChainContext.LoggerFactory, new StoreSettings(testChainContext.NodeSettings));
+            var blockRepository = new BlockRepository(testChainContext.Network, dataFolder, testChainContext.LoggerFactory);
 
             var blockStoreFlushCondition = new BlockStoreQueueFlushCondition(testChainContext.ChainState, testChainContext.InitialBlockDownloadState);
 

--- a/src/Stratis.Bitcoin.Features.LightWallet.Tests/LightWalletSyncManagerTest.cs
+++ b/src/Stratis.Bitcoin.Features.LightWallet.Tests/LightWalletSyncManagerTest.cs
@@ -4,11 +4,11 @@ using System.Threading;
 using Microsoft.Extensions.Logging;
 using Moq;
 using NBitcoin;
+using Stratis.Bitcoin.Consensus;
 using Stratis.Bitcoin.Features.Notifications.Interfaces;
 using Stratis.Bitcoin.Features.Wallet;
 using Stratis.Bitcoin.Features.Wallet.Interfaces;
 using Stratis.Bitcoin.Features.Wallet.Notifications;
-using Stratis.Bitcoin.Interfaces;
 using Stratis.Bitcoin.Primitives;
 using Stratis.Bitcoin.Signals;
 using Stratis.Bitcoin.Tests.Common;
@@ -21,7 +21,7 @@ namespace Stratis.Bitcoin.Features.LightWallet.Tests
 {
     public class LightWalletSyncManagerTest : LogsTestBase
     {
-        private readonly Mock<IBlockStore> blockStore;
+        private readonly Mock<IConsensusManager> consensusManager;
         private readonly Mock<IWalletManager> walletManager;
         private ConcurrentChain chain;
         private readonly Mock<IBlockNotification> blockNotification;
@@ -34,7 +34,7 @@ namespace Stratis.Bitcoin.Features.LightWallet.Tests
         {
             this.network = KnownNetworks.StratisMain;
 
-            this.blockStore = new Mock<IBlockStore>();
+            this.consensusManager = new Mock<IConsensusManager>();
             this.walletManager = new Mock<IWalletManager>();
             this.chain = new ConcurrentChain(this.network);
             this.blockNotification = new Mock<IBlockNotification>();
@@ -47,7 +47,7 @@ namespace Stratis.Bitcoin.Features.LightWallet.Tests
         public void Start_StartsBlockAndTransactionObserver()
         {
             var lightWalletSyncManager = new LightWalletSyncManager(this.LoggerFactory.Object, this.walletManager.Object, this.chain, this.network,
-                this.blockNotification.Object, this.signals.Object, this.nodeLifetime.Object, this.asyncLoopFactory.Object, this.blockStore.Object);
+                this.blockNotification.Object, this.signals.Object, this.nodeLifetime.Object, this.asyncLoopFactory.Object, this.consensusManager.Object);
 
             lightWalletSyncManager.Start();
 
@@ -66,7 +66,7 @@ namespace Stratis.Bitcoin.Features.LightWallet.Tests
             this.walletManager.Setup(w => w.ContainsWallets)
                 .Returns(false);
             var lightWalletSyncManager = new LightWalletSyncManager(this.LoggerFactory.Object, this.walletManager.Object, this.chain, this.network,
-                this.blockNotification.Object, this.signals.Object, this.nodeLifetime.Object, this.asyncLoopFactory.Object, this.blockStore.Object);
+                this.blockNotification.Object, this.signals.Object, this.nodeLifetime.Object, this.asyncLoopFactory.Object, this.consensusManager.Object);
 
             lightWalletSyncManager.Start();
 
@@ -90,7 +90,7 @@ namespace Stratis.Bitcoin.Features.LightWallet.Tests
                 .Returns(1);
 
             var lightWalletSyncManager = new LightWalletSyncManager(this.LoggerFactory.Object, this.walletManager.Object, this.chain, this.network,
-                this.blockNotification.Object, this.signals.Object, this.nodeLifetime.Object, this.asyncLoopFactory.Object, this.blockStore.Object);
+                this.blockNotification.Object, this.signals.Object, this.nodeLifetime.Object, this.asyncLoopFactory.Object, this.consensusManager.Object);
 
             lightWalletSyncManager.Start();
 
@@ -117,7 +117,7 @@ namespace Stratis.Bitcoin.Features.LightWallet.Tests
                 .Returns(new DateTimeOffset(new DateTime(2017, 1, 2)));
 
             var lightWalletSyncManager = new LightWalletSyncManager(this.LoggerFactory.Object, this.walletManager.Object, this.chain, this.network,
-                this.blockNotification.Object, this.signals.Object, this.nodeLifetime.Object, this.asyncLoopFactory.Object, this.blockStore.Object);
+                this.blockNotification.Object, this.signals.Object, this.nodeLifetime.Object, this.asyncLoopFactory.Object, this.consensusManager.Object);
 
             lightWalletSyncManager.Start();
 
@@ -145,7 +145,7 @@ namespace Stratis.Bitcoin.Features.LightWallet.Tests
                 .Returns(new List<uint256>() { this.chain.GetBlock(2).HashBlock });
 
             var lightWalletSyncManager = new LightWalletSyncManager(this.LoggerFactory.Object, this.walletManager.Object, this.chain, this.network,
-                this.blockNotification.Object, this.signals.Object, this.nodeLifetime.Object, this.asyncLoopFactory.Object, this.blockStore.Object);
+                this.blockNotification.Object, this.signals.Object, this.nodeLifetime.Object, this.asyncLoopFactory.Object, this.consensusManager.Object);
 
             lightWalletSyncManager.Start();
 
@@ -179,7 +179,7 @@ namespace Stratis.Bitcoin.Features.LightWallet.Tests
                 .Returns(new List<uint256>() { this.chain.Genesis.HashBlock });
 
             var lightWalletSyncManager = new LightWalletSyncManager(this.LoggerFactory.Object, this.walletManager.Object, this.chain, this.network,
-                this.blockNotification.Object, this.signals.Object, this.nodeLifetime.Object, this.asyncLoopFactory.Object, this.blockStore.Object);
+                this.blockNotification.Object, this.signals.Object, this.nodeLifetime.Object, this.asyncLoopFactory.Object, this.consensusManager.Object);
 
             lightWalletSyncManager.Start();
 
@@ -217,7 +217,7 @@ namespace Stratis.Bitcoin.Features.LightWallet.Tests
                 .Returns(new List<uint256>() { this.chain.GetBlock(3).HashBlock });
 
             var lightWalletSyncManager = new LightWalletSyncManager(this.LoggerFactory.Object, this.walletManager.Object, this.chain, this.network,
-                this.blockNotification.Object, this.signals.Object, this.nodeLifetime.Object, this.asyncLoopFactory.Object, this.blockStore.Object);
+                this.blockNotification.Object, this.signals.Object, this.nodeLifetime.Object, this.asyncLoopFactory.Object, this.consensusManager.Object);
 
             lightWalletSyncManager.Start();
 
@@ -255,7 +255,7 @@ namespace Stratis.Bitcoin.Features.LightWallet.Tests
                 .Returns(new List<uint256>() { this.chain.Genesis.HashBlock });
 
             var lightWalletSyncManager = new LightWalletSyncManager(this.LoggerFactory.Object, this.walletManager.Object, this.chain, this.network,
-                this.blockNotification.Object, this.signals.Object, this.nodeLifetime.Object, this.asyncLoopFactory.Object, this.blockStore.Object);
+                this.blockNotification.Object, this.signals.Object, this.nodeLifetime.Object, this.asyncLoopFactory.Object, this.consensusManager.Object);
 
             lightWalletSyncManager.Start();
 
@@ -287,7 +287,7 @@ namespace Stratis.Bitcoin.Features.LightWallet.Tests
                 .Returns(new DateTimeOffset(new DateTime(2000, 1, 1)));
 
             var lightWalletSyncManager = new LightWalletSyncManager(this.LoggerFactory.Object, this.walletManager.Object, this.chain, this.network,
-                this.blockNotification.Object, this.signals.Object, this.nodeLifetime.Object, this.asyncLoopFactory.Object, this.blockStore.Object);
+                this.blockNotification.Object, this.signals.Object, this.nodeLifetime.Object, this.asyncLoopFactory.Object, this.consensusManager.Object);
 
             lightWalletSyncManager.Start();
 
@@ -323,7 +323,7 @@ namespace Stratis.Bitcoin.Features.LightWallet.Tests
                 .Returns(asyncLoop.Object);
 
             var lightWalletSyncManager = new LightWalletSyncManager(this.LoggerFactory.Object, this.walletManager.Object, this.chain, this.network,
-                this.blockNotification.Object, this.signals.Object, this.nodeLifetime.Object, this.asyncLoopFactory.Object, this.blockStore.Object);
+                this.blockNotification.Object, this.signals.Object, this.nodeLifetime.Object, this.asyncLoopFactory.Object, this.consensusManager.Object);
 
             lightWalletSyncManager.Start();
             lightWalletSyncManager.SyncFromHeight(3);
@@ -339,7 +339,7 @@ namespace Stratis.Bitcoin.Features.LightWallet.Tests
         {
             this.chain = new ConcurrentChain(this.network);
             var lightWalletSyncManager = new LightWalletSyncManager(this.LoggerFactory.Object, this.walletManager.Object, this.chain, this.network,
-                this.blockNotification.Object, this.signals.Object, this.nodeLifetime.Object, this.asyncLoopFactory.Object, this.blockStore.Object);
+                this.blockNotification.Object, this.signals.Object, this.nodeLifetime.Object, this.asyncLoopFactory.Object, this.consensusManager.Object);
 
             lightWalletSyncManager.SyncFromHeight(3);
 
@@ -361,7 +361,7 @@ namespace Stratis.Bitcoin.Features.LightWallet.Tests
             {
                 this.chain = new ConcurrentChain(this.network);
                 var lightWalletSyncManager = new LightWalletSyncManager(this.LoggerFactory.Object, this.walletManager.Object, this.chain, this.network,
-                    this.blockNotification.Object, this.signals.Object, this.nodeLifetime.Object, this.asyncLoopFactory.Object, this.blockStore.Object);
+                    this.blockNotification.Object, this.signals.Object, this.nodeLifetime.Object, this.asyncLoopFactory.Object, this.consensusManager.Object);
 
                 lightWalletSyncManager.SyncFromHeight(-1);
             });
@@ -372,7 +372,7 @@ namespace Stratis.Bitcoin.Features.LightWallet.Tests
         {
             this.chain = WalletTestsHelpers.GenerateChainWithHeight(2, this.network);
             var lightWalletSyncManager = new LightWalletSyncManager(this.LoggerFactory.Object, this.walletManager.Object, this.chain, this.network,
-                this.blockNotification.Object, this.signals.Object, this.nodeLifetime.Object, this.asyncLoopFactory.Object, this.blockStore.Object);
+                this.blockNotification.Object, this.signals.Object, this.nodeLifetime.Object, this.asyncLoopFactory.Object, this.consensusManager.Object);
 
             lightWalletSyncManager.SyncFromHeight(1);
 
@@ -389,7 +389,7 @@ namespace Stratis.Bitcoin.Features.LightWallet.Tests
 
             this.chain = WalletTestsHelpers.GenerateChainWithHeight(2, this.network);
             var lightWalletSyncManager = new LightWalletSyncManager(this.LoggerFactory.Object, this.walletManager.Object, this.chain, this.network,
-                this.blockNotification.Object, this.signals.Object, this.nodeLifetime.Object, this.asyncLoopFactory.Object, this.blockStore.Object);
+                this.blockNotification.Object, this.signals.Object, this.nodeLifetime.Object, this.asyncLoopFactory.Object, this.consensusManager.Object);
 
             lightWalletSyncManager.SyncFromHeight(3);
 
@@ -409,7 +409,7 @@ namespace Stratis.Bitcoin.Features.LightWallet.Tests
         {
             this.chain = new ConcurrentChain(this.network);
             var lightWalletSyncManager = new LightWalletSyncManager(this.LoggerFactory.Object, this.walletManager.Object, this.chain, this.network,
-                this.blockNotification.Object, this.signals.Object, this.nodeLifetime.Object, this.asyncLoopFactory.Object, this.blockStore.Object);
+                this.blockNotification.Object, this.signals.Object, this.nodeLifetime.Object, this.asyncLoopFactory.Object, this.consensusManager.Object);
 
             lightWalletSyncManager.SyncFromDate(new DateTime(2017, 1, 1));
 
@@ -429,7 +429,7 @@ namespace Stratis.Bitcoin.Features.LightWallet.Tests
         {
             this.chain = WalletTestsHelpers.GenerateChainWithHeight(3, this.network);
             var lightWalletSyncManager = new LightWalletSyncManager(this.LoggerFactory.Object, this.walletManager.Object, this.chain, this.network,
-                this.blockNotification.Object, this.signals.Object, this.nodeLifetime.Object, this.asyncLoopFactory.Object, this.blockStore.Object);
+                this.blockNotification.Object, this.signals.Object, this.nodeLifetime.Object, this.asyncLoopFactory.Object, this.consensusManager.Object);
 
             lightWalletSyncManager.SyncFromDate(this.chain.GetBlock(1).Header.BlockTime.DateTime);
 
@@ -446,7 +446,7 @@ namespace Stratis.Bitcoin.Features.LightWallet.Tests
 
             this.chain = WalletTestsHelpers.GenerateChainWithHeight(2, this.network);
             var lightWalletSyncManager = new LightWalletSyncManager(this.LoggerFactory.Object, this.walletManager.Object, this.chain, this.network,
-                this.blockNotification.Object, this.signals.Object, this.nodeLifetime.Object, this.asyncLoopFactory.Object, this.blockStore.Object);
+                this.blockNotification.Object, this.signals.Object, this.nodeLifetime.Object, this.asyncLoopFactory.Object, this.consensusManager.Object);
 
             lightWalletSyncManager.SyncFromDate(this.chain.Tip.Header.BlockTime.DateTime.AddDays(15));
 
@@ -465,7 +465,7 @@ namespace Stratis.Bitcoin.Features.LightWallet.Tests
         public void ProcessTransaction_CallsWalletManager()
         {
             var lightWalletSyncManager = new LightWalletSyncManager(this.LoggerFactory.Object, this.walletManager.Object, this.chain, this.network,
-                this.blockNotification.Object, this.signals.Object, this.nodeLifetime.Object, this.asyncLoopFactory.Object, this.blockStore.Object);
+                this.blockNotification.Object, this.signals.Object, this.nodeLifetime.Object, this.asyncLoopFactory.Object, this.consensusManager.Object);
 
             var transaction = new Transaction()
             {
@@ -488,7 +488,7 @@ namespace Stratis.Bitcoin.Features.LightWallet.Tests
             this.chain = result.Chain;
             List<Block> blocks = result.Blocks;
             var lightWalletSyncManager = new LightWalletSyncManagerOverride(this.LoggerFactory.Object, this.walletManager.Object, this.chain, this.network,
-                this.blockNotification.Object, this.signals.Object, this.nodeLifetime.Object, this.asyncLoopFactory.Object, this.blockStore.Object);
+                this.blockNotification.Object, this.signals.Object, this.nodeLifetime.Object, this.asyncLoopFactory.Object, this.consensusManager.Object);
             lightWalletSyncManager.SetWalletTip(this.chain.GetBlock(3));
 
             Block blockToProcess = blocks[3];
@@ -511,7 +511,7 @@ namespace Stratis.Bitcoin.Features.LightWallet.Tests
             this.chain = result.Chain;
             List<Block> blocks = result.Blocks;
             var lightWalletSyncManager = new LightWalletSyncManagerOverride(this.LoggerFactory.Object, this.walletManager.Object, this.chain, this.network,
-              this.blockNotification.Object, this.signals.Object, this.nodeLifetime.Object, this.asyncLoopFactory.Object, this.blockStore.Object);
+              this.blockNotification.Object, this.signals.Object, this.nodeLifetime.Object, this.asyncLoopFactory.Object, this.consensusManager.Object);
 
             // set 2nd block as tip
             lightWalletSyncManager.SetWalletTip(this.chain.GetBlock(2));
@@ -538,7 +538,7 @@ namespace Stratis.Bitcoin.Features.LightWallet.Tests
             this.chain = result.Chain;
             List<Block> blocks = result.Blocks;
             var lightWalletSyncManager = new LightWalletSyncManagerOverride(this.LoggerFactory.Object, this.walletManager.Object, this.chain, this.network,
-              this.blockNotification.Object, this.signals.Object, this.nodeLifetime.Object, this.asyncLoopFactory.Object, this.blockStore.Object);
+              this.blockNotification.Object, this.signals.Object, this.nodeLifetime.Object, this.asyncLoopFactory.Object, this.consensusManager.Object);
 
             // set 2nd block as tip
             lightWalletSyncManager.SetWalletTip(this.chain.GetBlock(4));
@@ -566,7 +566,7 @@ namespace Stratis.Bitcoin.Features.LightWallet.Tests
             // right side chain containing the 'new' fork. Work on this.
             this.chain = result.RightChain;
             var lightWalletSyncManager = new LightWalletSyncManagerOverride(this.LoggerFactory.Object, this.walletManager.Object, this.chain, this.network,
-                this.blockNotification.Object, this.signals.Object, this.nodeLifetime.Object, this.asyncLoopFactory.Object, this.blockStore.Object);
+                this.blockNotification.Object, this.signals.Object, this.nodeLifetime.Object, this.asyncLoopFactory.Object, this.consensusManager.Object);
 
             // set 4th block of the old chain as tip. 2 ahead of the fork thus not being on the right chain.
             lightWalletSyncManager.SetWalletTip(leftChain.GetBlock(result.LeftForkBlocks[3].Header.GetHash()));
@@ -600,7 +600,7 @@ namespace Stratis.Bitcoin.Features.LightWallet.Tests
             this.chain = result.RightChain;
 
             var lightWalletSyncManager = new LightWalletSyncManagerOverride(this.LoggerFactory.Object, this.walletManager.Object, this.chain, this.network,
-               this.blockNotification.Object, this.signals.Object, this.nodeLifetime.Object, this.asyncLoopFactory.Object, this.blockStore.Object);
+               this.blockNotification.Object, this.signals.Object, this.nodeLifetime.Object, this.asyncLoopFactory.Object, this.consensusManager.Object);
 
             // set 4th block of the old chain as tip. 2 ahead of the fork thus not being on the right chain.
             lightWalletSyncManager.SetWalletTip(leftChain.GetBlock(result.LeftForkBlocks[3].Header.GetHash()));
@@ -631,8 +631,8 @@ namespace Stratis.Bitcoin.Features.LightWallet.Tests
         private class LightWalletSyncManagerOverride : LightWalletSyncManager
         {
             public LightWalletSyncManagerOverride(ILoggerFactory loggerFactory, IWalletManager walletManager, ConcurrentChain chain,
-                Network network, IBlockNotification blockNotification, ISignals signals, INodeLifetime nodeLifetime, IAsyncLoopFactory asyncLoopFactory, IBlockStore blockStore)
-                : base(loggerFactory, walletManager, chain, network, blockNotification, signals, nodeLifetime, asyncLoopFactory, blockStore)
+                Network network, IBlockNotification blockNotification, ISignals signals, INodeLifetime nodeLifetime, IAsyncLoopFactory asyncLoopFactory, IConsensusManager consensusManager)
+                : base(loggerFactory, walletManager, chain, network, blockNotification, signals, nodeLifetime, asyncLoopFactory, consensusManager)
             {
             }
 

--- a/src/Stratis.Bitcoin.Features.LightWallet.Tests/LightWalletSyncManagerTest.cs
+++ b/src/Stratis.Bitcoin.Features.LightWallet.Tests/LightWalletSyncManagerTest.cs
@@ -8,6 +8,7 @@ using Stratis.Bitcoin.Features.Notifications.Interfaces;
 using Stratis.Bitcoin.Features.Wallet;
 using Stratis.Bitcoin.Features.Wallet.Interfaces;
 using Stratis.Bitcoin.Features.Wallet.Notifications;
+using Stratis.Bitcoin.Interfaces;
 using Stratis.Bitcoin.Primitives;
 using Stratis.Bitcoin.Signals;
 using Stratis.Bitcoin.Tests.Common;
@@ -20,18 +21,20 @@ namespace Stratis.Bitcoin.Features.LightWallet.Tests
 {
     public class LightWalletSyncManagerTest : LogsTestBase
     {
-        private Mock<IWalletManager> walletManager;
+        private readonly Mock<IBlockStore> blockStore;
+        private readonly Mock<IWalletManager> walletManager;
         private ConcurrentChain chain;
-        private Mock<IBlockNotification> blockNotification;
-        private Mock<ISignals> signals;
-        private Mock<INodeLifetime> nodeLifetime;
-        private Mock<IAsyncLoopFactory> asyncLoopFactory;
-        private Network network;
+        private readonly Mock<IBlockNotification> blockNotification;
+        private readonly Mock<ISignals> signals;
+        private readonly Mock<INodeLifetime> nodeLifetime;
+        private readonly Mock<IAsyncLoopFactory> asyncLoopFactory;
+        private readonly Network network;
 
         public LightWalletSyncManagerTest()
         {
             this.network = KnownNetworks.StratisMain;
 
+            this.blockStore = new Mock<IBlockStore>();
             this.walletManager = new Mock<IWalletManager>();
             this.chain = new ConcurrentChain(this.network);
             this.blockNotification = new Mock<IBlockNotification>();
@@ -44,7 +47,7 @@ namespace Stratis.Bitcoin.Features.LightWallet.Tests
         public void Start_StartsBlockAndTransactionObserver()
         {
             var lightWalletSyncManager = new LightWalletSyncManager(this.LoggerFactory.Object, this.walletManager.Object, this.chain, this.network,
-                this.blockNotification.Object, this.signals.Object, this.nodeLifetime.Object, this.asyncLoopFactory.Object);
+                this.blockNotification.Object, this.signals.Object, this.nodeLifetime.Object, this.asyncLoopFactory.Object, this.blockStore.Object);
 
             lightWalletSyncManager.Start();
 
@@ -63,7 +66,7 @@ namespace Stratis.Bitcoin.Features.LightWallet.Tests
             this.walletManager.Setup(w => w.ContainsWallets)
                 .Returns(false);
             var lightWalletSyncManager = new LightWalletSyncManager(this.LoggerFactory.Object, this.walletManager.Object, this.chain, this.network,
-                this.blockNotification.Object, this.signals.Object, this.nodeLifetime.Object, this.asyncLoopFactory.Object);
+                this.blockNotification.Object, this.signals.Object, this.nodeLifetime.Object, this.asyncLoopFactory.Object, this.blockStore.Object);
 
             lightWalletSyncManager.Start();
 
@@ -87,7 +90,7 @@ namespace Stratis.Bitcoin.Features.LightWallet.Tests
                 .Returns(1);
 
             var lightWalletSyncManager = new LightWalletSyncManager(this.LoggerFactory.Object, this.walletManager.Object, this.chain, this.network,
-                this.blockNotification.Object, this.signals.Object, this.nodeLifetime.Object, this.asyncLoopFactory.Object);
+                this.blockNotification.Object, this.signals.Object, this.nodeLifetime.Object, this.asyncLoopFactory.Object, this.blockStore.Object);
 
             lightWalletSyncManager.Start();
 
@@ -114,7 +117,7 @@ namespace Stratis.Bitcoin.Features.LightWallet.Tests
                 .Returns(new DateTimeOffset(new DateTime(2017, 1, 2)));
 
             var lightWalletSyncManager = new LightWalletSyncManager(this.LoggerFactory.Object, this.walletManager.Object, this.chain, this.network,
-                this.blockNotification.Object, this.signals.Object, this.nodeLifetime.Object, this.asyncLoopFactory.Object);
+                this.blockNotification.Object, this.signals.Object, this.nodeLifetime.Object, this.asyncLoopFactory.Object, this.blockStore.Object);
 
             lightWalletSyncManager.Start();
 
@@ -142,7 +145,7 @@ namespace Stratis.Bitcoin.Features.LightWallet.Tests
                 .Returns(new List<uint256>() { this.chain.GetBlock(2).HashBlock });
 
             var lightWalletSyncManager = new LightWalletSyncManager(this.LoggerFactory.Object, this.walletManager.Object, this.chain, this.network,
-                this.blockNotification.Object, this.signals.Object, this.nodeLifetime.Object, this.asyncLoopFactory.Object);
+                this.blockNotification.Object, this.signals.Object, this.nodeLifetime.Object, this.asyncLoopFactory.Object, this.blockStore.Object);
 
             lightWalletSyncManager.Start();
 
@@ -176,7 +179,7 @@ namespace Stratis.Bitcoin.Features.LightWallet.Tests
                 .Returns(new List<uint256>() { this.chain.Genesis.HashBlock });
 
             var lightWalletSyncManager = new LightWalletSyncManager(this.LoggerFactory.Object, this.walletManager.Object, this.chain, this.network,
-                this.blockNotification.Object, this.signals.Object, this.nodeLifetime.Object, this.asyncLoopFactory.Object);
+                this.blockNotification.Object, this.signals.Object, this.nodeLifetime.Object, this.asyncLoopFactory.Object, this.blockStore.Object);
 
             lightWalletSyncManager.Start();
 
@@ -214,7 +217,7 @@ namespace Stratis.Bitcoin.Features.LightWallet.Tests
                 .Returns(new List<uint256>() { this.chain.GetBlock(3).HashBlock });
 
             var lightWalletSyncManager = new LightWalletSyncManager(this.LoggerFactory.Object, this.walletManager.Object, this.chain, this.network,
-                this.blockNotification.Object, this.signals.Object, this.nodeLifetime.Object, this.asyncLoopFactory.Object);
+                this.blockNotification.Object, this.signals.Object, this.nodeLifetime.Object, this.asyncLoopFactory.Object, this.blockStore.Object);
 
             lightWalletSyncManager.Start();
 
@@ -252,7 +255,7 @@ namespace Stratis.Bitcoin.Features.LightWallet.Tests
                 .Returns(new List<uint256>() { this.chain.Genesis.HashBlock });
 
             var lightWalletSyncManager = new LightWalletSyncManager(this.LoggerFactory.Object, this.walletManager.Object, this.chain, this.network,
-                this.blockNotification.Object, this.signals.Object, this.nodeLifetime.Object, this.asyncLoopFactory.Object);
+                this.blockNotification.Object, this.signals.Object, this.nodeLifetime.Object, this.asyncLoopFactory.Object, this.blockStore.Object);
 
             lightWalletSyncManager.Start();
 
@@ -284,7 +287,7 @@ namespace Stratis.Bitcoin.Features.LightWallet.Tests
                 .Returns(new DateTimeOffset(new DateTime(2000, 1, 1)));
 
             var lightWalletSyncManager = new LightWalletSyncManager(this.LoggerFactory.Object, this.walletManager.Object, this.chain, this.network,
-                this.blockNotification.Object, this.signals.Object, this.nodeLifetime.Object, this.asyncLoopFactory.Object);
+                this.blockNotification.Object, this.signals.Object, this.nodeLifetime.Object, this.asyncLoopFactory.Object, this.blockStore.Object);
 
             lightWalletSyncManager.Start();
 
@@ -320,7 +323,7 @@ namespace Stratis.Bitcoin.Features.LightWallet.Tests
                 .Returns(asyncLoop.Object);
 
             var lightWalletSyncManager = new LightWalletSyncManager(this.LoggerFactory.Object, this.walletManager.Object, this.chain, this.network,
-                this.blockNotification.Object, this.signals.Object, this.nodeLifetime.Object, this.asyncLoopFactory.Object);
+                this.blockNotification.Object, this.signals.Object, this.nodeLifetime.Object, this.asyncLoopFactory.Object, this.blockStore.Object);
 
             lightWalletSyncManager.Start();
             lightWalletSyncManager.SyncFromHeight(3);
@@ -336,7 +339,7 @@ namespace Stratis.Bitcoin.Features.LightWallet.Tests
         {
             this.chain = new ConcurrentChain(this.network);
             var lightWalletSyncManager = new LightWalletSyncManager(this.LoggerFactory.Object, this.walletManager.Object, this.chain, this.network,
-                this.blockNotification.Object, this.signals.Object, this.nodeLifetime.Object, this.asyncLoopFactory.Object);
+                this.blockNotification.Object, this.signals.Object, this.nodeLifetime.Object, this.asyncLoopFactory.Object, this.blockStore.Object);
 
             lightWalletSyncManager.SyncFromHeight(3);
 
@@ -358,7 +361,7 @@ namespace Stratis.Bitcoin.Features.LightWallet.Tests
             {
                 this.chain = new ConcurrentChain(this.network);
                 var lightWalletSyncManager = new LightWalletSyncManager(this.LoggerFactory.Object, this.walletManager.Object, this.chain, this.network,
-                    this.blockNotification.Object, this.signals.Object, this.nodeLifetime.Object, this.asyncLoopFactory.Object);
+                    this.blockNotification.Object, this.signals.Object, this.nodeLifetime.Object, this.asyncLoopFactory.Object, this.blockStore.Object);
 
                 lightWalletSyncManager.SyncFromHeight(-1);
             });
@@ -369,7 +372,7 @@ namespace Stratis.Bitcoin.Features.LightWallet.Tests
         {
             this.chain = WalletTestsHelpers.GenerateChainWithHeight(2, this.network);
             var lightWalletSyncManager = new LightWalletSyncManager(this.LoggerFactory.Object, this.walletManager.Object, this.chain, this.network,
-                this.blockNotification.Object, this.signals.Object, this.nodeLifetime.Object, this.asyncLoopFactory.Object);
+                this.blockNotification.Object, this.signals.Object, this.nodeLifetime.Object, this.asyncLoopFactory.Object, this.blockStore.Object);
 
             lightWalletSyncManager.SyncFromHeight(1);
 
@@ -386,7 +389,7 @@ namespace Stratis.Bitcoin.Features.LightWallet.Tests
 
             this.chain = WalletTestsHelpers.GenerateChainWithHeight(2, this.network);
             var lightWalletSyncManager = new LightWalletSyncManager(this.LoggerFactory.Object, this.walletManager.Object, this.chain, this.network,
-                this.blockNotification.Object, this.signals.Object, this.nodeLifetime.Object, this.asyncLoopFactory.Object);
+                this.blockNotification.Object, this.signals.Object, this.nodeLifetime.Object, this.asyncLoopFactory.Object, this.blockStore.Object);
 
             lightWalletSyncManager.SyncFromHeight(3);
 
@@ -406,7 +409,7 @@ namespace Stratis.Bitcoin.Features.LightWallet.Tests
         {
             this.chain = new ConcurrentChain(this.network);
             var lightWalletSyncManager = new LightWalletSyncManager(this.LoggerFactory.Object, this.walletManager.Object, this.chain, this.network,
-                this.blockNotification.Object, this.signals.Object, this.nodeLifetime.Object, this.asyncLoopFactory.Object);
+                this.blockNotification.Object, this.signals.Object, this.nodeLifetime.Object, this.asyncLoopFactory.Object, this.blockStore.Object);
 
             lightWalletSyncManager.SyncFromDate(new DateTime(2017, 1, 1));
 
@@ -426,7 +429,7 @@ namespace Stratis.Bitcoin.Features.LightWallet.Tests
         {
             this.chain = WalletTestsHelpers.GenerateChainWithHeight(3, this.network);
             var lightWalletSyncManager = new LightWalletSyncManager(this.LoggerFactory.Object, this.walletManager.Object, this.chain, this.network,
-                this.blockNotification.Object, this.signals.Object, this.nodeLifetime.Object, this.asyncLoopFactory.Object);
+                this.blockNotification.Object, this.signals.Object, this.nodeLifetime.Object, this.asyncLoopFactory.Object, this.blockStore.Object);
 
             lightWalletSyncManager.SyncFromDate(this.chain.GetBlock(1).Header.BlockTime.DateTime);
 
@@ -443,7 +446,7 @@ namespace Stratis.Bitcoin.Features.LightWallet.Tests
 
             this.chain = WalletTestsHelpers.GenerateChainWithHeight(2, this.network);
             var lightWalletSyncManager = new LightWalletSyncManager(this.LoggerFactory.Object, this.walletManager.Object, this.chain, this.network,
-                this.blockNotification.Object, this.signals.Object, this.nodeLifetime.Object, this.asyncLoopFactory.Object);
+                this.blockNotification.Object, this.signals.Object, this.nodeLifetime.Object, this.asyncLoopFactory.Object, this.blockStore.Object);
 
             lightWalletSyncManager.SyncFromDate(this.chain.Tip.Header.BlockTime.DateTime.AddDays(15));
 
@@ -462,7 +465,7 @@ namespace Stratis.Bitcoin.Features.LightWallet.Tests
         public void ProcessTransaction_CallsWalletManager()
         {
             var lightWalletSyncManager = new LightWalletSyncManager(this.LoggerFactory.Object, this.walletManager.Object, this.chain, this.network,
-                this.blockNotification.Object, this.signals.Object, this.nodeLifetime.Object, this.asyncLoopFactory.Object);
+                this.blockNotification.Object, this.signals.Object, this.nodeLifetime.Object, this.asyncLoopFactory.Object, this.blockStore.Object);
 
             var transaction = new Transaction()
             {
@@ -485,7 +488,7 @@ namespace Stratis.Bitcoin.Features.LightWallet.Tests
             this.chain = result.Chain;
             List<Block> blocks = result.Blocks;
             var lightWalletSyncManager = new LightWalletSyncManagerOverride(this.LoggerFactory.Object, this.walletManager.Object, this.chain, this.network,
-                this.blockNotification.Object, this.signals.Object, this.nodeLifetime.Object, this.asyncLoopFactory.Object);
+                this.blockNotification.Object, this.signals.Object, this.nodeLifetime.Object, this.asyncLoopFactory.Object, this.blockStore.Object);
             lightWalletSyncManager.SetWalletTip(this.chain.GetBlock(3));
 
             Block blockToProcess = blocks[3];
@@ -508,7 +511,7 @@ namespace Stratis.Bitcoin.Features.LightWallet.Tests
             this.chain = result.Chain;
             List<Block> blocks = result.Blocks;
             var lightWalletSyncManager = new LightWalletSyncManagerOverride(this.LoggerFactory.Object, this.walletManager.Object, this.chain, this.network,
-              this.blockNotification.Object, this.signals.Object, this.nodeLifetime.Object, this.asyncLoopFactory.Object);
+              this.blockNotification.Object, this.signals.Object, this.nodeLifetime.Object, this.asyncLoopFactory.Object, this.blockStore.Object);
 
             // set 2nd block as tip
             lightWalletSyncManager.SetWalletTip(this.chain.GetBlock(2));
@@ -535,7 +538,7 @@ namespace Stratis.Bitcoin.Features.LightWallet.Tests
             this.chain = result.Chain;
             List<Block> blocks = result.Blocks;
             var lightWalletSyncManager = new LightWalletSyncManagerOverride(this.LoggerFactory.Object, this.walletManager.Object, this.chain, this.network,
-              this.blockNotification.Object, this.signals.Object, this.nodeLifetime.Object, this.asyncLoopFactory.Object);
+              this.blockNotification.Object, this.signals.Object, this.nodeLifetime.Object, this.asyncLoopFactory.Object, this.blockStore.Object);
 
             // set 2nd block as tip
             lightWalletSyncManager.SetWalletTip(this.chain.GetBlock(4));
@@ -563,7 +566,7 @@ namespace Stratis.Bitcoin.Features.LightWallet.Tests
             // right side chain containing the 'new' fork. Work on this.
             this.chain = result.RightChain;
             var lightWalletSyncManager = new LightWalletSyncManagerOverride(this.LoggerFactory.Object, this.walletManager.Object, this.chain, this.network,
-                this.blockNotification.Object, this.signals.Object, this.nodeLifetime.Object, this.asyncLoopFactory.Object);
+                this.blockNotification.Object, this.signals.Object, this.nodeLifetime.Object, this.asyncLoopFactory.Object, this.blockStore.Object);
 
             // set 4th block of the old chain as tip. 2 ahead of the fork thus not being on the right chain.
             lightWalletSyncManager.SetWalletTip(leftChain.GetBlock(result.LeftForkBlocks[3].Header.GetHash()));
@@ -597,7 +600,7 @@ namespace Stratis.Bitcoin.Features.LightWallet.Tests
             this.chain = result.RightChain;
 
             var lightWalletSyncManager = new LightWalletSyncManagerOverride(this.LoggerFactory.Object, this.walletManager.Object, this.chain, this.network,
-               this.blockNotification.Object, this.signals.Object, this.nodeLifetime.Object, this.asyncLoopFactory.Object);
+               this.blockNotification.Object, this.signals.Object, this.nodeLifetime.Object, this.asyncLoopFactory.Object, this.blockStore.Object);
 
             // set 4th block of the old chain as tip. 2 ahead of the fork thus not being on the right chain.
             lightWalletSyncManager.SetWalletTip(leftChain.GetBlock(result.LeftForkBlocks[3].Header.GetHash()));
@@ -628,8 +631,8 @@ namespace Stratis.Bitcoin.Features.LightWallet.Tests
         private class LightWalletSyncManagerOverride : LightWalletSyncManager
         {
             public LightWalletSyncManagerOverride(ILoggerFactory loggerFactory, IWalletManager walletManager, ConcurrentChain chain,
-                Network network, IBlockNotification blockNotification, ISignals signals, INodeLifetime nodeLifetime, IAsyncLoopFactory asyncLoopFactory)
-                : base(loggerFactory, walletManager, chain, network, blockNotification, signals, nodeLifetime, asyncLoopFactory)
+                Network network, IBlockNotification blockNotification, ISignals signals, INodeLifetime nodeLifetime, IAsyncLoopFactory asyncLoopFactory, IBlockStore blockStore)
+                : base(loggerFactory, walletManager, chain, network, blockNotification, signals, nodeLifetime, asyncLoopFactory, blockStore)
             {
             }
 

--- a/src/Stratis.Bitcoin.Features.LightWallet.Tests/LightWalletSyncManagerTest.cs
+++ b/src/Stratis.Bitcoin.Features.LightWallet.Tests/LightWalletSyncManagerTest.cs
@@ -515,11 +515,10 @@ namespace Stratis.Bitcoin.Features.LightWallet.Tests
 
             // set 2nd block as tip
             lightWalletSyncManager.SetWalletTip(this.chain.GetBlock(2));
+
             //process 4th block in the list does not have same prevhash as which is loaded
             Block blockToProcess = blocks[3];
             lightWalletSyncManager.ProcessBlock(blockToProcess);
-
-            this.blockNotification.Verify(b => b.SyncFrom(this.chain.GetBlock(2).HashBlock));
 
             uint256 expectedBlockHash = this.chain.GetBlock(2).Header.GetHash();
             Assert.Equal(expectedBlockHash, lightWalletSyncManager.WalletTip.Header.GetHash());
@@ -579,7 +578,7 @@ namespace Stratis.Bitcoin.Features.LightWallet.Tests
 
             //expect the wallet tip to be set to the fork and the sync to be started from that block.
             Assert.Equal(this.chain.GetBlock(2).HashBlock, lightWalletSyncManager.WalletTip.HashBlock);
-            this.blockNotification.Verify(w => w.SyncFrom(this.chain.GetBlock(2).HashBlock));
+
             // expect no blocks to be processed.
             this.walletManager.Verify(w => w.ProcessBlock(It.IsAny<Block>(), It.IsAny<ChainedHeader>()), Times.Exactly(0));
         }

--- a/src/Stratis.Bitcoin.Features.LightWallet/Blocks/ILightWalletBlockStoreService.cs
+++ b/src/Stratis.Bitcoin.Features.LightWallet/Blocks/ILightWalletBlockStoreService.cs
@@ -3,9 +3,29 @@ using NBitcoin;
 
 namespace Stratis.Bitcoin.Features.LightWallet.Blocks
 {
+    /// <summary>
+    /// This service starts an async loop task that periodically deletes from the blockstore.
+    /// <para>
+    /// If the height of the node's block store is more than <see cref="LightWalletBlockStoreService.MaxBlocksToKeep"/>, the node will 
+    /// be pruned, leaving a margin of <see cref="LightWalletBlockStoreService.MaxBlocksToKeep"/> in the block database.
+    /// </para>
+    /// <para>
+    /// For example if the block store's height is 5000, the node will be pruned up to height 4000, meaning that 1000 blocks will be kept on disk.
+    /// </para>
+    /// </summary>
     public interface ILightWalletBlockStoreService : IDisposable
     {
+        /// <summary>
+        ///  This is the header of where the node has been pruned up to.
+        ///  <para>
+        ///  It should be noted that deleting (pruning) blocks from the repository only removes the reference, it does not decrease the actual size on disk.
+        ///  </para>
+        /// </summary>
         ChainedHeader PrunedUpToHeaderTip { get; }
+
+        /// <summary>
+        /// Starts an async loop task that periodically deletes from the blockstore.
+        /// </summary>
         void Start();
     }
 }

--- a/src/Stratis.Bitcoin.Features.LightWallet/Blocks/ILightWalletBlockStoreService.cs
+++ b/src/Stratis.Bitcoin.Features.LightWallet/Blocks/ILightWalletBlockStoreService.cs
@@ -5,7 +5,7 @@ namespace Stratis.Bitcoin.Features.LightWallet.Blocks
 {
     public interface ILightWalletBlockStoreService : IDisposable
     {
-        ChainedHeader PrunedUpToHeader { get; }
+        ChainedHeader PrunedUpToHeaderTip { get; }
         void Start();
     }
 }

--- a/src/Stratis.Bitcoin.Features.LightWallet/Blocks/ILightWalletBlockStoreService.cs
+++ b/src/Stratis.Bitcoin.Features.LightWallet/Blocks/ILightWalletBlockStoreService.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using NBitcoin;
+
+namespace Stratis.Bitcoin.Features.LightWallet.Blocks
+{
+    public interface ILightWalletBlockStoreService : IDisposable
+    {
+        ChainedHeader PrunedUpToHeader { get; }
+        void Start();
+    }
+}

--- a/src/Stratis.Bitcoin.Features.LightWallet/Blocks/IPruneBlockStoreService.cs
+++ b/src/Stratis.Bitcoin.Features.LightWallet/Blocks/IPruneBlockStoreService.cs
@@ -6,14 +6,14 @@ namespace Stratis.Bitcoin.Features.LightWallet.Blocks
     /// <summary>
     /// This service starts an async loop task that periodically deletes from the blockstore.
     /// <para>
-    /// If the height of the node's block store is more than <see cref="LightWalletBlockStoreService.MaxBlocksToKeep"/>, the node will 
-    /// be pruned, leaving a margin of <see cref="LightWalletBlockStoreService.MaxBlocksToKeep"/> in the block database.
+    /// If the height of the node's block store is more than <see cref="PruneBlockStoreService.MaxBlocksToKeep"/>, the node will 
+    /// be pruned, leaving a margin of <see cref="PruneBlockStoreService.MaxBlocksToKeep"/> in the block database.
     /// </para>
     /// <para>
     /// For example if the block store's height is 5000, the node will be pruned up to height 4000, meaning that 1000 blocks will be kept on disk.
     /// </para>
     /// </summary>
-    public interface ILightWalletBlockStoreService : IDisposable
+    public interface IPruneBlockStoreService : IDisposable
     {
         /// <summary>
         ///  This is the header of where the node has been pruned up to.
@@ -26,6 +26,6 @@ namespace Stratis.Bitcoin.Features.LightWallet.Blocks
         /// <summary>
         /// Starts an async loop task that periodically deletes from the blockstore.
         /// </summary>
-        void Start();
+        void Initialize();
     }
 }

--- a/src/Stratis.Bitcoin.Features.LightWallet/Blocks/LightWalletBlockStoreService.cs
+++ b/src/Stratis.Bitcoin.Features.LightWallet/Blocks/LightWalletBlockStoreService.cs
@@ -61,16 +61,16 @@ namespace Stratis.Bitcoin.Features.LightWallet.Blocks
         /// <returns>The awaited task.</returns>
         private async Task PruneBlocksAsync()
         {
-            if (this.blockRepository.TipHashAndHeight.Height < this.storeSettings.Prune)
+            if (this.blockRepository.TipHashAndHeight.Height < this.storeSettings.AmountOfBlocksToKeep)
                 return;
 
             if (this.blockRepository.TipHashAndHeight.Height == (this.PrunedUpToHeaderTip?.Height ?? 0))
                 return;
 
-            if (this.blockRepository.TipHashAndHeight.Height < (this.PrunedUpToHeaderTip?.Height ?? 0 + this.storeSettings.Prune))
+            if (this.blockRepository.TipHashAndHeight.Height < (this.PrunedUpToHeaderTip?.Height ?? 0 + this.storeSettings.AmountOfBlocksToKeep))
                 return;
 
-            var heightToPruneFrom = this.blockRepository.TipHashAndHeight.Height - this.storeSettings.Prune;
+            var heightToPruneFrom = this.blockRepository.TipHashAndHeight.Height - this.storeSettings.AmountOfBlocksToKeep;
             ChainedHeader startFrom = this.chainState.BlockStoreTip.GetAncestor(heightToPruneFrom);
             if (startFrom == null)
             {

--- a/src/Stratis.Bitcoin.Features.LightWallet/Blocks/LightWalletBlockStoreService.cs
+++ b/src/Stratis.Bitcoin.Features.LightWallet/Blocks/LightWalletBlockStoreService.cs
@@ -9,6 +9,7 @@ using Stratis.Bitcoin.Utilities;
 
 namespace Stratis.Bitcoin.Features.LightWallet.Blocks
 {
+    /// <inheritdoc/>
     public sealed class LightWalletBlockStoreService : ILightWalletBlockStoreService
     {
         private IAsyncLoop asyncLoop;
@@ -18,9 +19,11 @@ namespace Stratis.Bitcoin.Features.LightWallet.Blocks
         private readonly ILogger logger;
         private readonly INodeLifetime nodeLifetime;
 
+        /// <inheritdoc/>
         public ChainedHeader PrunedUpToHeaderTip { get; private set; }
 
-        private const int MaxBlocksToKeep = 500;
+        /// <summary> The amount of blocks that the node will store on disk.</summary>
+        private const int MaxBlocksToKeep = 1000;
 
         public LightWalletBlockStoreService(
             IAsyncLoopFactory asyncLoopFactory,
@@ -34,9 +37,9 @@ namespace Stratis.Bitcoin.Features.LightWallet.Blocks
             this.consensusManager = consensusManager;
             this.logger = loggerFactory.CreateLogger(this.GetType().FullName);
             this.nodeLifetime = nodeLifetime;
-
         }
 
+        /// <inheritdoc/>
         public void Start()
         {
             this.PrunedUpToHeaderTip = this.consensusManager.Tip.GetAncestor(this.blockRepository.PrunedTip.Height);
@@ -50,7 +53,7 @@ namespace Stratis.Bitcoin.Features.LightWallet.Blocks
         }
 
         /// <summary>
-        /// Deletes blocks continuously from the back of the store.
+        /// Delete blocks continuously from the back of the store.
         /// </summary>
         private async Task PruneBlocksAsync()
         {

--- a/src/Stratis.Bitcoin.Features.LightWallet/Blocks/LightWalletBlockStoreService.cs
+++ b/src/Stratis.Bitcoin.Features.LightWallet/Blocks/LightWalletBlockStoreService.cs
@@ -57,8 +57,6 @@ namespace Stratis.Bitcoin.Features.LightWallet.Blocks
             if (this.blockStore.TipHashAndHeight.Height == (this.PrunedUpToHeader?.Height ?? 0))
                 return;
 
-            // 1500 - 1000
-            // Pruned 1400 to 1000
             if (this.blockStore.TipHashAndHeight.Height < (this.PrunedUpToHeader?.Height ?? 0 + MaxBlocksToKeep))
                 return;
 

--- a/src/Stratis.Bitcoin.Features.LightWallet/Blocks/LightWalletBlockStoreService.cs
+++ b/src/Stratis.Bitcoin.Features.LightWallet/Blocks/LightWalletBlockStoreService.cs
@@ -86,7 +86,7 @@ namespace Stratis.Bitcoin.Features.LightWallet.Blocks
 
             this.PrunedUpToHeaderTip = prunedTip;
 
-            this.logger.LogInformation($"Store has been pruned up to {this.PrunedUpToHeaderTip}.");
+            this.logger.LogInformation($"Store has been pruned up to {this.PrunedUpToHeaderTip.Height}.");
         }
 
         /// <inheritdoc/>

--- a/src/Stratis.Bitcoin.Features.LightWallet/Blocks/LightWalletBlockStoreService.cs
+++ b/src/Stratis.Bitcoin.Features.LightWallet/Blocks/LightWalletBlockStoreService.cs
@@ -1,0 +1,95 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using NBitcoin;
+using Stratis.Bitcoin.Consensus;
+using Stratis.Bitcoin.Features.BlockStore;
+using Stratis.Bitcoin.Utilities;
+
+namespace Stratis.Bitcoin.Features.LightWallet.Blocks
+{
+    public sealed class LightWalletBlockStoreService : ILightWalletBlockStoreService
+    {
+        private IAsyncLoop asyncLoop;
+        private readonly IAsyncLoopFactory asyncLoopFactory;
+        private readonly IBlockRepository blockStore;
+        private readonly IConsensusManager consensusManager;
+        private readonly ILogger logger;
+        private readonly INodeLifetime nodeLifetime;
+
+        public ChainedHeader PrunedUpToHeader { get; private set; }
+
+        private const int MaxBlocksToKeep = 500;
+
+        public LightWalletBlockStoreService(
+            IAsyncLoopFactory asyncLoopFactory,
+            IBlockRepository blockStore,
+            IConsensusManager consensusManager,
+            ILoggerFactory loggerFactory,
+            INodeLifetime nodeLifetime)
+        {
+            this.asyncLoopFactory = asyncLoopFactory;
+            this.blockStore = blockStore;
+            this.consensusManager = consensusManager;
+            this.logger = loggerFactory.CreateLogger(this.GetType().FullName);
+            this.nodeLifetime = nodeLifetime;
+        }
+
+        public void Start()
+        {
+            this.asyncLoop = this.asyncLoopFactory.Run($"{this.GetType().Name}.{nameof(this.PruneBlocksAsync)}", async token =>
+            {
+                await PruneBlocksAsync();
+            },
+            this.nodeLifetime.ApplicationStopping,
+            repeatEvery: TimeSpans.TenSeconds);
+        }
+
+        /// <summary>
+        /// Deletes blocks continuously from the back of the store.
+        /// </summary>
+        private async Task PruneBlocksAsync()
+        {
+            if (this.blockStore.TipHashAndHeight.Height < MaxBlocksToKeep)
+                return;
+
+            if (this.blockStore.TipHashAndHeight.Height == (this.PrunedUpToHeader?.Height ?? 0))
+                return;
+
+            // 1500 - 1000
+            // Pruned 1400 to 1000
+            if (this.blockStore.TipHashAndHeight.Height < (this.PrunedUpToHeader?.Height ?? 0 + MaxBlocksToKeep))
+                return;
+
+            var heightToPruneFrom = this.blockStore.TipHashAndHeight.Height - MaxBlocksToKeep;
+            ChainedHeader startFrom = this.consensusManager.Tip.GetAncestor(heightToPruneFrom);
+            if (this.PrunedUpToHeader != null && startFrom == this.PrunedUpToHeader)
+                return;
+
+            this.logger.LogDebug($"Pruning triggered, delete from {heightToPruneFrom} to {this.PrunedUpToHeader?.Height ?? 0}.");
+
+            var chainedHeadersToDelete = new List<ChainedHeader>();
+
+            while (startFrom.Previous != null)
+            {
+                chainedHeadersToDelete.Add(startFrom);
+                startFrom = startFrom.Previous;
+            }
+
+            this.logger.LogDebug($"{chainedHeadersToDelete.Count} blocks will be pruned.");
+
+            await this.blockStore.DeleteBlocksAsync(chainedHeadersToDelete.Select(ch => ch.HashBlock).ToList());
+
+            this.PrunedUpToHeader = chainedHeadersToDelete.First();
+
+            this.logger.LogDebug($"Store has been pruned to {this.PrunedUpToHeader}");
+        }
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            this.asyncLoop?.Dispose();
+        }
+    }
+}

--- a/src/Stratis.Bitcoin.Features.LightWallet/Blocks/LightWalletBlockStoreService.cs
+++ b/src/Stratis.Bitcoin.Features.LightWallet/Blocks/LightWalletBlockStoreService.cs
@@ -72,8 +72,17 @@ namespace Stratis.Bitcoin.Features.LightWallet.Blocks
 
             var heightToPruneFrom = this.blockRepository.TipHashAndHeight.Height - this.storeSettings.Prune;
             ChainedHeader startFrom = this.chainState.BlockStoreTip.GetAncestor(heightToPruneFrom);
-            if (this.PrunedUpToHeaderTip != null && startFrom == this.PrunedUpToHeaderTip)
+            if (startFrom == null)
+            {
+                this.logger.LogInformation("Prune aborted, start block at height {0} was not found.", heightToPruneFrom);
                 return;
+            }
+
+            if (this.PrunedUpToHeaderTip != null && startFrom == this.PrunedUpToHeaderTip)
+            {
+                this.logger.LogInformation("Prune aborted, start block at height {0} equals the pruned tip.", heightToPruneFrom);
+                return;
+            }
 
             this.logger.LogInformation("Pruning triggered, delete from {0} to {1}.", heightToPruneFrom, this.PrunedUpToHeaderTip?.Height ?? 0);
 

--- a/src/Stratis.Bitcoin.Features.LightWallet/LightWalletFeature.cs
+++ b/src/Stratis.Bitcoin.Features.LightWallet/LightWalletFeature.cs
@@ -179,7 +179,7 @@ namespace Stratis.Bitcoin.Features.LightWallet
                         (manager.ContainsWallets ? height.ToString().PadRight(8) : "No Wallet".PadRight(8)) +
                         (manager.ContainsWallets ? (" LightWallet.Hash: ".PadRight(LoggingConfiguration.ColumnLength - 1) + hashBlock) : string.Empty));
 
-                log.AppendLine("LightWallet.Pruned:".PadRight(LoggingConfiguration.ColumnLength + 1) + this.lightWalletBlockStoreService.PrunedUpToHeader?.Height.ToString().PadRight(8));
+                log.AppendLine("LightWallet.Height.Pruned:".PadRight(LoggingConfiguration.ColumnLength + 1) + this.lightWalletBlockStoreService.PrunedUpToHeaderTip?.Height.ToString().PadRight(8));
             }
         }
 

--- a/src/Stratis.Bitcoin.Features.LightWallet/LightWalletFeature.cs
+++ b/src/Stratis.Bitcoin.Features.LightWallet/LightWalletFeature.cs
@@ -212,7 +212,6 @@ namespace Stratis.Bitcoin.Features.LightWallet
             {
                 features
                     .AddFeature<LightWalletFeature>()
-                    //.DependOn<BlockNotificationFeature>()
                     .DependOn<TransactionNotificationFeature>()
                     .FeatureServices(services =>
                     {

--- a/src/Stratis.Bitcoin.Features.LightWallet/LightWalletFeature.cs
+++ b/src/Stratis.Bitcoin.Features.LightWallet/LightWalletFeature.cs
@@ -14,6 +14,7 @@ using Stratis.Bitcoin.Configuration;
 using Stratis.Bitcoin.Configuration.Logging;
 using Stratis.Bitcoin.Connection;
 using Stratis.Bitcoin.Consensus;
+using Stratis.Bitcoin.Features.BlockStore;
 using Stratis.Bitcoin.Features.LightWallet.Blocks;
 using Stratis.Bitcoin.Features.LightWallet.Broadcasting;
 using Stratis.Bitcoin.Features.Notifications;
@@ -231,6 +232,7 @@ namespace Stratis.Bitcoin.Features.LightWallet
                         services.AddSingleton<StandardTransactionPolicy>();
 
                         services.AddSingleton<ILightWalletBlockStoreService, LightWalletBlockStoreService>();
+                        services.AddSingleton<IPrunedBlockRepository, PrunedBlockRepository>();
                     });
             });
 

--- a/src/Stratis.Bitcoin.Features.LightWallet/LightWalletFeature.cs
+++ b/src/Stratis.Bitcoin.Features.LightWallet/LightWalletFeature.cs
@@ -179,7 +179,7 @@ namespace Stratis.Bitcoin.Features.LightWallet
                         (manager.ContainsWallets ? height.ToString().PadRight(8) : "No Wallet".PadRight(8)) +
                         (manager.ContainsWallets ? (" LightWallet.Hash: ".PadRight(LoggingConfiguration.ColumnLength - 1) + hashBlock) : string.Empty));
 
-                log.AppendLine("LightWallet.Height.Pruned:".PadRight(LoggingConfiguration.ColumnLength + 1) + this.lightWalletBlockStoreService.PrunedUpToHeaderTip?.Height.ToString().PadRight(8));
+                log.AppendLine("LightWallet.Pruned:".PadRight(LoggingConfiguration.ColumnLength + 1) + this.lightWalletBlockStoreService.PrunedUpToHeaderTip?.Height.ToString().PadRight(8));
             }
         }
 

--- a/src/Stratis.Bitcoin.Features.LightWallet/LightWalletFeature.cs
+++ b/src/Stratis.Bitcoin.Features.LightWallet/LightWalletFeature.cs
@@ -14,6 +14,7 @@ using Stratis.Bitcoin.Configuration;
 using Stratis.Bitcoin.Configuration.Logging;
 using Stratis.Bitcoin.Connection;
 using Stratis.Bitcoin.Consensus;
+using Stratis.Bitcoin.Features.LightWallet.Blocks;
 using Stratis.Bitcoin.Features.LightWallet.Broadcasting;
 using Stratis.Bitcoin.Features.Notifications;
 using Stratis.Bitcoin.Features.Wallet;
@@ -65,21 +66,8 @@ namespace Stratis.Bitcoin.Features.LightWallet
 
         private readonly WalletSettings walletSettings;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="LightWalletFeature"/> class.
-        /// </summary>
-        /// <param name="walletSyncManager">The synchronization manager for the wallet, tasked with keeping the wallet synced with the network.</param>
-        /// <param name="walletManager">The wallet manager.</param>
-        /// <param name="connectionManager">The connection manager.</param>
-        /// <param name="chain">The chain of blocks.</param>
-        /// <param name="nodeDeployments">The node deployments.</param>
-        /// <param name="asyncLoopFactory">The asynchronous loop factory.</param>
-        /// <param name="nodeLifetime">The node lifetime.</param>
-        /// <param name="walletFeePolicy">The wallet fee policy.</param>
-        /// <param name="broadcasterBehavior">The broadcaster behaviour.</param>
-        /// <param name="loggerFactory">Factory to be used to create logger for the puller.</param>
-        /// <param name="nodeSettings">The settings for the node.</param>
-        /// <param name="walletSettings">The settings for the wallet.</param>
+        private readonly ILightWalletBlockStoreService lightWalletBlockStoreService;
+
         public LightWalletFeature(
             IWalletSyncManager walletSyncManager,
             IWalletManager walletManager,
@@ -93,7 +81,8 @@ namespace Stratis.Bitcoin.Features.LightWallet
             ILoggerFactory loggerFactory,
             NodeSettings nodeSettings,
             WalletSettings walletSettings,
-            INodeStats nodeStats)
+            INodeStats nodeStats,
+            ILightWalletBlockStoreService lightWalletBlockStoreService)
         {
             this.walletSyncManager = walletSyncManager;
             this.walletManager = walletManager;
@@ -108,6 +97,8 @@ namespace Stratis.Bitcoin.Features.LightWallet
             this.loggerFactory = loggerFactory;
             this.nodeSettings = nodeSettings;
             this.walletSettings = walletSettings;
+
+            this.lightWalletBlockStoreService = lightWalletBlockStoreService;
 
             nodeStats.RegisterStats(this.AddInlineStats, StatsType.Inline);
             nodeStats.RegisterStats(this.AddComponentStats, StatsType.Component);
@@ -134,6 +125,8 @@ namespace Stratis.Bitcoin.Features.LightWallet
             this.asyncLoop = this.StartDeploymentsChecksLoop();
 
             this.walletFeePolicy.Start();
+
+            this.lightWalletBlockStoreService.Start();
 
             this.connectionManager.Parameters.TemplateBehaviors.Add(this.broadcasterBehavior);
             return Task.CompletedTask;
@@ -171,13 +164,12 @@ namespace Stratis.Bitcoin.Features.LightWallet
             this.asyncLoop.Dispose();
             this.walletSyncManager.Stop();
             this.walletManager.Stop();
+            this.lightWalletBlockStoreService.Dispose();
         }
 
         public void AddInlineStats(StringBuilder log)
         {
-            var manager = this.walletManager as WalletManager;
-
-            if (manager != null)
+            if (this.walletManager is WalletManager manager)
             {
                 int height = manager.LastBlockHeight();
                 ChainedHeader block = this.chain.GetBlock(height);
@@ -186,6 +178,8 @@ namespace Stratis.Bitcoin.Features.LightWallet
                 log.AppendLine("LightWallet.Height: ".PadRight(LoggingConfiguration.ColumnLength + 1) +
                         (manager.ContainsWallets ? height.ToString().PadRight(8) : "No Wallet".PadRight(8)) +
                         (manager.ContainsWallets ? (" LightWallet.Hash: ".PadRight(LoggingConfiguration.ColumnLength - 1) + hashBlock) : string.Empty));
+
+                log.AppendLine("LightWallet.Pruned:".PadRight(LoggingConfiguration.ColumnLength + 1) + this.lightWalletBlockStoreService.PrunedUpToHeader?.Height.ToString().PadRight(8));
             }
         }
 
@@ -218,7 +212,7 @@ namespace Stratis.Bitcoin.Features.LightWallet
             {
                 features
                     .AddFeature<LightWalletFeature>()
-                    .DependOn<BlockNotificationFeature>()
+                    //.DependOn<BlockNotificationFeature>()
                     .DependOn<TransactionNotificationFeature>()
                     .FeatureServices(services =>
                     {
@@ -236,6 +230,8 @@ namespace Stratis.Bitcoin.Features.LightWallet
                         services.AddSingleton<WalletSettings>();
                         services.AddSingleton<IScriptAddressReader, ScriptAddressReader>();
                         services.AddSingleton<StandardTransactionPolicy>();
+
+                        services.AddSingleton<ILightWalletBlockStoreService, LightWalletBlockStoreService>();
                     });
             });
 

--- a/src/Stratis.Bitcoin.Features.LightWallet/LightWalletFeature.cs
+++ b/src/Stratis.Bitcoin.Features.LightWallet/LightWalletFeature.cs
@@ -66,7 +66,7 @@ namespace Stratis.Bitcoin.Features.LightWallet
 
         private readonly WalletSettings walletSettings;
 
-        private readonly ILightWalletBlockStoreService lightWalletBlockStoreService;
+        private readonly IPruneBlockStoreService lightWalletBlockStoreService;
 
         public LightWalletFeature(
             IWalletSyncManager walletSyncManager,
@@ -82,7 +82,7 @@ namespace Stratis.Bitcoin.Features.LightWallet
             NodeSettings nodeSettings,
             WalletSettings walletSettings,
             INodeStats nodeStats,
-            ILightWalletBlockStoreService lightWalletBlockStoreService)
+            IPruneBlockStoreService lightWalletBlockStoreService)
         {
             this.walletSyncManager = walletSyncManager;
             this.walletManager = walletManager;
@@ -126,7 +126,7 @@ namespace Stratis.Bitcoin.Features.LightWallet
 
             this.walletFeePolicy.Start();
 
-            this.lightWalletBlockStoreService.Start();
+            this.lightWalletBlockStoreService.Initialize();
 
             this.connectionManager.Parameters.TemplateBehaviors.Add(this.broadcasterBehavior);
             return Task.CompletedTask;
@@ -230,7 +230,7 @@ namespace Stratis.Bitcoin.Features.LightWallet
                         services.AddSingleton<IScriptAddressReader, ScriptAddressReader>();
                         services.AddSingleton<StandardTransactionPolicy>();
 
-                        services.AddSingleton<ILightWalletBlockStoreService, LightWalletBlockStoreService>();
+                        services.AddSingleton<IPruneBlockStoreService, PruneBlockStoreService>();
                     });
             });
 

--- a/src/Stratis.Bitcoin.Features.LightWallet/LightWalletFeature.cs
+++ b/src/Stratis.Bitcoin.Features.LightWallet/LightWalletFeature.cs
@@ -14,7 +14,6 @@ using Stratis.Bitcoin.Configuration;
 using Stratis.Bitcoin.Configuration.Logging;
 using Stratis.Bitcoin.Connection;
 using Stratis.Bitcoin.Consensus;
-using Stratis.Bitcoin.Features.BlockStore;
 using Stratis.Bitcoin.Features.LightWallet.Blocks;
 using Stratis.Bitcoin.Features.LightWallet.Broadcasting;
 using Stratis.Bitcoin.Features.Notifications;
@@ -232,7 +231,6 @@ namespace Stratis.Bitcoin.Features.LightWallet
                         services.AddSingleton<StandardTransactionPolicy>();
 
                         services.AddSingleton<ILightWalletBlockStoreService, LightWalletBlockStoreService>();
-                        services.AddSingleton<IPrunedBlockRepository, PrunedBlockRepository>();
                     });
             });
 

--- a/src/Stratis.Bitcoin.Features.LightWallet/LightWalletInitialBlockDownloadState.cs
+++ b/src/Stratis.Bitcoin.Features.LightWallet/LightWalletInitialBlockDownloadState.cs
@@ -7,7 +7,7 @@ namespace Stratis.Bitcoin.Features.LightWallet
     /// </summary>
     public class LightWalletInitialBlockDownloadState : IInitialBlockDownloadState
     {
-        private bool isInInitialBlockDownload;
+        private readonly bool isInInitialBlockDownload;
 
         public LightWalletInitialBlockDownloadState()
         {

--- a/src/Stratis.Bitcoin.Features.LightWallet/LightWalletSyncManager.cs
+++ b/src/Stratis.Bitcoin.Features.LightWallet/LightWalletSyncManager.cs
@@ -1,12 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using Microsoft.Extensions.Logging;
 using NBitcoin;
 using Stratis.Bitcoin.Features.Notifications.Interfaces;
 using Stratis.Bitcoin.Features.Wallet;
 using Stratis.Bitcoin.Features.Wallet.Interfaces;
 using Stratis.Bitcoin.Features.Wallet.Notifications;
+using Stratis.Bitcoin.Interfaces;
 using Stratis.Bitcoin.Signals;
 using Stratis.Bitcoin.Utilities;
 
@@ -41,6 +43,8 @@ namespace Stratis.Bitcoin.Features.LightWallet
 
         public ChainedHeader WalletTip => this.walletTip;
 
+        private IBlockStore blockStore;
+
         public LightWalletSyncManager(
             ILoggerFactory loggerFactory,
             IWalletManager walletManager,
@@ -49,7 +53,8 @@ namespace Stratis.Bitcoin.Features.LightWallet
             IBlockNotification blockNotification,
             ISignals signals,
             INodeLifetime nodeLifetime,
-            IAsyncLoopFactory asyncLoopFactory)
+            IAsyncLoopFactory asyncLoopFactory,
+            IBlockStore blockStore)
         {
             Guard.NotNull(loggerFactory, nameof(loggerFactory));
             Guard.NotNull(walletManager, nameof(walletManager));
@@ -59,6 +64,7 @@ namespace Stratis.Bitcoin.Features.LightWallet
             Guard.NotNull(signals, nameof(signals));
             Guard.NotNull(nodeLifetime, nameof(nodeLifetime));
             Guard.NotNull(asyncLoopFactory, nameof(asyncLoopFactory));
+            Guard.NotNull(blockStore, nameof(blockStore));
 
             this.walletManager = walletManager;
             this.chain = chain;
@@ -67,6 +73,7 @@ namespace Stratis.Bitcoin.Features.LightWallet
             this.logger = loggerFactory.CreateLogger(this.GetType().FullName);
             this.nodeLifetime = nodeLifetime;
             this.asyncLoopFactory = asyncLoopFactory;
+            this.blockStore = blockStore;
         }
 
         /// <inheritdoc />
@@ -210,7 +217,57 @@ namespace Stratis.Bitcoin.Features.LightWallet
 
                     // The wallet is falling behind we need to catch up.
                     this.logger.LogWarning("New tip '{0}' is too far in advance, put the puller back.", newTip);
-                    this.blockNotification.SyncFrom(this.walletTip.HashBlock);
+
+                    CancellationToken token = this.nodeLifetime.ApplicationStopping;
+
+                    ChainedHeader next = this.walletTip;
+                    while (next != newTip)
+                    {
+                        // While the wallet is catching up the entire node will wait.
+                        // If a wallet is recovered to a date in the past. Consensus will stop until the wallet is up to date.
+
+                        // TODO: This code should be replaced with a different approach
+                        // Similar to BlockStore the wallet should be standalone and not depend on consensus.
+                        // The block should be put in a queue and pushed to the wallet in an async way.
+                        // If the wallet is behind it will just read blocks from store (or download in case of a pruned node).
+
+                        token.ThrowIfCancellationRequested();
+
+                        next = newTip.GetAncestor(next.Height + 1);
+                        Block nextblock = null;
+                        int index = 0;
+                        while (true)
+                        {
+                            token.ThrowIfCancellationRequested();
+
+                            nextblock = this.blockStore.GetBlockAsync(next.HashBlock).GetAwaiter().GetResult();
+                            if (nextblock == null)
+                            {
+                                // The idea in this abandoning of the loop is to release consensus to push the block.
+                                // That will make the block available in the next push from consensus.
+                                index++;
+                                if (index > 10)
+                                {
+                                    this.logger.LogTrace("(-)[WALLET_CATCHUP_INDEX_MAX]");
+                                    return;
+                                }
+
+                                // Really ugly hack to let store catch up.
+                                // This will block the entire consensus pulling.
+                                this.logger.LogWarning("Wallet is behind the best chain and the next block is not found in store.");
+                                Thread.Sleep(100);
+                                continue;
+                            }
+
+                            break;
+                        }
+
+                        this.walletTip = next;
+                        this.walletManager.ProcessBlock(nextblock, next);
+                    }
+
+                    //this.blockNotification.SyncFrom(this.walletTip.HashBlock);
+
                     return;
                 }
                 else

--- a/src/Stratis.Bitcoin.Features.LightWallet/LightWalletSyncManager.cs
+++ b/src/Stratis.Bitcoin.Features.LightWallet/LightWalletSyncManager.cs
@@ -280,7 +280,8 @@ namespace Stratis.Bitcoin.Features.LightWallet
                     this.logger.LogTrace("Wallet tip '{0}' is ahead or equal to the new tip '{1}'.", this.walletTip, newTip.HashBlock);
                 }
             }
-            else this.logger.LogTrace("New block follows the previously known block '{0}'.", this.walletTip);
+            else
+                this.logger.LogTrace("New block follows the previously known block '{0}'.", this.walletTip);
 
             this.walletTip = newTip;
             this.walletManager.ProcessBlock(block, newTip);

--- a/src/Stratis.Bitcoin.Features.Miner/MiningFeature.cs
+++ b/src/Stratis.Bitcoin.Features.Miner/MiningFeature.cs
@@ -189,8 +189,8 @@ namespace Stratis.Bitcoin.Features.Miner
             if (this.minerSettings.Mine || this.minerSettings.Stake)
             {
                 services.Features.EnsureFeature<BlockStoreFeature>();
-                var blockSettings = services.ServiceProvider.GetService<StoreSettings>();
-                if (blockSettings.Prune)
+                var storeSettings = services.ServiceProvider.GetService<StoreSettings>();
+                if (storeSettings.Prune != 0)
                     throw new ConfigurationException("BlockStore prune mode is incompatible with mining and staking.");
             }
         }

--- a/src/Stratis.Bitcoin.Features.Miner/MiningFeature.cs
+++ b/src/Stratis.Bitcoin.Features.Miner/MiningFeature.cs
@@ -190,7 +190,7 @@ namespace Stratis.Bitcoin.Features.Miner
             {
                 services.Features.EnsureFeature<BlockStoreFeature>();
                 var storeSettings = services.ServiceProvider.GetService<StoreSettings>();
-                if (storeSettings.Prune != 0)
+                if (storeSettings.PruningEnabled)
                     throw new ConfigurationException("BlockStore prune mode is incompatible with mining and staking.");
             }
         }

--- a/src/Stratis.Bitcoin.Features.Notifications/BlockNotificationFeature.cs
+++ b/src/Stratis.Bitcoin.Features.Notifications/BlockNotificationFeature.cs
@@ -35,8 +35,13 @@ namespace Stratis.Bitcoin.Features.Notifications
 
         private readonly ILoggerFactory loggerFactory;
 
-        public BlockNotificationFeature(IBlockNotification blockNotification, IConnectionManager connectionManager,
-            IConsensusManager consensusManager, IChainState chainState, ConcurrentChain chain, ILoggerFactory loggerFactory)
+        public BlockNotificationFeature(
+            IBlockNotification blockNotification,
+            IConnectionManager connectionManager,
+            IConsensusManager consensusManager,
+            IChainState chainState,
+            ConcurrentChain chain,
+            ILoggerFactory loggerFactory)
         {
             this.blockNotification = blockNotification;
             this.connectionManager = connectionManager;

--- a/src/Stratis.Bitcoin.Features.Notifications/TransactionNotification.cs
+++ b/src/Stratis.Bitcoin.Features.Notifications/TransactionNotification.cs
@@ -5,7 +5,7 @@ using Stratis.Bitcoin.Utilities;
 namespace Stratis.Bitcoin.Features.Notifications
 {
     /// <summary>
-    /// Class used to broadcast about new transactions.
+    /// Class used to broadcast new transactions.
     /// </summary>
     public class TransactionNotification
     {

--- a/src/Stratis.Bitcoin.Features.Wallet.Tests/WalletSyncManagerTest.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet.Tests/WalletSyncManagerTest.cs
@@ -41,7 +41,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
         [Fact]
         public void Start_HavingPrunedStoreSetting_ThrowsWalletException()
         {
-            this.storeSettings.Prune = true;
+            this.storeSettings.Prune = 1;
 
             var walletSyncManager = new WalletSyncManager(this.LoggerFactory.Object, this.walletManager.Object, this.chain, KnownNetworks.StratisMain,
                 this.blockStore.Object, this.storeSettings, this.nodeLifetime.Object);
@@ -55,7 +55,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
         [Fact]
         public void Start_BlockOnChain_DoesNotReorgWalletManager()
         {
-            this.storeSettings.Prune = false;
+            this.storeSettings.Prune = 0;
             this.chain = WalletTestsHelpers.PrepareChainWithBlock();
             this.walletManager.Setup(w => w.WalletTipHash)
                 .Returns(this.chain.Tip.Header.GetHash());
@@ -72,7 +72,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
         [Fact]
         public void Start_BlockNotChain_ReorgsWalletManagerUsingWallet()
         {
-            this.storeSettings.Prune = false;
+            this.storeSettings.Prune = 0;
             this.chain = WalletTestsHelpers.GenerateChainWithHeight(5, KnownNetworks.StratisMain);
             this.walletManager.SetupGet(w => w.WalletTipHash)
                 .Returns(new uint256(125)); // try to load non-existing block to get chain to return null.

--- a/src/Stratis.Bitcoin.Features.Wallet.Tests/WalletSyncManagerTest.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet.Tests/WalletSyncManagerTest.cs
@@ -41,7 +41,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
         [Fact]
         public void Start_HavingPrunedStoreSetting_ThrowsWalletException()
         {
-            this.storeSettings.Prune = 1;
+            this.storeSettings.AmountOfBlocksToKeep = 1;
 
             var walletSyncManager = new WalletSyncManager(this.LoggerFactory.Object, this.walletManager.Object, this.chain, KnownNetworks.StratisMain,
                 this.blockStore.Object, this.storeSettings, this.nodeLifetime.Object);
@@ -55,7 +55,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
         [Fact]
         public void Start_BlockOnChain_DoesNotReorgWalletManager()
         {
-            this.storeSettings.Prune = 0;
+            this.storeSettings.AmountOfBlocksToKeep = 0;
             this.chain = WalletTestsHelpers.PrepareChainWithBlock();
             this.walletManager.Setup(w => w.WalletTipHash)
                 .Returns(this.chain.Tip.Header.GetHash());
@@ -72,7 +72,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
         [Fact]
         public void Start_BlockNotChain_ReorgsWalletManagerUsingWallet()
         {
-            this.storeSettings.Prune = 0;
+            this.storeSettings.AmountOfBlocksToKeep = 0;
             this.chain = WalletTestsHelpers.GenerateChainWithHeight(5, KnownNetworks.StratisMain);
             this.walletManager.SetupGet(w => w.WalletTipHash)
                 .Returns(new uint256(125)); // try to load non-existing block to get chain to return null.

--- a/src/Stratis.Bitcoin.Features.Wallet.Tests/WalletSyncManagerTest.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet.Tests/WalletSyncManagerTest.cs
@@ -42,6 +42,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
         public void Start_HavingPrunedStoreSetting_ThrowsWalletException()
         {
             this.storeSettings.AmountOfBlocksToKeep = 1;
+            this.storeSettings.PruningEnabled = true;
 
             var walletSyncManager = new WalletSyncManager(this.LoggerFactory.Object, this.walletManager.Object, this.chain, KnownNetworks.StratisMain,
                 this.blockStore.Object, this.storeSettings, this.nodeLifetime.Object);

--- a/src/Stratis.Bitcoin.Features.Wallet/Interfaces/IWalletSyncManager.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Interfaces/IWalletSyncManager.cs
@@ -22,27 +22,23 @@ namespace Stratis.Bitcoin.Features.Wallet.Interfaces
         /// <summary>
         /// Processes a new block.
         /// </summary>
-        /// <param name="block"></param>
         void ProcessBlock(Block block);
 
         /// <summary>
         /// Processes a new transaction which is in a pending state (not included in a block).
         /// </summary>
-        /// <param name="transaction"></param>
         void ProcessTransaction(Transaction transaction);
 
         /// <summary>
         /// Synchronize the wallet starting from the date passed as a parameter.
         /// </summary>
         /// <param name="date">The date from which to start the sync process.</param>
-        /// <returns>The height of the block sync will start from.</returns>
         void SyncFromDate(DateTime date);
 
         /// <summary>
         /// Synchronize the wallet starting from the height passed as a parameter.
         /// </summary>
         /// <param name="height">The height from which to start the sync process.</param>
-        /// <returns>The height of the block sync will start from.</returns>
         void SyncFromHeight(int height);
 
         /// <summary>

--- a/src/Stratis.Bitcoin.Features.Wallet/Interfaces/IWalletSyncManager.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Interfaces/IWalletSyncManager.cs
@@ -22,11 +22,13 @@ namespace Stratis.Bitcoin.Features.Wallet.Interfaces
         /// <summary>
         /// Processes a new block.
         /// </summary>
+        /// <param name="block">The block to process.</param>
         void ProcessBlock(Block block);
 
         /// <summary>
         /// Processes a new transaction which is in a pending state (not included in a block).
         /// </summary>
+        /// <param name="transaction">The transaction to process.</param>
         void ProcessTransaction(Transaction transaction);
 
         /// <summary>

--- a/src/Stratis.Bitcoin.Features.Wallet/WalletSyncManager.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/WalletSyncManager.cs
@@ -73,7 +73,7 @@ namespace Stratis.Bitcoin.Features.Wallet
             // if the wallet falls behind the block puller.
             // To support pruning the wallet will need to be
             // able to download blocks from peers to catch up.
-            if (this.storeSettings.Prune)
+            if (this.storeSettings.Prune != 0)
                 throw new WalletException("Wallet can not yet run on a pruned node");
 
             this.logger.LogInformation("WalletSyncManager initialized. Wallet at block {0}.", this.walletManager.LastBlockHeight());

--- a/src/Stratis.Bitcoin.Features.Wallet/WalletSyncManager.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/WalletSyncManager.cs
@@ -73,7 +73,7 @@ namespace Stratis.Bitcoin.Features.Wallet
             // if the wallet falls behind the block puller.
             // To support pruning the wallet will need to be
             // able to download blocks from peers to catch up.
-            if (this.storeSettings.Prune != 0)
+            if (this.storeSettings.PruningEnabled)
                 throw new WalletException("Wallet can not yet run on a pruned node");
 
             this.logger.LogInformation("WalletSyncManager initialized. Wallet at block {0}.", this.walletManager.LastBlockHeight());

--- a/src/Stratis.Bitcoin.IntegrationTests/BlockStore/BlockStoreTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/BlockStore/BlockStoreTests.cs
@@ -29,7 +29,7 @@ namespace Stratis.Bitcoin.IntegrationTests.BlockStore
         [Fact]
         public void BlockRepositoryPutBatch()
         {
-            using (var blockRepository = new BlockRepository(this.network, TestBase.CreateDataFolder(this), DateTimeProvider.Default, this.loggerFactory))
+            using (var blockRepository = new BlockRepository(this.network, TestBase.CreateDataFolder(this), this.loggerFactory))
             {
                 blockRepository.SetTxIndexAsync(true).Wait();
 

--- a/src/Stratis.Bitcoin.IntegrationTests/BlockStore/BlockStoreTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/BlockStore/BlockStoreTests.cs
@@ -2,7 +2,6 @@
 using System.Linq;
 using Microsoft.Extensions.Logging;
 using NBitcoin;
-using Stratis.Bitcoin.Configuration;
 using Stratis.Bitcoin.Features.BlockStore;
 using Stratis.Bitcoin.IntegrationTests.Common;
 using Stratis.Bitcoin.IntegrationTests.Common.EnvironmentMockUpHelpers;
@@ -30,7 +29,7 @@ namespace Stratis.Bitcoin.IntegrationTests.BlockStore
         [Fact]
         public void BlockRepositoryPutBatch()
         {
-            using (var blockRepository = new BlockRepository(this.network, TestBase.CreateDataFolder(this), this.loggerFactory, new StoreSettings(NodeSettings.Default(this.network))))
+            using (var blockRepository = new BlockRepository(this.network, TestBase.CreateDataFolder(this), this.loggerFactory))
             {
                 blockRepository.SetTxIndexAsync(true).Wait();
 

--- a/src/Stratis.Bitcoin.IntegrationTests/BlockStore/BlockStoreTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/BlockStore/BlockStoreTests.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using Microsoft.Extensions.Logging;
 using NBitcoin;
+using Stratis.Bitcoin.Configuration;
 using Stratis.Bitcoin.Features.BlockStore;
 using Stratis.Bitcoin.IntegrationTests.Common;
 using Stratis.Bitcoin.IntegrationTests.Common.EnvironmentMockUpHelpers;
@@ -29,7 +30,7 @@ namespace Stratis.Bitcoin.IntegrationTests.BlockStore
         [Fact]
         public void BlockRepositoryPutBatch()
         {
-            using (var blockRepository = new BlockRepository(this.network, TestBase.CreateDataFolder(this), this.loggerFactory))
+            using (var blockRepository = new BlockRepository(this.network, TestBase.CreateDataFolder(this), this.loggerFactory, new StoreSettings(NodeSettings.Default(this.network))))
             {
                 blockRepository.SetTxIndexAsync(true).Wait();
 

--- a/src/Stratis.BreezeD/Program.cs
+++ b/src/Stratis.BreezeD/Program.cs
@@ -1,13 +1,13 @@
 using System;
 using System.Linq;
 using System.Threading.Tasks;
-using NBitcoin;
-using NBitcoin.Networks;
 using NBitcoin.Protocol;
 using Stratis.Bitcoin;
 using Stratis.Bitcoin.Builder;
 using Stratis.Bitcoin.Configuration;
 using Stratis.Bitcoin.Features.Api;
+using Stratis.Bitcoin.Features.BlockStore;
+using Stratis.Bitcoin.Features.Consensus;
 using Stratis.Bitcoin.Features.LightWallet;
 using Stratis.Bitcoin.Features.Notifications;
 using Stratis.Bitcoin.Networks;
@@ -34,16 +34,18 @@ namespace Stratis.BreezeD
                     if (isTestNet)
                         args = args.Append("-addnode=51.141.28.47").ToArray(); // TODO: fix this temp hack
 
-                    nodeSettings = new NodeSettings(networksSelector:Networks.Stratis, protocolVersion: ProtocolVersion.ALT_PROTOCOL_VERSION, agent: agent, args:args);
+                    nodeSettings = new NodeSettings(networksSelector: Networks.Stratis, protocolVersion: ProtocolVersion.ALT_PROTOCOL_VERSION, agent: agent, args: args);
                 }
                 else
                 {
-                    nodeSettings = new NodeSettings(networksSelector:Networks.Bitcoin, agent: agent, args: args);
+                    nodeSettings = new NodeSettings(networksSelector: Networks.Bitcoin, agent: agent, args: args);
                 }
 
                 IFullNodeBuilder fullNodeBuilder = new FullNodeBuilder()
                     .UseNodeSettings(nodeSettings)
                     .UseLightWallet()
+                    .UseBlockStore()
+                    .UsePosConsensus()
                     .UseBlockNotification()
                     .UseTransactionNotification()
                     .UseApi();

--- a/src/Stratis.BreezeD/Program.cs
+++ b/src/Stratis.BreezeD/Program.cs
@@ -21,44 +21,38 @@ namespace Stratis.BreezeD
         {
             try
             {
-                // Get the API uri.
-                bool isTestNet = args.Contains("-testnet");
                 bool isStratis = args.Contains("stratis");
-
-                string agent = "Breeze";
 
                 NodeSettings nodeSettings;
 
                 if (isStratis)
                 {
-                    if (isTestNet)
-                        args = args.Append("-addnode=51.141.28.47").ToArray(); // TODO: fix this temp hack
-
-                    nodeSettings = new NodeSettings(networksSelector: Networks.Stratis, protocolVersion: ProtocolVersion.ALT_PROTOCOL_VERSION, agent: agent, args: args);
+                    nodeSettings = new NodeSettings(networksSelector: Networks.Stratis, protocolVersion: ProtocolVersion.PROVEN_HEADER_VERSION, agent: "Breeze", args: args)
+                    {
+                        MinProtocolVersion = ProtocolVersion.ALT_PROTOCOL_VERSION
+                    };
                 }
                 else
                 {
-                    nodeSettings = new NodeSettings(networksSelector: Networks.Bitcoin, agent: agent, args: args);
+                    nodeSettings = new NodeSettings(networksSelector: Networks.Bitcoin, agent: "Breeze", args: args);
                 }
 
                 IFullNodeBuilder fullNodeBuilder = new FullNodeBuilder()
                     .UseNodeSettings(nodeSettings)
-                    .UseLightWallet()
                     .UseBlockStore()
                     .UsePosConsensus()
+                    .UseLightWallet()
                     .UseBlockNotification()
                     .UseTransactionNotification()
                     .UseApi();
 
                 IFullNode node = fullNodeBuilder.Build();
 
-                // Start Full Node - this will also start the API.
-                if (node != null)
-                    await node.RunAsync();
+                await node.RunAsync();
             }
             catch (Exception ex)
             {
-                Console.WriteLine("There was a problem initializing the node. Details: '{0}'", ex.ToString());
+                Console.WriteLine($"There was a problem initializing the node: '{ex.ToString()}'");
             }
         }
     }

--- a/src/Stratis.BreezeD/Program.cs
+++ b/src/Stratis.BreezeD/Program.cs
@@ -63,7 +63,7 @@ namespace Stratis.BreezeD
             }
             catch (Exception ex)
             {
-                Console.WriteLine($"There was a problem initializing the node: '{ex.ToString()}'");
+                Console.WriteLine($"There was a problem initializing the node: '{ex}'");
             }
         }
     }

--- a/src/Stratis.BreezeD/Program.cs
+++ b/src/Stratis.BreezeD/Program.cs
@@ -25,26 +25,37 @@ namespace Stratis.BreezeD
 
                 NodeSettings nodeSettings;
 
+                IFullNodeBuilder fullNodeBuilder = null;
+
                 if (isStratis)
                 {
                     nodeSettings = new NodeSettings(networksSelector: Networks.Stratis, protocolVersion: ProtocolVersion.PROVEN_HEADER_VERSION, agent: "Breeze", args: args)
                     {
                         MinProtocolVersion = ProtocolVersion.ALT_PROTOCOL_VERSION
                     };
+
+                    fullNodeBuilder = new FullNodeBuilder()
+                                    .UseNodeSettings(nodeSettings)
+                                    .UseBlockStore()
+                                    .UsePosConsensus()
+                                    .UseLightWallet()
+                                    .UseBlockNotification()
+                                    .UseTransactionNotification()
+                                    .UseApi();
                 }
                 else
                 {
                     nodeSettings = new NodeSettings(networksSelector: Networks.Bitcoin, agent: "Breeze", args: args);
-                }
 
-                IFullNodeBuilder fullNodeBuilder = new FullNodeBuilder()
-                    .UseNodeSettings(nodeSettings)
-                    .UseBlockStore()
-                    .UsePosConsensus()
-                    .UseLightWallet()
-                    .UseBlockNotification()
-                    .UseTransactionNotification()
-                    .UseApi();
+                    fullNodeBuilder = new FullNodeBuilder()
+                                    .UseNodeSettings(nodeSettings)
+                                    .UseBlockStore()
+                                    .UsePowConsensus()
+                                    .UseLightWallet()
+                                    .UseBlockNotification()
+                                    .UseTransactionNotification()
+                                    .UseApi();
+                }
 
                 IFullNode node = fullNodeBuilder.Build();
 

--- a/src/Stratis.BreezeD/Properties/launchSettings.json
+++ b/src/Stratis.BreezeD/Properties/launchSettings.json
@@ -14,7 +14,7 @@
     },
     "Stratis Test": {
       "commandName": "Project",
-      "commandLineArgs": "stratis -testnet -debug=all -loglevel=debug"
+      "commandLineArgs": "stratis -testnet -prune=2880"
     }
   }
 }


### PR DESCRIPTION
In this PR the node will now prune its database on startup and shut down.

An async loop will run that periodically deletes blocks from the block store. It will keep blocks up until 1000 blocks from the store tip.

On shutdown the database will be "compacted" so that all the deleted references are removed from the file and the database file re-saved.

On startup the node will check to see if its needs to be pruned (i.e. if the pruned tip is more than 1000 blocks from the store tip) if it is needed the database will be pruned and shrunk.

Some tests are still failing which I am looking at.

I have tested this extensively and the breeze wallet syncs fully.

The size of the DB after compactin is about 290kb.