### PR TITLE
CLI to perform POST if GET not found

### DIFF
--- a/src/Stratis.Bitcoin.Cli/Program.cs
+++ b/src/Stratis.Bitcoin.Cli/Program.cs
@@ -9,11 +9,11 @@ using Flurl.Http;
 using NBitcoin;
 using NBitcoin.Protocol;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using Stratis.Bitcoin.Configuration;
 using Stratis.Bitcoin.Features.RPC;
 using Stratis.Bitcoin.Features.Api;
 using Stratis.Bitcoin.Utilities.Extensions;
-using Newtonsoft.Json.Linq;
 
 namespace Stratis.Bitcoin.Cli
 {
@@ -51,17 +51,13 @@ namespace Stratis.Bitcoin.Cli
                     argList.RemoveAt(0);
                 }
 
-                string method = "GET";
+                string method = "";
                 if (argList.Any())
                 {
                     method = argList.First().ToUpper();
                     if (method == "GET" || method == "POST" || method == "DELETE")
                     {
                         argList.RemoveAt(0);
-                    }
-                    else
-                    {
-                        method = "";
                     }
                 }
 

--- a/src/Stratis.Bitcoin.Cli/Program.cs
+++ b/src/Stratis.Bitcoin.Cli/Program.cs
@@ -59,6 +59,10 @@ namespace Stratis.Bitcoin.Cli
                     {
                         argList.RemoveAt(0);
                     }
+                    else
+                    {
+                        method = "";
+                    }
                 }
 
                 string command = string.Empty;

--- a/src/Stratis.Bitcoin.Cli/Stratis.Bitcoin.Cli.csproj
+++ b/src/Stratis.Bitcoin.Cli/Stratis.Bitcoin.Cli.csproj
@@ -8,6 +8,11 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Flurl" Version="2.8.0" />
+    <PackageReference Include="Flurl.Http" Version="2.4.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\NBitcoin\NBitcoin.csproj" />
     <ProjectReference Include="..\Stratis.Bitcoin.Features.Api\Stratis.Bitcoin.Features.Api.csproj" />
     <ProjectReference Include="..\Stratis.Bitcoin.Features.RPC\Stratis.Bitcoin.Features.RPC.csproj" />


### PR DESCRIPTION
Currently the CLI always performs a GET operation when calling the API. 

This PR adds a call to the POST method if the GET method is not found.

EDIT: This has changed in favor of specifying the method on the command line:

`dotnet run <Stratis.Bitcoin.Cli/Stratis.Bitcoin.Cli.dll> [network-name] [options] [method] <command> [arguments]`