### PR TITLE
[NBitcoin] Optimise byte array creation

### DIFF
--- a/src/NBitcoin/Target.cs
+++ b/src/NBitcoin/Target.cs
@@ -160,12 +160,13 @@ namespace NBitcoin
             byte[] array = input.ToByteArray();
 
             int missingZero = 32 - array.Length;
+
             if(missingZero < 0)
                 throw new InvalidOperationException("Awful bug, this should never happen");
+
             if(missingZero != 0)
-            {
-                array = new byte[missingZero].Concat(array).ToArray();
-            }
+                return new uint256(new byte[missingZero].Concat(array), false);
+
             return new uint256(array, false);
         }
 

--- a/src/Stratis.Bitcoin.Features.Consensus/StakeValidator.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/StakeValidator.cs
@@ -412,14 +412,12 @@ namespace Stratis.Bitcoin.Features.Consensus
             byte[] array = input.ToByteArray();
 
             int missingZero = 32 - array.Length;
+
             if (missingZero < 0)
-            {
-                //throw new InvalidOperationException("Awful bug, this should never happen");
-                array = array.Skip(Math.Abs(missingZero)).ToArray();
-            }
+                return new uint256(array.Skip(Math.Abs(missingZero)).ToArray());
 
             if (missingZero > 0)
-                array = new byte[missingZero].Concat(array).ToArray();
+                return new uint256(new byte[missingZero].Concat(array).ToArray(), false);
 
             return new uint256(array, false);
         }

--- a/src/Stratis.Bitcoin.Features.Consensus/StakeValidator.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/StakeValidator.cs
@@ -414,7 +414,7 @@ namespace Stratis.Bitcoin.Features.Consensus
             int missingZero = 32 - array.Length;
 
             if (missingZero < 0)
-                return new uint256(array.Skip(Math.Abs(missingZero)).ToArray());
+                return new uint256(array.Skip(Math.Abs(missingZero)).ToArray(), false);
 
             if (missingZero > 0)
                 return new uint256(new byte[missingZero].Concat(array).ToArray(), false);


### PR DESCRIPTION
Optimised array creation in `Target` and `StakeValidator`.

This is to help combat memory fragmentation in the node during IBD. The node is struggling to release unused or free space once it exits IBD.

Before:

```
0:000> !dumpgen 2 -stat
       Count      Total Size      Type     
   3,756,208    180,297,984   NBitcoin.uint256
     742,164    441,369,177   System.Byte[]
     582,818    544,742,724   **** FREE ****
```
After fixing some byte array creation:

```
0:000> !dumpgen 2 -stat
       Count      Total Size      Type
   2,467,683    115,490,916   System.Int32[]
   4,153,281    199,357,488   NBitcoin.uint256
     822,896    448,630,928   **** FREE ****

GEN 2:
  2,489,824    116,410,048   System.Int32[]
     879,858    188,783,732   **** FREE ****  
```