### PR TITLE
[SC] Start of moving gas and memory meter implementations to CLR

### DIFF
--- a/src/Stratis.SmartContracts.CLR.Tests/ContractExecutorTestContext.cs
+++ b/src/Stratis.SmartContracts.CLR.Tests/ContractExecutorTestContext.cs
@@ -47,7 +47,7 @@ namespace Stratis.SmartContracts.CLR.Tests
             this.ModuleDefinitionReader = new ContractModuleDefinitionReader();
             this.Vm = new ReflectionVirtualMachine(this.Validator, this.LoggerFactory, this.AssemblyLoader, this.ModuleDefinitionReader);
             this.StateProcessor = new StateProcessor(this.Vm, this.AddressGenerator);
-            this.InternalTxExecutorFactory = new InternalExecutorFactory(this.LoggerFactory, this.StateProcessor);
+            this.InternalTxExecutorFactory = new InternalExecutorFactory(this.StateProcessor);
             this.SmartContractStateFactory = new SmartContractStateFactory(this.ContractPrimitiveSerializer, this.InternalTxExecutorFactory, this.Serializer);
         }
     }

--- a/src/Stratis.SmartContracts.CLR.Tests/ContractExecutorTests.cs
+++ b/src/Stratis.SmartContracts.CLR.Tests/ContractExecutorTests.cs
@@ -57,7 +57,7 @@ namespace Stratis.SmartContracts.CLR.Tests
             this.serializer = new Serializer(this.contractPrimitiveSerializer);
             this.vm = new ReflectionVirtualMachine(this.validator, this.loggerFactory, this.assemblyLoader, this.moduleDefinitionReader);
             this.stateProcessor = new StateProcessor(this.vm, this.addressGenerator);
-            this.internalTxExecutorFactory = new InternalExecutorFactory(this.loggerFactory, this.stateProcessor);
+            this.internalTxExecutorFactory = new InternalExecutorFactory(this.stateProcessor);
             this.smartContractStateFactory = new SmartContractStateFactory(this.contractPrimitiveSerializer, this.internalTxExecutorFactory, this.serializer);
             
             this.callDataSerializer = new CallDataSerializer(this.contractPrimitiveSerializer);

--- a/src/Stratis.SmartContracts.CLR.Tests/ExecutorFixture.cs
+++ b/src/Stratis.SmartContracts.CLR.Tests/ExecutorFixture.cs
@@ -58,7 +58,7 @@ namespace Stratis.SmartContracts.CLR.Tests
                     It.IsAny<ContractTxData>(),
                     It.IsAny<ulong>(),
                     It.IsAny<uint160>(),
-                    It.IsAny<Gas>(),
+                    It.IsAny<ulong>(),
                     It.IsAny<bool>()))
                 .Returns((this.Fee, this.Refund));            
             this.RefundProcessor = refundProcessor;

--- a/src/Stratis.SmartContracts.CLR.Tests/ExecutorSpecification.cs
+++ b/src/Stratis.SmartContracts.CLR.Tests/ExecutorSpecification.cs
@@ -65,7 +65,7 @@ namespace Stratis.SmartContracts.CLR.Tests
                         contractTxData,
                         fixture.MempoolFee,
                         fixture.ContractTransactionContext.Sender,
-                        It.IsAny<Gas>(),
+                        It.IsAny<ulong>(),
                         false),
                 Times.Once);
 
@@ -140,7 +140,7 @@ namespace Stratis.SmartContracts.CLR.Tests
                         contractTxData,
                         fixture.MempoolFee,
                         fixture.ContractTransactionContext.Sender,
-                        It.IsAny<Gas>(),
+                        It.IsAny<ulong>(),
                         false),
                 Times.Once);
 
@@ -220,7 +220,7 @@ namespace Stratis.SmartContracts.CLR.Tests
                         contractTxData,
                         fixture.MempoolFee,
                         fixture.ContractTransactionContext.Sender,
-                        It.IsAny<Gas>(),
+                        It.IsAny<ulong>(),
                         false),
                 Times.Once);
 

--- a/src/Stratis.SmartContracts.CLR.Tests/GasMeterTests.cs
+++ b/src/Stratis.SmartContracts.CLR.Tests/GasMeterTests.cs
@@ -11,7 +11,7 @@ namespace Stratis.SmartContracts.CLR.Tests
             var gas = new Gas(1000);
             var gasMeter = new GasMeter(gas);
 
-            Assert.Equal(gas, gasMeter.GasLimit);
+            Assert.Equal(gas, gasMeter.Limit);
         }
 
         [Fact]
@@ -20,7 +20,7 @@ namespace Stratis.SmartContracts.CLR.Tests
             var gas = new Gas(1000);
             var gasMeter = new GasMeter(gas);
 
-            Assert.Equal(gas, gasMeter.GasAvailable);
+            Assert.Equal(gas, gasMeter.Available);
         }
 
         [Fact]
@@ -29,7 +29,7 @@ namespace Stratis.SmartContracts.CLR.Tests
             var gas = new Gas(1000);
             var gasMeter = new GasMeter(gas);
 
-            Assert.Equal(Gas.None, gasMeter.GasConsumed);
+            Assert.Equal(Gas.None, gasMeter.Consumed);
         }
 
         [Fact]
@@ -42,8 +42,8 @@ namespace Stratis.SmartContracts.CLR.Tests
 
             gasMeter.Spend(consumed);
 
-            Assert.Equal(consumed, gasMeter.GasConsumed);
-            Assert.Equal(diff, gasMeter.GasAvailable);
+            Assert.Equal(consumed, gasMeter.Consumed);
+            Assert.Equal(diff, gasMeter.Available);
         }
 
         [Fact]

--- a/src/Stratis.SmartContracts.CLR.Tests/InternalExecutorSpecification.cs
+++ b/src/Stratis.SmartContracts.CLR.Tests/InternalExecutorSpecification.cs
@@ -24,9 +24,9 @@ namespace Stratis.SmartContracts.CLR.Tests
                 .Returns(stateTransitionResult);
 
             var internalExecutor = new InternalExecutor(
-                fixture.LoggerFactory,
                 fixture.State.Object,
-                fixture.StateProcessor.Object);
+                fixture.StateProcessor.Object,
+                fixture.GasMeter.Object);
 
             ICreateResult result = internalExecutor.Create<string>(fixture.SmartContractState, amount, parameters, gasLimit);
 
@@ -67,9 +67,9 @@ namespace Stratis.SmartContracts.CLR.Tests
                 .Returns(stateTransitionResult);
 
             var internalExecutor = new InternalExecutor(
-                fixture.LoggerFactory,
                 fixture.State.Object,
-                fixture.StateProcessor.Object);
+                fixture.StateProcessor.Object,
+                fixture.GasMeter.Object);
 
             ICreateResult result = internalExecutor.Create<string>(fixture.SmartContractState, amount, parameters, gasLimit);
 
@@ -104,9 +104,9 @@ namespace Stratis.SmartContracts.CLR.Tests
             fixture.SetGasMeterLimitBelow(gasLimit);
 
             var internalExecutor = new InternalExecutor(
-                fixture.LoggerFactory,
                 fixture.State.Object,
-                fixture.StateProcessor.Object);
+                fixture.StateProcessor.Object,
+                fixture.GasMeter.Object);
 
             ICreateResult result = internalExecutor.Create<string>(fixture.SmartContractState, amount, parameters, gasLimit);
 
@@ -144,9 +144,9 @@ namespace Stratis.SmartContracts.CLR.Tests
                 .Returns(stateTransitionResult);
 
             var internalExecutor = new InternalExecutor(
-                fixture.LoggerFactory,
                 fixture.State.Object,
-                fixture.StateProcessor.Object);
+                fixture.StateProcessor.Object,
+                fixture.GasMeter.Object);
 
             ITransferResult result = internalExecutor.Call(fixture.SmartContractState, to, amount, method, parameters, gasLimit);
 
@@ -190,9 +190,9 @@ namespace Stratis.SmartContracts.CLR.Tests
                 .Returns(stateTransitionResult);
 
             var internalExecutor = new InternalExecutor(
-                fixture.LoggerFactory,
                 fixture.State.Object,
-                fixture.StateProcessor.Object);
+                fixture.StateProcessor.Object,
+                fixture.GasMeter.Object);
 
             ITransferResult result = internalExecutor.Call(fixture.SmartContractState, to, amount, method, parameters, gasLimit);
 
@@ -230,9 +230,9 @@ namespace Stratis.SmartContracts.CLR.Tests
             fixture.SetGasMeterLimitBelow(gasLimit);
 
             var internalExecutor = new InternalExecutor(
-                fixture.LoggerFactory,
                 fixture.State.Object,
-                fixture.StateProcessor.Object);
+                fixture.StateProcessor.Object,
+                fixture.GasMeter.Object);
 
             ITransferResult result = internalExecutor.Call(fixture.SmartContractState, to, amount, method, parameters, gasLimit);
 
@@ -266,9 +266,9 @@ namespace Stratis.SmartContracts.CLR.Tests
                 .Returns(stateTransitionResult);
 
             var internalExecutor = new InternalExecutor(
-                fixture.LoggerFactory,
                 fixture.State.Object,
-                fixture.StateProcessor.Object);
+                fixture.StateProcessor.Object,
+                fixture.GasMeter.Object);
 
             ITransferResult result = internalExecutor.Transfer(fixture.SmartContractState, to, amount);
 
@@ -307,9 +307,9 @@ namespace Stratis.SmartContracts.CLR.Tests
                 .Returns(stateTransitionResult);
 
             var internalExecutor = new InternalExecutor(
-                fixture.LoggerFactory,
                 fixture.State.Object,
-                fixture.StateProcessor.Object);
+                fixture.StateProcessor.Object,
+                fixture.GasMeter.Object);
 
             ITransferResult result = internalExecutor.Transfer(fixture.SmartContractState, to, amount);
 
