### PR TITLE
[ProvenHeaders] Remove same hash check

### DIFF
--- a/src/Stratis.Bitcoin.Features.Consensus/ProvenBlockHeaders/ProvenBlockHeaderRepository.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/ProvenBlockHeaders/ProvenBlockHeaderRepository.cs
@@ -145,14 +145,6 @@ namespace Stratis.Bitcoin.Features.Consensus.ProvenBlockHeaders
 
             Guard.Assert(newTip.Hash == headers.Values.Last().GetHash());
 
-            if ((this.provenBlockHeaderTip != null) && (newTip.Hash == this.provenBlockHeaderTip.GetHash()))
-            {
-                this.logger.LogTrace("Block hash mismatch {0}:'{1}',{2}:'{3}')", nameof(newTip), newTip, nameof(this.provenBlockHeaderTip), this.provenBlockHeaderTip);
-                this.logger.LogTrace("(-)[BLOCKHASH_MISMATCH])");
-
-                throw new ProvenBlockHeaderException("Invalid new tip hash, tip hash has not changed.");
-            }
-
             Task task = Task.Run(() =>
             {
                 this.logger.LogTrace("({0}.Count():{1})", nameof(headers), headers.Count());

--- a/src/Stratis.Bitcoin/Consensus/ChainedHeaderTree.cs
+++ b/src/Stratis.Bitcoin/Consensus/ChainedHeaderTree.cs
@@ -6,7 +6,6 @@ using NBitcoin;
 using Stratis.Bitcoin.Base;
 using Stratis.Bitcoin.Configuration.Settings;
 using Stratis.Bitcoin.Consensus.Validators;
-using Stratis.Bitcoin.Interfaces;
 using Stratis.Bitcoin.Primitives;
 using Stratis.Bitcoin.Utilities;
 
@@ -641,7 +640,7 @@ namespace Stratis.Bitcoin.Consensus
             if (insufficientInfo)
             {
                 this.logger.LogTrace("(-)[INSUFF_INFO]");
-                return new ConnectNewHeadersResult() {Consumed = null};
+                return new ConnectNewHeadersResult() { Consumed = null };
             }
 
             if (newChainedHeaders == null)


### PR DESCRIPTION
This check is redundant as when we reorg we just overwrite the values in the proven header repo. I.e. it is possible to call flush chain and the `provenBlockHeaderTip` be the same as the new tip we are trying to store.

Relates to #3012 