### PR TITLE
Add more logs to CM when failed to reconnect the old chain.

### DIFF
--- a/src/Stratis.Bitcoin/Consensus/ConsensusManager.cs
+++ b/src/Stratis.Bitcoin/Consensus/ConsensusManager.cs
@@ -739,9 +739,9 @@ namespace Stratis.Bitcoin.Consensus
 
             // We failed to jump back on the previous chain after a failed reorg.
             // And we failed to reconnect the old chain, database might be corrupted.
-            this.logger.LogError("A critical error has prevented reconnecting blocks");
+            this.logger.LogError("A critical error has prevented reconnecting blocks, error = {0}", connectBlockResult.Error);
             this.logger.LogTrace("(-)[FAILED_TO_RECONNECT]");
-            throw new ConsensusException("A critical error has prevented reconnecting blocks.");
+            throw new ConsensusException("A critical error has prevented reconnecting blocks");
         }
 
         /// <summary>

--- a/src/Stratis.Bitcoin/Consensus/ConsensusManager.cs
+++ b/src/Stratis.Bitcoin/Consensus/ConsensusManager.cs
@@ -741,7 +741,7 @@ namespace Stratis.Bitcoin.Consensus
             // And we failed to reconnect the old chain, database might be corrupted.
             this.logger.LogError("A critical error has prevented reconnecting blocks, error = {0}", connectBlockResult.Error);
             this.logger.LogTrace("(-)[FAILED_TO_RECONNECT]");
-            throw new ConsensusException("A critical error has prevented reconnecting blocks");
+            throw new ConsensusException("A critical error has prevented reconnecting blocks.");
         }
 
         /// <summary>


### PR DESCRIPTION
We recently observed a failed reorg and when trying to reconnect the older chain back we failed.
This will at least provide the consensus reason for the failure.