### PR TITLE
Remove some logging about logging

### DIFF
--- a/src/Stratis.Bitcoin/Utilities/LoggingExtensions.cs
+++ b/src/Stratis.Bitcoin/Utilities/LoggingExtensions.cs
@@ -1,10 +1,12 @@
 ﻿using Microsoft.Extensions.Logging;
+using TracerAttributes;
 
 namespace Stratis.Bitcoin.Utilities
 {
     /// <summary>
     /// Extension methods for classes and interfaces related to logging.
     /// </summary>
+    [NoTrace]
     public static class LoggingExtensions
     {
         /// <summary>

--- a/src/Stratis.Bitcoin/Utilities/PrefixLogger.cs
+++ b/src/Stratis.Bitcoin/Utilities/PrefixLogger.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Microsoft.Extensions.Logging;
 using Stratis.Bitcoin.Configuration.Logging;
+using TracerAttributes;
 
 namespace Stratis.Bitcoin.Utilities
 {
@@ -13,6 +14,7 @@ namespace Stratis.Bitcoin.Utilities
     /// the logging output will not go to the console even if the logging
     /// level is at or above the minimum logging level for the console.
     /// </remarks>
+    [NoTrace]
     public class PrefixLogger : ILogger
     {
         /// <summary>Internal NLog logger instance.</summary>


### PR DESCRIPTION
I was looking at some full logs and I noticed that we log what we're about to log.
Look here:

![image](https://user-images.githubusercontent.com/1867877/50832449-1e63b480-1346-11e9-80c4-bb3d1743a837.png)

The blue bit is the log, the red bit is the meta-log.