@@ -342,9 +342,9 @@ namespace Stratis.SmartContracts.CLR.Tests
             var to = "0x95D34980095380851902ccd9A1Fb4C813C2cb639".HexToAddress();
 
             var internalExecutor = new InternalExecutor(
-                fixture.LoggerFactory,
                 fixture.State.Object,
-                fixture.StateProcessor.Object);
+                fixture.StateProcessor.Object,
+                fixture.GasMeter.Object);
 
             ITransferResult result = internalExecutor.Transfer(fixture.SmartContractState, to, amount);
 

--- a/src/Stratis.SmartContracts.CLR.Tests/InternalExecutorTestFixture.cs
+++ b/src/Stratis.SmartContracts.CLR.Tests/InternalExecutorTestFixture.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Extensions.Logging;
 using Moq;
 using NBitcoin;
+using Stratis.SmartContracts.RuntimeObserver;
 
 namespace Stratis.SmartContracts.CLR.Tests
 {
@@ -20,7 +21,7 @@ namespace Stratis.SmartContracts.CLR.Tests
             this.State = state;
             this.StateProcessor = new Mock<IStateProcessor>();
 
-            this.GasMeter = new Mock<IGasMeter>();
+            this.GasMeter = new Mock<IResourceMeter>();
 
             var smartContractState = Mock.Of<ISmartContractState>(s =>
                 s.Message == new Message("0x0000000000000000000000000000000000000001".HexToAddress(), "0x0000000000000000000000000000000000000002".HexToAddress(), 100) &&
@@ -35,7 +36,7 @@ namespace Stratis.SmartContracts.CLR.Tests
 
         public ISmartContractState SmartContractState { get; }
 
-        public Mock<IGasMeter> GasMeter { get; }
+        public Mock<IResourceMeter> GasMeter { get; }
 
         public IState Snapshot { get; }
 
@@ -47,12 +48,12 @@ namespace Stratis.SmartContracts.CLR.Tests
 
         public void SetGasMeterLimitAbove(Gas minimum)
         {
-            this.GasMeter.SetupGet(g => g.GasAvailable).Returns((Gas)(minimum + 1));
+            this.GasMeter.SetupGet(g => g.Available).Returns((Gas)(minimum + 1));
         }
 
         public void SetGasMeterLimitBelow(Gas maximum)
         {
-            this.GasMeter.SetupGet(g => g.GasAvailable).Returns((Gas)(maximum - 1));
+            this.GasMeter.SetupGet(g => g.Available).Returns((Gas)(maximum - 1));
         }
     }
 }

--- a/src/Stratis.SmartContracts.CLR.Tests/InternalExecutorTestFixture.cs
+++ b/src/Stratis.SmartContracts.CLR.Tests/InternalExecutorTestFixture.cs
@@ -24,8 +24,7 @@ namespace Stratis.SmartContracts.CLR.Tests
             this.GasMeter = new Mock<IResourceMeter>();
 
             var smartContractState = Mock.Of<ISmartContractState>(s =>
-                s.Message == new Message("0x0000000000000000000000000000000000000001".HexToAddress(), "0x0000000000000000000000000000000000000002".HexToAddress(), 100) &&
-                s.GasMeter == this.GasMeter.Object);
+                s.Message == new Message("0x0000000000000000000000000000000000000001".HexToAddress(), "0x0000000000000000000000000000000000000002".HexToAddress(), 100));
 
             this.SmartContractState = smartContractState;
 

--- a/src/Stratis.SmartContracts.CLR.Tests/MeteredPersistenceStrategyTests.cs
+++ b/src/Stratis.SmartContracts.CLR.Tests/MeteredPersistenceStrategyTests.cs
@@ -50,7 +50,7 @@ namespace Stratis.SmartContracts.CLR.Tests
             sr.Verify(s => s.SetStorageValue(testAddress, testKey, testValue));            
 
             // Test that gas is used
-            Assert.True(gasMeter.GasConsumed < availableGas);
+            Assert.True(gasMeter.Consumed < availableGas);
         }
     }
 }

--- a/src/Stratis.SmartContracts.CLR.Tests/ReflectionVirtualMachineTests.cs
+++ b/src/Stratis.SmartContracts.CLR.Tests/ReflectionVirtualMachineTests.cs
@@ -119,9 +119,8 @@ public class Contract : SmartContract
 
             byte[] contractExecutionCode = compilationResult.Compilation;
 
-            var gasMeter = new GasMeter((Gas)5000000);
-
             // Set up the state with an empty gasmeter so that out of gas occurs
+            var gasMeter = new GasMeter((Gas)0);
             var contractState = Mock.Of<ISmartContractState>(s =>
                 s.Block == Mock.Of<IBlock>(b => b.Number == 1 && b.Coinbase == this.TestAddress) &&
                 s.Message == new Message(this.TestAddress, this.TestAddress, 0) &&

--- a/src/Stratis.SmartContracts.CLR.Tests/StateTransitionSpecification.cs
+++ b/src/Stratis.SmartContracts.CLR.Tests/StateTransitionSpecification.cs
@@ -2,6 +2,7 @@
 using NBitcoin;
 using Stratis.SmartContracts.Core.State;
 using Stratis.SmartContracts.Core.State.AccountAbstractionLayer;
+using Stratis.SmartContracts.RuntimeObserver;
 using Xunit;
 
 namespace Stratis.SmartContracts.CLR.Tests
@@ -41,7 +42,11 @@ namespace Stratis.SmartContracts.CLR.Tests
                 null
             );
 
-            this.vm.Setup(v => v.Create(this.contractStateRoot.Object, It.IsAny<ISmartContractState>(), externalCreateMessage.Code, externalCreateMessage.Parameters, null))
+            this.vm.Setup(v => v.Create(this.contractStateRoot.Object,
+                    It.IsAny<ISmartContractState>(), 
+                    It.IsAny<IResourceMeter>(),                    
+                    externalCreateMessage.Code, 
+                    externalCreateMessage.Parameters, null))
                 .Returns(vmExecutionResult);
 
             var state = new Mock<IState>();
@@ -60,7 +65,11 @@ namespace Stratis.SmartContracts.CLR.Tests
 
             state.Verify(s => s.CreateSmartContractState(state.Object, It.IsAny<GasMeter>(), newContractAddress, externalCreateMessage, this.contractStateRoot.Object));
 
-            this.vm.Verify(v => v.Create(this.contractStateRoot.Object, It.IsAny<ISmartContractState>(), externalCreateMessage.Code, externalCreateMessage.Parameters, null), Times.Once);
+            this.vm.Verify(v => v.Create(this.contractStateRoot.Object,
+                It.IsAny<ISmartContractState>(),
+                It.IsAny<IResourceMeter>(),
+                externalCreateMessage.Code,
+                externalCreateMessage.Parameters, null), Times.Once);
 
             Assert.True(result.IsSuccess);
             Assert.NotNull(result.Success);
@@ -83,7 +92,7 @@ namespace Stratis.SmartContracts.CLR.Tests
                 null
             );
 
-            this.vm.Setup(v => v.Create(this.contractStateRoot.Object, It.IsAny<ISmartContractState>(), externalCreateMessage.Code, externalCreateMessage.Parameters, null))
+            this.vm.Setup(v => v.Create(this.contractStateRoot.Object, It.IsAny<ISmartContractState>(), It.IsAny<IResourceMeter>(), externalCreateMessage.Code, externalCreateMessage.Parameters, null))
                 .Returns(vmExecutionResult);
 
             var state = new Mock<IState>();
@@ -98,7 +107,7 @@ namespace Stratis.SmartContracts.CLR.Tests
 
             this.contractStateRoot.Verify(ts => ts.CreateAccount(newContractAddress), Times.Once);
 
-            this.vm.Verify(v => v.Create(this.contractStateRoot.Object, It.IsAny<ISmartContractState>(), externalCreateMessage.Code, externalCreateMessage.Parameters, null), Times.Once);
+            this.vm.Verify(v => v.Create(this.contractStateRoot.Object, It.IsAny<ISmartContractState>(), It.IsAny<IResourceMeter>(), externalCreateMessage.Code, externalCreateMessage.Parameters, null), Times.Once);
 
             Assert.False(result.IsSuccess);
             Assert.True(result.IsFailure);
@@ -135,7 +144,7 @@ namespace Stratis.SmartContracts.CLR.Tests
                 .Returns(typeName);
 
             this.vm.Setup(v =>
-                    v.ExecuteMethod(It.IsAny<ISmartContractState>(), externalCallMessage.Method, code, typeName))
+                    v.ExecuteMethod(It.IsAny<ISmartContractState>(), It.IsAny<IResourceMeter>(), externalCallMessage.Method, code, typeName))
                 .Returns(vmExecutionResult);
 
             var state = new Mock<IState>();
@@ -154,7 +163,7 @@ namespace Stratis.SmartContracts.CLR.Tests
             state.Verify(s => s.CreateSmartContractState(state.Object, It.IsAny<GasMeter>(), externalCallMessage.To, externalCallMessage, this.contractStateRoot.Object));
 
             this.vm.Verify(
-                v => v.ExecuteMethod(It.IsAny<ISmartContractState>(), externalCallMessage.Method, code, typeName),
+                v => v.ExecuteMethod(It.IsAny<ISmartContractState>(), It.IsAny<IResourceMeter>(), externalCallMessage.Method, code, typeName),
                 Times.Once);
 
             Assert.True(result.IsSuccess);
@@ -191,7 +200,7 @@ namespace Stratis.SmartContracts.CLR.Tests
                 .Returns(typeName);
 
             this.vm.Setup(v =>
-                    v.ExecuteMethod(It.IsAny<ISmartContractState>(), externalCallMessage.Method, code, typeName))
+                    v.ExecuteMethod(It.IsAny<ISmartContractState>(), It.IsAny<IResourceMeter>(), externalCallMessage.Method, code, typeName))
                 .Returns(vmExecutionResult);
 
             var state = new Mock<IState>();
