### PR TITLE
Inline serialization of complex types for database transactions

### DIFF
--- a/src/Stratis.Bitcoin.Features.BlockStore.Tests/BlockRepositoryTest.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore.Tests/BlockRepositoryTest.cs
@@ -527,8 +527,7 @@ namespace Stratis.Bitcoin.Features.BlockStore.Tests
 
         private IBlockRepository SetupRepository(Network main, string dir)
         {
-            var dBreezeSerializer = new DBreezeSerializer();
-            dBreezeSerializer.Initialize(main);
+            var dBreezeSerializer = new DBreezeSerializer(main);
 
             var repository = new BlockRepository(main, dir, DateTimeProvider.Default, this.LoggerFactory.Object, dBreezeSerializer);
             repository.InitializeAsync().GetAwaiter().GetResult();

--- a/src/Stratis.Bitcoin.Features.BlockStore.Tests/BlockRepositoryTest.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore.Tests/BlockRepositoryTest.cs
@@ -527,7 +527,10 @@ namespace Stratis.Bitcoin.Features.BlockStore.Tests
 
         private IBlockRepository SetupRepository(Network main, string dir)
         {
-            var repository = new BlockRepository(main, dir, DateTimeProvider.Default, this.LoggerFactory.Object);
+            var dBreezeSerializer = new DBreezeSerializer();
+            dBreezeSerializer.Initialize(main);
+
+            var repository = new BlockRepository(main, dir, DateTimeProvider.Default, this.LoggerFactory.Object, dBreezeSerializer);
             repository.InitializeAsync().GetAwaiter().GetResult();
 
             return repository;

--- a/src/Stratis.Bitcoin.Features.BlockStore.Tests/BlockRepositoryTest.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore.Tests/BlockRepositoryTest.cs
@@ -24,10 +24,10 @@ namespace Stratis.Bitcoin.Features.BlockStore.Tests
             {
                 DBreeze.Transactions.Transaction transaction = engine.GetTransaction();
 
-                Row<byte[], HashHeightPair> blockRow = transaction.Select<byte[], HashHeightPair>("Common", new byte[0]);
+                Row<byte[], byte[]> blockRow = transaction.Select<byte[], byte[]>("Common", new byte[0]);
                 Row<byte[], bool> txIndexRow = transaction.Select<byte[], bool>("Common", new byte[1]);
 
-                Assert.Equal(this.Network.GetGenesis().GetHash(), blockRow.Value.Hash);
+                Assert.Equal(this.Network.GetGenesis().GetHash(), this.DBreezeSerializer.Deserialize<HashHeightPair>(blockRow.Value).Hash);
                 Assert.False(txIndexRow.Value);
             }
         }
@@ -41,8 +41,8 @@ namespace Stratis.Bitcoin.Features.BlockStore.Tests
             {
                 DBreeze.Transactions.Transaction transaction = engine.GetTransaction();
 
-                transaction.Insert<byte[], HashHeightPair>("Common", new byte[0], new HashHeightPair(new uint256(56), 1));
-                transaction.Insert<byte[], bool>("Common", new byte[1], true);
+                transaction.Insert<byte[], byte[]>("Common", new byte[0], this.DBreezeSerializer.Serialize(new HashHeightPair(new uint256(56), 1)));
+                transaction.Insert("Common", new byte[1], true);
                 transaction.Commit();
             }
 
@@ -54,10 +54,10 @@ namespace Stratis.Bitcoin.Features.BlockStore.Tests
             {
                 DBreeze.Transactions.Transaction transaction = engine.GetTransaction();
 
-                Row<byte[], HashHeightPair> blockRow = transaction.Select<byte[], HashHeightPair>("Common", new byte[0]);
+                Row<byte[], byte[]> blockRow = transaction.Select<byte[], byte[]>("Common", new byte[0]);
                 Row<byte[], bool> txIndexRow = transaction.Select<byte[], bool>("Common", new byte[1]);
 
-                Assert.Equal(new HashHeightPair(new uint256(56), 1), blockRow.Value);
+                Assert.Equal(new HashHeightPair(new uint256(56), 1), this.DBreezeSerializer.Deserialize<HashHeightPair>(blockRow.Value));
                 Assert.True(txIndexRow.Value);
             }
         }
@@ -71,7 +71,7 @@ namespace Stratis.Bitcoin.Features.BlockStore.Tests
             {
                 DBreeze.Transactions.Transaction transaction = engine.GetTransaction();
 
-                transaction.Insert<byte[], HashHeightPair>("Common", new byte[0], new HashHeightPair(uint256.Zero, 1));
+                transaction.Insert<byte[], byte[]>("Common", new byte[0], this.DBreezeSerializer.Serialize(new HashHeightPair(uint256.Zero, 1)));
                 transaction.Insert<byte[], bool>("Common", new byte[1], false);
                 transaction.Commit();
             }
@@ -94,7 +94,7 @@ namespace Stratis.Bitcoin.Features.BlockStore.Tests
             {
                 DBreeze.Transactions.Transaction transaction = engine.GetTransaction();
                 var blockId = new uint256(8920);
-                transaction.Insert<byte[], HashHeightPair>("Common", new byte[0], new HashHeightPair(uint256.Zero, 1));
+                transaction.Insert<byte[], byte[]>("Common", new byte[0], this.DBreezeSerializer.Serialize(new HashHeightPair(uint256.Zero, 1)));
                 transaction.Insert<byte[], bool>("Common", new byte[1], true);
                 transaction.Commit();
             }
@@ -124,7 +124,7 @@ namespace Stratis.Bitcoin.Features.BlockStore.Tests
                 DBreeze.Transactions.Transaction transaction = engine.GetTransaction();
                 transaction.Insert<byte[], byte[]>("Block", block.Header.GetHash().ToBytes(), block.ToBytes());
                 transaction.Insert<byte[], byte[]>("Transaction", trans.GetHash().ToBytes(), block.Header.GetHash().ToBytes());
-                transaction.Insert<byte[], HashHeightPair>("Common", new byte[0], new HashHeightPair(uint256.Zero, 1));
+                transaction.Insert<byte[], byte[]>("Common", new byte[0], this.DBreezeSerializer.Serialize(new HashHeightPair(uint256.Zero, 1)));
                 transaction.Insert<byte[], bool>("Common", new byte[1], true);
                 transaction.Commit();
             }
@@ -146,7 +146,7 @@ namespace Stratis.Bitcoin.Features.BlockStore.Tests
             using (var engine = new DBreezeEngine(dir))
             {
                 DBreeze.Transactions.Transaction transaction = engine.GetTransaction();
-                transaction.Insert<byte[], HashHeightPair>("Common", new byte[0], new HashHeightPair(uint256.Zero, 1));
+                transaction.Insert<byte[], byte[]>("Common", new byte[0], this.DBreezeSerializer.Serialize(new HashHeightPair(uint256.Zero, 1)));
                 transaction.Insert<byte[], bool>("Common", new byte[1], false);
                 transaction.Commit();
             }
@@ -168,7 +168,7 @@ namespace Stratis.Bitcoin.Features.BlockStore.Tests
             using (var engine = new DBreezeEngine(dir))
             {
                 DBreeze.Transactions.Transaction transaction = engine.GetTransaction();
-                transaction.Insert<byte[], HashHeightPair>("Common", new byte[0], new HashHeightPair(uint256.Zero, 1));
+                transaction.Insert<byte[], byte[]>("Common", new byte[0], this.DBreezeSerializer.Serialize(new HashHeightPair(uint256.Zero, 1)));
                 transaction.Insert<byte[], bool>("Common", new byte[1], true);
                 transaction.Commit();
             }
@@ -191,7 +191,7 @@ namespace Stratis.Bitcoin.Features.BlockStore.Tests
             {
                 DBreeze.Transactions.Transaction transaction = engine.GetTransaction();
                 transaction.Insert<byte[], byte[]>("Transaction", new uint256(26).ToBytes(), new uint256(42).ToBytes());
-                transaction.Insert<byte[], HashHeightPair>("Common", new byte[0], new HashHeightPair(uint256.Zero, 1));
+                transaction.Insert<byte[], byte[]>("Common", new byte[0], this.DBreezeSerializer.Serialize(new HashHeightPair(uint256.Zero, 1)));
                 transaction.Insert<byte[], bool>("Common", new byte[1], true);
                 transaction.Commit();
             }
@@ -232,7 +232,7 @@ namespace Stratis.Bitcoin.Features.BlockStore.Tests
             using (var engine = new DBreezeEngine(dir))
             {
                 DBreeze.Transactions.Transaction trans = engine.GetTransaction();
-                trans.Insert<byte[], HashHeightPair>("Common", new byte[0], new HashHeightPair(uint256.Zero, 1));
+                trans.Insert<byte[], byte[]>("Common", new byte[0], this.DBreezeSerializer.Serialize(new HashHeightPair(uint256.Zero, 1)));
                 trans.Insert<byte[], bool>("Common", new byte[1], true);
                 trans.Commit();
             }
