### PR TITLE
[RPC] - Refresh wallet unlock when transaction is sent

### DIFF
--- a/src/Stratis.Bitcoin.Features.ColdStaking/ColdStakingManager.cs
+++ b/src/Stratis.Bitcoin.Features.ColdStaking/ColdStakingManager.cs
@@ -447,6 +447,7 @@ namespace Stratis.Bitcoin.Features.ColdStaking
                 TransactionFee = feeAmount,
                 MinConfirmations = 0,
                 Shuffle = false,
+                Sign = false,
                 Recipients = new[] { new Recipient { Amount = amount, ScriptPubKey = destination } }.ToList()
             };
 

--- a/src/Stratis.Bitcoin.Features.Wallet.Tests/WalletTransactionHandlerTest.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet.Tests/WalletTransactionHandlerTest.cs
@@ -622,6 +622,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
                 FeeType = feeType,
                 OpReturnData = opReturnData,
                 WalletPassword = password,
+                Sign = !string.IsNullOrEmpty(password),
                 Recipients = new[] { new Recipient { Amount = amount, ScriptPubKey = destinationScript } }.ToList()
             };
         }

--- a/src/Stratis.Bitcoin.Features.Wallet/WalletTransactionHandler.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/WalletTransactionHandler.cs
@@ -261,9 +261,6 @@ namespace Stratis.Bitcoin.Features.Wallet
             }
             else
             {
-                if (string.IsNullOrEmpty(context.WalletPassword))
-                    return;
-
                 privateKey = Key.Parse(wallet.EncryptedSeed, context.WalletPassword, wallet.Network);
                 this.privateKeyCache.Set(cacheKey, privateKey.ToString(wallet.Network).ToSecureString(), new TimeSpan(0, 5, 0));
             }


### PR DESCRIPTION
Fixes #3015 

Previously would reset the unlock timeout back to the hardcoded 5 minutes after creating the transaction instead of using the duration specified in the original unlocking request.

Also changed the error handling for signing the transaction in the wallet transaction builder context. Make use of "Sign" in the context to specify when to sign the transaction instead of relying on passing in a null password for wallet. Otherwise can get strange errors that are hard to diagnose such as the one specified in the issue above.
