### PR TITLE
[Consensus] Implement transaction timestamp consensus logic

### DIFF
--- a/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/CoinviewRule.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/CoinviewRule.cs
@@ -208,6 +208,16 @@ namespace Stratis.Bitcoin.Features.Consensus.Rules.CommonRules
         public abstract void CheckMaturity(UnspentOutputs coins, int spendHeight);
 
         /// <summary>
+        /// Contains checks that need to be performed on each input once UTXO data is available.
+        /// </summary>
+        /// <param name="transaction">The transaction that is having its input examined.</param>
+        /// <param name="inputIndex">The index of the input being examined.</param>
+        /// <param name="coins">The unspent output consumed by the input being examined.</param>
+        protected virtual void CheckInputValidity(Transaction transaction, int inputIndex, UnspentOutputs coins)
+        {
+        }
+
+        /// <summary>
         /// Checks that transaction's inputs are valid.
         /// </summary>
         /// <param name="transaction">Transaction to check.</param>
@@ -231,6 +241,8 @@ namespace Stratis.Bitcoin.Features.Consensus.Rules.CommonRules
                 UnspentOutputs coins = inputs.AccessCoins(prevout.Hash);
 
                 this.CheckMaturity(coins, spendHeight);
+
+                this.CheckInputValidity(transaction, i, coins);
 
                 // Check for negative or overflow input values.
                 valueIn += coins.TryGetOutput(prevout.N).Value;

--- a/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/PosCoinviewRule.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/PosCoinviewRule.cs
@@ -112,6 +112,14 @@ namespace Stratis.Bitcoin.Features.Consensus.Rules.CommonRules
             }
         }
 
+        /// <inheritdoc />
+        protected override void CheckInputValidity(Transaction transaction, int inputIndex, UnspentOutputs coins)
+        {
+            // Transaction timestamp earlier than input transaction - main.cpp, CTransaction::ConnectInputs
+            if (coins.Time > transaction.Time)
+                ConsensusErrors.BadTransactionEarlyTimestamp.Throw();
+        }
+
         /// <summary>
         /// Checks and computes stake.
         /// </summary>

--- a/src/Stratis.Bitcoin/Consensus/ConsensusErrors.cs
+++ b/src/Stratis.Bitcoin/Consensus/ConsensusErrors.cs
@@ -49,6 +49,7 @@
         public static readonly ConsensusError BadTransactionInBelowOut = new ConsensusError("bad-txns-in-belowout", "input value below output value");
         public static readonly ConsensusError BadTransactionNegativeFee = new ConsensusError("bad-txns-fee-negative", "negative fee");
         public static readonly ConsensusError BadTransactionFeeOutOfRange = new ConsensusError("bad-txns-fee-outofrange", "fee out of range");
+        public static readonly ConsensusError BadTransactionEarlyTimestamp = new ConsensusError("bad-txns-early-timestamp", "timestamp earlier than input");
 
         public static readonly ConsensusError BadTransactionScriptError = new ConsensusError("bad-txns-script-failed", "a script failed");
 


### PR DESCRIPTION
Fixes #3018 

Note that `MempoolValidator` calls the consensus rule and thus the logic is used by the mempool as well as by the consensus engine.