### PR TITLE
Dispose the PH repository when the PH store gets disposed.

### DIFF
--- a/src/Stratis.Bitcoin.Features.Consensus/ProvenBlockHeaders/ProvenBlockHeaderStore.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/ProvenBlockHeaders/ProvenBlockHeaderStore.cs
@@ -301,6 +301,7 @@ namespace Stratis.Bitcoin.Features.Consensus.ProvenBlockHeaders
         /// <inheritdoc />
         public void Dispose()
         {
+            this.provenBlockHeaderRepository.Dispose();
         }
     }
 }


### PR DESCRIPTION
I was running some tests and noticed that the repository wasn't being disposed and DBreeze was locking the folder. 
This fixes it.