@@ -247,11 +247,11 @@ namespace Stratis.Bitcoin.Features.BlockStore.Tests
             {
                 DBreeze.Transactions.Transaction trans = engine.GetTransaction();
 
-                Row<byte[], HashHeightPair> blockHashKeyRow = trans.Select<byte[], HashHeightPair>("Common", new byte[0]);
+                Row<byte[], byte[]> blockHashKeyRow = trans.Select<byte[], byte[]>("Common", new byte[0]);
                 Dictionary<byte[], byte[]> blockDict = trans.SelectDictionary<byte[], byte[]>("Block");
                 Dictionary<byte[], byte[]> transDict = trans.SelectDictionary<byte[], byte[]>("Transaction");
 
-                Assert.Equal(new HashHeightPair(nextBlockHash, 100), blockHashKeyRow.Value);
+                Assert.Equal(new HashHeightPair(nextBlockHash, 100), this.DBreezeSerializer.Deserialize<HashHeightPair>(blockHashKeyRow.Value));
                 Assert.Equal(2, blockDict.Count);
                 Assert.Equal(3, transDict.Count);
 
@@ -427,11 +427,11 @@ namespace Stratis.Bitcoin.Features.BlockStore.Tests
             {
                 DBreeze.Transactions.Transaction trans = engine.GetTransaction();
 
-                Row<byte[], HashHeightPair> blockHashKeyRow = trans.Select<byte[], HashHeightPair>("Common", new byte[0]);
+                Row<byte[], byte[]> blockHashKeyRow = trans.Select<byte[], byte[]>("Common", new byte[0]);
                 Dictionary<byte[], byte[]> blockDict = trans.SelectDictionary<byte[], byte[]>("Block");
                 Dictionary<byte[], byte[]> transDict = trans.SelectDictionary<byte[], byte[]>("Transaction");
 
-                Assert.Equal(tip, blockHashKeyRow.Value);
+                Assert.Equal(tip, this.DBreezeSerializer.Deserialize<HashHeightPair>(blockHashKeyRow.Value));
                 Assert.Empty(blockDict);
                 Assert.Empty(transDict);
             }
@@ -467,12 +467,12 @@ namespace Stratis.Bitcoin.Features.BlockStore.Tests
             using (var engine = new DBreezeEngine(dir))
             {
                 DBreeze.Transactions.Transaction dbreezeTransaction = engine.GetTransaction();
-                Dictionary<byte[], Block> blockDict = dbreezeTransaction.SelectDictionary<byte[], Block>("Block");
+                Dictionary<byte[], byte[]> blockDict = dbreezeTransaction.SelectDictionary<byte[], byte[]>("Block");
                 Dictionary<byte[], byte[]> transDict = dbreezeTransaction.SelectDictionary<byte[], byte[]>("Transaction");
 
                 // Block stored as expected.
                 Assert.Single(blockDict);
-                Assert.Equal(block.GetHash(), blockDict.FirstOrDefault().Value.GetHash());
+                Assert.Equal(block.GetHash(), this.DBreezeSerializer.Deserialize<Block>(blockDict.FirstOrDefault().Value).GetHash());
 
                 // Transaction row in database stored as expected.
                 Assert.Single(transDict);
@@ -513,12 +513,12 @@ namespace Stratis.Bitcoin.Features.BlockStore.Tests
             using (var engine = new DBreezeEngine(dir))
             {
                 DBreeze.Transactions.Transaction dbreezeTransaction = engine.GetTransaction();
-                Dictionary<byte[], Block> blockDict = dbreezeTransaction.SelectDictionary<byte[], Block>("Block");
+                Dictionary<byte[], byte[]> blockDict = dbreezeTransaction.SelectDictionary<byte[], byte[]>("Block");
                 Dictionary<byte[], byte[]> transDict = dbreezeTransaction.SelectDictionary<byte[], byte[]>("Transaction");
 
                 // Block still stored as expected.
                 Assert.Single(blockDict);
-                Assert.Equal(block.GetHash(), blockDict.FirstOrDefault().Value.GetHash());
+                Assert.Equal(block.GetHash(), this.DBreezeSerializer.Deserialize<Block>(blockDict.FirstOrDefault().Value).GetHash());
 
                 // No transactions indexed.
                 Assert.Empty(transDict);

--- a/src/Stratis.Bitcoin.Features.BlockStore.Tests/BlockStoreTests.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore.Tests/BlockStoreTests.cs
@@ -9,7 +9,6 @@ using NBitcoin.DataEncoders;
 using Stratis.Bitcoin.Base;
 using Stratis.Bitcoin.Configuration;
 using Stratis.Bitcoin.Interfaces;
-using Stratis.Bitcoin.Networks;
 using Stratis.Bitcoin.Primitives;
 using Stratis.Bitcoin.Tests.Common;
 using Stratis.Bitcoin.Utilities;
@@ -40,9 +39,6 @@ namespace Stratis.Bitcoin.Features.BlockStore.Tests
         {
             this.network = KnownNetworks.StratisMain;
             this.repositoryTipHashAndHeight = new HashHeightPair(this.network.GenesisHash, 0);
-
-            var serializer = new DBreezeSerializer();
-            serializer.Initialize(new StratisMain());
 
             this.random = new Random();
 

--- a/src/Stratis.Bitcoin.Features.BlockStore/BlockRepository.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/BlockRepository.cs
@@ -170,7 +170,7 @@ namespace Stratis.Bitcoin.Features.BlockStore
 
                     if (blockRow.Exists)
                     {
-                        var block = this.dBreezeSerializer.Deserializer<Block>(blockRow.Value);
+                        var block = this.dBreezeSerializer.Deserialize<Block>(blockRow.Value);
                         res = block.Transactions.FirstOrDefault(t => t.GetHash() == trxid);
                     }
                 }
@@ -276,7 +276,7 @@ namespace Stratis.Bitcoin.Features.BlockStore
                         IEnumerable<Row<byte[], byte[]>> blockRows = dbreezeTransaction.SelectForward<byte[], byte[]>(BlockTableName);
                         foreach (Row<byte[], byte[]> blockRow in blockRows)
                         {
-                            var block = this.dBreezeSerializer.Deserializer<Block>(blockRow.Value);
+                            var block = this.dBreezeSerializer.Deserialize<Block>(blockRow.Value);
                             foreach (Transaction transaction in block.Transactions)
                             {
                                 dbreezeTransaction.Insert<byte[], byte[]>(TransactionTableName, transaction.GetHash().ToBytes(), block.GetHash().ToBytes());
@@ -364,7 +364,7 @@ namespace Stratis.Bitcoin.Features.BlockStore
 
                 Row<byte[], byte[]> row = dbreezeTransaction.Select<byte[], byte[]>(CommonTableName, RepositoryTipKey);
                 if (row.Exists)
-                    this.TipHashAndHeight = this.dBreezeSerializer.Deserializer<HashHeightPair>(row.Value);
+                    this.TipHashAndHeight = this.dBreezeSerializer.Deserialize<HashHeightPair>(row.Value);
 
                 dbreezeTransaction.ValuesLazyLoadingIsOn = true;
             }
@@ -393,7 +393,7 @@ namespace Stratis.Bitcoin.Features.BlockStore
                     byte[] key = hash.ToBytes();
                     Row<byte[], byte[]> blockRow = transaction.Select<byte[], byte[]>(BlockTableName, key);
                     if (blockRow.Exists)
-                        res = this.dBreezeSerializer.Deserializer<Block>(blockRow.Value);
+                        res = this.dBreezeSerializer.Deserialize<Block>(blockRow.Value);
                 }
 
                 // If searching for genesis block, return it.
@@ -491,7 +491,7 @@ namespace Stratis.Bitcoin.Features.BlockStore
                 Row<byte[], byte[]> blockRow = dbreezeTransaction.Select<byte[], byte[]>(BlockTableName, key.Item2);
                 if (blockRow.Exists)
                 {
-                    results[key.Item1] = this.dBreezeSerializer.Deserializer<Block>(blockRow.Value);
+                    results[key.Item1] = this.dBreezeSerializer.Deserialize<Block>(blockRow.Value);
 
                     this.logger.LogTrace("Block hash '{0}' loaded from the store.", key.Item1);
                 }

--- a/src/Stratis.Bitcoin.Features.BlockStore/BlockRepository.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/BlockRepository.cs
@@ -237,7 +237,7 @@ namespace Stratis.Bitcoin.Features.BlockStore
                 Row<byte[], byte[]> blockRow = dbreezeTransaction.Select<byte[], byte[]>(BlockTableName, blockId.ToBytes());
                 if (!blockRow.Exists)
                 {
-                    dbreezeTransaction.Insert<byte[], byte[]>(BlockTableName, blockId.ToBytes(), this.dBreezeSerializer.Serializer(block));
+                    dbreezeTransaction.Insert<byte[], byte[]>(BlockTableName, blockId.ToBytes(), this.dBreezeSerializer.Serialize(block));
 
                     if (this.TxIndex)
                     {
@@ -375,7 +375,7 @@ namespace Stratis.Bitcoin.Features.BlockStore
         private void SaveTipHashAndHeight(DBreeze.Transactions.Transaction dbreezeTransaction, HashHeightPair newTip)
         {
             this.TipHashAndHeight = newTip;
-            dbreezeTransaction.Insert(CommonTableName, RepositoryTipKey, this.dBreezeSerializer.Serializer(newTip));
+            dbreezeTransaction.Insert(CommonTableName, RepositoryTipKey, this.dBreezeSerializer.Serialize(newTip));
         }
 
         /// <inheritdoc />

--- a/src/Stratis.Bitcoin.Features.BlockStore/BlockRepository.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/BlockRepository.cs
@@ -91,12 +91,16 @@ namespace Stratis.Bitcoin.Features.BlockStore
         /// <summary>Provider of time functions.</summary>
         private readonly IDateTimeProvider dateTimeProvider;
 
-        public BlockRepository(Network network, DataFolder dataFolder, IDateTimeProvider dateTimeProvider, ILoggerFactory loggerFactory)
-            : this(network, dataFolder.BlockPath, dateTimeProvider, loggerFactory)
+        private readonly DBreezeSerializer dBreezeSerializer;
+
+        public BlockRepository(Network network, DataFolder dataFolder, IDateTimeProvider dateTimeProvider,
+            ILoggerFactory loggerFactory, DBreezeSerializer dBreezeSerializer)
+            : this(network, dataFolder.BlockPath, dateTimeProvider, loggerFactory, dBreezeSerializer)
         {
         }
 
-        public BlockRepository(Network network, string folder, IDateTimeProvider dateTimeProvider, ILoggerFactory loggerFactory)
+        public BlockRepository(Network network, string folder, IDateTimeProvider dateTimeProvider,
+            ILoggerFactory loggerFactory, DBreezeSerializer dBreezeSerializer)
         {
             Guard.NotNull(network, nameof(network));
             Guard.NotEmpty(folder, nameof(folder));
@@ -107,6 +111,7 @@ namespace Stratis.Bitcoin.Features.BlockStore
             this.DBreeze = new DBreezeEngine(folder);
             this.network = network;
             this.dateTimeProvider = dateTimeProvider;
+            this.dBreezeSerializer = dBreezeSerializer;
         }
 
         /// <inheritdoc />
@@ -154,16 +159,20 @@ namespace Stratis.Bitcoin.Features.BlockStore
                 {
                     transaction.ValuesLazyLoadingIsOn = false;
 
-                    Row<byte[], uint256> transactionRow = transaction.Select<byte[], uint256>(TransactionTableName, trxid.ToBytes());
+                    Row<byte[], byte[]> transactionRow = transaction.Select<byte[], byte[]>(TransactionTableName, trxid.ToBytes());
                     if (!transactionRow.Exists)
                     {
                         this.logger.LogTrace("(-)[NO_BLOCK]:null");
                         return null;
                     }
 
-                    Row<byte[], Block> blockRow = transaction.Select<byte[], Block>(BlockTableName, transactionRow.Value.ToBytes());
+                    Row<byte[], byte[]> blockRow = transaction.Select<byte[], byte[]>(BlockTableName, transactionRow.Value);
+
                     if (blockRow.Exists)
-                        res = blockRow.Value.Transactions.FirstOrDefault(t => t.GetHash() == trxid);
+                    {
+                        var block = this.dBreezeSerializer.Deserializer<Block>(blockRow.Value);
+                        res = block.Transactions.FirstOrDefault(t => t.GetHash() == trxid);
+                    }
                 }
 
                 return res;
@@ -190,9 +199,9 @@ namespace Stratis.Bitcoin.Features.BlockStore
                 {
                     transaction.ValuesLazyLoadingIsOn = false;
 
-                    Row<byte[], uint256> transactionRow = transaction.Select<byte[], uint256>(TransactionTableName, trxid.ToBytes());
+                    Row<byte[], byte[]> transactionRow = transaction.Select<byte[], byte[]>(TransactionTableName, trxid.ToBytes());
                     if (transactionRow.Exists)
-                        res = transactionRow.Value;
+                        res = new uint256(transactionRow.Value);
                 }
 
                 return res;
@@ -225,10 +234,10 @@ namespace Stratis.Bitcoin.Features.BlockStore
                 Block block = kv.Value;
 
                 // If the block is already in store don't write it again.
-                Row<byte[], Block> blockRow = dbreezeTransaction.Select<byte[], Block>(BlockTableName, blockId.ToBytes());
+                Row<byte[], byte[]> blockRow = dbreezeTransaction.Select<byte[], byte[]>(BlockTableName, blockId.ToBytes());
                 if (!blockRow.Exists)
                 {
-                    dbreezeTransaction.Insert<byte[], Block>(BlockTableName, blockId.ToBytes(), block);
+                    dbreezeTransaction.Insert<byte[], byte[]>(BlockTableName, blockId.ToBytes(), this.dBreezeSerializer.Serializer(block));
 
                     if (this.TxIndex)
                     {
@@ -249,7 +258,7 @@ namespace Stratis.Bitcoin.Features.BlockStore
 
             // Index transactions.
             foreach ((Transaction transaction, Block block) in transactions)
-                dbreezeTransaction.Insert<byte[], uint256>(TransactionTableName, transaction.GetHash().ToBytes(), block.GetHash());
+                dbreezeTransaction.Insert(TransactionTableName, transaction.GetHash().ToBytes(), block.GetHash().ToBytes());
         }
 
         /// <inheritdoc />
@@ -264,12 +273,13 @@ namespace Stratis.Bitcoin.Features.BlockStore
                     if (this.TxIndex)
                     {
                         // Insert transactions to database.
-                        IEnumerable<Row<byte[], Block>> blockRows = dbreezeTransaction.SelectForward<byte[], Block>(BlockTableName);
-                        foreach (Row<byte[], Block> blockRow in blockRows)
+                        IEnumerable<Row<byte[], byte[]>> blockRows = dbreezeTransaction.SelectForward<byte[], byte[]>(BlockTableName);
+                        foreach (Row<byte[], byte[]> blockRow in blockRows)
                         {
-                            foreach (Transaction transaction in blockRow.Value.Transactions)
+                            var block = this.dBreezeSerializer.Deserializer<Block>(blockRow.Value);
+                            foreach (Transaction transaction in block.Transactions)
                             {
-                                dbreezeTransaction.Insert<byte[], uint256>(TransactionTableName, transaction.GetHash().ToBytes(), blockRow.Value.GetHash());
+                                dbreezeTransaction.Insert<byte[], byte[]>(TransactionTableName, transaction.GetHash().ToBytes(), block.GetHash().ToBytes());
                             }
                         }
                     }
@@ -352,9 +362,9 @@ namespace Stratis.Bitcoin.Features.BlockStore
             {
                 dbreezeTransaction.ValuesLazyLoadingIsOn = false;
 
-                Row<byte[], HashHeightPair> row = dbreezeTransaction.Select<byte[], HashHeightPair>(CommonTableName, RepositoryTipKey);
+                Row<byte[], byte[]> row = dbreezeTransaction.Select<byte[], byte[]>(CommonTableName, RepositoryTipKey);
                 if (row.Exists)
-                    this.TipHashAndHeight = row.Value;
+                    this.TipHashAndHeight = this.dBreezeSerializer.Deserializer<HashHeightPair>(row.Value);
 
                 dbreezeTransaction.ValuesLazyLoadingIsOn = true;
             }
@@ -365,7 +375,7 @@ namespace Stratis.Bitcoin.Features.BlockStore
         private void SaveTipHashAndHeight(DBreeze.Transactions.Transaction dbreezeTransaction, HashHeightPair newTip)
         {
             this.TipHashAndHeight = newTip;
-            dbreezeTransaction.Insert<byte[], HashHeightPair>(CommonTableName, RepositoryTipKey, this.TipHashAndHeight);
+            dbreezeTransaction.Insert(CommonTableName, RepositoryTipKey, this.dBreezeSerializer.Serializer(newTip));
         }
 
         /// <inheritdoc />
@@ -381,9 +391,9 @@ namespace Stratis.Bitcoin.Features.BlockStore
                     transaction.ValuesLazyLoadingIsOn = false;
 
                     byte[] key = hash.ToBytes();
-                    Row<byte[], Block> blockRow = transaction.Select<byte[], Block>(BlockTableName, key);
+                    Row<byte[], byte[]> blockRow = transaction.Select<byte[], byte[]>(BlockTableName, key);
                     if (blockRow.Exists)
-                        res = blockRow.Value;
+                        res = this.dBreezeSerializer.Deserializer<Block>(blockRow.Value);
                 }
 
                 // If searching for genesis block, return it.
@@ -432,7 +442,7 @@ namespace Stratis.Bitcoin.Features.BlockStore
                 {
                     // Lazy loading is on so we don't fetch the whole value, just the row.
                     byte[] key = hash.ToBytes();
-                    Row<byte[], Block> blockRow = transaction.Select<byte[], Block>("Block", key);
+                    Row<byte[], byte[]> blockRow = transaction.Select<byte[], byte[]>("Block", key);
                     if (blockRow.Exists)
                         res = true;
                 }
@@ -478,10 +488,10 @@ namespace Stratis.Bitcoin.Features.BlockStore
 
             foreach ((uint256, byte[]) key in keys)
             {
-                Row<byte[], Block> blockRow = dbreezeTransaction.Select<byte[], Block>(BlockTableName, key.Item2);
+                Row<byte[], byte[]> blockRow = dbreezeTransaction.Select<byte[], byte[]>(BlockTableName, key.Item2);
                 if (blockRow.Exists)
                 {
-                    results[key.Item1] = blockRow.Value;
+                    results[key.Item1] = this.dBreezeSerializer.Deserializer<Block>(blockRow.Value);
 
                     this.logger.LogTrace("Block hash '{0}' loaded from the store.", key.Item1);
                 }

--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/ProvenBlockHeaders/ProvenBlockHeaderRepositoryTests.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/ProvenBlockHeaders/ProvenBlockHeaderRepositoryTests.cs
@@ -64,8 +64,8 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.ProvenBlockHeaders
                 txn.SynchronizeTables(ProvenBlockHeaderTable);
                 txn.ValuesLazyLoadingIsOn = false;
 
-                var headerOut = txn.Select<byte[], ProvenBlockHeader>(ProvenBlockHeaderTable, blockHashHeightPair.Height.ToBytes()).Value;
-                var hashHeightPairOut = txn.Select<byte[], HashHeightPair>(BlockHashTable, new byte[0].ToBytes()).Value;
+                var headerOut = this.dBreezeSerializer.Deserialize<ProvenBlockHeader>(txn.Select<byte[], byte[]>(ProvenBlockHeaderTable, blockHashHeightPair.Height.ToBytes()).Value);
+                var hashHeightPairOut = this.DBreezeSerializer.Deserialize<HashHeightPair>(txn.Select<byte[], byte[]>(BlockHashTable, new byte[0].ToBytes()).Value);
 
                 headerOut.Should().NotBeNull();
                 headerOut.GetHash().Should().Be(provenBlockHeaderIn.GetHash());
@@ -99,11 +99,11 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.ProvenBlockHeaders
                 txn.SynchronizeTables(ProvenBlockHeaderTable);
                 txn.ValuesLazyLoadingIsOn = false;
 
-                var headersOut = txn.SelectDictionary<byte[], ProvenBlockHeader>(ProvenBlockHeaderTable);
+                var headersOut = txn.SelectDictionary<byte[], byte[]>(ProvenBlockHeaderTable);
 
                 headersOut.Keys.Count.Should().Be(2);
-                headersOut.First().Value.GetHash().Should().Be(items[0].GetHash());
-                headersOut.Last().Value.GetHash().Should().Be(items[1].GetHash());
+                this.dBreezeSerializer.Deserialize<ProvenBlockHeader>(headersOut.First().Value).GetHash().Should().Be(items[0].GetHash());
+                this.dBreezeSerializer.Deserialize<ProvenBlockHeader>(headersOut.Last().Value).GetHash().Should().Be(items[1].GetHash());
             }
         }
 
@@ -119,7 +119,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.ProvenBlockHeaders
             using (var engine = new DBreezeEngine(folder))
             {
                 DBreeze.Transactions.Transaction txn = engine.GetTransaction();
-                txn.Insert<byte[], ProvenBlockHeader>(ProvenBlockHeaderTable, blockHeight.ToBytes(), headerIn);
+                txn.Insert<byte[], byte[]>(ProvenBlockHeaderTable, blockHeight.ToBytes(), this.dBreezeSerializer.Serialize(headerIn));
                 txn.Commit();
             }
 
@@ -141,8 +141,8 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.ProvenBlockHeaders
             using (var engine = new DBreezeEngine(folder))
             {
                 DBreeze.Transactions.Transaction txn = engine.GetTransaction();
-                txn.Insert<byte[], ProvenBlockHeader>(ProvenBlockHeaderTable, 1.ToBytes(), CreateNewProvenBlockHeaderMock());
-                txn.Insert<byte[], HashHeightPair>(BlockHashTable, new byte[0], new HashHeightPair(new uint256(), 1));
+                txn.Insert<byte[], byte[]>(ProvenBlockHeaderTable, 1.ToBytes(), this.dBreezeSerializer.Serialize(CreateNewProvenBlockHeaderMock()));
+                txn.Insert<byte[], byte[]>(BlockHashTable, new byte[0], this.DBreezeSerializer.Serialize(new HashHeightPair(new uint256(), 1)));
                 txn.Commit();
             }
 

--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/ProvenBlockHeaders/ProvenBlockHeaderRepositoryTests.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/ProvenBlockHeaders/ProvenBlockHeaderRepositoryTests.cs
@@ -19,12 +19,15 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.ProvenBlockHeaders
     public class ProvenBlockHeaderRepositoryTests : LogsTestBase
     {
         private readonly Mock<ILoggerFactory> loggerFactory;
+        private readonly DBreezeSerializer dBreezeSerializer;
         private const string ProvenBlockHeaderTable = "ProvenBlockHeader";
         private const string BlockHashTable = "BlockHashHeight";
 
         public ProvenBlockHeaderRepositoryTests() : base(KnownNetworks.StratisTest)
         {
             this.loggerFactory = new Mock<ILoggerFactory>();
+            this.dBreezeSerializer = new DBreezeSerializer();
+            this.dBreezeSerializer.Initialize(this.Network);
         }
 
         [Fact]
@@ -184,7 +187,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.ProvenBlockHeaders
 
         private ProvenBlockHeaderRepository SetupRepository(Network network, string folder)
         {
-            var repo = new ProvenBlockHeaderRepository(network, folder, this.LoggerFactory.Object);
+            var repo = new ProvenBlockHeaderRepository(network, folder, this.LoggerFactory.Object, this.dBreezeSerializer);
 
             Task task = repo.InitializeAsync();
 

--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/ProvenBlockHeaders/ProvenBlockHeaderRepositoryTests.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/ProvenBlockHeaders/ProvenBlockHeaderRepositoryTests.cs
@@ -26,8 +26,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.ProvenBlockHeaders
         public ProvenBlockHeaderRepositoryTests() : base(KnownNetworks.StratisTest)
         {
             this.loggerFactory = new Mock<ILoggerFactory>();
-            this.dBreezeSerializer = new DBreezeSerializer();
-            this.dBreezeSerializer.Initialize(this.Network);
+            this.dBreezeSerializer = new DBreezeSerializer(this.Network);
         }
 
         [Fact]

--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/ProvenBlockHeaders/ProvenBlockHeaderStoreTests.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/ProvenBlockHeaders/ProvenBlockHeaderStoreTests.cs
@@ -25,8 +25,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.ProvenBlockHeaders
         {
             var nodeStats = new NodeStats(DateTimeProvider.Default);
 
-            var dBreezeSerializer = new DBreezeSerializer();
-            dBreezeSerializer.Initialize(this.Network);
+            var dBreezeSerializer = new DBreezeSerializer(this.Network);
 
             this.provenBlockHeaderRepository = new ProvenBlockHeaderRepository(this.Network, CreateTestDir(this), this.LoggerFactory.Object, dBreezeSerializer);
 

--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/ProvenBlockHeaders/ProvenBlockHeaderStoreTests.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/ProvenBlockHeaders/ProvenBlockHeaderStoreTests.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
@@ -26,7 +25,10 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.ProvenBlockHeaders
         {
             var nodeStats = new NodeStats(DateTimeProvider.Default);
 
-            this.provenBlockHeaderRepository = new ProvenBlockHeaderRepository(this.Network, CreateTestDir(this), this.LoggerFactory.Object);
+            var dBreezeSerializer = new DBreezeSerializer();
+            dBreezeSerializer.Initialize(this.Network);
+
+            this.provenBlockHeaderRepository = new ProvenBlockHeaderRepository(this.Network, CreateTestDir(this), this.LoggerFactory.Object, dBreezeSerializer);
 
             this.provenBlockHeaderStore = new ProvenBlockHeaderStore(DateTimeProvider.Default, this.LoggerFactory.Object, this.provenBlockHeaderRepository, nodeStats);
         }

--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/TestChainFactory.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/TestChainFactory.cs
@@ -136,8 +136,8 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests
             testChainContext.PartialValidator = new PartialValidator(testChainContext.ConsensusRules, testChainContext.LoggerFactory);
             testChainContext.FullValidator = new FullValidator(testChainContext.ConsensusRules, testChainContext.LoggerFactory);
 
-            var dBreezeSerializer = new DBreezeSerializer();
-            dBreezeSerializer.Initialize(network);
+            var dBreezeSerializer = new DBreezeSerializer(network);
+
             var blockRepository = new BlockRepository(testChainContext.Network, dataFolder, testChainContext.DateTimeProvider, testChainContext.LoggerFactory, dBreezeSerializer);
 
             var blockStoreFlushCondition = new BlockStoreQueueFlushCondition(testChainContext.ChainState, testChainContext.InitialBlockDownloadState);

--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/TestChainFactory.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/TestChainFactory.cs
@@ -136,7 +136,9 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests
             testChainContext.PartialValidator = new PartialValidator(testChainContext.ConsensusRules, testChainContext.LoggerFactory);
             testChainContext.FullValidator = new FullValidator(testChainContext.ConsensusRules, testChainContext.LoggerFactory);
 
-            var blockRepository = new BlockRepository(testChainContext.Network, dataFolder, testChainContext.DateTimeProvider, testChainContext.LoggerFactory);
+            var dBreezeSerializer = new DBreezeSerializer();
+            dBreezeSerializer.Initialize(network);
+            var blockRepository = new BlockRepository(testChainContext.Network, dataFolder, testChainContext.DateTimeProvider, testChainContext.LoggerFactory, dBreezeSerializer);
 
             var blockStoreFlushCondition = new BlockStoreQueueFlushCondition(testChainContext.ChainState, testChainContext.InitialBlockDownloadState);
 

--- a/src/Stratis.Bitcoin.Features.Consensus/CoinViews/DBreezeCoinView.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/CoinViews/DBreezeCoinView.cs
@@ -50,7 +50,7 @@ namespace Stratis.Bitcoin.Features.Consensus.CoinViews
         /// <param name="dateTimeProvider">Provider of time functions.</param>
         /// <param name="loggerFactory">Factory to be used to create logger for the puller.</param>
         /// <param name="nodeStats"></param>
-        /// <param name="dBreezeSerializer1"></param>
+        /// <param name="dBreezeSerializer">The serializer to use for <see cref="IBitcoinSerializable"/> objects.</param>
         public DBreezeCoinView(Network network, DataFolder dataFolder, IDateTimeProvider dateTimeProvider,
             ILoggerFactory loggerFactory, INodeStats nodeStats, DBreezeSerializer dBreezeSerializer)
             : this(network, dataFolder.CoinViewPath, dateTimeProvider, loggerFactory, nodeStats, dBreezeSerializer)
@@ -65,7 +65,7 @@ namespace Stratis.Bitcoin.Features.Consensus.CoinViews
         /// <param name="dateTimeProvider">Provider of time functions.</param>
         /// <param name="loggerFactory">Factory to be used to create logger for the puller.</param>
         /// <param name="nodeStats"></param>
-        /// <param name="dBreezeSerializer1"></param>
+        /// <param name="dBreezeSerializer">The serializer to use for <see cref="IBitcoinSerializable"/> objects.</param>
         public DBreezeCoinView(Network network, string folder, IDateTimeProvider dateTimeProvider,
             ILoggerFactory loggerFactory, INodeStats nodeStats, DBreezeSerializer dBreezeSerializer)
         {

--- a/src/Stratis.Bitcoin.Features.Consensus/CoinViews/DBreezeCoinView.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/CoinViews/DBreezeCoinView.cs
@@ -250,7 +250,7 @@ namespace Stratis.Bitcoin.Features.Consensus.CoinViews
                             var coin = toInsert[i];
                             this.logger.LogTrace("Outputs of transaction ID '{0}' are NOT PRUNABLE and will be inserted into the database. {1}/{2}.", coin.TransactionId, i, toInsert.Count);
 
-                            transaction.Insert("Coins", coin.TransactionId.ToBytes(false), this.dBreezeSerializer.Serializer(coin.ToCoins()));
+                            transaction.Insert("Coins", coin.TransactionId.ToBytes(false), this.dBreezeSerializer.Serialize(coin.ToCoins()));
                         }
 
                         if (rewindDataList != null)
@@ -260,7 +260,7 @@ namespace Stratis.Bitcoin.Features.Consensus.CoinViews
                             {
                                 this.logger.LogTrace("Rewind state #{0} created.", nextRewindIndex);
 
-                                transaction.Insert("Rewind", nextRewindIndex, this.dBreezeSerializer.Serializer(rewindData));
+                                transaction.Insert("Rewind", nextRewindIndex, this.dBreezeSerializer.Serialize(rewindData));
                                 nextRewindIndex++;
                             }
                         }
@@ -352,7 +352,7 @@ namespace Stratis.Bitcoin.Features.Consensus.CoinViews
                         foreach (UnspentOutputs coin in rewindData.OutputsToRestore)
                         {
                             this.logger.LogTrace("Outputs of transaction ID '{0}' will be restored.", coin.TransactionId);
-                            transaction.Insert("Coins", coin.TransactionId.ToBytes(false), this.dBreezeSerializer.Serializer(coin.ToCoins()));
+                            transaction.Insert("Coins", coin.TransactionId.ToBytes(false), this.dBreezeSerializer.Serialize(coin.ToCoins()));
                         }
 
                         res = rewindData.PreviousBlockHash;
@@ -397,7 +397,7 @@ namespace Stratis.Bitcoin.Features.Consensus.CoinViews
             {
                 if (!stakeEntry.InStore)
                 {
-                    transaction.Insert("Stake", stakeEntry.BlockId.ToBytes(false), this.dBreezeSerializer.Serializer(stakeEntry.BlockStake));
+                    transaction.Insert("Stake", stakeEntry.BlockId.ToBytes(false), this.dBreezeSerializer.Serialize(stakeEntry.BlockStake));
                     stakeEntry.InStore = true;
                 }
             }

--- a/src/Stratis.Bitcoin.Features.Consensus/CoinViews/DBreezeCoinView.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/CoinViews/DBreezeCoinView.cs
@@ -153,7 +153,7 @@ namespace Stratis.Bitcoin.Features.Consensus.CoinViews
                         foreach (uint256 input in txIds)
                         {
                             Row<byte[], byte[]> row = transaction.Select<byte[], byte[]>("Coins", input.ToBytes(false));
-                            UnspentOutputs outputs = row.Exists ? new UnspentOutputs(input, this.dBreezeSerializer.Deserializer<Coins>(row.Value)) : null;
+                            UnspentOutputs outputs = row.Exists ? new UnspentOutputs(input, this.dBreezeSerializer.Deserialize<Coins>(row.Value)) : null;
 
                             this.logger.LogTrace("Outputs for '{0}' were {1}.", input, outputs == null ? "NOT loaded" : "loaded");
 
@@ -311,7 +311,7 @@ namespace Stratis.Bitcoin.Features.Consensus.CoinViews
                 {
                     transaction.SynchronizeTables("BlockHash", "Coins", "Rewind");
                     Row<int, byte[]> row = transaction.Select<int, byte[]>("Rewind", height);
-                    return row.Exists ? this.dBreezeSerializer.Deserializer<RewindData>(row.Value) : null;
+                    return row.Exists ? this.dBreezeSerializer.Deserialize<RewindData>(row.Value) : null;
                 }
             });
 
@@ -340,7 +340,7 @@ namespace Stratis.Bitcoin.Features.Consensus.CoinViews
 
                         Row<int, byte[]> firstRow = transaction.SelectBackward<int, byte[]>("Rewind").FirstOrDefault();
                         transaction.RemoveKey("Rewind", firstRow.Key);
-                        var rewindData = this.dBreezeSerializer.Deserializer<RewindData>(firstRow.Value);
+                        var rewindData = this.dBreezeSerializer.Deserialize<RewindData>(firstRow.Value);
                         this.SetBlockHash(transaction, rewindData.PreviousBlockHash);
 
                         foreach (uint256 txId in rewindData.TransactionsToRemove)
@@ -423,7 +423,7 @@ namespace Stratis.Bitcoin.Features.Consensus.CoinViews
 
                         if (stakeRow.Exists)
                         {
-                            blockStake.BlockStake = this.dBreezeSerializer.Deserializer<BlockStake>(stakeRow.Value);
+                            blockStake.BlockStake = this.dBreezeSerializer.Deserialize<BlockStake>(stakeRow.Value);
                             blockStake.InStore = true;
                         }
                     }

--- a/src/Stratis.Bitcoin.Features.Consensus/CoinViews/DBreezeCoinView.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/CoinViews/DBreezeCoinView.cs
@@ -40,6 +40,8 @@ namespace Stratis.Bitcoin.Features.Consensus.CoinViews
         /// <summary>Access to dBreeze database.</summary>
         private readonly DBreezeEngine dBreeze;
 
+        private DBreezeSerializer dBreezeSerializer;
+
         /// <summary>
         /// Initializes a new instance of the object.
         /// </summary>
@@ -47,8 +49,11 @@ namespace Stratis.Bitcoin.Features.Consensus.CoinViews
         /// <param name="dataFolder">Information about path locations to important folders and files on disk.</param>
         /// <param name="dateTimeProvider">Provider of time functions.</param>
         /// <param name="loggerFactory">Factory to be used to create logger for the puller.</param>
-        public DBreezeCoinView(Network network, DataFolder dataFolder, IDateTimeProvider dateTimeProvider, ILoggerFactory loggerFactory, INodeStats nodeStats)
-            : this(network, dataFolder.CoinViewPath, dateTimeProvider, loggerFactory, nodeStats)
+        /// <param name="nodeStats"></param>
+        /// <param name="dBreezeSerializer1"></param>
+        public DBreezeCoinView(Network network, DataFolder dataFolder, IDateTimeProvider dateTimeProvider,
+            ILoggerFactory loggerFactory, INodeStats nodeStats, DBreezeSerializer dBreezeSerializer)
+            : this(network, dataFolder.CoinViewPath, dateTimeProvider, loggerFactory, nodeStats, dBreezeSerializer)
         {
         }
 
@@ -59,10 +64,15 @@ namespace Stratis.Bitcoin.Features.Consensus.CoinViews
         /// <param name="folder">Path to the folder with coinview database files.</param>
         /// <param name="dateTimeProvider">Provider of time functions.</param>
         /// <param name="loggerFactory">Factory to be used to create logger for the puller.</param>
-        public DBreezeCoinView(Network network, string folder, IDateTimeProvider dateTimeProvider, ILoggerFactory loggerFactory, INodeStats nodeStats)
+        /// <param name="nodeStats"></param>
+        /// <param name="dBreezeSerializer1"></param>
+        public DBreezeCoinView(Network network, string folder, IDateTimeProvider dateTimeProvider,
+            ILoggerFactory loggerFactory, INodeStats nodeStats, DBreezeSerializer dBreezeSerializer)
         {
             Guard.NotNull(network, nameof(network));
             Guard.NotEmpty(folder, nameof(folder));
+
+            this.dBreezeSerializer = dBreezeSerializer;
 
             // Create the coinview folder if it does not exist.
             Directory.CreateDirectory(folder);
@@ -73,6 +83,7 @@ namespace Stratis.Bitcoin.Features.Consensus.CoinViews
             this.performanceCounter = new BackendPerformanceCounter(dateTimeProvider);
 
             nodeStats.RegisterStats(this.AddBenchStats, StatsType.Benchmark, 400);
+
         }
 
         /// <summary>
@@ -141,8 +152,8 @@ namespace Stratis.Bitcoin.Features.Consensus.CoinViews
                         int i = 0;
                         foreach (uint256 input in txIds)
                         {
-                            Row<byte[], Coins> row = transaction.Select<byte[], Coins>("Coins", input.ToBytes(false));
-                            UnspentOutputs outputs = row.Exists ? new UnspentOutputs(input, row.Value) : null;
+                            Row<byte[], byte[]> row = transaction.Select<byte[], byte[]>("Coins", input.ToBytes(false));
+                            UnspentOutputs outputs = row.Exists ? new UnspentOutputs(input, this.dBreezeSerializer.Deserializer<Coins>(row.Value)) : null;
 
                             this.logger.LogTrace("Outputs for '{0}' were {1}.", input, outputs == null ? "NOT loaded" : "loaded");
 
@@ -168,9 +179,9 @@ namespace Stratis.Bitcoin.Features.Consensus.CoinViews
         {
             if (this.blockHash == null)
             {
-                Row<byte[], uint256> row = transaction.Select<byte[], uint256>("BlockHash", blockHashKey);
+                Row<byte[], byte[]> row = transaction.Select<byte[], byte[]>("BlockHash", blockHashKey);
                 if (row.Exists)
-                    this.blockHash = row.Value;
+                    this.blockHash = new uint256(row.Value);
             }
 
             return this.blockHash;
@@ -184,7 +195,7 @@ namespace Stratis.Bitcoin.Features.Consensus.CoinViews
         private void SetBlockHash(DBreeze.Transactions.Transaction transaction, uint256 nextBlockHash)
         {
             this.blockHash = nextBlockHash;
-            transaction.Insert<byte[], uint256>("BlockHash", blockHashKey, nextBlockHash);
+            transaction.Insert<byte[], byte[]>("BlockHash", blockHashKey, nextBlockHash.ToBytes());
         }
 
         /// <inheritdoc />
@@ -239,7 +250,7 @@ namespace Stratis.Bitcoin.Features.Consensus.CoinViews
                             var coin = toInsert[i];
                             this.logger.LogTrace("Outputs of transaction ID '{0}' are NOT PRUNABLE and will be inserted into the database. {1}/{2}.", coin.TransactionId, i, toInsert.Count);
 
-                            transaction.Insert("Coins", coin.TransactionId.ToBytes(false), coin.ToCoins());
+                            transaction.Insert("Coins", coin.TransactionId.ToBytes(false), this.dBreezeSerializer.Serializer(coin.ToCoins()));
                         }
 
                         if (rewindDataList != null)
@@ -249,7 +260,7 @@ namespace Stratis.Bitcoin.Features.Consensus.CoinViews
                             {
                                 this.logger.LogTrace("Rewind state #{0} created.", nextRewindIndex);
 
-                                transaction.Insert("Rewind", nextRewindIndex, rewindData);
+                                transaction.Insert("Rewind", nextRewindIndex, this.dBreezeSerializer.Serializer(rewindData));
                                 nextRewindIndex++;
                             }
                         }
@@ -286,7 +297,7 @@ namespace Stratis.Bitcoin.Features.Consensus.CoinViews
             bool prevLazySettings = transaction.ValuesLazyLoadingIsOn;
 
             transaction.ValuesLazyLoadingIsOn = true;
-            Row<int, RewindData> firstRow = transaction.SelectBackward<int, RewindData>("Rewind").FirstOrDefault();
+            Row<int, byte[]> firstRow = transaction.SelectBackward<int, byte[]>("Rewind").FirstOrDefault();
             transaction.ValuesLazyLoadingIsOn = prevLazySettings;
 
             return firstRow != null ? firstRow.Key : 0;
@@ -299,8 +310,8 @@ namespace Stratis.Bitcoin.Features.Consensus.CoinViews
                 using (DBreeze.Transactions.Transaction transaction = this.CreateTransaction())
                 {
                     transaction.SynchronizeTables("BlockHash", "Coins", "Rewind");
-                    Row<int, RewindData> row = transaction.Select<int, RewindData>("Rewind", height);
-                    return row.Exists ? row.Value : null;
+                    Row<int, byte[]> row = transaction.Select<int, byte[]>("Rewind", height);
+                    return row.Exists ? this.dBreezeSerializer.Deserializer<RewindData>(row.Value) : null;
                 }
             });
 
@@ -327,23 +338,24 @@ namespace Stratis.Bitcoin.Features.Consensus.CoinViews
                     {
                         transaction.ValuesLazyLoadingIsOn = false;
 
-                        Row<int, RewindData> firstRow = transaction.SelectBackward<int, RewindData>("Rewind").FirstOrDefault();
+                        Row<int, byte[]> firstRow = transaction.SelectBackward<int, byte[]>("Rewind").FirstOrDefault();
                         transaction.RemoveKey("Rewind", firstRow.Key);
-                        this.SetBlockHash(transaction, firstRow.Value.PreviousBlockHash);
+                        var rewindData = this.dBreezeSerializer.Deserializer<RewindData>(firstRow.Value);
+                        this.SetBlockHash(transaction, rewindData.PreviousBlockHash);
 
-                        foreach (uint256 txId in firstRow.Value.TransactionsToRemove)
+                        foreach (uint256 txId in rewindData.TransactionsToRemove)
                         {
                             this.logger.LogTrace("Outputs of transaction ID '{0}' will be removed.", txId);
                             transaction.RemoveKey("Coins", txId.ToBytes(false));
                         }
 
-                        foreach (UnspentOutputs coin in firstRow.Value.OutputsToRestore)
+                        foreach (UnspentOutputs coin in rewindData.OutputsToRestore)
                         {
                             this.logger.LogTrace("Outputs of transaction ID '{0}' will be restored.", coin.TransactionId);
-                            transaction.Insert("Coins", coin.TransactionId.ToBytes(false), coin.ToCoins());
+                            transaction.Insert("Coins", coin.TransactionId.ToBytes(false), this.dBreezeSerializer.Serializer(coin.ToCoins()));
                         }
 
-                        res = firstRow.Value.PreviousBlockHash;
+                        res = rewindData.PreviousBlockHash;
                     }
 
                     transaction.Commit();
@@ -385,7 +397,7 @@ namespace Stratis.Bitcoin.Features.Consensus.CoinViews
             {
                 if (!stakeEntry.InStore)
                 {
-                    transaction.Insert<byte[], BlockStake>("Stake", stakeEntry.BlockId.ToBytes(false), stakeEntry.BlockStake);
+                    transaction.Insert("Stake", stakeEntry.BlockId.ToBytes(false), this.dBreezeSerializer.Serializer(stakeEntry.BlockStake));
                     stakeEntry.InStore = true;
                 }
             }
@@ -407,11 +419,11 @@ namespace Stratis.Bitcoin.Features.Consensus.CoinViews
                     foreach (StakeItem blockStake in blocklist)
                     {
                         this.logger.LogTrace("Loading POS block hash '{0}' from the database.", blockStake.BlockId);
-                        Row<byte[], BlockStake> stakeRow = transaction.Select<byte[], BlockStake>("Stake", blockStake.BlockId.ToBytes(false));
+                        Row<byte[], byte[]> stakeRow = transaction.Select<byte[], byte[]>("Stake", blockStake.BlockId.ToBytes(false));
 
                         if (stakeRow.Exists)
                         {
-                            blockStake.BlockStake = stakeRow.Value;
+                            blockStake.BlockStake = this.dBreezeSerializer.Deserializer<BlockStake>(stakeRow.Value);
                             blockStake.InStore = true;
                         }
                     }

--- a/src/Stratis.Bitcoin.Features.Consensus/ProvenBlockHeaders/ProvenBlockHeaderRepository.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/ProvenBlockHeaders/ProvenBlockHeaderRepository.cs
@@ -60,7 +60,7 @@ namespace Stratis.Bitcoin.Features.Consensus.ProvenBlockHeaders
         /// <param name="network">Specification of the network the node runs on - RegTest/TestNet/MainNet.</param>
         /// <param name="folder"><see cref="ProvenBlockHeaderRepository"/> folder path to the DBreeze database files.</param>
         /// <param name="loggerFactory">Factory to create a logger for this type.</param>
-        /// <param name="dBreezeSerializer">DBreeze serializer</param>
+        /// <param name="dBreezeSerializer">The serializer to use for <see cref="IBitcoinSerializable"/> objects.</param>
         public ProvenBlockHeaderRepository(Network network, DataFolder folder, ILoggerFactory loggerFactory,
             DBreezeSerializer dBreezeSerializer)
         : this(network, folder.ProvenBlockHeaderPath, loggerFactory, dBreezeSerializer)
@@ -73,7 +73,7 @@ namespace Stratis.Bitcoin.Features.Consensus.ProvenBlockHeaders
         /// <param name="network">Specification of the network the node runs on - RegTest/TestNet/MainNet.</param>
         /// <param name="folder"><see cref="ProvenBlockHeaderRepository"/> folder path to the DBreeze database files.</param>
         /// <param name="loggerFactory">Factory to create a logger for this type.</param>
-        /// <param name="dBreezeSerializer">DBreeze serializer</param>
+        /// <param name="dBreezeSerializer">The serializer to use for <see cref="IBitcoinSerializable"/> objects.</param>
         public ProvenBlockHeaderRepository(Network network, string folder, ILoggerFactory loggerFactory,
             DBreezeSerializer dBreezeSerializer)
         {

--- a/src/Stratis.Bitcoin.Features.Consensus/ProvenBlockHeaders/ProvenBlockHeaderRepository.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/ProvenBlockHeaders/ProvenBlockHeaderRepository.cs
@@ -49,6 +49,8 @@ namespace Stratis.Bitcoin.Features.Consensus.ProvenBlockHeaders
         /// </summary>
         private ProvenBlockHeader provenBlockHeaderTip;
 
+        private readonly DBreezeSerializer dBreezeSerializer;
+
         /// <inheritdoc />
         public HashHeightPair TipHashHeight { get; private set; }
 
@@ -58,8 +60,10 @@ namespace Stratis.Bitcoin.Features.Consensus.ProvenBlockHeaders
         /// <param name="network">Specification of the network the node runs on - RegTest/TestNet/MainNet.</param>
         /// <param name="folder"><see cref="ProvenBlockHeaderRepository"/> folder path to the DBreeze database files.</param>
         /// <param name="loggerFactory">Factory to create a logger for this type.</param>
-        public ProvenBlockHeaderRepository(Network network, DataFolder folder, ILoggerFactory loggerFactory)
-        : this(network, folder.ProvenBlockHeaderPath, loggerFactory)
+        /// <param name="dBreezeSerializer">DBreeze serializer</param>
+        public ProvenBlockHeaderRepository(Network network, DataFolder folder, ILoggerFactory loggerFactory,
+            DBreezeSerializer dBreezeSerializer)
+        : this(network, folder.ProvenBlockHeaderPath, loggerFactory, dBreezeSerializer)
         {
         }
 
@@ -69,10 +73,13 @@ namespace Stratis.Bitcoin.Features.Consensus.ProvenBlockHeaders
         /// <param name="network">Specification of the network the node runs on - RegTest/TestNet/MainNet.</param>
         /// <param name="folder"><see cref="ProvenBlockHeaderRepository"/> folder path to the DBreeze database files.</param>
         /// <param name="loggerFactory">Factory to create a logger for this type.</param>
-        public ProvenBlockHeaderRepository(Network network, string folder, ILoggerFactory loggerFactory)
+        /// <param name="dBreezeSerializer">DBreeze serializer</param>
+        public ProvenBlockHeaderRepository(Network network, string folder, ILoggerFactory loggerFactory,
+            DBreezeSerializer dBreezeSerializer)
         {
             Guard.NotNull(network, nameof(network));
             Guard.NotNull(folder, nameof(folder));
+            this.dBreezeSerializer = dBreezeSerializer;
 
             this.logger = loggerFactory.CreateLogger(this.GetType().FullName);
 
@@ -118,10 +125,10 @@ namespace Stratis.Bitcoin.Features.Consensus.ProvenBlockHeaders
 
                     transaction.ValuesLazyLoadingIsOn = false;
 
-                    Row<byte[], ProvenBlockHeader> row = transaction.Select<byte[], ProvenBlockHeader>(ProvenBlockHeaderTable, blockHeight.ToBytes());
+                    Row<byte[], byte[]> row = transaction.Select<byte[], byte[]>(ProvenBlockHeaderTable, blockHeight.ToBytes());
 
                     if (row.Exists)
-                        return row.Value;
+                        return this.dBreezeSerializer.Deserializer<ProvenBlockHeader>(row.Value);
 
                     return null;
                 }
@@ -175,7 +182,7 @@ namespace Stratis.Bitcoin.Features.Consensus.ProvenBlockHeaders
         {
             Guard.NotNull(newTip, nameof(newTip));
 
-            transaction.Insert<byte[], HashHeightPair>(BlockHashHeightTable, blockHashHeightKey, newTip);
+            transaction.Insert(BlockHashHeightTable, blockHashHeightKey, this.dBreezeSerializer.Serializer(newTip));
         }
 
         /// <summary>
@@ -186,7 +193,7 @@ namespace Stratis.Bitcoin.Features.Consensus.ProvenBlockHeaders
         private void InsertHeaders(DBreeze.Transactions.Transaction transaction, SortedDictionary<int, ProvenBlockHeader> headers)
         {
             foreach (KeyValuePair<int, ProvenBlockHeader> header in headers)
-                transaction.Insert<byte[], ProvenBlockHeader>(ProvenBlockHeaderTable, header.Key.ToBytes(), header.Value);
+                transaction.Insert(ProvenBlockHeaderTable, header.Key.ToBytes(), this.dBreezeSerializer.Serializer(header.Value));
 
             // Store the latest ProvenBlockHeader in memory.
             this.provenBlockHeaderTip = headers.Last().Value;
@@ -201,10 +208,10 @@ namespace Stratis.Bitcoin.Features.Consensus.ProvenBlockHeaders
         {
             HashHeightPair tipHash = null;
 
-            Row<byte[], HashHeightPair> row = transaction.Select<byte[], HashHeightPair>(BlockHashHeightTable, blockHashHeightKey);
+            Row<byte[], byte[]> row = transaction.Select<byte[], byte[]>(BlockHashHeightTable, blockHashHeightKey);
 
             if (row.Exists)
-                tipHash = row.Value;
+                tipHash = this.dBreezeSerializer.Deserializer<HashHeightPair>(row.Value);
 
             return tipHash;
         }

--- a/src/Stratis.Bitcoin.Features.Consensus/ProvenBlockHeaders/ProvenBlockHeaderRepository.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/ProvenBlockHeaders/ProvenBlockHeaderRepository.cs
@@ -128,7 +128,7 @@ namespace Stratis.Bitcoin.Features.Consensus.ProvenBlockHeaders
                     Row<byte[], byte[]> row = transaction.Select<byte[], byte[]>(ProvenBlockHeaderTable, blockHeight.ToBytes());
 
                     if (row.Exists)
-                        return this.dBreezeSerializer.Deserializer<ProvenBlockHeader>(row.Value);
+                        return this.dBreezeSerializer.Deserialize<ProvenBlockHeader>(row.Value);
 
                     return null;
                 }
@@ -211,7 +211,7 @@ namespace Stratis.Bitcoin.Features.Consensus.ProvenBlockHeaders
             Row<byte[], byte[]> row = transaction.Select<byte[], byte[]>(BlockHashHeightTable, blockHashHeightKey);
 
             if (row.Exists)
-                tipHash = this.dBreezeSerializer.Deserializer<HashHeightPair>(row.Value);
+                tipHash = this.dBreezeSerializer.Deserialize<HashHeightPair>(row.Value);
 
             return tipHash;
         }

--- a/src/Stratis.Bitcoin.Features.Consensus/ProvenBlockHeaders/ProvenBlockHeaderRepository.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/ProvenBlockHeaders/ProvenBlockHeaderRepository.cs
@@ -182,7 +182,7 @@ namespace Stratis.Bitcoin.Features.Consensus.ProvenBlockHeaders
         {
             Guard.NotNull(newTip, nameof(newTip));
 
-            transaction.Insert(BlockHashHeightTable, blockHashHeightKey, this.dBreezeSerializer.Serializer(newTip));
+            transaction.Insert(BlockHashHeightTable, blockHashHeightKey, this.dBreezeSerializer.Serialize(newTip));
         }
 
         /// <summary>
@@ -193,7 +193,7 @@ namespace Stratis.Bitcoin.Features.Consensus.ProvenBlockHeaders
         private void InsertHeaders(DBreeze.Transactions.Transaction transaction, SortedDictionary<int, ProvenBlockHeader> headers)
         {
             foreach (KeyValuePair<int, ProvenBlockHeader> header in headers)
-                transaction.Insert(ProvenBlockHeaderTable, header.Key.ToBytes(), this.dBreezeSerializer.Serializer(header.Value));
+                transaction.Insert(ProvenBlockHeaderTable, header.Key.ToBytes(), this.dBreezeSerializer.Serialize(header.Value));
 
             // Store the latest ProvenBlockHeader in memory.
             this.provenBlockHeaderTip = headers.Last().Value;

--- a/src/Stratis.Bitcoin.IntegrationTests/BlockStore/BlockStoreSignaledTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/BlockStore/BlockStoreSignaledTests.cs
@@ -72,8 +72,6 @@ namespace Stratis.Bitcoin.IntegrationTests.BlockStore
             this.loggerFactory = new LoggerFactory();
 
             this.network = new BitcoinRegTest();
-            var serializer = new DBreezeSerializer();
-            serializer.Initialize(this.network);
         }
 
         [Fact]

--- a/src/Stratis.Bitcoin.IntegrationTests/BlockStore/BlockStoreTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/BlockStore/BlockStoreTests.cs
@@ -23,8 +23,7 @@ namespace Stratis.Bitcoin.IntegrationTests.BlockStore
             this.loggerFactory = new LoggerFactory();
 
             this.network = new BitcoinRegTest();
-            this.dBreezeSerializer = new DBreezeSerializer();
-            this.dBreezeSerializer.Initialize(this.network);
+            this.dBreezeSerializer = new DBreezeSerializer(this.network);
         }
 
         [Fact]

--- a/src/Stratis.Bitcoin.IntegrationTests/BlockStore/BlockStoreTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/BlockStore/BlockStoreTests.cs
@@ -16,20 +16,21 @@ namespace Stratis.Bitcoin.IntegrationTests.BlockStore
     {
         private readonly ILoggerFactory loggerFactory;
         private readonly Network network;
+        private readonly DBreezeSerializer dBreezeSerializer;
 
         public BlockStoreTests()
         {
             this.loggerFactory = new LoggerFactory();
 
             this.network = new BitcoinRegTest();
-            var serializer = new DBreezeSerializer();
-            serializer.Initialize(this.network);
+            this.dBreezeSerializer = new DBreezeSerializer();
+            this.dBreezeSerializer.Initialize(this.network);
         }
 
         [Fact]
         public void BlockRepositoryPutBatch()
         {
-            using (var blockRepository = new BlockRepository(this.network, TestBase.CreateDataFolder(this), DateTimeProvider.Default, this.loggerFactory))
+            using (var blockRepository = new BlockRepository(this.network, TestBase.CreateDataFolder(this), DateTimeProvider.Default, this.loggerFactory, this.dBreezeSerializer))
             {
                 blockRepository.SetTxIndexAsync(true).Wait();
 

--- a/src/Stratis.Bitcoin.IntegrationTests/CoinViewTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/CoinViewTests.cs
@@ -27,7 +27,7 @@ namespace Stratis.Bitcoin.IntegrationTests
         protected readonly ILoggerFactory loggerFactory;
         private readonly Network network;
         private readonly Network regTest;
-        private readonly DBreezeSerializer dbreezeSerializer;
+        private readonly DBreezeSerializer dBreezeSerializer;
 
         /// <summary>
         /// Initializes logger factory for tests in this class.
@@ -37,8 +37,8 @@ namespace Stratis.Bitcoin.IntegrationTests
             this.loggerFactory = new LoggerFactory();
             this.network = KnownNetworks.Main;
             this.regTest = KnownNetworks.RegTest;
-            this.dbreezeSerializer = new DBreezeSerializer();
-            this.dbreezeSerializer.Initialize(this.network);
+            this.dBreezeSerializer = new DBreezeSerializer();
+            this.dBreezeSerializer.Initialize(this.network);
         }
 
         [Fact]
@@ -282,7 +282,7 @@ namespace Stratis.Bitcoin.IntegrationTests
         [Fact]
         public void CanSaveChainIncrementally()
         {
-            using (var repo = new ChainRepository(TestBase.CreateTestDir(this), this.loggerFactory))
+            using (var repo = new ChainRepository(TestBase.CreateTestDir(this), this.loggerFactory, this.dBreezeSerializer))
             {
                 var chain = new ConcurrentChain(this.regTest);
 

--- a/src/Stratis.Bitcoin.IntegrationTests/CoinViewTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/CoinViewTests.cs
@@ -37,8 +37,7 @@ namespace Stratis.Bitcoin.IntegrationTests
             this.loggerFactory = new LoggerFactory();
             this.network = KnownNetworks.Main;
             this.regTest = KnownNetworks.RegTest;
-            this.dBreezeSerializer = new DBreezeSerializer();
-            this.dBreezeSerializer.Initialize(this.network);
+            this.dBreezeSerializer = new DBreezeSerializer(this.network);
         }
 
         [Fact]

--- a/src/Stratis.Bitcoin.IntegrationTests/NodeContext.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/NodeContext.cs
@@ -4,7 +4,6 @@ using System.Runtime.CompilerServices;
 using Microsoft.Extensions.Logging;
 using NBitcoin;
 using Stratis.Bitcoin.Features.Consensus.CoinViews;
-using Stratis.Bitcoin.Networks;
 using Stratis.Bitcoin.Tests.Common;
 using Stratis.Bitcoin.Utilities;
 
@@ -24,7 +23,9 @@ namespace Stratis.Bitcoin.IntegrationTests
             this.Network = network;
             this.FolderName = TestBase.CreateTestDir(caller, name);
             var dateTimeProvider = new DateTimeProvider();
-            this.PersistentCoinView = new DBreezeCoinView(network, this.FolderName, dateTimeProvider, this.loggerFactory, new NodeStats(dateTimeProvider));
+            var serializer = new DBreezeSerializer();
+            serializer.Initialize(this.Network);
+            this.PersistentCoinView = new DBreezeCoinView(network, this.FolderName, dateTimeProvider, this.loggerFactory, new NodeStats(dateTimeProvider), serializer);
             this.PersistentCoinView.InitializeAsync().GetAwaiter().GetResult();
             this.cleanList = new List<IDisposable> {this.PersistentCoinView};
         }
@@ -61,7 +62,9 @@ namespace Stratis.Bitcoin.IntegrationTests
             this.PersistentCoinView.Dispose();
             this.cleanList.Remove(this.PersistentCoinView);
             var dateTimeProvider = new DateTimeProvider();
-            this.PersistentCoinView = new DBreezeCoinView(this.Network, this.FolderName, dateTimeProvider, this.loggerFactory, new NodeStats(dateTimeProvider));
+            var serializer = new DBreezeSerializer();
+            serializer.Initialize(this.Network);
+            this.PersistentCoinView = new DBreezeCoinView(this.Network, this.FolderName, dateTimeProvider, this.loggerFactory, new NodeStats(dateTimeProvider), serializer);
             this.PersistentCoinView.InitializeAsync().GetAwaiter().GetResult();
             this.cleanList.Add(this.PersistentCoinView);
         }

--- a/src/Stratis.Bitcoin.IntegrationTests/NodeContext.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/NodeContext.cs
@@ -23,8 +23,7 @@ namespace Stratis.Bitcoin.IntegrationTests
             this.Network = network;
             this.FolderName = TestBase.CreateTestDir(caller, name);
             var dateTimeProvider = new DateTimeProvider();
-            var serializer = new DBreezeSerializer();
-            serializer.Initialize(this.Network);
+            var serializer = new DBreezeSerializer(this.Network);
             this.PersistentCoinView = new DBreezeCoinView(network, this.FolderName, dateTimeProvider, this.loggerFactory, new NodeStats(dateTimeProvider), serializer);
             this.PersistentCoinView.InitializeAsync().GetAwaiter().GetResult();
             this.cleanList = new List<IDisposable> {this.PersistentCoinView};
@@ -62,8 +61,7 @@ namespace Stratis.Bitcoin.IntegrationTests
             this.PersistentCoinView.Dispose();
             this.cleanList.Remove(this.PersistentCoinView);
             var dateTimeProvider = new DateTimeProvider();
-            var serializer = new DBreezeSerializer();
-            serializer.Initialize(this.Network);
+            var serializer = new DBreezeSerializer(this.Network);
             this.PersistentCoinView = new DBreezeCoinView(this.Network, this.FolderName, dateTimeProvider, this.loggerFactory, new NodeStats(dateTimeProvider), serializer);
             this.PersistentCoinView.InitializeAsync().GetAwaiter().GetResult();
             this.cleanList.Add(this.PersistentCoinView);

--- a/src/Stratis.Bitcoin.Tests.Common/TestBase.cs
+++ b/src/Stratis.Bitcoin.Tests.Common/TestBase.cs
@@ -5,12 +5,14 @@ using System.Linq;
 using FluentAssertions;
 using NBitcoin;
 using Stratis.Bitcoin.Configuration;
+using Stratis.Bitcoin.Utilities;
 
 namespace Stratis.Bitcoin.Tests.Common
 {
     public class TestBase
     {
         public Network Network { get; protected set; }
+        public DBreezeSerializer DBreezeSerializer { get; }
 
         /// <summary>
         /// Initializes logger factory for inherited tests.
@@ -18,6 +20,7 @@ namespace Stratis.Bitcoin.Tests.Common
         public TestBase(Network network)
         {
             this.Network = network;
+            this.DBreezeSerializer = new DBreezeSerializer(network);
         }
 
         public static string AssureEmptyDir(string dir)

--- a/src/Stratis.Bitcoin.Tests.Common/TestBase.cs
+++ b/src/Stratis.Bitcoin.Tests.Common/TestBase.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using FluentAssertions;
 using NBitcoin;
 using Stratis.Bitcoin.Configuration;
-using Stratis.Bitcoin.Utilities;
 
 namespace Stratis.Bitcoin.Tests.Common
 {
@@ -19,8 +18,6 @@ namespace Stratis.Bitcoin.Tests.Common
         public TestBase(Network network)
         {
             this.Network = network;
-            var serializer = new DBreezeSerializer();
-            serializer.Initialize(this.Network);
         }
 
         public static string AssureEmptyDir(string dir)

--- a/src/Stratis.Bitcoin.Tests/Base/ChainRepositoryTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Base/ChainRepositoryTest.cs
@@ -17,8 +17,7 @@ namespace Stratis.Bitcoin.Tests.Base
 
         public ChainRepositoryTest() : base(KnownNetworks.StratisRegTest)
         {
-            this.dBreezeSerializer = new DBreezeSerializer();
-            this.dBreezeSerializer.Initialize(this.Network);
+            this.dBreezeSerializer = new DBreezeSerializer(this.Network);
         }
 
         [Fact]

--- a/src/Stratis.Bitcoin.Tests/Base/ChainRepositoryTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Base/ChainRepositoryTest.cs
@@ -1,21 +1,24 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Threading.Tasks;
 using DBreeze;
 using DBreeze.DataTypes;
 using Microsoft.Extensions.Logging;
 using NBitcoin;
 using Stratis.Bitcoin.Base;
-using Stratis.Bitcoin.Networks;
 using Stratis.Bitcoin.Tests.Common;
+using Stratis.Bitcoin.Utilities;
 using Xunit;
 
 namespace Stratis.Bitcoin.Tests.Base
 {
     public class ChainRepositoryTest : TestBase
     {
+        private readonly DBreezeSerializer dBreezeSerializer;
+
         public ChainRepositoryTest() : base(KnownNetworks.StratisRegTest)
         {
+            this.dBreezeSerializer = new DBreezeSerializer();
+            this.dBreezeSerializer.Initialize(this.Network);
         }
 
         [Fact]
@@ -25,7 +28,7 @@ namespace Stratis.Bitcoin.Tests.Base
             var chain = new ConcurrentChain(KnownNetworks.StratisRegTest);
             this.AppendBlock(chain);
 
-            using (var repo = new ChainRepository(dir, new LoggerFactory()))
+            using (var repo = new ChainRepository(dir, new LoggerFactory(), this.dBreezeSerializer))
             {
                 repo.SaveAsync(chain).GetAwaiter().GetResult();
             }
@@ -70,7 +73,7 @@ namespace Stratis.Bitcoin.Tests.Base
                     transaction.Commit();
                 }
             }
-            using (var repo = new ChainRepository(dir, new LoggerFactory()))
+            using (var repo = new ChainRepository(dir, new LoggerFactory(), this.dBreezeSerializer))
             {
                 var testChain = new ConcurrentChain(KnownNetworks.StratisRegTest);
                 testChain.SetTip(repo.LoadAsync(testChain.Genesis).GetAwaiter().GetResult());

--- a/src/Stratis.Bitcoin.Tests/FinalizedBlockInfoRepositoryTest.cs
+++ b/src/Stratis.Bitcoin.Tests/FinalizedBlockInfoRepositoryTest.cs
@@ -15,8 +15,7 @@ namespace Stratis.Bitcoin.Tests
         public FinalizedBlockInfoRepositoryTest() : base(KnownNetworks.StratisRegTest)
         {
             this.loggerFactory = new LoggerFactory();
-            this.dBreezeSerializer = new DBreezeSerializer();
-            this.dBreezeSerializer.Initialize(this.Network);
+            this.dBreezeSerializer = new DBreezeSerializer(this.Network);
         }
 
         [Fact]

--- a/src/Stratis.Bitcoin.Tests/FinalizedBlockInfoRepositoryTest.cs
+++ b/src/Stratis.Bitcoin.Tests/FinalizedBlockInfoRepositoryTest.cs
@@ -2,6 +2,7 @@
 using Microsoft.Extensions.Logging;
 using NBitcoin;
 using Stratis.Bitcoin.Tests.Common;
+using Stratis.Bitcoin.Utilities;
 using Xunit;
 
 namespace Stratis.Bitcoin.Tests
@@ -9,10 +10,13 @@ namespace Stratis.Bitcoin.Tests
     public class FinalizedBlockInfoRepositoryTest : TestBase
     {
         private readonly ILoggerFactory loggerFactory;
+        private readonly DBreezeSerializer dBreezeSerializer;
 
         public FinalizedBlockInfoRepositoryTest() : base(KnownNetworks.StratisRegTest)
         {
             this.loggerFactory = new LoggerFactory();
+            this.dBreezeSerializer = new DBreezeSerializer();
+            this.dBreezeSerializer.Initialize(this.Network);
         }
 
         [Fact]
@@ -20,12 +24,12 @@ namespace Stratis.Bitcoin.Tests
         {
             string dir = CreateTestDir(this);
 
-            using (var repo = new FinalizedBlockInfoRepository(dir, this.loggerFactory))
+            using (var repo = new FinalizedBlockInfoRepository(dir, this.loggerFactory, this.dBreezeSerializer))
             {
                 repo.SaveFinalizedBlockHashAndHeight(uint256.One, 777);
             }
 
-            using (var repo = new FinalizedBlockInfoRepository(dir, this.loggerFactory))
+            using (var repo = new FinalizedBlockInfoRepository(dir, this.loggerFactory, this.dBreezeSerializer))
             {
                 await repo.LoadFinalizedBlockInfoAsync(this.Network);
                 Assert.Equal(777, repo.GetFinalizedBlockInfo().Height);
@@ -37,7 +41,7 @@ namespace Stratis.Bitcoin.Tests
         {
             string dir = CreateTestDir(this);
 
-            using (var repo = new FinalizedBlockInfoRepository(dir, this.loggerFactory))
+            using (var repo = new FinalizedBlockInfoRepository(dir, this.loggerFactory, this.dBreezeSerializer))
             {
                 repo.SaveFinalizedBlockHashAndHeight(uint256.One, 777);
                 repo.SaveFinalizedBlockHashAndHeight(uint256.One, 555);
@@ -45,7 +49,7 @@ namespace Stratis.Bitcoin.Tests
                 Assert.Equal(777, repo.GetFinalizedBlockInfo().Height);
             }
 
-            using (var repo = new FinalizedBlockInfoRepository(dir, this.loggerFactory))
+            using (var repo = new FinalizedBlockInfoRepository(dir, this.loggerFactory, this.dBreezeSerializer))
             {
                 await repo.LoadFinalizedBlockInfoAsync(this.Network);
                 Assert.Equal(777, repo.GetFinalizedBlockInfo().Height);

--- a/src/Stratis.Bitcoin.Tests/Utilities/DBreezeTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Utilities/DBreezeTest.cs
@@ -25,8 +25,7 @@ namespace Stratis.Bitcoin.Tests.Utilities
         /// </summary>
         public DBreezeTest() : base(KnownNetworks.StratisRegTest)
         {
-            this.dbreezeSerializer = new DBreezeSerializer();
-            this.dbreezeSerializer.Initialize(this.Network);
+            this.dbreezeSerializer = new DBreezeSerializer(this.Network);
         }
 
         [Fact]

--- a/src/Stratis.Bitcoin.Tests/Utilities/DBreezeTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Utilities/DBreezeTest.cs
@@ -67,7 +67,7 @@ namespace Stratis.Bitcoin.Tests.Utilities
             Block genesis = network.GetGenesis();
             var coins = new Coins(genesis.Transactions[0], 0);
 
-            var result = (Coins)this.dbreezeSerializer.Deserializer(coins.ToBytes(KnownNetworks.StratisRegTest.Consensus.ConsensusFactory), typeof(Coins));
+            var result = (Coins)this.dbreezeSerializer.Deserialize(coins.ToBytes(KnownNetworks.StratisRegTest.Consensus.ConsensusFactory), typeof(Coins));
 
             Assert.Equal(coins.CoinBase, result.CoinBase);
             Assert.Equal(coins.Height, result.Height);
@@ -88,7 +88,7 @@ namespace Stratis.Bitcoin.Tests.Utilities
             Block genesis = network.GetGenesis();
             BlockHeader blockHeader = genesis.Header;
 
-            var result = (BlockHeader)this.dbreezeSerializer.Deserializer(blockHeader.ToBytes(KnownNetworks.StratisRegTest.Consensus.ConsensusFactory), typeof(BlockHeader));
+            var result = (BlockHeader)this.dbreezeSerializer.Deserialize(blockHeader.ToBytes(KnownNetworks.StratisRegTest.Consensus.ConsensusFactory), typeof(BlockHeader));
 
             Assert.Equal(blockHeader.GetHash(), result.GetHash());
         }
@@ -100,7 +100,7 @@ namespace Stratis.Bitcoin.Tests.Utilities
             Block genesis = network.GetGenesis();
             var rewindData = new RewindData(genesis.GetHash());
 
-            var result = (RewindData)this.dbreezeSerializer.Deserializer(rewindData.ToBytes(), typeof(RewindData));
+            var result = (RewindData)this.dbreezeSerializer.Deserialize(rewindData.ToBytes(), typeof(RewindData));
 
             Assert.Equal(genesis.GetHash(), result.PreviousBlockHash);
         }
@@ -110,7 +110,7 @@ namespace Stratis.Bitcoin.Tests.Utilities
         {
             uint256 val = uint256.One;
 
-            var result = (uint256)this.dbreezeSerializer.Deserializer(val.ToBytes(), typeof(uint256));
+            var result = (uint256)this.dbreezeSerializer.Deserialize(val.ToBytes(), typeof(uint256));
 
             Assert.Equal(val, result);
         }
@@ -121,7 +121,7 @@ namespace Stratis.Bitcoin.Tests.Utilities
             Network network = KnownNetworks.StratisRegTest;
             Block block = network.GetGenesis();
 
-            var result = (Block)this.dbreezeSerializer.Deserializer(block.ToBytes(KnownNetworks.StratisRegTest.Consensus.ConsensusFactory), typeof(Block));
+            var result = (Block)this.dbreezeSerializer.Deserialize(block.ToBytes(KnownNetworks.StratisRegTest.Consensus.ConsensusFactory), typeof(Block));
 
             Assert.Equal(block.GetHash(), result.GetHash());
         }
@@ -133,7 +133,7 @@ namespace Stratis.Bitcoin.Tests.Utilities
             {
                 string test = "Should throw exception.";
 
-                this.dbreezeSerializer.Deserializer(Encoding.UTF8.GetBytes(test), typeof(string));
+                this.dbreezeSerializer.Deserialize(Encoding.UTF8.GetBytes(test), typeof(string));
             });
         }
 
@@ -147,7 +147,7 @@ namespace Stratis.Bitcoin.Tests.Utilities
         [Fact]
         public void DeserializeAnyIBitcoinSerializableDoesNotThrowException()
         {
-            var result = (UnknownBitcoinSerialisable)this.dbreezeSerializer.Deserializer(Encoding.UTF8.GetBytes("useless"), typeof(UnknownBitcoinSerialisable));
+            var result = (UnknownBitcoinSerialisable)this.dbreezeSerializer.Deserialize(Encoding.UTF8.GetBytes("useless"), typeof(UnknownBitcoinSerialisable));
             result.ReadWriteCalls.Should().Be(1);
         }
 

--- a/src/Stratis.Bitcoin.Tests/Utilities/DBreezeTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Utilities/DBreezeTest.cs
@@ -34,7 +34,7 @@ namespace Stratis.Bitcoin.Tests.Utilities
         {
             Block block = KnownNetworks.StratisRegTest.Consensus.ConsensusFactory.CreateBlock();
 
-            byte[] result = this.dbreezeSerializer.Serializer(block);
+            byte[] result = this.dbreezeSerializer.Serialize(block);
 
             Assert.Equal(block.ToBytes(), result);
         }
@@ -44,7 +44,7 @@ namespace Stratis.Bitcoin.Tests.Utilities
         {
             var val = new uint256();
 
-            byte[] result = this.dbreezeSerializer.Serializer(val);
+            byte[] result = this.dbreezeSerializer.Serialize(val);
 
             Assert.Equal(val.ToBytes(), result);
         }
@@ -56,7 +56,7 @@ namespace Stratis.Bitcoin.Tests.Utilities
             {
                 string test = "Should throw exception.";
 
-                this.dbreezeSerializer.Serializer(test);
+                this.dbreezeSerializer.Serialize(test);
             });
         }
 
@@ -155,7 +155,7 @@ namespace Stratis.Bitcoin.Tests.Utilities
         public void SerializeAnyIBitcoinSerializableDoesNotThrowException()
         {
             var serialisable = new UnknownBitcoinSerialisable();
-            this.dbreezeSerializer.Serializer(serialisable);
+            this.dbreezeSerializer.Serialize(serialisable);
             serialisable.ReadWriteCalls.Should().Be(1);
         }
 

--- a/src/Stratis.Bitcoin/Base/BaseFeature.cs
+++ b/src/Stratis.Bitcoin/Base/BaseFeature.cs
@@ -173,8 +173,6 @@ namespace Stratis.Bitcoin.Base
         /// <inheritdoc />
         public override async Task InitializeAsync()
         {
-            this.dbreezeSerializer.Initialize(this.chain.Network);
-
             await this.StartChainAsync().ConfigureAwait(false);
 
             if (this.provenBlockHeaderStore != null)

--- a/src/Stratis.Bitcoin/Base/BaseFeature.cs
+++ b/src/Stratis.Bitcoin/Base/BaseFeature.cs
@@ -82,9 +82,6 @@ namespace Stratis.Bitcoin.Base
         /// <summary>State of time synchronization feature that stores collected data samples.</summary>
         private readonly ITimeSyncBehaviorState timeSyncBehaviorState;
 
-        /// <summary>Provider of binary (de)serialization for data stored in the database.</summary>
-        private readonly DBreezeSerializer dbreezeSerializer;
-
         /// <summary>Manager of node's network peers.</summary>
         private IPeerAddressManager peerAddressManager;
 
@@ -116,8 +113,7 @@ namespace Stratis.Bitcoin.Base
         /// <inheritdoc cref="IPartialValidator"/>
         private readonly IPartialValidator partialValidator;
 
-        public BaseFeature(
-            NodeSettings nodeSettings,
+        public BaseFeature(NodeSettings nodeSettings,
             DataFolder dataFolder,
             INodeLifetime nodeLifetime,
             ConcurrentChain chain,
@@ -128,7 +124,6 @@ namespace Stratis.Bitcoin.Base
             IDateTimeProvider dateTimeProvider,
             IAsyncLoopFactory asyncLoopFactory,
             ITimeSyncBehaviorState timeSyncBehaviorState,
-            DBreezeSerializer dbreezeSerializer,
             ILoggerFactory loggerFactory,
             IInitialBlockDownloadState initialBlockDownloadState,
             IPeerBanning peerBanning,
@@ -166,7 +161,6 @@ namespace Stratis.Bitcoin.Base
             this.asyncLoopFactory = asyncLoopFactory;
             this.timeSyncBehaviorState = timeSyncBehaviorState;
             this.loggerFactory = loggerFactory;
-            this.dbreezeSerializer = dbreezeSerializer;
             this.logger = loggerFactory.CreateLogger(this.GetType().FullName);
         }
 

--- a/src/Stratis.Bitcoin/Base/ChainRepository.cs
+++ b/src/Stratis.Bitcoin/Base/ChainRepository.cs
@@ -65,7 +65,7 @@ namespace Stratis.Bitcoin.Base
                     if (!firstRow.Exists)
                         return genesisHeader;
 
-                    BlockHeader previousHeader = this.dBreezeSerializer.Deserializer<BlockHeader>(firstRow.Value);
+                    BlockHeader previousHeader = this.dBreezeSerializer.Deserialize<BlockHeader>(firstRow.Value);
                     Guard.Assert(previousHeader.GetHash() == genesisHeader.HashBlock); // can't swap networks
 
                     foreach (Row<int, byte[]> row in transaction.SelectForwardSkip<int, byte[]>("Chain", 1))
@@ -73,7 +73,7 @@ namespace Stratis.Bitcoin.Base
                         if ((tip != null) && (previousHeader.HashPrevBlock != tip.HashBlock))
                             break;
 
-                        BlockHeader blockHeader = this.dBreezeSerializer.Deserializer<BlockHeader>(row.Value);
+                        BlockHeader blockHeader = this.dBreezeSerializer.Deserialize<BlockHeader>(row.Value);
                         tip = new ChainedHeader(previousHeader, blockHeader.HashPrevBlock, tip);
                         previousHeader = blockHeader;
                     }

--- a/src/Stratis.Bitcoin/Base/ChainRepository.cs
+++ b/src/Stratis.Bitcoin/Base/ChainRepository.cs
@@ -24,6 +24,8 @@ namespace Stratis.Bitcoin.Base
 
     public class ChainRepository : IChainRepository
     {
+        private readonly DBreezeSerializer dBreezeSerializer;
+
         /// <summary>Instance logger.</summary>
         private readonly ILogger logger;
 
@@ -32,8 +34,9 @@ namespace Stratis.Bitcoin.Base
 
         private BlockLocator locator;
 
-        public ChainRepository(string folder, ILoggerFactory loggerFactory)
+        public ChainRepository(string folder, ILoggerFactory loggerFactory, DBreezeSerializer dBreezeSerializer)
         {
+            this.dBreezeSerializer = dBreezeSerializer;
             Guard.NotEmpty(folder, nameof(folder));
             Guard.NotNull(loggerFactory, nameof(loggerFactory));
 
@@ -43,8 +46,8 @@ namespace Stratis.Bitcoin.Base
             this.dbreeze = new DBreezeEngine(folder);
         }
 
-        public ChainRepository(DataFolder dataFolder, ILoggerFactory loggerFactory)
-            : this(dataFolder.ChainPath, loggerFactory)
+        public ChainRepository(DataFolder dataFolder, ILoggerFactory loggerFactory, DBreezeSerializer dBreezeSerializer)
+            : this(dataFolder.ChainPath, loggerFactory, dBreezeSerializer)
         {
         }
 
@@ -57,21 +60,22 @@ namespace Stratis.Bitcoin.Base
                 {
                     transaction.ValuesLazyLoadingIsOn = false;
                     ChainedHeader tip = null;
-                    Row<int, BlockHeader> firstRow = transaction.Select<int, BlockHeader>("Chain", 0);
+                    Row<int, byte[]> firstRow = transaction.Select<int, byte[]>("Chain", 0);
 
                     if (!firstRow.Exists)
                         return genesisHeader;
 
-                    BlockHeader previousHeader = firstRow.Value;
+                    BlockHeader previousHeader = this.dBreezeSerializer.Deserializer<BlockHeader>(firstRow.Value);
                     Guard.Assert(previousHeader.GetHash() == genesisHeader.HashBlock); // can't swap networks
 
-                    foreach (Row<int, BlockHeader> row in transaction.SelectForwardSkip<int, BlockHeader>("Chain", 1))
+                    foreach (Row<int, byte[]> row in transaction.SelectForwardSkip<int, byte[]>("Chain", 1))
                     {
                         if ((tip != null) && (previousHeader.HashPrevBlock != tip.HashBlock))
                             break;
 
-                        tip = new ChainedHeader(previousHeader, row.Value.HashPrevBlock, tip);
-                        previousHeader = row.Value;
+                        BlockHeader blockHeader = this.dBreezeSerializer.Deserializer<BlockHeader>(row.Value);
+                        tip = new ChainedHeader(previousHeader, blockHeader.HashPrevBlock, tip);
+                        previousHeader = blockHeader;
                     }
 
                     if (previousHeader != null)
@@ -127,7 +131,7 @@ namespace Stratis.Bitcoin.Base
                             header = newHeader;
                         }
 
-                        transaction.Insert("Chain", block.Height, header);
+                        transaction.Insert("Chain", block.Height, this.dBreezeSerializer.Serializer(header));
                     }
 
                     this.locator = tip.GetLocator();

--- a/src/Stratis.Bitcoin/Base/ChainRepository.cs
+++ b/src/Stratis.Bitcoin/Base/ChainRepository.cs
@@ -131,7 +131,7 @@ namespace Stratis.Bitcoin.Base
                             header = newHeader;
                         }
 
-                        transaction.Insert("Chain", block.Height, this.dBreezeSerializer.Serializer(header));
+                        transaction.Insert("Chain", block.Height, this.dBreezeSerializer.Serialize(header));
                     }
 
                     this.locator = tip.GetLocator();

--- a/src/Stratis.Bitcoin/FinalizedBlockInfoRepository.cs
+++ b/src/Stratis.Bitcoin/FinalizedBlockInfoRepository.cs
@@ -148,7 +148,7 @@ namespace Stratis.Bitcoin
                         this.logger.LogTrace("Finalized block height doesn't exist in the database.");
                     }
                     else
-                        this.finalizedBlockInfo = this.dBreezeSerializer.Deserializer<HashHeightPair>(row.Value);
+                        this.finalizedBlockInfo = this.dBreezeSerializer.Deserialize<HashHeightPair>(row.Value);
                 }
             });
             return task;

