### PR TITLE
Fix sending_transaction_near_policy_byte_limit

### DIFF
--- a/src/Stratis.Bitcoin.IntegrationTests/Wallet/SendingTransactionOverPolicyByteLimitSpecification_Steps.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/Wallet/SendingTransactionOverPolicyByteLimitSpecification_Steps.cs
@@ -53,7 +53,7 @@ namespace Stratis.Bitcoin.IntegrationTests.Wallet
 
         private void node1_builds_undersize_transaction_to_send_to_node2()
         {
-            Node1BuildsTransactionToSendToNode2(2450);
+            Node1BuildsTransactionToSendToNode2(2650);
         }
 
         private void serialized_size_of_transaction_is_close_to_upper_limit()


### PR DESCRIPTION
Fixes this test case which was not building a transaction big enough to be sufficiently near the policy byte limit (95,000 to 100,000 bytes). 