@@ -208,7 +217,7 @@ namespace Stratis.SmartContracts.CLR.Tests
             state.Verify(s => s.CreateSmartContractState(state.Object, It.IsAny<GasMeter>(), externalCallMessage.To, externalCallMessage, this.contractStateRoot.Object));
 
             this.vm.Verify(
-                v => v.ExecuteMethod(It.IsAny<ISmartContractState>(), externalCallMessage.Method, code, typeName),
+                v => v.ExecuteMethod(It.IsAny<ISmartContractState>(), It.IsAny<IResourceMeter>(), externalCallMessage.Method, code, typeName),
                 Times.Once);
 
             Assert.True(result.IsFailure);
@@ -274,7 +283,7 @@ namespace Stratis.SmartContracts.CLR.Tests
                 .Setup(sr => sr.GetCode(internalCreateMessage.From))
                 .Returns(code);
 
-            this.vm.Setup(v => v.Create(this.contractStateRoot.Object, It.IsAny<ISmartContractState>(), code, internalCreateMessage.Parameters, internalCreateMessage.Type))
+            this.vm.Setup(v => v.Create(this.contractStateRoot.Object, It.IsAny<ISmartContractState>(), It.IsAny<IResourceMeter>(), code, internalCreateMessage.Parameters, internalCreateMessage.Type))
                 .Returns(vmExecutionResult);
 
             var state = new Mock<IState>();
@@ -303,7 +312,7 @@ namespace Stratis.SmartContracts.CLR.Tests
             state.Verify(s => s.CreateSmartContractState(state.Object, It.IsAny<GasMeter>(), newContractAddress, internalCreateMessage, this.contractStateRoot.Object));
 
             // Verify the VM was invoked