--- a/src/Stratis.Bitcoin/FinalizedBlockInfoRepository.cs
+++ b/src/Stratis.Bitcoin/FinalizedBlockInfoRepository.cs
@@ -36,6 +36,8 @@ namespace Stratis.Bitcoin
 
     public class FinalizedBlockInfoRepository : IFinalizedBlockInfoRepository
     {
+        private readonly DBreezeSerializer dBreezeSerializer;
+
         /// <summary>Instance logger.</summary>
         private readonly ILogger logger;
 
@@ -62,8 +64,9 @@ namespace Stratis.Bitcoin
 
         private readonly AsyncManualResetEvent queueUpdatedEvent;
 
-        public FinalizedBlockInfoRepository(string folder, ILoggerFactory loggerFactory)
+        public FinalizedBlockInfoRepository(string folder, ILoggerFactory loggerFactory, DBreezeSerializer dBreezeSerializer)
         {
+            this.dBreezeSerializer = dBreezeSerializer;
             Guard.NotEmpty(folder, nameof(folder));
             Guard.NotNull(loggerFactory, nameof(loggerFactory));
 
@@ -80,8 +83,8 @@ namespace Stratis.Bitcoin
             this.finalizedBlockInfoPersistingTask = this.PersistFinalizedBlockInfoContinuouslyAsync();
         }
 
-        public FinalizedBlockInfoRepository(DataFolder dataFolder, ILoggerFactory loggerFactory)
-            : this(dataFolder.FinalizedBlockInfoPath, loggerFactory)
+        public FinalizedBlockInfoRepository(DataFolder dataFolder, ILoggerFactory loggerFactory, DBreezeSerializer dBreezeSerializer)
+            : this(dataFolder.FinalizedBlockInfoPath, loggerFactory, dBreezeSerializer)
         {
         }
 
@@ -115,7 +118,7 @@ namespace Stratis.Bitcoin
 
                 using (DBreeze.Transactions.Transaction transaction = this.dbreeze.GetTransaction())
                 {
-                    transaction.Insert<byte[], HashHeightPair>("FinalizedBlock", finalizedBlockKey, lastFinalizedBlock);
+                    transaction.Insert("FinalizedBlock", finalizedBlockKey, this.dBreezeSerializer.Serializer(lastFinalizedBlock));
                     transaction.Commit();
                 }
 
@@ -138,14 +141,14 @@ namespace Stratis.Bitcoin
                 {
                     transaction.ValuesLazyLoadingIsOn = false;
 
-                    Row<byte[], HashHeightPair> row = transaction.Select<byte[], HashHeightPair>("FinalizedBlock", finalizedBlockKey);
+                    Row<byte[], byte[]> row = transaction.Select<byte[], byte[]>("FinalizedBlock", finalizedBlockKey);
                     if (!row.Exists)
                     {
                         this.finalizedBlockInfo = new HashHeightPair(network.GenesisHash, 0);
                         this.logger.LogTrace("Finalized block height doesn't exist in the database.");
                     }
                     else
-                        this.finalizedBlockInfo = row.Value;
+                        this.finalizedBlockInfo = this.dBreezeSerializer.Deserializer<HashHeightPair>(row.Value);
                 }
             });
             return task;

