### PR TITLE
Attach ProvenHeadersReservedSlotsBehavior to peer behaviors in PoS network

### DIFF
--- a/src/Stratis.Bitcoin.Features.Consensus/Behaviors/ProvenHeadersReservedSlotsBehavior.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/Behaviors/ProvenHeadersReservedSlotsBehavior.cs
@@ -74,7 +74,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Behaviors
                     if (nodeToDisconnect != null)
                     {
                         this.logger.LogDebug("Disconnecting legacy peer ({0}). Can't serve Proven Header.", nodeToDisconnect.PeerEndPoint);
-                        peer.Disconnect("Reserving connection slot for a Proven Header enabled peer.");
+                        nodeToDisconnect.Disconnect("Reserving connection slot for a Proven Header enabled peer.");
                     }
                 }
                 else

--- a/src/Stratis.Bitcoin.Features.Consensus/PosConsensusFeature.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/PosConsensusFeature.cs
@@ -80,6 +80,8 @@ namespace Stratis.Bitcoin.Features.Consensus
             connectionParameters.TemplateBehaviors.Remove(defaultConsensusManagerBehavior);
             connectionParameters.TemplateBehaviors.Add(new ProvenHeadersConsensusManagerBehavior(this.chain, this.initialBlockDownloadState, this.consensusManager, this.peerBanning, this.loggerFactory, this.network, this.chainState, this.checkpoints, this.provenBlockHeaderStore, this.connectionManagerSettings));
 
+            connectionParameters.TemplateBehaviors.Add(new ProvenHeadersReservedSlotsBehavior(this.connectionManager, this.loggerFactory));
+
             return Task.CompletedTask;
         }
 

--- a/src/Stratis.Bitcoin.IntegrationTests/ProvenHeaderTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/ProvenHeaderTests.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using Stratis.Bitcoin.IntegrationTests.Common;
+using Stratis.Bitcoin.IntegrationTests.Common.EnvironmentMockUpHelpers;
+using Stratis.Bitcoin.Networks;
+using Xunit;
+using System.Linq;
+using Stratis.Bitcoin.Builder;
+using Stratis.Bitcoin.Features.BlockStore;
+using Stratis.Bitcoin.Features.Consensus;
+using Stratis.Bitcoin.Features.MemoryPool;
+using NBitcoin.Protocol;
+using System.Threading.Tasks;
+using Stratis.Bitcoin.Features.RPC;
+using Stratis.Bitcoin.Features.Api;
+
+namespace Stratis.Bitcoin.IntegrationTests
+{
+    public class ProvenHeaderTests
+    {
+
+        /// <summary>
+        /// Prevent network being matched by name and replaced with a different network
+        /// in the <see cref="Configuration.NodeSettings" /> constructor.
+        /// </summary>
+        public class StratisOverrideRegTest : StratisRegTest
+        {
+            public StratisOverrideRegTest(string name = null) : base()
+            {
+                this.Name = name ?? Guid.NewGuid().ToString();
+            }
+        }
+
+
+        public CoreNode CreateNode(NodeBuilder nodeBuilder, string agent, ProtocolVersion version = ProtocolVersion.ALT_PROTOCOL_VERSION, NodeConfigParameters configParameters = null)
+        {
+            var callback = new Action<IFullNodeBuilder>(builder => builder
+                .UseBlockStore()
+                .UsePosConsensus()
+                .UseMempool()
+                .AddRPC()
+                .UseApi()
+                .UseTestChainedHeaderTree()
+                .MockIBD()
+                );
+
+            return nodeBuilder.CreateCustomNode(callback, new StratisOverrideRegTest(), ProtocolVersion.PROVEN_HEADER_VERSION, agent: agent, configParameters: configParameters);
+        }
+
+        /// <summary>
+        /// Tests that a slot is reserved for at least one PH enabled peer.
+        /// </summary>
+        [Fact(Skip = "WIP")]
+        public void LegacyNodesConnectsToProvenHeaderEnabledNode_AndLastOneIsDisconnectedToReserveSlot()
+        {
+            using (NodeBuilder builder = NodeBuilder.Create(this).WithLogsEnabled())
+            {
+                // Create separate network parameters for this test.
+                CoreNode phEnabledNode = this.CreateNode(builder, "ph-enabled", ProtocolVersion.PROVEN_HEADER_VERSION, new NodeConfigParameters { { "maxoutboundconnections", "3" } }).Start();
+                CoreNode legacyNode1 = this.CreateNode(builder, "legacy1", ProtocolVersion.ALT_PROTOCOL_VERSION).Start();
+                CoreNode legacyNode2 = this.CreateNode(builder, "legacy2", ProtocolVersion.ALT_PROTOCOL_VERSION).Start();
+                CoreNode legacyNode3 = this.CreateNode(builder, "legacy3", ProtocolVersion.ALT_PROTOCOL_VERSION).Start();
+
+                TestHelper.Connect(phEnabledNode, legacyNode1);
+                TestHelper.Connect(phEnabledNode, legacyNode2);
+                TestHelper.Connect(phEnabledNode, legacyNode3);
+
+                // TODO: ProvenHeadersReservedSlotsBehavior kicks in only during peer discovery, so it doesn't trigger when we have an inbound connection or
+                // when we are using addnode/connect.
+                // We need to configure a peers.json file or mock the PeerDiscovery to let phEnabledNode try to connect to legacyNode1, legacyNode2 and legacyNode3
+                // With a maxoutboundconnections = 3, we expect the 3rd peer being disconnected to reserve a slot for a ph enabled node.
+
+                // Assert.Equal(phEnabledNode.FullNode.ConnectionManager.ConnectedPeers.Count() == 2);
+            }
+        }
+    }
+}


### PR DESCRIPTION
fixed a bug in ProvenHeadersReservedSlotsBehavior that was disconnecting the wrong peer.
attached ProvenHeadersReservedSlotsBehavior to peer behaviors template.

Created part of an integration test to cover the scenario (skipped because incomplete).