-            this.vm.Verify(v => v.Create(this.contractStateRoot.Object, It.IsAny<ISmartContractState>(), code, internalCreateMessage.Parameters, internalCreateMessage.Type), Times.Once);
+            this.vm.Verify(v => v.Create(this.contractStateRoot.Object, It.IsAny<ISmartContractState>(), It.IsAny<IResourceMeter>(), code, internalCreateMessage.Parameters, internalCreateMessage.Type), Times.Once);
 
             // Verify the value was added to the internal transfer list
             state.Verify(s => s.AddInternalTransfer(It.Is<TransferInfo>(t => t.From == internalCreateMessage.From 
@@ -339,6 +348,7 @@ namespace Stratis.SmartContracts.CLR.Tests
             this.vm.Setup(v =>
                     v.Create(It.IsAny<IStateRepository>(),
                         It.IsAny<ISmartContractState>(),
+                        It.IsAny<IResourceMeter>(),
                         It.IsAny<byte[]>(),
                         It.IsAny<object[]>(),
                         It.IsAny<string>()))
@@ -364,6 +374,7 @@ namespace Stratis.SmartContracts.CLR.Tests
                 v => v.Create(
                     this.contractStateRoot.Object,
                     It.IsAny<ISmartContractState>(), 
+                    It.IsAny<IResourceMeter>(),
                     code,
                     internalCreateMessage.Parameters,
                     internalCreateMessage.Type),
@@ -422,7 +433,7 @@ namespace Stratis.SmartContracts.CLR.Tests
                 null
             );
 
-            this.vm.Setup(v => v.Create(this.contractStateRoot.Object, It.IsAny<ISmartContractState>(), createMessage.Code, createMessage.Parameters, null))
+            this.vm.Setup(v => v.Create(this.contractStateRoot.Object, It.IsAny<ISmartContractState>(), It.IsAny<IResourceMeter>(), createMessage.Code, createMessage.Parameters, null))
                 .Returns(vmExecutionResult);
 
             var state = new Mock<IState>();
@@ -437,7 +448,7 @@ namespace Stratis.SmartContracts.CLR.Tests
 
             this.contractStateRoot.Verify(ts => ts.CreateAccount(newContractAddress), Times.Once);
 
-            this.vm.Verify(v => v.Create(this.contractStateRoot.Object, It.IsAny<ISmartContractState>(), createMessage.Code, createMessage.Parameters, null), Times.Once);
+            this.vm.Verify(v => v.Create(this.contractStateRoot.Object, It.IsAny<ISmartContractState>(), It.IsAny<IResourceMeter>(), createMessage.Code, createMessage.Parameters, null), Times.Once);
 
             Assert.False(result.IsSuccess);
             Assert.True(result.IsFailure);
@@ -473,7 +484,7 @@ namespace Stratis.SmartContracts.CLR.Tests
                 .Setup(sr => sr.GetContractType(internalCallMessage.To))
                 .Returns(typeName);
 
-            this.vm.Setup(v => v.ExecuteMethod(It.IsAny<ISmartContractState>(), internalCallMessage.Method, code, typeName))
+            this.vm.Setup(v => v.ExecuteMethod(It.IsAny<ISmartContractState>(), It.IsAny<IResourceMeter>(), internalCallMessage.Method, code, typeName))
                 .Returns(vmExecutionResult);
 
             var state = new Mock<IState>();
@@ -497,7 +508,7 @@ namespace Stratis.SmartContracts.CLR.Tests
             state.Verify(s => s.CreateSmartContractState(state.Object, It.IsAny<GasMeter>(), internalCallMessage.To, internalCallMessage, this.contractStateRoot.Object));
 
             // Verify the VM was invoked
-            this.vm.Verify(v => v.ExecuteMethod(It.IsAny<ISmartContractState>(), internalCallMessage.Method, code, typeName), Times.Once);
+            this.vm.Verify(v => v.ExecuteMethod(It.IsAny<ISmartContractState>(), It.IsAny<IResourceMeter>(), internalCallMessage.Method, code, typeName), Times.Once);
 
             // Verify the value was added to the internal transfer list
             state.Verify(s => s.AddInternalTransfer(It.Is<TransferInfo>(t => t.From == internalCallMessage.From
@@ -530,6 +541,7 @@ namespace Stratis.SmartContracts.CLR.Tests
 
             this.vm.Setup(v => v.ExecuteMethod(
                     It.IsAny<ISmartContractState>(),
+                    It.IsAny<IResourceMeter>(),
                     internalCallMessage.Method,
                     code,
                     typeName))
@@ -557,6 +569,7 @@ namespace Stratis.SmartContracts.CLR.Tests
             this.vm.Verify(
                 v => v.ExecuteMethod(
                     It.IsAny<ISmartContractState>(),
+                    It.IsAny<IResourceMeter>(),
                     internalCallMessage.Method,
                     code,
                     typeName),
@@ -650,6 +663,7 @@ namespace Stratis.SmartContracts.CLR.Tests
 
             this.vm.Setup(v => v.ExecuteMethod(
                     It.IsAny<ISmartContractState>(),
+                    It.IsAny<IResourceMeter>(),
                     callMessage.Method,
                     code,
                     null))
@@ -673,6 +687,7 @@ namespace Stratis.SmartContracts.CLR.Tests
             this.vm.Verify(
                 v => v.ExecuteMethod(
                     It.IsAny<ISmartContractState>(),
+                    It.IsAny<IResourceMeter>(),
                     callMessage.Method,
                     code,
                     null),
@@ -708,7 +723,7 @@ namespace Stratis.SmartContracts.CLR.Tests
                 .Setup(sr => sr.GetContractType(contractTransferMessage.To))
                 .Returns(typeName);
 
-            this.vm.Setup(v => v.ExecuteMethod(It.IsAny<ISmartContractState>(), contractTransferMessage.Method, code, typeName))
+            this.vm.Setup(v => v.ExecuteMethod(It.IsAny<ISmartContractState>(), It.IsAny<IResourceMeter>(), contractTransferMessage.Method, code, typeName))
                 .Returns(vmExecutionResult);
 
             var state = new Mock<IState>();
@@ -732,7 +747,7 @@ namespace Stratis.SmartContracts.CLR.Tests
             state.Verify(s => s.CreateSmartContractState(state.Object, It.IsAny<GasMeter>(), contractTransferMessage.To, contractTransferMessage, this.contractStateRoot.Object));
 
             // Verify the VM was invoked
-            this.vm.Verify(v => v.ExecuteMethod(It.IsAny<ISmartContractState>(), contractTransferMessage.Method, code, typeName), Times.Once);
+            this.vm.Verify(v => v.ExecuteMethod(It.IsAny<ISmartContractState>(), It.IsAny<IResourceMeter>(), contractTransferMessage.Method, code, typeName), Times.Once);
 
             // Verify the value was added to the internal transfer list
             state.Verify(s => s.AddInternalTransfer(It.Is<TransferInfo>(t => t.From == contractTransferMessage.From
@@ -764,6 +779,7 @@ namespace Stratis.SmartContracts.CLR.Tests
 
             this.vm.Setup(v => v.ExecuteMethod(
                     It.IsAny<ISmartContractState>(),
+                    It.IsAny<IResourceMeter>(),
                     contractTransferMessage.Method,
                     code,
                     typeName))
@@ -791,6 +807,7 @@ namespace Stratis.SmartContracts.CLR.Tests
             this.vm.Verify(
                 v => v.ExecuteMethod(
                     It.IsAny<ISmartContractState>(),
+                    It.IsAny<IResourceMeter>(),
                     contractTransferMessage.Method,
                     code,
                     typeName),
@@ -868,7 +885,7 @@ namespace Stratis.SmartContracts.CLR.Tests
             this.contractStateRoot.Verify(s => s.GetCode(contractTransferMessage.To), Times.Once);
 
             // Verify the VM was NOT invoked
-            this.vm.Verify(v => v.ExecuteMethod(It.IsAny<ISmartContractState>(), It.IsAny<MethodCall>(), It.IsAny<byte[]>(), It.IsAny<string>()), Times.Never);
+            this.vm.Verify(v => v.ExecuteMethod(It.IsAny<ISmartContractState>(), It.IsAny<IResourceMeter>(), It.IsAny<MethodCall>(), It.IsAny<byte[]>(), It.IsAny<string>()), Times.Never);
 
             // Verify the value was added to the internal transfer list
             state.Verify(s => s.AddInternalTransfer(It.Is<TransferInfo>(t => t.From == contractTransferMessage.From

--- a/src/Stratis.SmartContracts.CLR/BaseMessage.cs
+++ b/src/Stratis.SmartContracts.CLR/BaseMessage.cs
@@ -4,7 +4,7 @@ namespace Stratis.SmartContracts.CLR
 {
     public abstract class BaseMessage
     {
-        protected BaseMessage(uint160 from, ulong amount, Gas gasLimit)
+        protected BaseMessage(uint160 from, ulong amount, ulong gasLimit)
         {
             this.From = from;
             this.Amount = amount;
@@ -24,6 +24,6 @@ namespace Stratis.SmartContracts.CLR
         /// <summary>
         /// The maximum amount of gas that can be expended while executing the message.
         /// </summary>
-        public Gas GasLimit { get; }
+        public ulong GasLimit { get; }
     }
 }

--- a/src/Stratis.SmartContracts.CLR/CallDataSerializer.cs
+++ b/src/Stratis.SmartContracts.CLR/CallDataSerializer.cs
@@ -142,7 +142,7 @@ namespace Stratis.SmartContracts.CLR
         {
             byte[] vmVersion = this.primitiveSerializer.Serialize(contractTxData.VmVersion);
             byte[] gasPrice = this.primitiveSerializer.Serialize(contractTxData.GasPrice);
-            byte[] gasLimit = this.primitiveSerializer.Serialize(contractTxData.GasLimit.Value);
+            byte[] gasLimit = this.primitiveSerializer.Serialize(contractTxData.GasLimit);
             bytes[0] = contractTxData.OpCodeType;
             vmVersion.CopyTo(bytes, OpcodeSize);
             gasPrice.CopyTo(bytes, OpcodeSize + VmVersionSize);

--- a/src/Stratis.SmartContracts.CLR/CallMessage.cs
+++ b/src/Stratis.SmartContracts.CLR/CallMessage.cs
@@ -7,7 +7,7 @@ namespace Stratis.SmartContracts.CLR
     /// </summary>
     public abstract class CallMessage : BaseMessage
     {
-        protected CallMessage(uint160 to, uint160 from, ulong amount, Gas gasLimit, MethodCall methodCall)
+        protected CallMessage(uint160 to, uint160 from, ulong amount, ulong gasLimit, MethodCall methodCall)
             : base(from, amount, gasLimit)
         {
             this.To = to;

--- a/src/Stratis.SmartContracts.CLR/ContractExecutor.cs
+++ b/src/Stratis.SmartContracts.CLR/ContractExecutor.cs
@@ -115,7 +115,7 @@ namespace Stratis.SmartContracts.CLR
                 NewContractAddress = !revert && creation ? result.Success?.ContractAddress : null,
                 ErrorMessage = result.Error?.GetErrorMessage(),
                 Revert = revert,
-                GasConsumed = result.GasConsumed,
+                GasConsumed = (ulong) result.GasConsumed,
                 Return = result.Success?.ExecutionResult,
                 InternalTransaction = internalTransaction,
                 Fee = fee,

--- a/src/Stratis.SmartContracts.CLR/ContractExecutor.cs
+++ b/src/Stratis.SmartContracts.CLR/ContractExecutor.cs
@@ -115,7 +115,7 @@ namespace Stratis.SmartContracts.CLR
                 NewContractAddress = !revert && creation ? result.Success?.ContractAddress : null,
                 ErrorMessage = result.Error?.GetErrorMessage(),
                 Revert = revert,
-                GasConsumed = (ulong) result.GasConsumed,
+                GasConsumed = result.GasConsumed,
                 Return = result.Success?.ExecutionResult,
                 InternalTransaction = internalTransaction,
                 Fee = fee,

--- a/src/Stratis.SmartContracts.CLR/ContractLogging/MeteredContractLogger.cs
+++ b/src/Stratis.SmartContracts.CLR/ContractLogging/MeteredContractLogger.cs
@@ -1,5 +1,6 @@
 ﻿using Stratis.SmartContracts.Core.Receipts;
 using Stratis.SmartContracts.CLR.Serialization;
+using Stratis.SmartContracts.RuntimeObserver;
 
 namespace Stratis.SmartContracts.CLR.ContractLogging
 {
@@ -9,11 +10,11 @@ namespace Stratis.SmartContracts.CLR.ContractLogging
     /// </summary>
     public class MeteredContractLogger : IContractLogger
     {
-        private readonly IGasMeter gasMeter;
+        private readonly IResourceMeter gasMeter;
         private readonly IContractLogger logger;
         private readonly IContractPrimitiveSerializer serializer;
 
-        public MeteredContractLogger(IGasMeter gasMeter, IContractLogger logger, IContractPrimitiveSerializer serializer)
+        public MeteredContractLogger(IResourceMeter gasMeter, IContractLogger logger, IContractPrimitiveSerializer serializer)
         {
             this.gasMeter = gasMeter;
             this.logger = logger;

--- a/src/Stratis.SmartContracts.CLR/ContractTransferMessage.cs
+++ b/src/Stratis.SmartContracts.CLR/ContractTransferMessage.cs
@@ -10,7 +10,7 @@ namespace Stratis.SmartContracts.CLR
     /// </summary>
     public class ContractTransferMessage : InternalCallMessage
     {
-        public ContractTransferMessage(uint160 to, uint160 from, ulong amount, Gas gasLimit) 
+        public ContractTransferMessage(uint160 to, uint160 from, ulong amount, ulong gasLimit) 
             : base(to, from, amount, gasLimit, MethodCall.Receive())
         {
         }

--- a/src/Stratis.SmartContracts.CLR/ContractTxData.cs
+++ b/src/Stratis.SmartContracts.CLR/ContractTxData.cs
@@ -48,7 +48,7 @@ namespace Stratis.SmartContracts.CLR
         public uint160 ContractAddress { get; }
 
         /// <summary>The maximum amount of gas units that can spent to execute this contract.</summary>
-        public Gas GasLimit { get; }
+        public ulong GasLimit { get; }
 
         /// <summary>The amount it costs per unit of gas to execute the contract.</summary>
         public ulong GasPrice { get; }

--- a/src/Stratis.SmartContracts.CLR/Exceptions/MemoryConsumptionException.cs
+++ b/src/Stratis.SmartContracts.CLR/Exceptions/MemoryConsumptionException.cs
@@ -1,12 +1,13 @@
 ﻿using System;
+using Stratis.SmartContracts.Core.Exceptions;
 
-namespace Stratis.SmartContracts.RuntimeObserver
+namespace Stratis.SmartContracts.CLR.Exceptions
 {
     /// <summary>
     /// Thrown when the amount of memory consumed by contract execution 
     /// exceeds the network-enforced limit.
     /// </summary>
-    public class MemoryConsumptionException : Exception
+    public class MemoryConsumptionException : SmartContractException
     {
         public MemoryConsumptionException(string message) : base(message) { }
     }

--- a/src/Stratis.SmartContracts.CLR/ExternalCallMessage.cs
+++ b/src/Stratis.SmartContracts.CLR/ExternalCallMessage.cs
@@ -7,7 +7,7 @@ namespace Stratis.SmartContracts.CLR
     /// </summary>
     public class ExternalCallMessage : CallMessage
     {
-        public ExternalCallMessage(uint160 to, uint160 from, ulong amount, Gas gasLimit, MethodCall methodCall) 
+        public ExternalCallMessage(uint160 to, uint160 from, ulong amount, ulong gasLimit, MethodCall methodCall) 
             : base(to, from, amount, gasLimit, methodCall)
         {
         }

--- a/src/Stratis.SmartContracts.CLR/ExternalCreateMessage.cs
+++ b/src/Stratis.SmartContracts.CLR/ExternalCreateMessage.cs
@@ -7,7 +7,7 @@ namespace Stratis.SmartContracts.CLR
     /// </summary>
     public class ExternalCreateMessage : BaseMessage
     {
-        public ExternalCreateMessage(uint160 from, ulong amount, Gas gasLimit, byte[] code, object[] parameters)
+        public ExternalCreateMessage(uint160 from, ulong amount, ulong gasLimit, byte[] code, object[] parameters)
             : base(from, amount, gasLimit)
         {
             this.Code = code;

--- a/src/Stratis.SmartContracts.CLR/GasPriceList.cs
+++ b/src/Stratis.SmartContracts.CLR/GasPriceList.cs
@@ -19,26 +19,26 @@ namespace Stratis.SmartContracts.CLR
         /// <summary>The cost for transferring funds to a P2PKH from inside a contract.</summary>
         public const ulong TransferCost = 1_000;
 
-        public const int StoragePerByteSavedGasCost = 20;
-        public const int StoragePerByteRetrievedGasCost = 1;
-        public const int LogPerTopicByteCost = 2;
-        public const int LogPerByteCost = 1;
-        public const int MethodCallGasCost = 5;
-        public const int InstructionGasCost = 1;
-        public const ulong StorageCheckContractExistsCost = 5;
+        public const uint StoragePerByteSavedGasCost = 20;
+        public const uint StoragePerByteRetrievedGasCost = 1;
+        public const uint LogPerTopicByteCost = 2;
+        public const uint LogPerByteCost = 1;
+        public const uint MethodCallGasCost = 5;
+        public const uint InstructionGasCost = 1;
+        public const long StorageCheckContractExistsCost = 5;
 
         /// <summary>
         /// Get the gas cost for a specific instruction. For v1 all instructions are priced equally.
         /// </summary>
-        public static Gas InstructionOperationCost(Instruction instruction)
+        public static ulong InstructionOperationCost(Instruction instruction)
         {
             OpCode opcode = instruction.OpCode;
-            Gas cost;
+            ulong cost;
 
             switch (opcode.Name)
             {
                 default:
-                    cost = (Gas)InstructionGasCost;
+                    cost = InstructionGasCost;
                     break;
             }
 
@@ -48,44 +48,39 @@ namespace Stratis.SmartContracts.CLR
         /// <summary>
         /// Gas cost to log an event inside a contract.
         /// </summary>
-        public static Gas LogOperationCost(IEnumerable<byte[]> topics, byte[] data)
+        public static ulong LogOperationCost(IEnumerable<byte[]> topics, byte[] data)
         {
-            int topicCost = topics.Select(x => x.Length * LogPerTopicByteCost).Sum();
-            int dataCost = data.Length * LogPerByteCost;
-            return (Gas)(ulong) (topicCost + dataCost);
+            long topicCost = topics.Select(x => x.Length * LogPerTopicByteCost).Sum();
+            long dataCost = data.Length * LogPerByteCost;
+            return (ulong) (topicCost + dataCost);
         }
 
         /// <summary>
         /// Get cost to store this key and value.
         /// </summary>
-        public static Gas StorageSaveOperationCost(byte[] keyBytes, byte[] valueBytes)
+        public static ulong StorageSaveOperationCost(byte[] keyBytes, byte[] valueBytes)
         {
             int keyLen = keyBytes != null ? keyBytes.Length : 0;
             int valueLen = valueBytes != null ? valueBytes.Length : 0;
-
-            Gas cost = (Gas)(ulong)(StoragePerByteSavedGasCost * keyLen + StoragePerByteSavedGasCost * valueLen);
-            return cost;
+            return (ulong)(StoragePerByteSavedGasCost * keyLen + StoragePerByteSavedGasCost * valueLen);
         }
 
         /// <summary>
         /// Get cost to retrieve this value via key.
         /// </summary>
-        public static Gas StorageRetrieveOperationCost(byte[] keyBytes, byte[] valueBytes)
+        public static ulong StorageRetrieveOperationCost(byte[] keyBytes, byte[] valueBytes)
         {
             int keyLen = keyBytes != null ? keyBytes.Length : 0;
             int valueLen = valueBytes != null ? valueBytes.Length : 0;
-
-            Gas cost = (Gas)(ulong)(StoragePerByteRetrievedGasCost * keyLen + StoragePerByteRetrievedGasCost * valueLen);
-            return cost;
+            return (ulong)(StoragePerByteRetrievedGasCost * keyLen + StoragePerByteRetrievedGasCost * valueLen);
         }
 
         /// <summary>
         /// TODO - Add actual costs
         /// </summary>
-        /// <param name="methodToCall"></param>
-        public static Gas MethodCallCost(MethodReference methodToCall)
+        public static ulong MethodCallCost(MethodReference methodToCall)
         {
-            return (Gas)MethodCallGasCost;
+            return MethodCallGasCost;
         }
     }
 }

--- a/src/Stratis.SmartContracts.CLR/IInternalExecutorFactory.cs
+++ b/src/Stratis.SmartContracts.CLR/IInternalExecutorFactory.cs
@@ -1,7 +1,9 @@
-﻿namespace Stratis.SmartContracts.CLR
+﻿using Stratis.SmartContracts.RuntimeObserver;
+
+namespace Stratis.SmartContracts.CLR
 {
     public interface IInternalExecutorFactory
     {
-        IInternalTransactionExecutor Create(IState state);
+        IInternalTransactionExecutor Create(IState state, IResourceMeter gasMeter);
     }
 }

--- a/src/Stratis.SmartContracts.CLR/ILRewrite/CodeSegment.cs
+++ b/src/Stratis.SmartContracts.CLR/ILRewrite/CodeSegment.cs
@@ -28,14 +28,14 @@ namespace Stratis.SmartContracts.CLR.ILRewrite
         /// <summary>
         /// Total gas cost to execute the instructions in this segment.
         /// </summary>
-        public Gas CalculateGasCost()
+        public ulong CalculateGasCost()
         {
-            Gas gasTally = (Gas) 0;
+            ulong gasTally = 0;
 
             foreach (Instruction instruction in this.Instructions)
             {
-                Gas instructionCost = GasPriceList.InstructionOperationCost(instruction);
-                gasTally = (Gas)(gasTally + instructionCost);
+                ulong instructionCost = GasPriceList.InstructionOperationCost(instruction);
+                gasTally = gasTally + instructionCost;
 
                 if (instruction.IsMethodCall())
                 {
@@ -44,8 +44,8 @@ namespace Stratis.SmartContracts.CLR.ILRewrite
                     // If it's a method outside this contract then we will add some cost.
                     if (this.methodDefinition.DeclaringType != methodToCall.DeclaringType)
                     {
-                        Gas methodCallCost = GasPriceList.MethodCallCost(methodToCall);
-                        gasTally = (Gas)(gasTally + methodCallCost);
+                        ulong methodCallCost = GasPriceList.MethodCallCost(methodToCall);
+                        gasTally = gasTally + methodCallCost;
                     }
                 }
             }

--- a/src/Stratis.SmartContracts.CLR/ILRewrite/GasInjectorRewriter.cs
+++ b/src/Stratis.SmartContracts.CLR/ILRewrite/GasInjectorRewriter.cs
@@ -83,7 +83,7 @@ namespace Stratis.SmartContracts.CLR.ILRewrite
         {
             Instruction first = codeSegment.Instructions.First();
             Instruction newFirst = il.CreateLdlocBest(variable);
-            long segmentCost = (long) codeSegment.CalculateGasCost().Value;
+            ulong segmentCost = codeSegment.CalculateGasCost();
 
             il.Body.SimplifyMacros();
             il.InsertBefore(first, newFirst); // load observer

--- a/src/Stratis.SmartContracts.CLR/ISmartContractStateFactory.cs
+++ b/src/Stratis.SmartContracts.CLR/ISmartContractStateFactory.cs
@@ -1,5 +1,6 @@
 ﻿using NBitcoin;
 using Stratis.SmartContracts.Core.State;
+using Stratis.SmartContracts.RuntimeObserver;
 
 namespace Stratis.SmartContracts.CLR
 {
@@ -8,7 +9,7 @@ namespace Stratis.SmartContracts.CLR
         /// <summary>
         /// Sets up a new <see cref="ISmartContractState"/> based on the current state.
         /// </summary>        
-        ISmartContractState Create(IState state, IGasMeter gasMeter, uint160 address, BaseMessage message,
+        ISmartContractState Create(IState state, IResourceMeter gasMeter, uint160 address, BaseMessage message,
             IStateRepository repository);
     }
 }

--- a/src/Stratis.SmartContracts.CLR/IState.cs
+++ b/src/Stratis.SmartContracts.CLR/IState.cs
@@ -5,6 +5,7 @@ using Stratis.SmartContracts.Core.State;
 using Stratis.SmartContracts.Core.State.AccountAbstractionLayer;
 using Stratis.SmartContracts.CLR.ContractLogging;
 using Stratis.SmartContracts.CLR.Serialization;
+using Stratis.SmartContracts.RuntimeObserver;
 
 namespace Stratis.SmartContracts.CLR
 {
@@ -22,7 +23,7 @@ namespace Stratis.SmartContracts.CLR
         void AddInternalTransfer(TransferInfo transferInfo);
         ulong GetBalance(uint160 address);
         uint160 GenerateAddress(IAddressGenerator addressGenerator);
-        ISmartContractState CreateSmartContractState(IState state, IGasMeter gasMeter, uint160 address, BaseMessage message, IStateRepository repository);
+        ISmartContractState CreateSmartContractState(IState state, IResourceMeter gasMeter, uint160 address, BaseMessage message, IStateRepository repository);
         void AddInitialTransfer(TransferInfo initialTransfer);
     }
 }

--- a/src/Stratis.SmartContracts.CLR/IVirtualMachine.cs
+++ b/src/Stratis.SmartContracts.CLR/IVirtualMachine.cs
@@ -1,15 +1,20 @@
 ﻿using Stratis.SmartContracts.Core.State;
+using Stratis.SmartContracts.RuntimeObserver;
 
 namespace Stratis.SmartContracts.CLR
 {
     public interface IVirtualMachine
     {
-        VmExecutionResult Create(IStateRepository repository, ISmartContractState contractState,
+        VmExecutionResult Create(IStateRepository repository, 
+            ISmartContractState contractState,
+            IResourceMeter gasMeter,
             byte[] contractCode,
             object[] parameters,
             string typeName = null);
 
-        VmExecutionResult ExecuteMethod(ISmartContractState contractState, MethodCall methodCall,
+        VmExecutionResult ExecuteMethod(ISmartContractState contractState,
+            IResourceMeter gasMeter,
+            MethodCall methodCall,
             byte[] contractCode, string typeName);
     }
 }

--- a/src/Stratis.SmartContracts.CLR/InternalCallMessage.cs
+++ b/src/Stratis.SmartContracts.CLR/InternalCallMessage.cs
@@ -8,7 +8,7 @@ namespace Stratis.SmartContracts.CLR
     /// </summary>
     public class InternalCallMessage : CallMessage
     {
-        public InternalCallMessage(uint160 to, uint160 from, ulong amount, Gas gasLimit, MethodCall methodCall)
+        public InternalCallMessage(uint160 to, uint160 from, ulong amount, ulong gasLimit, MethodCall methodCall)
             : base(to, from, amount, gasLimit, methodCall)
         {
         }

--- a/src/Stratis.SmartContracts.CLR/InternalCreateMessage.cs
+++ b/src/Stratis.SmartContracts.CLR/InternalCreateMessage.cs
@@ -8,7 +8,7 @@ namespace Stratis.SmartContracts.CLR
     /// </summary>
     public class InternalCreateMessage : BaseMessage
     {
-        public InternalCreateMessage(uint160 from, ulong amount, Gas gasLimit, object[] parameters, string typeName)
+        public InternalCreateMessage(uint160 from, ulong amount, ulong gasLimit, object[] parameters, string typeName)
             : base(from, amount, gasLimit)
         {
             this.Parameters = parameters;

--- a/src/Stratis.SmartContracts.CLR/InternalExecutorFactory.cs
+++ b/src/Stratis.SmartContracts.CLR/InternalExecutorFactory.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Extensions.Logging;
+using Stratis.SmartContracts.RuntimeObserver;
 
 namespace Stratis.SmartContracts.CLR
 {
@@ -7,18 +8,16 @@ namespace Stratis.SmartContracts.CLR
     /// </summary>
     public sealed class InternalExecutorFactory : IInternalExecutorFactory
     {
-        private readonly ILoggerFactory loggerFactory;
         private readonly IStateProcessor stateProcessor;
 
-        public InternalExecutorFactory(ILoggerFactory loggerFactory, IStateProcessor stateProcessor)
+        public InternalExecutorFactory(IStateProcessor stateProcessor)
         {
-            this.loggerFactory = loggerFactory;
             this.stateProcessor = stateProcessor;
         }
 
-        public IInternalTransactionExecutor Create(IState state)
+        public IInternalTransactionExecutor Create(IState state, IResourceMeter gasMeter)
         {
-            return new InternalExecutor(this.loggerFactory, state, this.stateProcessor);
+            return new InternalExecutor(state, this.stateProcessor, gasMeter);
         }
     }
 }

--- a/src/Stratis.SmartContracts.CLR/Local/ILocalExecutionResult.cs
+++ b/src/Stratis.SmartContracts.CLR/Local/ILocalExecutionResult.cs
@@ -8,7 +8,7 @@ namespace Stratis.SmartContracts.CLR.Local
     public interface ILocalExecutionResult
     {
         IReadOnlyList<TransferInfo> InternalTransfers { get; }
-        Gas GasConsumed { get; }
+        ulong GasConsumed { get; }
         bool Revert { get; }
         ContractErrorMessage ErrorMessage { get; }
         object Return { get; }

--- a/src/Stratis.SmartContracts.CLR/Local/LocalExecutionResult.cs
+++ b/src/Stratis.SmartContracts.CLR/Local/LocalExecutionResult.cs
@@ -8,7 +8,7 @@ namespace Stratis.SmartContracts.CLR.Local
     public class LocalExecutionResult : ILocalExecutionResult
     {
         public IReadOnlyList<TransferInfo> InternalTransfers { get; set; }
-        public Gas GasConsumed { get; set; }
+        public ulong GasConsumed { get; set; }
         public bool Revert { get; set; }
         public ContractErrorMessage ErrorMessage { get; set; }
         public object Return { get; set; }

--- a/src/Stratis.SmartContracts.CLR/MemoryMeter.cs
+++ b/src/Stratis.SmartContracts.CLR/MemoryMeter.cs
@@ -1,20 +1,23 @@
-﻿using Stratis.SmartContracts.CLR.Exceptions;
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Stratis.SmartContracts.CLR.Exceptions;
 using Stratis.SmartContracts.RuntimeObserver;
 
 namespace Stratis.SmartContracts.CLR
 {
-    public sealed class GasMeter : IResourceMeter
+    public class MemoryMeter : IResourceMeter
     {
         public ulong Available { get; private set; }
 
         public ulong Consumed => this.Limit - this.Available;
 
-        public ulong Limit { get; }
+        public ulong Limit { get; private set; }
 
-        public GasMeter(ulong available)
+        public MemoryMeter(ulong available)
         {
-            this.Available = available;
             this.Limit = available;
+            this.Available = available;
         }
 
         public void Spend(ulong toSpend)
@@ -27,7 +30,7 @@ namespace Stratis.SmartContracts.CLR
 
             this.Available = 0;
 
-            throw new OutOfGasException("Went over gas limit of " + this.Limit);
+            throw new MemoryConsumptionException($"Smart contract has allocated too much memory. Spent more than {this.Limit} memory units when allocating strings or arrays.");
         }
     }
 }

--- a/src/Stratis.SmartContracts.CLR/ReflectionVirtualMachine.cs
+++ b/src/Stratis.SmartContracts.CLR/ReflectionVirtualMachine.cs
@@ -39,7 +39,12 @@ namespace Stratis.SmartContracts.CLR
         /// <summary>
         /// Creates a new instance of a smart contract by invoking the contract's constructor
         /// </summary>
-        public VmExecutionResult Create(IStateRepository repository, ISmartContractState contractState, byte[] contractCode, object[] parameters, string typeName = null)
+        public VmExecutionResult Create(IStateRepository repository, 
+            ISmartContractState contractState,
+            IResourceMeter gasMeter,
+            byte[] contractCode,
+            object[] parameters,
+            string typeName = null)
         {
             string typeToInstantiate;
             ContractByteCode code;
@@ -66,7 +71,7 @@ namespace Stratis.SmartContracts.CLR
 
                 typeToInstantiate = typeName ?? moduleDefinition.ContractType.Name;
 
-                var observer = new Observer(contractState.GasMeter, MemoryUnitLimit);
+                var observer = new Observer(gasMeter, new MemoryMeter(MemoryUnitLimit));
                 var rewriter = new ObserverRewriter(observer);
                 moduleDefinition.Rewrite(rewriter);
 
@@ -113,14 +118,19 @@ namespace Stratis.SmartContracts.CLR
         /// <summary>
         /// Invokes a method on an existing smart contract
         /// </summary>
-        public VmExecutionResult ExecuteMethod(ISmartContractState contractState, MethodCall methodCall, byte[] contractCode, string typeName)
+        public VmExecutionResult ExecuteMethod(
+            ISmartContractState contractState,
+            IResourceMeter gasMeter,
+            MethodCall methodCall,
+            byte[] contractCode,
+            string typeName)
         {
             ContractByteCode code;
 
             // Code we're loading from database - can assume it's valid.
             using (IContractModuleDefinition moduleDefinition = this.moduleDefinitionReader.Read(contractCode).Value)
             {
-                var observer = new Observer(contractState.GasMeter, MemoryUnitLimit);
+                var observer = new Observer(gasMeter, new MemoryMeter(MemoryUnitLimit));
                 var rewriter = new ObserverRewriter(observer);
                 moduleDefinition.Rewrite(rewriter);
                 code = moduleDefinition.ToByteCode();

--- a/src/Stratis.SmartContracts.CLR/ResultProcessors/ContractRefundProcessor.cs
+++ b/src/Stratis.SmartContracts.CLR/ResultProcessors/ContractRefundProcessor.cs
@@ -18,7 +18,7 @@ namespace Stratis.SmartContracts.CLR.ResultProcessors
 
         public (Money, TxOut) Process(ContractTxData contractTxData,
             ulong mempoolFee, uint160 sender,
-            Gas gasConsumed,
+            ulong gasConsumed,
             bool outOfGas)
         {
 
@@ -30,7 +30,7 @@ namespace Stratis.SmartContracts.CLR.ResultProcessors
                 return (fee, null);
             }
 
-            var refund = new Money(contractTxData.GasCostBudget - (gasConsumed * contractTxData.GasPrice));
+            var refund = new Money(contractTxData.GasCostBudget - ((ulong)gasConsumed * contractTxData.GasPrice));
 
             TxOut ret = null;
 

--- a/src/Stratis.SmartContracts.CLR/ResultProcessors/IContractRefundProcessor.cs
+++ b/src/Stratis.SmartContracts.CLR/ResultProcessors/IContractRefundProcessor.cs
@@ -12,7 +12,7 @@ namespace Stratis.SmartContracts.CLR.ResultProcessors
         /// </summary>
         (Money, TxOut) Process(ContractTxData contractTxData,
             ulong mempoolFee, uint160 sender,
-            Gas gasConsumed,
+            ulong gasConsumed,
             bool outOfGas);
     }
 }

--- a/src/Stratis.SmartContracts.CLR/SmartContractState.cs
+++ b/src/Stratis.SmartContracts.CLR/SmartContractState.cs
@@ -12,7 +12,6 @@ namespace Stratis.SmartContracts.CLR
             IMessage message,
             IPersistentState persistentState,
             ISerializer serializer,
-            IGasMeter gasMeter,
             IContractLogger contractLogger,
             IInternalTransactionExecutor internalTransactionExecutor,
             IInternalHashHelper internalHashHelper,
@@ -22,7 +21,7 @@ namespace Stratis.SmartContracts.CLR
             this.Message = message;
             this.PersistentState = persistentState;
             this.Serializer = serializer;
-            this.GasMeter = gasMeter;
+            this.GasMeter = null;
             this.ContractLogger = contractLogger;
             this.InternalTransactionExecutor = internalTransactionExecutor;
             this.InternalHashHelper = internalHashHelper;
@@ -37,6 +36,9 @@ namespace Stratis.SmartContracts.CLR
 
         public ISerializer Serializer { get; }
 
+        /// <summary>
+        /// Void. Going to be removed.
+        /// </summary>
         public IGasMeter GasMeter { get; }
 
         public IContractLogger ContractLogger { get; }

--- a/src/Stratis.SmartContracts.CLR/SmartContractStateFactory.cs
+++ b/src/Stratis.SmartContracts.CLR/SmartContractStateFactory.cs
@@ -2,6 +2,7 @@
 using Stratis.SmartContracts.Core.State;
 using Stratis.SmartContracts.CLR.ContractLogging;
 using Stratis.SmartContracts.CLR.Serialization;
+using Stratis.SmartContracts.RuntimeObserver;
 
 namespace Stratis.SmartContracts.CLR
 {
@@ -24,7 +25,7 @@ namespace Stratis.SmartContracts.CLR
         /// <summary>
         /// Sets up a new <see cref="ISmartContractState"/> based on the current state.
         /// </summary>        
-        public ISmartContractState Create(IState state, IGasMeter gasMeter, uint160 address, BaseMessage message, IStateRepository repository)
+        public ISmartContractState Create(IState state, IResourceMeter gasMeter, uint160 address, BaseMessage message, IStateRepository repository)
         {
             IPersistenceStrategy persistenceStrategy = new MeteredPersistenceStrategy(repository, gasMeter, new BasicKeyEncodingStrategy());
 
@@ -41,9 +42,8 @@ namespace Stratis.SmartContracts.CLR
                 ),
                 persistentState,
                 this.serializer,
-                gasMeter,
                 contractLogger,
-                this.InternalTransactionExecutorFactory.Create(state),
+                this.InternalTransactionExecutorFactory.Create(state, gasMeter),
                 new InternalHashHelper(),
                 () => state.GetBalance(address));
 

--- a/src/Stratis.SmartContracts.CLR/State.cs
+++ b/src/Stratis.SmartContracts.CLR/State.cs
@@ -6,6 +6,7 @@ using Stratis.SmartContracts.Core.State;
 using Stratis.SmartContracts.Core.State.AccountAbstractionLayer;
 using Stratis.SmartContracts.CLR.ContractLogging;
 using Stratis.SmartContracts.CLR.Serialization;
+using Stratis.SmartContracts.RuntimeObserver;
 
 namespace Stratis.SmartContracts.CLR
 {
@@ -83,7 +84,7 @@ namespace Stratis.SmartContracts.CLR
         /// <summary>
         /// Sets up a new <see cref="ISmartContractState"/> based on the current state.
         /// </summary>
-        public ISmartContractState CreateSmartContractState(IState state, IGasMeter gasMeter, uint160 address, BaseMessage message, IStateRepository repository) 
+        public ISmartContractState CreateSmartContractState(IState state, IResourceMeter gasMeter, uint160 address, BaseMessage message, IStateRepository repository) 
         {
             return this.smartContractStateFactory.Create(state, gasMeter, address, message, repository);
         }

--- a/src/Stratis.SmartContracts.CLR/StateTransitionResult.cs
+++ b/src/Stratis.SmartContracts.CLR/StateTransitionResult.cs
@@ -46,7 +46,7 @@ namespace Stratis.SmartContracts.CLR
     public class StateTransitionSuccess
     {
         public StateTransitionSuccess(
-            Gas gasConsumed,
+            ulong gasConsumed,
             uint160 contractAddress,
             object result = null)
         {
@@ -63,7 +63,7 @@ namespace Stratis.SmartContracts.CLR
         /// <summary>
         /// Gas consumed during execution.
         /// </summary>
-        public Gas GasConsumed { get; }
+        public ulong GasConsumed { get; }
 
         /// <summary>
         /// The receiving contract's address.
@@ -77,7 +77,7 @@ namespace Stratis.SmartContracts.CLR
     /// </summary>
     public class StateTransitionError
     {
-        public StateTransitionError(Gas gasConsumed, StateTransitionErrorKind kind, ContractErrorMessage vmError)
+        public StateTransitionError(ulong gasConsumed, StateTransitionErrorKind kind, ContractErrorMessage vmError)
         {
             this.Kind = kind;
             this.GasConsumed = gasConsumed;
@@ -98,7 +98,7 @@ namespace Stratis.SmartContracts.CLR
         /// <summary>
         /// The gas consumed during execution.
         /// </summary>
-        public Gas GasConsumed { get; }
+        public ulong GasConsumed { get; }
 
         public ContractErrorMessage GetErrorMessage()
         {
@@ -142,7 +142,7 @@ namespace Stratis.SmartContracts.CLR
         /// <summary>
         /// The gas consumed during the state transition.
         /// </summary>
-        public Gas GasConsumed => this.IsSuccess ? this.Success.GasConsumed : this.Error.GasConsumed;
+        public ulong GasConsumed => this.IsSuccess ? this.Success.GasConsumed : this.Error.GasConsumed;
 
         public bool IsSuccess { get; }
 
@@ -163,7 +163,7 @@ namespace Stratis.SmartContracts.CLR
         /// <summary>
         /// Creates a new result for a successful state transition.
         /// </summary>
-        public static StateTransitionResult Ok(Gas gasConsumed,
+        public static StateTransitionResult Ok(ulong gasConsumed,
             uint160 contractAddress,
             object result = null)
         {
@@ -174,7 +174,7 @@ namespace Stratis.SmartContracts.CLR
         /// <summary>
         /// Creates a new result for a failed state transition due to a VM exception.
         /// </summary>
-        public static StateTransitionResult Fail(Gas gasConsumed, VmExecutionError vmError)
+        public static StateTransitionResult Fail(ulong gasConsumed, VmExecutionError vmError)
         {
             // If VM execution ran out of gas we return a different kind of state transition error.
             StateTransitionErrorKind errorKind = vmError.ErrorKind == VmExecutionErrorKind.OutOfGas
@@ -187,7 +187,7 @@ namespace Stratis.SmartContracts.CLR
         /// <summary>
         /// Creates a new result for a failed state transition.
         /// </summary>
-        public static StateTransitionResult Fail(Gas gasConsumed, StateTransitionErrorKind kind)
+        public static StateTransitionResult Fail(ulong gasConsumed, StateTransitionErrorKind kind)
         {
             return new StateTransitionResult(new StateTransitionError(gasConsumed, kind, null));
         }

--- a/src/Stratis.SmartContracts.IntegrationTests/ContractExecutionFailureTests.cs
+++ b/src/Stratis.SmartContracts.IntegrationTests/ContractExecutionFailureTests.cs
@@ -13,6 +13,7 @@ using Stratis.SmartContracts.Core;
 using Stratis.SmartContracts.Core.Util;
 using Stratis.SmartContracts.CLR;
 using Stratis.SmartContracts.CLR.Compilation;
+using Stratis.SmartContracts.CLR.Exceptions;
 using Stratis.SmartContracts.CLR.Serialization;
 using Stratis.SmartContracts.Tests.Common.MockChain;
 using Xunit;
@@ -44,7 +45,7 @@ namespace Stratis.SmartContracts.IntegrationTests
             var serializer =
                 new CallDataSerializer(new ContractPrimitiveSerializer(this.node1.CoreNode.FullNode.Network));
 
-            var txData = serializer.Serialize(new ContractTxData(1, 1, (Gas)(GasPriceList.BaseCost + 1), new uint160(1), "Test"));
+            var txData = serializer.Serialize(new ContractTxData(1, 1, (Gas)(ulong)(GasPriceList.BaseCost + 1), new uint160(1), "Test"));
 
             var random = new Random();
             byte[] bytes = new byte[101];
@@ -115,7 +116,7 @@ namespace Stratis.SmartContracts.IntegrationTests
             Assert.Equal(response.TransactionId.ToString(), receipt.TransactionHash);
             Assert.Empty(receipt.Logs);
             Assert.False(receipt.Success);
-            Assert.Equal(GasPriceList.CreateCost, receipt.GasUsed);
+            Assert.Equal(GasPriceList.CreateCost, (long) receipt.GasUsed);
             Assert.Null(receipt.NewContractAddress);
             Assert.Equal(this.node1.MinerAddress.Address, receipt.From);
             Assert.Null(receipt.To);
@@ -159,7 +160,7 @@ namespace Stratis.SmartContracts.IntegrationTests
             Assert.Equal(response.TransactionId.ToString(), receipt.TransactionHash);
             Assert.Empty(receipt.Logs);
             Assert.False(receipt.Success);
-            Assert.Equal(GasPriceList.CreateCost, receipt.GasUsed);
+            Assert.Equal(GasPriceList.CreateCost, (long) receipt.GasUsed);
             Assert.Null(receipt.NewContractAddress);
             Assert.Equal(this.node1.MinerAddress.Address, receipt.From);
             Assert.Null(receipt.To);
@@ -305,7 +306,7 @@ namespace Stratis.SmartContracts.IntegrationTests
             Assert.Equal(response.TransactionId.ToString(), receipt.TransactionHash);
             Assert.Empty(receipt.Logs);
             Assert.False(receipt.Success);
-            Assert.Equal(GasPriceList.BaseCost, receipt.GasUsed);
+            Assert.Equal(GasPriceList.BaseCost, (long) receipt.GasUsed);
             Assert.Null(receipt.NewContractAddress);
             Assert.Equal(this.node1.MinerAddress.Address, receipt.From);
             Assert.Equal(StateTransitionErrors.NoCode, receipt.Error);
@@ -351,7 +352,7 @@ namespace Stratis.SmartContracts.IntegrationTests
             Assert.Equal(response.TransactionId.ToString(), receipt.TransactionHash);
             Assert.Empty(receipt.Logs);
             Assert.False(receipt.Success);
-            Assert.Equal(GasPriceList.BaseCost, receipt.GasUsed);
+            Assert.Equal(GasPriceList.BaseCost, (long) receipt.GasUsed);
             Assert.Null(receipt.NewContractAddress);
             Assert.Equal(this.node1.MinerAddress.Address, receipt.From);
             Assert.Equal(ContractInvocationErrors.MethodDoesNotExist, receipt.Error);
@@ -404,7 +405,7 @@ namespace Stratis.SmartContracts.IntegrationTests
             Assert.Equal(response.TransactionId.ToString(), receipt.TransactionHash);
             Assert.Empty(receipt.Logs);
             Assert.False(receipt.Success);
-            Assert.Equal(GasPriceList.BaseCost, receipt.GasUsed);
+            Assert.Equal(GasPriceList.BaseCost, (long) receipt.GasUsed);
             Assert.Null(receipt.NewContractAddress);
             Assert.Equal(this.node1.MinerAddress.Address, receipt.From);
             Assert.Equal(ContractInvocationErrors.MethodDoesNotExist, receipt.Error);
@@ -456,7 +457,7 @@ namespace Stratis.SmartContracts.IntegrationTests
             Assert.Equal(response.TransactionId.ToString(), receipt.TransactionHash);
             Assert.Empty(receipt.Logs);
             Assert.False(receipt.Success);
-            Assert.Equal(GasPriceList.CreateCost, receipt.GasUsed);
+            Assert.Equal(GasPriceList.CreateCost, (long) receipt.GasUsed);
             Assert.Null(receipt.NewContractAddress);
             Assert.Equal(this.node1.MinerAddress.Address, receipt.From);
             Assert.StartsWith(ContractInvocationErrors.MethodDoesNotExist, receipt.Error); // The error for constructor not found vs method does not exist could be different in future.
@@ -513,7 +514,7 @@ namespace Stratis.SmartContracts.IntegrationTests
             Assert.Equal(response.TransactionId.ToString(), receipt.TransactionHash);
             Assert.Empty(receipt.Logs);
             Assert.False(receipt.Success);
-            Assert.Equal(GasPriceList.CreateCost, receipt.GasUsed);
+            Assert.Equal(GasPriceList.CreateCost, (long) receipt.GasUsed);
             Assert.Null(receipt.NewContractAddress);
             Assert.Equal(this.node1.MinerAddress.Address, receipt.From);
             Assert.Null(receipt.To);
@@ -649,7 +650,7 @@ namespace Stratis.SmartContracts.IntegrationTests
             Assert.True(GasPriceList.BaseCost < receipt.GasUsed);
             Assert.Null(receipt.NewContractAddress);
             Assert.Equal(this.node1.MinerAddress.Address, receipt.From);
-            Assert.StartsWith($"{typeof(RuntimeObserver.MemoryConsumptionException).FullName}", receipt.Error);
+            Assert.StartsWith($"{typeof(MemoryConsumptionException).FullName}", receipt.Error);
             Assert.Equal(preResponse.NewContractAddress, receipt.To);
         }
 

--- a/src/Stratis.SmartContracts.IntegrationTests/ContractExecutionFailureTests.cs
+++ b/src/Stratis.SmartContracts.IntegrationTests/ContractExecutionFailureTests.cs
@@ -116,7 +116,7 @@ namespace Stratis.SmartContracts.IntegrationTests
             Assert.Equal(response.TransactionId.ToString(), receipt.TransactionHash);
             Assert.Empty(receipt.Logs);
             Assert.False(receipt.Success);
-            Assert.Equal(GasPriceList.CreateCost, (long) receipt.GasUsed);
+            Assert.Equal(GasPriceList.CreateCost, receipt.GasUsed);
             Assert.Null(receipt.NewContractAddress);
             Assert.Equal(this.node1.MinerAddress.Address, receipt.From);
             Assert.Null(receipt.To);
@@ -160,7 +160,7 @@ namespace Stratis.SmartContracts.IntegrationTests
             Assert.Equal(response.TransactionId.ToString(), receipt.TransactionHash);
             Assert.Empty(receipt.Logs);
             Assert.False(receipt.Success);
-            Assert.Equal(GasPriceList.CreateCost, (long) receipt.GasUsed);
+            Assert.Equal(GasPriceList.CreateCost, receipt.GasUsed);
             Assert.Null(receipt.NewContractAddress);
             Assert.Equal(this.node1.MinerAddress.Address, receipt.From);
             Assert.Null(receipt.To);
@@ -306,7 +306,7 @@ namespace Stratis.SmartContracts.IntegrationTests
             Assert.Equal(response.TransactionId.ToString(), receipt.TransactionHash);
             Assert.Empty(receipt.Logs);
             Assert.False(receipt.Success);
-            Assert.Equal(GasPriceList.BaseCost, (long) receipt.GasUsed);
+            Assert.Equal(GasPriceList.BaseCost, receipt.GasUsed);
             Assert.Null(receipt.NewContractAddress);
             Assert.Equal(this.node1.MinerAddress.Address, receipt.From);
             Assert.Equal(StateTransitionErrors.NoCode, receipt.Error);
@@ -352,7 +352,7 @@ namespace Stratis.SmartContracts.IntegrationTests
             Assert.Equal(response.TransactionId.ToString(), receipt.TransactionHash);
             Assert.Empty(receipt.Logs);
             Assert.False(receipt.Success);
-            Assert.Equal(GasPriceList.BaseCost, (long) receipt.GasUsed);
+            Assert.Equal(GasPriceList.BaseCost, receipt.GasUsed);
             Assert.Null(receipt.NewContractAddress);
             Assert.Equal(this.node1.MinerAddress.Address, receipt.From);
             Assert.Equal(ContractInvocationErrors.MethodDoesNotExist, receipt.Error);
@@ -405,7 +405,7 @@ namespace Stratis.SmartContracts.IntegrationTests
             Assert.Equal(response.TransactionId.ToString(), receipt.TransactionHash);
             Assert.Empty(receipt.Logs);
             Assert.False(receipt.Success);
-            Assert.Equal(GasPriceList.BaseCost, (long) receipt.GasUsed);
+            Assert.Equal(GasPriceList.BaseCost, receipt.GasUsed);
             Assert.Null(receipt.NewContractAddress);
             Assert.Equal(this.node1.MinerAddress.Address, receipt.From);
             Assert.Equal(ContractInvocationErrors.MethodDoesNotExist, receipt.Error);
@@ -457,7 +457,7 @@ namespace Stratis.SmartContracts.IntegrationTests
             Assert.Equal(response.TransactionId.ToString(), receipt.TransactionHash);
             Assert.Empty(receipt.Logs);
             Assert.False(receipt.Success);
-            Assert.Equal(GasPriceList.CreateCost, (long) receipt.GasUsed);
+            Assert.Equal(GasPriceList.CreateCost, receipt.GasUsed);
             Assert.Null(receipt.NewContractAddress);
             Assert.Equal(this.node1.MinerAddress.Address, receipt.From);
             Assert.StartsWith(ContractInvocationErrors.MethodDoesNotExist, receipt.Error); // The error for constructor not found vs method does not exist could be different in future.
@@ -514,7 +514,7 @@ namespace Stratis.SmartContracts.IntegrationTests
             Assert.Equal(response.TransactionId.ToString(), receipt.TransactionHash);
             Assert.Empty(receipt.Logs);
             Assert.False(receipt.Success);
-            Assert.Equal(GasPriceList.CreateCost, (long) receipt.GasUsed);
+            Assert.Equal(GasPriceList.CreateCost, receipt.GasUsed);
             Assert.Null(receipt.NewContractAddress);
             Assert.Equal(this.node1.MinerAddress.Address, receipt.From);
             Assert.Null(receipt.To);

--- a/src/Stratis.SmartContracts.IntegrationTests/PoW/SmartContractMinerTests.cs
+++ b/src/Stratis.SmartContracts.IntegrationTests/PoW/SmartContractMinerTests.cs
@@ -311,7 +311,7 @@ namespace Stratis.SmartContracts.IntegrationTests.PoW
                 this.moduleDefinitionReader = new ContractModuleDefinitionReader();
                 this.reflectionVirtualMachine = new ReflectionVirtualMachine(this.validator, this.loggerFactory, this.assemblyLoader, this.moduleDefinitionReader);
                 this.stateProcessor = new StateProcessor(this.reflectionVirtualMachine, this.AddressGenerator);
-                this.internalTxExecutorFactory = new InternalExecutorFactory(this.loggerFactory, this.stateProcessor);
+                this.internalTxExecutorFactory = new InternalExecutorFactory(this.stateProcessor);
                 this.primitiveSerializer = new ContractPrimitiveSerializer(this.network);
                 this.serializer = new Serializer(this.primitiveSerializer);
                 this.smartContractStateFactory = new SmartContractStateFactory(this.primitiveSerializer, this.internalTxExecutorFactory, this.serializer);

--- a/src/Stratis.SmartContracts.RuntimeObserver/IResourceMeter.cs
+++ b/src/Stratis.SmartContracts.RuntimeObserver/IResourceMeter.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Stratis.SmartContracts.RuntimeObserver
+{
+    public interface IResourceMeter
+    {
+        ulong Available { get; }
+
+        ulong Consumed { get; }
+
+        ulong Limit { get; }
+
+        void Spend(ulong toSpend);
+    }
+}

--- a/src/Stratis.SmartContracts.RuntimeObserver/Observer.cs
+++ b/src/Stratis.SmartContracts.RuntimeObserver/Observer.cs
@@ -1,4 +1,6 @@
-﻿namespace Stratis.SmartContracts.RuntimeObserver
+﻿using System.Buffers;
+
+namespace Stratis.SmartContracts.RuntimeObserver
 {
     /// <summary>
     /// Is able to hold metrics about the current runtime.
@@ -6,28 +8,14 @@
     /// </summary>
     public class Observer
     {
-        /// <summary>
-        /// The limit for 'memory units'.
-        /// 
-        /// A 'memory unit' is spent for any operation that reserves a significant chunk of memory. 
-        /// 
-        /// Standard allocations for primitives aren't counted as memory units as they are trivially small
-        /// and the instructions that cause them will run the contract out of gas eventually.
-        /// 
-        /// String primitives and method parameters are always limited by the size of transactions and will be costly.
-        /// 
-        /// So 'memory units' are spent when allocating arrays or performing string concatenations.
-        /// </summary>
-        private readonly long memoryLimit;
+        public IResourceMeter MemoryMeter { get; private set; }
 
-        public IGasMeter GasMeter { get; }
+        public IResourceMeter GasMeter { get; private set; }
 
-        public long MemoryConsumed { get; private set; }
-
-        public Observer(IGasMeter gasMeter, long memoryLimit)
+        public Observer(IResourceMeter gasMeter, IResourceMeter memoryMeter)
         {
             this.GasMeter = gasMeter;
-            this.memoryLimit = memoryLimit;
+            this.MemoryMeter = memoryMeter;
         }
 
         /// <summary>
@@ -35,18 +23,15 @@
         /// </summary>
         public void SpendGas(long gas)
         {
-            this.GasMeter.Spend((Gas) gas);
+            this.GasMeter.Spend((ulong)gas);
         }
 
         /// <summary>
-        /// Register that some amount of memory has been reserved. If it goes over the allowed limit, throw an exception.
+        /// Register that some amount of memory has been reserved.
         /// </summary>
         public void SpendMemory(long memory)
         {
-            this.MemoryConsumed += memory;
-
-            if (this.MemoryConsumed > this.memoryLimit)
-                throw new MemoryConsumptionException($"Smart contract has allocated too much memory. Spent more than {this.memoryLimit} memory units when allocating strings or arrays.");
+            this.MemoryMeter.Spend((ulong)memory);
         }
 
         /// <summary>


### PR DESCRIPTION
Can push this into master without affecting Consensus after all.

- IGasMeter replaced with IResourceMeter and used for memory too.
- CLR now decides how to handle memory limit, rather than RuntimeObserver.
- Remove all mentions of `IGasMeter` and  `Stratis.SmartContracts.Gas` from .CLR and .CLR.Validation.

Future niceties:
- Reintroduce `Gas` (Will be .CLR.Gas or .Core.Gas this time though)
- Remove `IGasMeter` and `Gas` from Stratis.SmartContracts