--- a/src/Stratis.Bitcoin/FinalizedBlockInfoRepository.cs
+++ b/src/Stratis.Bitcoin/FinalizedBlockInfoRepository.cs
@@ -118,7 +118,7 @@ namespace Stratis.Bitcoin
 
                 using (DBreeze.Transactions.Transaction transaction = this.dbreeze.GetTransaction())
                 {
-                    transaction.Insert("FinalizedBlock", finalizedBlockKey, this.dBreezeSerializer.Serializer(lastFinalizedBlock));
+                    transaction.Insert("FinalizedBlock", finalizedBlockKey, this.dBreezeSerializer.Serialize(lastFinalizedBlock));
                     transaction.Commit();
                 }
 

--- a/src/Stratis.Bitcoin/Utilities/DBreezeSerializer.cs
+++ b/src/Stratis.Bitcoin/Utilities/DBreezeSerializer.cs
@@ -19,8 +19,8 @@ namespace Stratis.Bitcoin.Utilities
         public void Initialize(Network network)
         {
             this.Network = network;
-            CustomSerializator.ByteArraySerializator = this.Serializer;
-            CustomSerializator.ByteArrayDeSerializator = this.Deserializer;
+            //CustomSerializator.ByteArraySerializator = this.Serializer;
+            //CustomSerializator.ByteArrayDeSerializator = this.Deserializer;
         }
 
         /// <summary>
@@ -28,7 +28,7 @@ namespace Stratis.Bitcoin.Utilities
         /// </summary>
         /// <param name="obj">Object to be serialized.</param>
         /// <returns>Binary data representing the serialized object.</returns>
-        internal byte[] Serializer(object obj)
+        public byte[] Serializer(object obj)
         {
             var serializable = obj as IBitcoinSerializable;
             if (serializable != null)
@@ -83,13 +83,18 @@ namespace Stratis.Bitcoin.Utilities
             return res;
         }
 
+        public T Deserializer<T>(byte[] bytes)
+        {
+            return (T) this.Deserializer(bytes, typeof(T));
+        }
+
         /// <summary>
         /// Deserializes binary data to an object of specific type.
         /// </summary>
         /// <param name="bytes">Binary data representing a serialized object.</param>
         /// <param name="type">Type of the serialized object.</param>
         /// <returns>Deserialized object.</returns>
-        internal object Deserializer(byte[] bytes, Type type)
+        public object Deserializer(byte[] bytes, Type type)
         {
             if (type == typeof(Coins))
             {

--- a/src/Stratis.Bitcoin/Utilities/DBreezeSerializer.cs
+++ b/src/Stratis.Bitcoin/Utilities/DBreezeSerializer.cs
@@ -11,17 +11,12 @@ namespace Stratis.Bitcoin.Utilities
     /// </summary>
     public class DBreezeSerializer
     {
-        public Network Network { get; private set; }
-
-        /// <summary>
-        /// Initializes custom serializers for DBreeze engine.
-        /// </summary>
-        public void Initialize(Network network)
+        public DBreezeSerializer(Network network)
         {
             this.Network = network;
-            //CustomSerializator.ByteArraySerializator = this.Serializer;
-            //CustomSerializator.ByteArrayDeSerializator = this.Deserializer;
         }
+
+        public Network Network { get; }
 
         /// <summary>
         /// Serializes object to a binary data format.

--- a/src/Stratis.Bitcoin/Utilities/DBreezeSerializer.cs
+++ b/src/Stratis.Bitcoin/Utilities/DBreezeSerializer.cs
@@ -23,7 +23,7 @@ namespace Stratis.Bitcoin.Utilities
         /// </summary>
         /// <param name="obj">Object to be serialized.</param>
         /// <returns>Binary data representing the serialized object.</returns>
-        public byte[] Serializer(object obj)
+        public byte[] Serialize(object obj)
         {
             var serializable = obj as IBitcoinSerializable;
             if (serializable != null)
@@ -48,7 +48,7 @@ namespace Stratis.Bitcoin.Utilities
                 int itemIndex = 0;
                 foreach (object arrayObject in arr)
                 {
-                    byte[] serializedObject = this.Serializer(arrayObject);
+                    byte[] serializedObject = this.Serialize(arrayObject);
                     serializedItems[itemIndex] = serializedObject;
                     itemIndex++;
                 }

--- a/src/Stratis.Bitcoin/Utilities/DBreezeSerializer.cs
+++ b/src/Stratis.Bitcoin/Utilities/DBreezeSerializer.cs
@@ -78,9 +78,9 @@ namespace Stratis.Bitcoin.Utilities
             return res;
         }
 
-        public T Deserializer<T>(byte[] bytes)
+        public T Deserialize<T>(byte[] bytes)
         {
-            return (T) this.Deserializer(bytes, typeof(T));
+            return (T) this.Deserialize(bytes, typeof(T));
         }
 
         /// <summary>
@@ -89,7 +89,7 @@ namespace Stratis.Bitcoin.Utilities
         /// <param name="bytes">Binary data representing a serialized object.</param>
         /// <param name="type">Type of the serialized object.</param>
         /// <returns>Deserialized object.</returns>
-        public object Deserializer(byte[] bytes, Type type)
+        public object Deserialize(byte[] bytes, Type type)
         {
             if (type == typeof(Coins))
             {


### PR DESCRIPTION
What:
Removes responsibility for complex object serialization from DBreeze and pushes it into the repository layer.

Why:
Solves an issue with DBreeze whereby a static `ByteArray(De)Serializator` instance can not be shared across multiple networks. Closes stratisproject/FederatedSideChains#297.

Summary:
* Inline all complex object serialization.
* Remove use of `CustomSerializator.ByteArraySerializator` and `CustomSerializator.ByteArrayDeSerializator`.
* DI `Network` into `DBreezeSerializer`
* Rename serialization methods to better fit the API

Chain syncs up to 100k. Tests are passing. I will let CI run the integration ones.

cc @codingupastorm @quantumagi 