### PR TITLE
[SC] Move Gas Meter into RuntimeObserver v2

### DIFF
--- a/src/Stratis.Bitcoin.Features.SmartContracts.Tests/Consensus/Rules/SmartContractFormatRuleTest.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts.Tests/Consensus/Rules/SmartContractFormatRuleTest.cs
@@ -72,7 +72,7 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Tests.Consensus.Rules
 
             var totalSuppliedSatoshis = gasBudgetSatoshis + relayFeeSatoshis;
 
-            var contractTxData = new ContractTxData(1, (ulong)gasPriceSatoshis, (Gas)gasLimit, 0, "TestMethod");
+            var contractTxData = new ContractTxData(1, (ulong)gasPriceSatoshis, (Stratis.SmartContracts.RuntimeObserver.Gas)gasLimit, 0, "TestMethod");
             var serialized = this.callDataSerializer.Serialize(contractTxData);
 
             Transaction funding = new Transaction
@@ -119,7 +119,7 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Tests.Consensus.Rules
 
             var totalSuppliedSatoshis = gasBudgetSatoshis + relayFeeSatoshis;
 
-            var contractTxData = new ContractTxData(1, (ulong)gasPriceSatoshis, (Gas)gasLimit, 0, "TestMethod");
+            var contractTxData = new ContractTxData(1, (ulong)gasPriceSatoshis, (Stratis.SmartContracts.RuntimeObserver.Gas)gasLimit, 0, "TestMethod");
             var serialized = this.callDataSerializer.Serialize(contractTxData);
 
             Transaction funding = new Transaction
@@ -170,7 +170,7 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Tests.Consensus.Rules
 
             var higherGasLimit = gasLimit + 10000;
 
-            var contractTxData = new ContractTxData(1, (ulong)gasPriceSatoshis, (Gas)higherGasLimit, 0, "TestMethod");
+            var contractTxData = new ContractTxData(1, (ulong)gasPriceSatoshis, (Stratis.SmartContracts.RuntimeObserver.Gas)higherGasLimit, 0, "TestMethod");
             var serialized = this.callDataSerializer.Serialize(contractTxData);
 
             Transaction funding = new Transaction

--- a/src/Stratis.Bitcoin.Features.SmartContracts.Tests/Controllers/SmartContractWalletControllerTest.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts.Tests/Controllers/SmartContractWalletControllerTest.cs
@@ -49,8 +49,8 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Tests.Controllers
         {
             ulong gasPrice = SmartContractMempoolValidator.MinGasPrice;
             int vmVersion = 1;
-            Gas gasLimit = (Gas)(SmartContractFormatRule.GasLimitMaximum / 2);
-            var contractTxData = new ContractTxData(vmVersion, gasPrice, gasLimit,new byte[]{0, 1, 2, 3});
+            var gasLimit = (Stratis.SmartContracts.RuntimeObserver.Gas)(SmartContractFormatRule.GasLimitMaximum / 2);
+            var contractTxData = new ContractTxData(vmVersion, gasPrice, gasLimit, new byte[]{0, 1, 2, 3});
             var callDataSerializer = new CallDataSerializer(new ContractPrimitiveSerializer(new SmartContractsRegTest()));
             var contractCreateScript = new Script(callDataSerializer.Serialize(contractTxData));
 
@@ -94,7 +94,7 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Tests.Controllers
             this.receiptRepository.Setup(x => x.Retrieve(It.IsAny<uint256>()))
                 .Returns(new Receipt(null, 0, new Log[0], null, null, null, uint160.Zero, true, null, null));
             this.callDataSerializer.Setup(x => x.Deserialize(It.IsAny<byte[]>()))
-                .Returns(Result.Ok(new ContractTxData(0, 0, (Gas) 0, new uint160(0), null, null)));
+                .Returns(Result.Ok(new ContractTxData(0, 0, (Stratis.SmartContracts.RuntimeObserver.Gas) 0, new uint160(0), null, null)));
 
             var controller = new SmartContractWalletController(
                 this.broadcasterManager.Object,

--- a/src/Stratis.Bitcoin.Features.SmartContracts/Wallet/SmartContractTransactionService.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts/Wallet/SmartContractTransactionService.cs
@@ -9,6 +9,7 @@ using Stratis.SmartContracts;
 using Stratis.SmartContracts.CLR;
 using Stratis.SmartContracts.CLR.Serialization;
 using Stratis.SmartContracts.Core;
+using Stratis.SmartContracts.RuntimeObserver;
 
 namespace Stratis.Bitcoin.Features.SmartContracts.Wallet
 {
@@ -63,7 +64,7 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Wallet
                 try
                 {
                     var methodParameters = this.methodParameterStringSerializer.Deserialize(request.Parameters);
-                    txData = new ContractTxData(ReflectionVirtualMachine.VmVersion, (Gas)request.GasPrice, (Gas)request.GasLimit, addressNumeric, request.MethodName, methodParameters);
+                    txData = new ContractTxData(ReflectionVirtualMachine.VmVersion, (Stratis.SmartContracts.RuntimeObserver.Gas)request.GasPrice, (Stratis.SmartContracts.RuntimeObserver.Gas)request.GasLimit, addressNumeric, request.MethodName, methodParameters);
                 }
                 catch (MethodParameterStringSerializerException exception)
                 {
@@ -72,7 +73,7 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Wallet
             }
             else
             {
-                txData = new ContractTxData(ReflectionVirtualMachine.VmVersion, (Gas)request.GasPrice, (Gas)request.GasLimit, addressNumeric, request.MethodName);
+                txData = new ContractTxData(ReflectionVirtualMachine.VmVersion, (Stratis.SmartContracts.RuntimeObserver.Gas)request.GasPrice, (Stratis.SmartContracts.RuntimeObserver.Gas)request.GasLimit, addressNumeric, request.MethodName);
             }
 
             HdAddress senderAddress = null;
@@ -121,7 +122,7 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Wallet
                 try
                 {
                     var methodParameters = this.methodParameterStringSerializer.Deserialize(request.Parameters);
-                    txData = new ContractTxData(ReflectionVirtualMachine.VmVersion, (Gas)request.GasPrice, (Gas)request.GasLimit, request.ContractCode.HexToByteArray(), methodParameters);
+                    txData = new ContractTxData(ReflectionVirtualMachine.VmVersion, (Stratis.SmartContracts.RuntimeObserver.Gas)request.GasPrice, (Stratis.SmartContracts.RuntimeObserver.Gas)request.GasLimit, request.ContractCode.HexToByteArray(), methodParameters);
                 }
                 catch (MethodParameterStringSerializerException exception)
                 {
@@ -130,7 +131,7 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Wallet
             }
             else
             {
-                txData = new ContractTxData(ReflectionVirtualMachine.VmVersion, (Gas)request.GasPrice, (Gas)request.GasLimit, request.ContractCode.HexToByteArray());
+                txData = new ContractTxData(ReflectionVirtualMachine.VmVersion, (Stratis.SmartContracts.RuntimeObserver.Gas)request.GasPrice, (Stratis.SmartContracts.RuntimeObserver.Gas)request.GasLimit, request.ContractCode.HexToByteArray());
             }
 
             HdAddress senderAddress = null;
@@ -175,10 +176,10 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Wallet
             {
                 object[] methodParameters = this.methodParameterStringSerializer.Deserialize(request.Parameters);
 
-                return new ContractTxData(ReflectionVirtualMachine.VmVersion, (Gas)request.GasPrice, (Gas)request.GasLimit, contractAddress, request.MethodName, methodParameters);                
+                return new ContractTxData(ReflectionVirtualMachine.VmVersion, (Stratis.SmartContracts.RuntimeObserver.Gas)request.GasPrice, (Stratis.SmartContracts.RuntimeObserver.Gas)request.GasLimit, contractAddress, request.MethodName, methodParameters);                
             }
 
-            return new ContractTxData(ReflectionVirtualMachine.VmVersion, (Gas)request.GasPrice, (Gas)request.GasLimit, contractAddress, request.MethodName);
+            return new ContractTxData(ReflectionVirtualMachine.VmVersion, (Stratis.SmartContracts.RuntimeObserver.Gas)request.GasPrice, (Stratis.SmartContracts.RuntimeObserver.Gas)request.GasLimit, contractAddress, request.MethodName);
         }
 
     }

--- a/src/Stratis.SmartContracts.CLR.Tests/AuctionTests.cs
+++ b/src/Stratis.SmartContracts.CLR.Tests/AuctionTests.cs
@@ -28,7 +28,6 @@ namespace Stratis.SmartContracts.CLR.Tests
             var message = new TestMessage
             {
                 ContractAddress = this.TestAddress,
-                GasLimit = (Gas)GasLimit,
                 Sender = this.TestAddress,
                 Value = Value
             };
@@ -124,8 +123,6 @@ namespace Stratis.SmartContracts.CLR.Tests
         public Address ContractAddress { get; set; }
 
         public Address Sender { get; set; }
-
-        public Gas GasLimit { get; set; }
 
         public ulong Value { get; set; }
     }

--- a/src/Stratis.SmartContracts.CLR.Tests/CallDataSerializerTests.cs
+++ b/src/Stratis.SmartContracts.CLR.Tests/CallDataSerializerTests.cs
@@ -29,7 +29,7 @@ namespace Stratis.SmartContracts.CLR.Tests
                 }"
             );
 
-            var contractTxData = new ContractTxData(1, 1, (Gas)5000, contractExecutionCode);
+            var contractTxData = new ContractTxData(1, 1, (RuntimeObserver.Gas)5000, contractExecutionCode);
             var callDataResult = this.Serializer.Deserialize(this.Serializer.Serialize(contractTxData));
             var callData = callDataResult.Value;
 
@@ -37,8 +37,8 @@ namespace Stratis.SmartContracts.CLR.Tests
             Assert.Equal(1, callData.VmVersion);
             Assert.Equal((byte)ScOpcodeType.OP_CREATECONTRACT, callData.OpCodeType);
             Assert.Equal<byte[]>(contractExecutionCode, callData.ContractExecutionCode);
-            Assert.Equal((Gas)1, callData.GasPrice);
-            Assert.Equal((Gas)5000, callData.GasLimit);
+            Assert.Equal((RuntimeObserver.Gas)1, callData.GasPrice);
+            Assert.Equal((RuntimeObserver.Gas)5000, callData.GasLimit);
         }
 
         [Fact]
@@ -68,7 +68,7 @@ namespace Stratis.SmartContracts.CLR.Tests
                 '#'
             };
 
-            var contractTxData = new ContractTxData(1, 1, (Gas)5000, contractExecutionCode, methodParameters);
+            var contractTxData = new ContractTxData(1, 1, (RuntimeObserver.Gas)5000, contractExecutionCode, methodParameters);
 
             var callDataResult = this.Serializer.Deserialize(this.Serializer.Serialize(contractTxData));
             var callData = callDataResult.Value;
@@ -101,7 +101,7 @@ namespace Stratis.SmartContracts.CLR.Tests
         [Fact]
         public void SmartContract_CanSerialize_OP_CALLCONTRACT_WithoutMethodParameters()
         {          
-            var contractTxData = new ContractTxData(1, 1, (Gas)5000, 100, "Execute");
+            var contractTxData = new ContractTxData(1, 1, (RuntimeObserver.Gas)5000, 100, "Execute");
 
             var callDataResult = this.Serializer.Deserialize(this.Serializer.Serialize(contractTxData));
             var callData = callDataResult.Value;
@@ -131,7 +131,7 @@ namespace Stratis.SmartContracts.CLR.Tests
                 "0x95D34980095380851902ccd9A1Fb4C813C2cb639".HexToAddress()
             };
 
-            var contractTxData = new ContractTxData(1, 1, (Gas)5000, 100, "Execute", methodParameters);
+            var contractTxData = new ContractTxData(1, 1, (RuntimeObserver.Gas)5000, 100, "Execute", methodParameters);
             var callDataResult = this.Serializer.Deserialize(this.Serializer.Serialize(contractTxData));
             var callData = callDataResult.Value;
 

--- a/src/Stratis.SmartContracts.CLR.Tests/ContractExecutorTests.cs
+++ b/src/Stratis.SmartContracts.CLR.Tests/ContractExecutorTests.cs
@@ -76,7 +76,7 @@ namespace Stratis.SmartContracts.CLR.Tests
 
 
             //Call smart contract and add to transaction-------------
-            var contractTxData = new ContractTxData(1, 1, (Gas)500_000, ToAddress, "ThrowException");
+            var contractTxData = new ContractTxData(1, 1, (RuntimeObserver.Gas)500_000, ToAddress, "ThrowException");
             var transactionCall = new Transaction();
             TxOut callTxOut = transactionCall.AddOutput(0, new Script(this.callDataSerializer.Serialize(contractTxData)));
             callTxOut.Value = 100;
@@ -90,7 +90,7 @@ namespace Stratis.SmartContracts.CLR.Tests
 
             IContractTransactionContext transactionContext = new ContractTransactionContext(BlockHeight, CoinbaseAddress, MempoolFee, SenderAddress, transactionCall);
             
-            var executor = new ContractExecutor(this.loggerFactory,
+            var executor = new ContractExecutor(
                 this.callDataSerializer,
                 this.state,
                 this.refundProcessor,
@@ -114,7 +114,7 @@ namespace Stratis.SmartContracts.CLR.Tests
         [Fact]
         public void SmartContractExecutor_CallContract_DoesNotExist_Refund()
         {
-            var contractTxData = new ContractTxData(1, 1, (Gas) 10000, ToAddress, "TestMethod");
+            var contractTxData = new ContractTxData(1, 1, (RuntimeObserver.Gas) 10000, ToAddress, "TestMethod");
 
             var transaction = new Transaction();
             TxOut txOut = transaction.AddOutput(0, new Script(this.callDataSerializer.Serialize(contractTxData)));
@@ -122,7 +122,7 @@ namespace Stratis.SmartContracts.CLR.Tests
 
             IContractTransactionContext transactionContext = new ContractTransactionContext(BlockHeight, CoinbaseAddress, MempoolFee, new uint160(2), transaction);
 
-            var executor = new ContractExecutor(this.loggerFactory,
+            var executor = new ContractExecutor(
                 this.callDataSerializer,
                 this.state,
                 this.refundProcessor,
@@ -142,13 +142,13 @@ namespace Stratis.SmartContracts.CLR.Tests
             Assert.True(compilationResult.Success);
             byte[] contractCode = compilationResult.Compilation;
 
-            var contractTxData = new ContractTxData(0, (Gas) 1, (Gas)500_000, contractCode);
+            var contractTxData = new ContractTxData(0, (RuntimeObserver.Gas) 1, (RuntimeObserver.Gas)500_000, contractCode);
             var tx = new Transaction();
             tx.AddOutput(0, new Script(this.callDataSerializer.Serialize(contractTxData)));
 
             IContractTransactionContext transactionContext = new ContractTransactionContext(BlockHeight, CoinbaseAddress, MempoolFee, new uint160(2), tx);
 
-            var executor = new ContractExecutor(this.loggerFactory,
+            var executor = new ContractExecutor(
                 this.callDataSerializer,
                 this.state,
                 this.refundProcessor,
@@ -173,13 +173,13 @@ namespace Stratis.SmartContracts.CLR.Tests
 
             object[] methodParameters = { 5 };
 
-            var contractTxData = new ContractTxData(0, (Gas)1, (Gas)500_000, contractCode, methodParameters);
+            var contractTxData = new ContractTxData(0, (RuntimeObserver.Gas)1, (RuntimeObserver.Gas)500_000, contractCode, methodParameters);
             var tx = new Transaction();
             tx.AddOutput(0, new Script(this.callDataSerializer.Serialize(contractTxData)));
 
             IContractTransactionContext transactionContext = new ContractTransactionContext(BlockHeight, CoinbaseAddress, MempoolFee, new uint160(2), tx);
 
-            var executor = new ContractExecutor(this.loggerFactory,
+            var executor = new ContractExecutor(
                 this.callDataSerializer,
                 this.state,
                 this.refundProcessor,
@@ -202,13 +202,13 @@ namespace Stratis.SmartContracts.CLR.Tests
 
             object[] methodParameters = { true };
 
-            var contractTxData = new ContractTxData(0, (Gas)1, (Gas)500_000, contractCode, methodParameters);
+            var contractTxData = new ContractTxData(0, (RuntimeObserver.Gas)1, (RuntimeObserver.Gas)500_000, contractCode, methodParameters);
             var tx = new Transaction();
             tx.AddOutput(0, new Script(this.callDataSerializer.Serialize(contractTxData)));
 
             IContractTransactionContext transactionContext = new ContractTransactionContext(BlockHeight, CoinbaseAddress, MempoolFee, new uint160(2), tx);
 
-            var executor = new ContractExecutor(this.loggerFactory,
+            var executor = new ContractExecutor(
                 this.callDataSerializer,
                 this.state,
                 this.refundProcessor,
@@ -235,7 +235,7 @@ namespace Stratis.SmartContracts.CLR.Tests
             //-------------------------------------------------------
 
             // Add contract creation code to transaction-------------
-            var contractTxData = new ContractTxData(1, (Gas)1, (Gas)500_000, contractExecutionCode);
+            var contractTxData = new ContractTxData(1, (RuntimeObserver.Gas)1, (RuntimeObserver.Gas)500_000, contractExecutionCode);
             var transaction = new Transaction();
             TxOut txOut = transaction.AddOutput(0, new Script(this.callDataSerializer.Serialize(contractTxData)));
             txOut.Value = 100;
@@ -245,7 +245,7 @@ namespace Stratis.SmartContracts.CLR.Tests
             //and get the module definition
             IContractTransactionContext transactionContext = new ContractTransactionContext(BlockHeight, CoinbaseAddress, MempoolFee, SenderAddress, transaction);
 
-            var executor = new ContractExecutor(this.loggerFactory,
+            var executor = new ContractExecutor(
                 this.callDataSerializer,
                 this.state,
                 this.refundProcessor,
@@ -269,7 +269,7 @@ namespace Stratis.SmartContracts.CLR.Tests
             //-------------------------------------------------------
 
             //Call smart contract and add to transaction-------------
-            contractTxData = new ContractTxData(1, (Gas)1, (Gas)500_000, contractExecutionCode);
+            contractTxData = new ContractTxData(1, (RuntimeObserver.Gas)1, (RuntimeObserver.Gas)500_000, contractExecutionCode);
             transaction = new Transaction();
             txOut = transaction.AddOutput(0, new Script(this.callDataSerializer.Serialize(contractTxData)));
             txOut.Value = 100;
@@ -287,18 +287,18 @@ namespace Stratis.SmartContracts.CLR.Tests
 
             // Invoke infinite loop
 
-            var gasLimit = (Gas)500_000;
+            var gasLimit = (RuntimeObserver.Gas)500_000;
 
             object[] parameters = { address1.ToAddress() };
 
-            contractTxData = new ContractTxData(1, (Gas)1, gasLimit, address2, "CallInfiniteLoop", parameters);
+            contractTxData = new ContractTxData(1, (RuntimeObserver.Gas)1, gasLimit, address2, "CallInfiniteLoop", parameters);
             transaction = new Transaction();
             txOut = transaction.AddOutput(0, new Script(this.callDataSerializer.Serialize(contractTxData)));
             txOut.Value = 100;
 
             transactionContext = new ContractTransactionContext(BlockHeight, CoinbaseAddress, MempoolFee, SenderAddress, transaction);
 
-            var callExecutor = new ContractExecutor(this.loggerFactory,
+            var callExecutor = new ContractExecutor(
                 this.callDataSerializer,
                 this.state,
                 this.refundProcessor,
@@ -335,7 +335,7 @@ namespace Stratis.SmartContracts.CLR.Tests
         {
             var transactionValue = (Money)100;
 
-            var executor = new ContractExecutor(this.loggerFactory,
+            var executor = new ContractExecutor(
                 this.callDataSerializer,
                 this.state,
                 this.refundProcessor,
@@ -348,7 +348,7 @@ namespace Stratis.SmartContracts.CLR.Tests
             Assert.True(compilationResult.Success);
             byte[] contractExecutionCode = compilationResult.Compilation;
 
-            var contractTxData = new ContractTxData(1, (Gas)1, (Gas)500_000, contractExecutionCode);
+            var contractTxData = new ContractTxData(1, (RuntimeObserver.Gas)1, (RuntimeObserver.Gas)500_000, contractExecutionCode);
 
             var transaction = new Transaction();
             TxOut txOut = transaction.AddOutput(0, new Script(this.callDataSerializer.Serialize(contractTxData)));
@@ -358,7 +358,7 @@ namespace Stratis.SmartContracts.CLR.Tests
             IContractExecutionResult result = executor.Execute(transactionContext);
             uint160 contractAddress = result.NewContractAddress;
 
-            contractTxData = new ContractTxData(1, (Gas)1, (Gas)500_000, contractAddress, methodName, methodParameters);
+            contractTxData = new ContractTxData(1, (RuntimeObserver.Gas)1, (RuntimeObserver.Gas)500_000, contractAddress, methodName, methodParameters);
 
             transaction = new Transaction();
             txOut = transaction.AddOutput(0, new Script(this.callDataSerializer.Serialize(contractTxData)));

--- a/src/Stratis.SmartContracts.CLR.Tests/ContractParametersJsonResolverTests.cs
+++ b/src/Stratis.SmartContracts.CLR.Tests/ContractParametersJsonResolverTests.cs
@@ -43,7 +43,7 @@ namespace Stratis.SmartContracts.CLR.Tests
             var execResult = new LocalExecutionResult
             {
                 ErrorMessage = new ContractErrorMessage("Error message"),
-                GasConsumed = (Gas) 69,
+                GasConsumed = (RuntimeObserver.Gas) 69,
                 Return = testAddress
             };
 

--- a/src/Stratis.SmartContracts.CLR.Tests/ContractRefundProcessorTests.cs
+++ b/src/Stratis.SmartContracts.CLR.Tests/ContractRefundProcessorTests.cs
@@ -26,10 +26,10 @@ namespace Stratis.SmartContracts.CLR.Tests
         {
             var contractAddress = new uint160(1);
 
-            var contractTxData = new ContractTxData(1, 1, (Gas)5000, contractAddress, "ThrowException");
+            var contractTxData = new ContractTxData(1, 1, (RuntimeObserver.Gas)5000, contractAddress, "ThrowException");
             var sender = new uint160(2);
 
-            (Money fee, TxOut refund) = this.refundProcessor.Process(contractTxData, new Money(10500), sender, (Gas)950, false);
+            (Money fee, TxOut refund) = this.refundProcessor.Process(contractTxData, new Money(10500), sender, (RuntimeObserver.Gas)950, false);
 
             Assert.Equal(6450, fee);
             Assert.Equal(sender.ToBytes(), refund.ScriptPubKey.GetDestination(this.network).ToBytes());
@@ -41,10 +41,10 @@ namespace Stratis.SmartContracts.CLR.Tests
         {
             var contractAddress = new uint160(1);
 
-            var contractTxData = new ContractTxData(1, 1, (Gas)5000, contractAddress, "ThrowException");
+            var contractTxData = new ContractTxData(1, 1, (RuntimeObserver.Gas)5000, contractAddress, "ThrowException");
             var sender = new uint160(2);
 
-            (Money fee, TxOut refund) = this.refundProcessor.Process(contractTxData, new Money(10500), sender, (Gas)5000, false);
+            (Money fee, TxOut refund) = this.refundProcessor.Process(contractTxData, new Money(10500), sender, (RuntimeObserver.Gas)5000, false);
 
             Assert.Equal(10500, fee);
             Assert.Null(refund);
@@ -55,10 +55,10 @@ namespace Stratis.SmartContracts.CLR.Tests
         {
             var contractAddress = new uint160(1);
 
-            var contractTxData = new ContractTxData(1, 1, (Gas)5000, contractAddress, "ThrowException");
+            var contractTxData = new ContractTxData(1, 1, (RuntimeObserver.Gas)5000, contractAddress, "ThrowException");
             var sender = new uint160(2);
 
-            (Money fee, TxOut refund) = this.refundProcessor.Process(contractTxData, new Money(10500), sender, (Gas)5000, true);
+            (Money fee, TxOut refund) = this.refundProcessor.Process(contractTxData, new Money(10500), sender, (RuntimeObserver.Gas)5000, true);
 
             Assert.Equal(10500, fee);
             Assert.Null(refund);

--- a/src/Stratis.SmartContracts.CLR.Tests/ExecutorFixture.cs
+++ b/src/Stratis.SmartContracts.CLR.Tests/ExecutorFixture.cs
@@ -58,7 +58,7 @@ namespace Stratis.SmartContracts.CLR.Tests
                     It.IsAny<ContractTxData>(),
                     It.IsAny<ulong>(),
                     It.IsAny<uint160>(),
-                    It.IsAny<Gas>(),
+                    It.IsAny<RuntimeObserver.Gas>(),
                     It.IsAny<bool>()))
                 .Returns((this.Fee, this.Refund));            
             this.RefundProcessor = refundProcessor;

--- a/src/Stratis.SmartContracts.CLR.Tests/ExecutorSpecification.cs
+++ b/src/Stratis.SmartContracts.CLR.Tests/ExecutorSpecification.cs
@@ -10,11 +10,11 @@ namespace Stratis.SmartContracts.CLR.Tests
         [Fact]
         public void Create_Contract_Success()
         {
-            var contractTxData = new ContractTxData(1, 1, (Gas) 1000, new byte[] { 0xAA, 0xBB, 0xCC });
+            var contractTxData = new ContractTxData(1, 1, (RuntimeObserver.Gas) 1000, new byte[] { 0xAA, 0xBB, 0xCC });
 
             VmExecutionResult vmExecutionResult = VmExecutionResult.Ok(new object(), null);
 
-            StateTransitionResult stateTransitionResult = StateTransitionResult.Ok((Gas)100, uint160.One, vmExecutionResult.Success.Result);
+            StateTransitionResult stateTransitionResult = StateTransitionResult.Ok((RuntimeObserver.Gas)100, uint160.One, vmExecutionResult.Success.Result);
 
             var fixture = new ExecutorFixture(contractTxData);
             IState snapshot = fixture.State.Object.Snapshot();
@@ -24,7 +24,6 @@ namespace Stratis.SmartContracts.CLR.Tests
                 .Returns(stateTransitionResult);
 
             var sut = new ContractExecutor(
-                fixture.LoggerFactory,
                 fixture.CallDataSerializer.Object,
                 fixture.ContractStateRoot.Object,
                 fixture.RefundProcessor.Object,
@@ -65,7 +64,7 @@ namespace Stratis.SmartContracts.CLR.Tests
                         contractTxData,
                         fixture.MempoolFee,
                         fixture.ContractTransactionContext.Sender,
-                        It.IsAny<Gas>(),
+                        It.IsAny<RuntimeObserver.Gas>(),
                         false),
                 Times.Once);
 
@@ -84,9 +83,9 @@ namespace Stratis.SmartContracts.CLR.Tests
         [Fact]
         public void Create_Contract_Failure()
         {
-            var contractTxData = new ContractTxData(1, 1, (Gas)1000, new byte[] { 0xAA, 0xBB, 0xCC });
+            var contractTxData = new ContractTxData(1, 1, (RuntimeObserver.Gas)1000, new byte[] { 0xAA, 0xBB, 0xCC });
             
-            StateTransitionResult stateTransitionResult = StateTransitionResult.Fail((Gas) 100, StateTransitionErrorKind.VmError);
+            StateTransitionResult stateTransitionResult = StateTransitionResult.Fail((RuntimeObserver.Gas) 100, StateTransitionErrorKind.VmError);
             
             var fixture = new ExecutorFixture(contractTxData);
             IState snapshot = fixture.State.Object.Snapshot();
@@ -96,7 +95,6 @@ namespace Stratis.SmartContracts.CLR.Tests
                 .Returns(stateTransitionResult);
 
             var sut = new ContractExecutor(
-                fixture.LoggerFactory,
                 fixture.CallDataSerializer.Object,
                 fixture.ContractStateRoot.Object,
                 fixture.RefundProcessor.Object,
@@ -140,7 +138,7 @@ namespace Stratis.SmartContracts.CLR.Tests
                         contractTxData,
                         fixture.MempoolFee,
                         fixture.ContractTransactionContext.Sender,
-                        It.IsAny<Gas>(),
+                        It.IsAny<RuntimeObserver.Gas>(),
                         false),
                 Times.Once);
 
@@ -160,11 +158,11 @@ namespace Stratis.SmartContracts.CLR.Tests
         public void Call_Contract_Success()
         {
             var parameters = new object[] { };
-            var contractTxData = new ContractTxData(1, 1, (Gas)1000, uint160.One, "TestMethod", parameters);
+            var contractTxData = new ContractTxData(1, 1, (RuntimeObserver.Gas)1000, uint160.One, "TestMethod", parameters);
 
             VmExecutionResult vmExecutionResult = VmExecutionResult.Ok(new object(), null);
 
-            StateTransitionResult stateTransitionResult = StateTransitionResult.Ok((Gas)100, uint160.One, vmExecutionResult.Success.Result);
+            StateTransitionResult stateTransitionResult = StateTransitionResult.Ok((RuntimeObserver.Gas)100, uint160.One, vmExecutionResult.Success.Result);
 
             var fixture = new ExecutorFixture(contractTxData);
             IState snapshot = fixture.State.Object.Snapshot();
@@ -174,7 +172,6 @@ namespace Stratis.SmartContracts.CLR.Tests
                 .Returns(stateTransitionResult);
 
             var sut = new ContractExecutor(
-                fixture.LoggerFactory,
                 fixture.CallDataSerializer.Object,
                 fixture.ContractStateRoot.Object,
                 fixture.RefundProcessor.Object,
@@ -220,7 +217,7 @@ namespace Stratis.SmartContracts.CLR.Tests
                         contractTxData,
                         fixture.MempoolFee,
                         fixture.ContractTransactionContext.Sender,
-                        It.IsAny<Gas>(),
+                        It.IsAny<RuntimeObserver.Gas>(),
                         false),
                 Times.Once);
 
@@ -240,9 +237,9 @@ namespace Stratis.SmartContracts.CLR.Tests
         public void Call_Contract_Failure()
         {
             var parameters = new object[] { };
-            var contractTxData = new ContractTxData(1, 1, (Gas)1000, uint160.One, "TestMethod", parameters);
+            var contractTxData = new ContractTxData(1, 1, (RuntimeObserver.Gas)1000, uint160.One, "TestMethod", parameters);
 
-            StateTransitionResult stateTransitionResult = StateTransitionResult.Fail((Gas)100, StateTransitionErrorKind.VmError);
+            StateTransitionResult stateTransitionResult = StateTransitionResult.Fail((RuntimeObserver.Gas)100, StateTransitionErrorKind.VmError);
 
             var fixture = new ExecutorFixture(contractTxData);
             IState snapshot = fixture.State.Object.Snapshot();
@@ -252,7 +249,6 @@ namespace Stratis.SmartContracts.CLR.Tests
                 .Returns(stateTransitionResult);
 
             var sut = new ContractExecutor(
-                fixture.LoggerFactory,
                 fixture.CallDataSerializer.Object,
                 fixture.ContractStateRoot.Object,
                 fixture.RefundProcessor.Object,

--- a/src/Stratis.SmartContracts.CLR.Tests/GasMeterTests.cs
+++ b/src/Stratis.SmartContracts.CLR.Tests/GasMeterTests.cs
@@ -1,4 +1,5 @@
 ﻿using Stratis.SmartContracts.CLR.Exceptions;
+using Stratis.SmartContracts.CLR.Metering;
 using Xunit;
 
 namespace Stratis.SmartContracts.CLR.Tests
@@ -8,7 +9,7 @@ namespace Stratis.SmartContracts.CLR.Tests
         [Fact]
         public void SmartContracts_GasMeter_NewHasCorrectInitialGas()
         {
-            var gas = new Gas(1000);
+            var gas = new RuntimeObserver.Gas(1000);
             var gasMeter = new GasMeter(gas);
 
             Assert.Equal(gas, gasMeter.GasLimit);
@@ -17,7 +18,7 @@ namespace Stratis.SmartContracts.CLR.Tests
         [Fact]
         public void SmartContracts_GasMeter_NewHasAllAvailableGas()
         {
-            var gas = new Gas(1000);
+            var gas = new RuntimeObserver.Gas(1000);
             var gasMeter = new GasMeter(gas);
 
             Assert.Equal(gas, gasMeter.GasAvailable);
@@ -26,18 +27,18 @@ namespace Stratis.SmartContracts.CLR.Tests
         [Fact]
         public void SmartContracts_GasMeter_NewHasNoConsumedGas()
         {
-            var gas = new Gas(1000);
+            var gas = new RuntimeObserver.Gas(1000);
             var gasMeter = new GasMeter(gas);
 
-            Assert.Equal(Gas.None, gasMeter.GasConsumed);
+            Assert.Equal(RuntimeObserver.Gas.None, gasMeter.GasConsumed);
         }
 
         [Fact]
         public void SmartContracts_GasMeter_HasEnoughGasOperation()
         {
-            var diff = (Gas)100;
-            var gas = new Gas(1000);
-            var consumed = (Gas)(gas - diff);
+            var diff = (RuntimeObserver.Gas)100;
+            var gas = new RuntimeObserver.Gas(1000);
+            var consumed = (RuntimeObserver.Gas)(gas - diff);
             var gasMeter = new GasMeter(gas);
 
             gasMeter.Spend(consumed);
@@ -49,8 +50,8 @@ namespace Stratis.SmartContracts.CLR.Tests
         [Fact]
         public void SmartContract_GasMeter_DoesNotHaveEnoughGasOperation()
         {
-            var gas = new Gas(1000);
-            var operationCost = new Gas(1500);
+            var gas = new RuntimeObserver.Gas(1000);
+            var operationCost = new RuntimeObserver.Gas(1500);
             var gasMeter = new GasMeter(gas);
 
             Assert.Throws<OutOfGasException>(() => gasMeter.Spend(operationCost));

--- a/src/Stratis.SmartContracts.CLR.Tests/GasPriceListTests.cs
+++ b/src/Stratis.SmartContracts.CLR.Tests/GasPriceListTests.cs
@@ -47,7 +47,7 @@ namespace Stratis.SmartContracts.CLR.Tests
         {
             byte[] key = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9 };
             byte[] value = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
-            Gas cost = (Gas)(GasPriceList.StoragePerByteSavedGasCost * key.Length +  GasPriceList.StoragePerByteSavedGasCost * value.Length);
+            var cost = (RuntimeObserver.Gas)(GasPriceList.StoragePerByteSavedGasCost * key.Length +  GasPriceList.StoragePerByteSavedGasCost * value.Length);
 
             Assert.Equal(cost, GasPriceList.StorageSaveOperationCost(key, value));
         }
@@ -57,7 +57,7 @@ namespace Stratis.SmartContracts.CLR.Tests
         {
             byte[] key = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9 };
             byte[] value = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
-            Gas cost = (Gas)(GasPriceList.StoragePerByteRetrievedGasCost * key.Length + GasPriceList.StoragePerByteRetrievedGasCost * value.Length);
+            var cost = (RuntimeObserver.Gas)(GasPriceList.StoragePerByteRetrievedGasCost * key.Length + GasPriceList.StoragePerByteRetrievedGasCost * value.Length);
 
             Assert.Equal(cost, GasPriceList.StorageRetrieveOperationCost(key, value));
         }
@@ -70,7 +70,7 @@ namespace Stratis.SmartContracts.CLR.Tests
                 new byte[]{ 1, 2, 3, 4, 5, 6 }
             };
             byte[] data = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
-            Gas cost = (Gas)(GasPriceList.LogPerTopicByteCost * topics[0].Length + GasPriceList.LogPerByteCost * data.Length);
+            var cost = (RuntimeObserver.Gas)(GasPriceList.LogPerTopicByteCost * topics[0].Length + GasPriceList.LogPerByteCost * data.Length);
 
             Assert.Equal(cost, GasPriceList.LogOperationCost(topics, data));
         }
@@ -85,7 +85,7 @@ namespace Stratis.SmartContracts.CLR.Tests
             TypeDefinition type = moduleDefinition.Types.First(t => t.FullName.Contains("DateTime"));
             MethodDefinition method = type.Methods.First(m => m.FullName.Contains("Parse"));
 
-            Assert.Equal((Gas) GasPriceList.MethodCallGasCost, GasPriceList.MethodCallCost(method));
+            Assert.Equal((RuntimeObserver.Gas) GasPriceList.MethodCallGasCost, GasPriceList.MethodCallCost(method));
         }
     }
 }

--- a/src/Stratis.SmartContracts.CLR.Tests/InternalExecutorSpecification.cs
+++ b/src/Stratis.SmartContracts.CLR.Tests/InternalExecutorSpecification.cs
@@ -11,20 +11,20 @@ namespace Stratis.SmartContracts.CLR.Tests
         {
             ulong amount = 100UL;
             var parameters = new object[] { };
-            var gasLimit = (Gas)100_000;
+            var gasLimit = (RuntimeObserver.Gas)100_000;
 
             var fixture = new InternalExecutorTestFixture();
             
             fixture.SetGasMeterLimitAbove(gasLimit);
             
-            StateTransitionResult stateTransitionResult = StateTransitionResult.Ok((Gas) 1000, uint160.One, new object());
+            StateTransitionResult stateTransitionResult = StateTransitionResult.Ok((RuntimeObserver.Gas) 1000, uint160.One, new object());
             
             fixture.StateProcessor
                 .Setup(sp => sp.Apply(It.IsAny<IState>(), It.IsAny<InternalCreateMessage>()))
                 .Returns(stateTransitionResult);
 
             var internalExecutor = new InternalExecutor(
-                fixture.LoggerFactory,
+                fixture.GasMeter.Object,
                 fixture.State.Object,
                 fixture.StateProcessor.Object);
 
@@ -54,20 +54,20 @@ namespace Stratis.SmartContracts.CLR.Tests
         {
             ulong amount = 100UL;
             var parameters = new object[] { };
-            var gasLimit = (Gas)100_000;
+            var gasLimit = (RuntimeObserver.Gas)100_000;
 
             var fixture = new InternalExecutorTestFixture();
 
             fixture.SetGasMeterLimitAbove(gasLimit);
 
-            StateTransitionResult stateTransitionResult = StateTransitionResult.Fail((Gas)1000, StateTransitionErrorKind.VmError);
+            StateTransitionResult stateTransitionResult = StateTransitionResult.Fail((RuntimeObserver.Gas)1000, StateTransitionErrorKind.VmError);
 
             fixture.StateProcessor
                 .Setup(sp => sp.Apply(It.IsAny<IState>(), It.IsAny<InternalCreateMessage>()))
                 .Returns(stateTransitionResult);
 
             var internalExecutor = new InternalExecutor(
-                fixture.LoggerFactory,
+                fixture.GasMeter.Object,
                 fixture.State.Object,
                 fixture.StateProcessor.Object);
 
@@ -97,14 +97,14 @@ namespace Stratis.SmartContracts.CLR.Tests
         {
             ulong amount = 100UL;
             var parameters = new object[] { };
-            var gasLimit = (Gas)100_000;
+            var gasLimit = (RuntimeObserver.Gas)100_000;
 
             var fixture = new InternalExecutorTestFixture();
 
             fixture.SetGasMeterLimitBelow(gasLimit);
 
             var internalExecutor = new InternalExecutor(
-                fixture.LoggerFactory,
+                fixture.GasMeter.Object,
                 fixture.State.Object,
                 fixture.StateProcessor.Object);
 
@@ -117,7 +117,7 @@ namespace Stratis.SmartContracts.CLR.Tests
 
             fixture.State.Verify(s => s.TransitionTo(fixture.Snapshot), Times.Never);
 
-            fixture.GasMeter.Verify(g => g.Spend(It.IsAny<Gas>()), Times.Never);
+            fixture.GasMeter.Verify(g => g.Spend(It.IsAny<RuntimeObserver.Gas>()), Times.Never);
 
             Assert.False(result.Success);
             Assert.Equal(default(Address), result.NewContractAddress);
@@ -132,19 +132,19 @@ namespace Stratis.SmartContracts.CLR.Tests
             var to = "0x95D34980095380851902ccd9A1Fb4C813C2cb639".HexToAddress();
             var method = "Test";
             var parameters = new object[] { };
-            var gasLimit = (Gas)100_000;
+            var gasLimit = (RuntimeObserver.Gas)100_000;
 
             
             fixture.SetGasMeterLimitAbove(gasLimit);
 
-            StateTransitionResult stateTransitionResult = StateTransitionResult.Ok((Gas)1000, uint160.One, new object());
+            StateTransitionResult stateTransitionResult = StateTransitionResult.Ok((RuntimeObserver.Gas)1000, uint160.One, new object());
 
             fixture.StateProcessor
                 .Setup(sp => sp.Apply(It.IsAny<IState>(), It.IsAny<InternalCallMessage>()))
                 .Returns(stateTransitionResult);
 
             var internalExecutor = new InternalExecutor(
-                fixture.LoggerFactory,
+                fixture.GasMeter.Object,
                 fixture.State.Object,
                 fixture.StateProcessor.Object);
 
@@ -179,18 +179,18 @@ namespace Stratis.SmartContracts.CLR.Tests
             var to = "0x95D34980095380851902ccd9A1Fb4C813C2cb639".HexToAddress();
             var method = "Test";
             var parameters = new object[] { };
-            var gasLimit = (Gas)100_000;
+            var gasLimit = (RuntimeObserver.Gas)100_000;
             
             fixture.SetGasMeterLimitAbove(gasLimit);
 
-            StateTransitionResult stateTransitionResult = StateTransitionResult.Fail((Gas)1000, StateTransitionErrorKind.VmError);
+            StateTransitionResult stateTransitionResult = StateTransitionResult.Fail((RuntimeObserver.Gas)1000, StateTransitionErrorKind.VmError);
 
             fixture.StateProcessor
                 .Setup(sp => sp.Apply(It.IsAny<IState>(), It.IsAny<InternalCallMessage>()))
                 .Returns(stateTransitionResult);
 
             var internalExecutor = new InternalExecutor(
-                fixture.LoggerFactory,
+                fixture.GasMeter.Object,
                 fixture.State.Object,
                 fixture.StateProcessor.Object);
 
@@ -225,12 +225,12 @@ namespace Stratis.SmartContracts.CLR.Tests
             var to = "0x95D34980095380851902ccd9A1Fb4C813C2cb639".HexToAddress();
             var method = "Test";
             var parameters = new object[] { };
-            var gasLimit = (Gas)100_000;
+            var gasLimit = (RuntimeObserver.Gas)100_000;
 
             fixture.SetGasMeterLimitBelow(gasLimit);
 
             var internalExecutor = new InternalExecutor(
-                fixture.LoggerFactory,
+                fixture.GasMeter.Object,
                 fixture.State.Object,
                 fixture.StateProcessor.Object);
 
@@ -243,7 +243,7 @@ namespace Stratis.SmartContracts.CLR.Tests
 
             fixture.State.Verify(s => s.TransitionTo(fixture.Snapshot), Times.Never);
 
-            fixture.GasMeter.Verify(g => g.Spend(It.IsAny<Gas>()), Times.Never);
+            fixture.GasMeter.Verify(g => g.Spend(It.IsAny<RuntimeObserver.Gas>()), Times.Never);
 
             Assert.False(result.Success);
             Assert.Null(result.ReturnValue);
@@ -257,16 +257,16 @@ namespace Stratis.SmartContracts.CLR.Tests
             ulong amount = 100UL;
             var to = "0x95D34980095380851902ccd9A1Fb4C813C2cb639".HexToAddress();
 
-            fixture.SetGasMeterLimitAbove((Gas) InternalExecutor.DefaultGasLimit);
+            fixture.SetGasMeterLimitAbove((RuntimeObserver.Gas) InternalExecutor.DefaultGasLimit);
 
-            StateTransitionResult stateTransitionResult = StateTransitionResult.Ok((Gas)1000, uint160.One, new object());
+            StateTransitionResult stateTransitionResult = StateTransitionResult.Ok((RuntimeObserver.Gas)1000, uint160.One, new object());
 
             fixture.StateProcessor
                 .Setup(sp => sp.Apply(It.IsAny<IState>(), It.IsAny<ContractTransferMessage>()))
                 .Returns(stateTransitionResult);
 
             var internalExecutor = new InternalExecutor(
-                fixture.LoggerFactory,
+                fixture.GasMeter.Object,
                 fixture.State.Object,
                 fixture.StateProcessor.Object);
 
@@ -298,16 +298,16 @@ namespace Stratis.SmartContracts.CLR.Tests
             ulong amount = 100UL;
             var to = "0x95D34980095380851902ccd9A1Fb4C813C2cb639".HexToAddress();
 
-            fixture.SetGasMeterLimitAbove((Gas)InternalExecutor.DefaultGasLimit);
+            fixture.SetGasMeterLimitAbove((RuntimeObserver.Gas)InternalExecutor.DefaultGasLimit);
 
-            StateTransitionResult stateTransitionResult = StateTransitionResult.Fail((Gas)1000, StateTransitionErrorKind.VmError);
+            StateTransitionResult stateTransitionResult = StateTransitionResult.Fail((RuntimeObserver.Gas)1000, StateTransitionErrorKind.VmError);
 
             fixture.StateProcessor
                 .Setup(sp => sp.Apply(It.IsAny<IState>(), It.IsAny<ContractTransferMessage>()))
                 .Returns(stateTransitionResult);
 
             var internalExecutor = new InternalExecutor(
-                fixture.LoggerFactory,
+                fixture.GasMeter.Object,
                 fixture.State.Object,
                 fixture.StateProcessor.Object);
 
@@ -336,13 +336,13 @@ namespace Stratis.SmartContracts.CLR.Tests
         {
             var fixture = new InternalExecutorTestFixture();
 
-            fixture.SetGasMeterLimitBelow((Gas) GasPriceList.TransferCost);
+            fixture.SetGasMeterLimitBelow((RuntimeObserver.Gas) GasPriceList.TransferCost);
 
             ulong amount = 100UL;
             var to = "0x95D34980095380851902ccd9A1Fb4C813C2cb639".HexToAddress();
 
             var internalExecutor = new InternalExecutor(
-                fixture.LoggerFactory,
+                fixture.GasMeter.Object,
                 fixture.State.Object,
                 fixture.StateProcessor.Object);
 
@@ -355,7 +355,7 @@ namespace Stratis.SmartContracts.CLR.Tests
 
             fixture.State.Verify(s => s.TransitionTo(fixture.Snapshot), Times.Never);
 
-            fixture.GasMeter.Verify(g => g.Spend(It.IsAny<Gas>()), Times.Never);
+            fixture.GasMeter.Verify(g => g.Spend(It.IsAny<RuntimeObserver.Gas>()), Times.Never);
 
             Assert.False(result.Success);
             Assert.Null(result.ReturnValue);

--- a/src/Stratis.SmartContracts.CLR.Tests/InternalExecutorTestFixture.cs
+++ b/src/Stratis.SmartContracts.CLR.Tests/InternalExecutorTestFixture.cs
@@ -20,11 +20,10 @@ namespace Stratis.SmartContracts.CLR.Tests
             this.State = state;
             this.StateProcessor = new Mock<IStateProcessor>();
 
-            this.GasMeter = new Mock<IGasMeter>();
+            this.GasMeter = new Mock<RuntimeObserver.IGasMeter>();
 
             var smartContractState = Mock.Of<ISmartContractState>(s =>
-                s.Message == new Message("0x0000000000000000000000000000000000000001".HexToAddress(), "0x0000000000000000000000000000000000000002".HexToAddress(), 100) &&
-                s.GasMeter == this.GasMeter.Object);
+                s.Message == new Message("0x0000000000000000000000000000000000000001".HexToAddress(), "0x0000000000000000000000000000000000000002".HexToAddress(), 100));
 
             this.SmartContractState = smartContractState;
 
@@ -35,7 +34,7 @@ namespace Stratis.SmartContracts.CLR.Tests
 
         public ISmartContractState SmartContractState { get; }
 
-        public Mock<IGasMeter> GasMeter { get; }
+        public Mock<RuntimeObserver.IGasMeter> GasMeter { get; }
 
         public IState Snapshot { get; }
 
@@ -45,14 +44,14 @@ namespace Stratis.SmartContracts.CLR.Tests
 
         public ILoggerFactory LoggerFactory { get; }
 
-        public void SetGasMeterLimitAbove(Gas minimum)
+        public void SetGasMeterLimitAbove(RuntimeObserver.Gas minimum)
         {
-            this.GasMeter.SetupGet(g => g.GasAvailable).Returns((Gas)(minimum + 1));
+            this.GasMeter.SetupGet(g => g.GasAvailable).Returns((RuntimeObserver.Gas)(minimum + 1));
         }
 
-        public void SetGasMeterLimitBelow(Gas maximum)
+        public void SetGasMeterLimitBelow(RuntimeObserver.Gas maximum)
         {
-            this.GasMeter.SetupGet(g => g.GasAvailable).Returns((Gas)(maximum - 1));
+            this.GasMeter.SetupGet(g => g.GasAvailable).Returns((RuntimeObserver.Gas)(maximum - 1));
         }
     }
 }

--- a/src/Stratis.SmartContracts.CLR.Tests/LocalExecutorSpecification.cs
+++ b/src/Stratis.SmartContracts.CLR.Tests/LocalExecutorSpecification.cs
@@ -15,11 +15,11 @@ namespace Stratis.SmartContracts.CLR.Tests
         public void Call_Contract_Success()
         {
             var parameters = new object[] { };
-            var contractTxData = new ContractTxData(1, 1, (Gas)1000, uint160.One, "TestMethod", parameters);
+            var contractTxData = new ContractTxData(1, 1, (RuntimeObserver.Gas)1000, uint160.One, "TestMethod", parameters);
 
             VmExecutionResult vmExecutionResult = VmExecutionResult.Ok(new object(), null);
 
-            StateTransitionResult stateTransitionResult = StateTransitionResult.Ok((Gas)100, uint160.One, vmExecutionResult.Success.Result);
+            StateTransitionResult stateTransitionResult = StateTransitionResult.Ok((RuntimeObserver.Gas)100, uint160.One, vmExecutionResult.Success.Result);
 
             var fixture = new ExecutorFixture(contractTxData);
             IState snapshot = fixture.State.Object.Snapshot();
@@ -79,9 +79,9 @@ namespace Stratis.SmartContracts.CLR.Tests
         public void Call_Contract_Failure()
         {
             var parameters = new object[] { };
-            var contractTxData = new ContractTxData(1, 1, (Gas)1000, uint160.One, "TestMethod", parameters);
+            var contractTxData = new ContractTxData(1, 1, (RuntimeObserver.Gas)1000, uint160.One, "TestMethod", parameters);
 
-            StateTransitionResult stateTransitionResult = StateTransitionResult.Fail((Gas)100, StateTransitionErrorKind.VmError);
+            StateTransitionResult stateTransitionResult = StateTransitionResult.Fail((RuntimeObserver.Gas)100, StateTransitionErrorKind.VmError);
 
             var fixture = new ExecutorFixture(contractTxData);
             IState snapshot = fixture.State.Object.Snapshot();

--- a/src/Stratis.SmartContracts.CLR.Tests/MeteredPersistenceStrategyTests.cs
+++ b/src/Stratis.SmartContracts.CLR.Tests/MeteredPersistenceStrategyTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Moq;
 using NBitcoin;
+using Stratis.SmartContracts.CLR.Metering;
 using Stratis.SmartContracts.Core.State;
 using Xunit;
 
@@ -15,7 +16,7 @@ namespace Stratis.SmartContracts.CLR.Tests
         {
             var sr = new Mock<IStateRepository>();
 
-            Assert.Throws<ArgumentNullException>(() => new MeteredPersistenceStrategy(null, new GasMeter((Gas) 0), this.keyEncodingStrategy));
+            Assert.Throws<ArgumentNullException>(() => new MeteredPersistenceStrategy(null, new GasMeter((RuntimeObserver.Gas) 0), this.keyEncodingStrategy));
             Assert.Throws<ArgumentNullException>(() => new MeteredPersistenceStrategy(sr.Object, null, this.keyEncodingStrategy));
         }
 
@@ -33,7 +34,7 @@ namespace Stratis.SmartContracts.CLR.Tests
                 It.IsAny<byte[]>(),
                 It.IsAny<byte[]>()));
 
-            Gas availableGas = (Gas) 100000;
+            var availableGas = (RuntimeObserver.Gas) 100000;
             GasMeter gasMeter = new GasMeter(availableGas);
 
             MeteredPersistenceStrategy strategy = new MeteredPersistenceStrategy(

--- a/src/Stratis.SmartContracts.CLR.Tests/ObserverTests.cs
+++ b/src/Stratis.SmartContracts.CLR.Tests/ObserverTests.cs
@@ -8,6 +8,7 @@ using Stratis.SmartContracts.CLR.Compilation;
 using Stratis.SmartContracts.CLR.ContractLogging;
 using Stratis.SmartContracts.CLR.ILRewrite;
 using Stratis.SmartContracts.CLR.Loader;
+using Stratis.SmartContracts.CLR.Metering;
 using Stratis.SmartContracts.CLR.Serialization;
 using Stratis.SmartContracts.Core.State;
 using Stratis.SmartContracts.Networks;
@@ -93,7 +94,7 @@ namespace Stratis.SmartContracts.CLR.Tests
         private readonly Network network;
         private readonly IContractModuleDefinitionReader moduleReader;
         private readonly ContractAssemblyLoader assemblyLoader;
-        private readonly IGasMeter gasMeter;
+        private readonly RuntimeObserver.IGasMeter gasMeter;
 
         public ObserverTests()
         {
@@ -103,7 +104,7 @@ namespace Stratis.SmartContracts.CLR.Tests
             this.repository = context.State;
             this.moduleReader = new ContractModuleDefinitionReader();
             this.assemblyLoader = new ContractAssemblyLoader();
-            this.gasMeter = new GasMeter((Gas)5000000);
+            this.gasMeter = new GasMeter((RuntimeObserver.Gas)5000000);
 
             var block = new TestBlock
             {
@@ -113,7 +114,6 @@ namespace Stratis.SmartContracts.CLR.Tests
             var message = new TestMessage  
             {
                 ContractAddress = this.TestAddress,
-                GasLimit = (Gas)GasLimit,
                 Sender = this.TestAddress,
                 Value = Value
             };
@@ -122,18 +122,17 @@ namespace Stratis.SmartContracts.CLR.Tests
             var network = new SmartContractsRegTest();
             var serializer = new ContractPrimitiveSerializer(network);
             this.state = new SmartContractState(
-                new Stratis.SmartContracts.Block(1, this.TestAddress),
+                new Block(1, this.TestAddress),
                 new Message(this.TestAddress, this.TestAddress, 0),
                 new PersistentState(new MeteredPersistenceStrategy(this.repository, this.gasMeter, new BasicKeyEncodingStrategy()),
                     context.Serializer, this.TestAddress.ToUint160()),
                 context.Serializer,
-                this.gasMeter,
                 new ContractLogHolder(),
                 Mock.Of<IInternalTransactionExecutor>(),
                 new InternalHashHelper(),
                 () => 1000);
 
-            this.rewriter = new ObserverRewriter(new Observer(this.gasMeter, ReflectionVirtualMachine.MemoryUnitLimit));
+            this.rewriter = new ObserverRewriter(new Observer(this.gasMeter, new MemoryMeter(ReflectionVirtualMachine.MemoryUnitLimit)));
         }
 
         [Fact]
@@ -167,7 +166,7 @@ namespace Stratis.SmartContracts.CLR.Tests
 
             IContractInvocationResult result = contract.Invoke(callData);
             // Number here shouldn't be hardcoded - note this is really only to let us know of consensus failure
-            Assert.Equal(22uL, this.state.GasMeter.GasConsumed);
+            Assert.Equal(22uL, this.gasMeter.GasConsumed);
         }
 
         [Fact]
@@ -196,7 +195,7 @@ namespace Stratis.SmartContracts.CLR.Tests
             IContractInvocationResult result = TimeoutHelper.RunCodeWithTimeout(3, () => contract.Invoke(callData));
 
             Assert.False(result.IsSuccess);
-            Assert.Equal((Gas)0, this.gasMeter.GasAvailable);
+            Assert.Equal((RuntimeObserver.Gas)0, this.gasMeter.GasAvailable);
             Assert.Equal(this.gasMeter.GasLimit, this.gasMeter.GasConsumed);
             Assert.Equal(this.gasMeter.GasLimit, this.gasMeter.GasConsumed);
         }
@@ -221,7 +220,7 @@ namespace Stratis.SmartContracts.CLR.Tests
             IContractInvocationResult result = contract.InvokeConstructor(null);
 
             // Number here shouldn't be hardcoded - note this is really only to let us know of consensus failure
-            Assert.Equal((Gas)369, this.gasMeter.GasConsumed);
+            Assert.Equal((RuntimeObserver.Gas)369, this.gasMeter.GasConsumed);
         }
 
         [Fact]
@@ -244,7 +243,7 @@ namespace Stratis.SmartContracts.CLR.Tests
             IContractInvocationResult result = contract.InvokeConstructor(new[] { "Test Owner" });
 
             // Number here shouldn't be hardcoded - note this is really only to let us know of consensus failure
-            Assert.Equal((Gas)328, this.gasMeter.GasConsumed);
+            Assert.Equal((RuntimeObserver.Gas)328, this.gasMeter.GasConsumed);
         }
 
         [Fact]

--- a/src/Stratis.SmartContracts.CLR.Tests/StateTransitionSpecification.cs
+++ b/src/Stratis.SmartContracts.CLR.Tests/StateTransitionSpecification.cs
@@ -36,12 +36,12 @@ namespace Stratis.SmartContracts.CLR.Tests
             var externalCreateMessage = new ExternalCreateMessage(
                 uint160.Zero,
                 10,
-                (Gas)(GasPriceList.BaseCost + 100000),
+                (RuntimeObserver.Gas)(GasPriceList.BaseCost + 100000),
                 new byte[0],
                 null
             );
 
-            this.vm.Setup(v => v.Create(this.contractStateRoot.Object, It.IsAny<ISmartContractState>(), externalCreateMessage.Code, externalCreateMessage.Parameters, null))
+            this.vm.Setup(v => v.Create(this.contractStateRoot.Object, It.IsAny<ISmartContractState>(), It.IsAny<RuntimeObserver.IGasMeter>(), externalCreateMessage.Code, externalCreateMessage.Parameters, null))
                 .Returns(vmExecutionResult);
 
             var state = new Mock<IState>();
@@ -58,9 +58,9 @@ namespace Stratis.SmartContracts.CLR.Tests
 
             this.contractStateRoot.Verify(s => s.CreateAccount(newContractAddress), Times.Once);
 
-            state.Verify(s => s.CreateSmartContractState(state.Object, It.IsAny<GasMeter>(), newContractAddress, externalCreateMessage, this.contractStateRoot.Object));
+            state.Verify(s => s.CreateSmartContractState(state.Object, It.IsAny<RuntimeObserver.IGasMeter>(), newContractAddress, externalCreateMessage, this.contractStateRoot.Object));
 
-            this.vm.Verify(v => v.Create(this.contractStateRoot.Object, It.IsAny<ISmartContractState>(), externalCreateMessage.Code, externalCreateMessage.Parameters, null), Times.Once);
+            this.vm.Verify(v => v.Create(this.contractStateRoot.Object, It.IsAny<ISmartContractState>(), It.IsAny<RuntimeObserver.IGasMeter>(), externalCreateMessage.Code, externalCreateMessage.Parameters, null), Times.Once);
 
             Assert.True(result.IsSuccess);
             Assert.NotNull(result.Success);
@@ -78,12 +78,12 @@ namespace Stratis.SmartContracts.CLR.Tests
             var externalCreateMessage = new ExternalCreateMessage(
                 uint160.Zero,
                 10,
-                (Gas)(GasPriceList.BaseCost + 100000),
+                (RuntimeObserver.Gas)(GasPriceList.BaseCost + 100000),
                 new byte[0],
                 null
             );
 
-            this.vm.Setup(v => v.Create(this.contractStateRoot.Object, It.IsAny<ISmartContractState>(), externalCreateMessage.Code, externalCreateMessage.Parameters, null))
+            this.vm.Setup(v => v.Create(this.contractStateRoot.Object, It.IsAny<ISmartContractState>(), It.IsAny<RuntimeObserver.IGasMeter>(), externalCreateMessage.Code, externalCreateMessage.Parameters, null))
                 .Returns(vmExecutionResult);
 
             var state = new Mock<IState>();
@@ -98,7 +98,7 @@ namespace Stratis.SmartContracts.CLR.Tests
 
             this.contractStateRoot.Verify(ts => ts.CreateAccount(newContractAddress), Times.Once);
 
-            this.vm.Verify(v => v.Create(this.contractStateRoot.Object, It.IsAny<ISmartContractState>(), externalCreateMessage.Code, externalCreateMessage.Parameters, null), Times.Once);
+            this.vm.Verify(v => v.Create(this.contractStateRoot.Object, It.IsAny<ISmartContractState>(), It.IsAny<RuntimeObserver.IGasMeter>(), externalCreateMessage.Code, externalCreateMessage.Parameters, null), Times.Once);
 
             Assert.False(result.IsSuccess);
             Assert.True(result.IsFailure);
@@ -111,7 +111,7 @@ namespace Stratis.SmartContracts.CLR.Tests
         [Fact]
         public void ExternalCall_Success()
         {
-            var gasLimit = (Gas)(GasPriceList.BaseCost + 100000);
+            var gasLimit = (RuntimeObserver.Gas)(GasPriceList.BaseCost + 100000);
             var vmExecutionResult = VmExecutionResult.Ok(true, "Test");
 
             // Code must have a length to pass precondition checks.
@@ -135,7 +135,7 @@ namespace Stratis.SmartContracts.CLR.Tests
                 .Returns(typeName);
 
             this.vm.Setup(v =>
-                    v.ExecuteMethod(It.IsAny<ISmartContractState>(), externalCallMessage.Method, code, typeName))
+                    v.ExecuteMethod(It.IsAny<ISmartContractState>(), It.IsAny<RuntimeObserver.IGasMeter>(), externalCallMessage.Method, code, typeName))
                 .Returns(vmExecutionResult);
 
             var state = new Mock<IState>();
@@ -151,10 +151,10 @@ namespace Stratis.SmartContracts.CLR.Tests
 
             this.contractStateRoot.Verify(sr => sr.GetContractType(externalCallMessage.To), Times.Once);
 
-            state.Verify(s => s.CreateSmartContractState(state.Object, It.IsAny<GasMeter>(), externalCallMessage.To, externalCallMessage, this.contractStateRoot.Object));
+            state.Verify(s => s.CreateSmartContractState(state.Object, It.IsAny<RuntimeObserver.IGasMeter>(), externalCallMessage.To, externalCallMessage, this.contractStateRoot.Object));
 
             this.vm.Verify(
-                v => v.ExecuteMethod(It.IsAny<ISmartContractState>(), externalCallMessage.Method, code, typeName),
+                v => v.ExecuteMethod(It.IsAny<ISmartContractState>(), It.IsAny<RuntimeObserver.IGasMeter>(), externalCallMessage.Method, code, typeName),
                 Times.Once);
 
             Assert.True(result.IsSuccess);
@@ -167,7 +167,7 @@ namespace Stratis.SmartContracts.CLR.Tests
         [Fact]
         public void ExternalCall_Vm_Error()
         {
-            var gasLimit = (Gas)(GasPriceList.BaseCost + 100000);
+            var gasLimit = (RuntimeObserver.Gas)(GasPriceList.BaseCost + 100000);
             var vmExecutionResult = VmExecutionResult.Fail(VmExecutionErrorKind.InvocationFailed, "Error");
 
             // Code must have a length to pass precondition checks.
@@ -191,7 +191,7 @@ namespace Stratis.SmartContracts.CLR.Tests
                 .Returns(typeName);
 
             this.vm.Setup(v =>
-                    v.ExecuteMethod(It.IsAny<ISmartContractState>(), externalCallMessage.Method, code, typeName))
+                    v.ExecuteMethod(It.IsAny<ISmartContractState>(), It.IsAny<RuntimeObserver.IGasMeter>(), externalCallMessage.Method, code, typeName))
                 .Returns(vmExecutionResult);
 
             var state = new Mock<IState>();
@@ -205,10 +205,10 @@ namespace Stratis.SmartContracts.CLR.Tests
 
             this.contractStateRoot.Verify(sr => sr.GetContractType(externalCallMessage.To), Times.Once);
 
-            state.Verify(s => s.CreateSmartContractState(state.Object, It.IsAny<GasMeter>(), externalCallMessage.To, externalCallMessage, this.contractStateRoot.Object));
+            state.Verify(s => s.CreateSmartContractState(state.Object, It.IsAny<RuntimeObserver.IGasMeter>(), externalCallMessage.To, externalCallMessage, this.contractStateRoot.Object));
 
             this.vm.Verify(
-                v => v.ExecuteMethod(It.IsAny<ISmartContractState>(), externalCallMessage.Method, code, typeName),
+                v => v.ExecuteMethod(It.IsAny<ISmartContractState>(), It.IsAny<RuntimeObserver.IGasMeter>(), externalCallMessage.Method, code, typeName),
                 Times.Once);
 
             Assert.True(result.IsFailure);
@@ -221,7 +221,7 @@ namespace Stratis.SmartContracts.CLR.Tests
         [Fact]
         public void ExternalCall_Code_Null()
         {
-            var gasLimit = (Gas)(GasPriceList.BaseCost + 100000);
+            var gasLimit = (RuntimeObserver.Gas)(GasPriceList.BaseCost + 100000);
 
             var externalCallMessage = new ExternalCallMessage(
                 uint160.Zero,
@@ -248,7 +248,7 @@ namespace Stratis.SmartContracts.CLR.Tests
             Assert.NotNull(result.Error);
             Assert.Null(result.Error.VmError);
             Assert.Equal(StateTransitionErrorKind.NoCode, result.Error.Kind);
-            Assert.Equal((Gas) GasPriceList.BaseCost, result.GasConsumed);
+            Assert.Equal((RuntimeObserver.Gas) GasPriceList.BaseCost, result.GasConsumed);
         }
 
         [Fact]
@@ -265,7 +265,7 @@ namespace Stratis.SmartContracts.CLR.Tests
             var internalCreateMessage = new InternalCreateMessage(
                 uint160.Zero,
                 10,
-                (Gas)(GasPriceList.BaseCost + 100000),
+                (RuntimeObserver.Gas)(GasPriceList.BaseCost + 100000),
                 new object[] {},
                 typeName
             );
@@ -274,7 +274,7 @@ namespace Stratis.SmartContracts.CLR.Tests
                 .Setup(sr => sr.GetCode(internalCreateMessage.From))
                 .Returns(code);
 
-            this.vm.Setup(v => v.Create(this.contractStateRoot.Object, It.IsAny<ISmartContractState>(), code, internalCreateMessage.Parameters, internalCreateMessage.Type))
+            this.vm.Setup(v => v.Create(this.contractStateRoot.Object, It.IsAny<ISmartContractState>(), It.IsAny<RuntimeObserver.IGasMeter>(), code, internalCreateMessage.Parameters, internalCreateMessage.Type))
                 .Returns(vmExecutionResult);
 
             var state = new Mock<IState>();
@@ -300,10 +300,10 @@ namespace Stratis.SmartContracts.CLR.Tests
             this.contractStateRoot.Verify(s => s.CreateAccount(newContractAddress), Times.Once);
 
             // Verify we set up the smart contract state
-            state.Verify(s => s.CreateSmartContractState(state.Object, It.IsAny<GasMeter>(), newContractAddress, internalCreateMessage, this.contractStateRoot.Object));
+            state.Verify(s => s.CreateSmartContractState(state.Object, It.IsAny<RuntimeObserver.IGasMeter>(), newContractAddress, internalCreateMessage, this.contractStateRoot.Object));
 
             // Verify the VM was invoked
-            this.vm.Verify(v => v.Create(this.contractStateRoot.Object, It.IsAny<ISmartContractState>(), code, internalCreateMessage.Parameters, internalCreateMessage.Type), Times.Once);
+            this.vm.Verify(v => v.Create(this.contractStateRoot.Object, It.IsAny<ISmartContractState>(), It.IsAny<RuntimeObserver.IGasMeter>(), code, internalCreateMessage.Parameters, internalCreateMessage.Type), Times.Once);
 
             // Verify the value was added to the internal transfer list
             state.Verify(s => s.AddInternalTransfer(It.Is<TransferInfo>(t => t.From == internalCreateMessage.From 
@@ -331,7 +331,7 @@ namespace Stratis.SmartContracts.CLR.Tests
             var internalCreateMessage = new InternalCreateMessage(
                 uint160.Zero,
                 10,
-                (Gas)(GasPriceList.BaseCost + 100000),
+                (RuntimeObserver.Gas)(GasPriceList.BaseCost + 100000),
                 new object[] { },
                 typeName
             );
@@ -339,6 +339,7 @@ namespace Stratis.SmartContracts.CLR.Tests
             this.vm.Setup(v =>
                     v.Create(It.IsAny<IStateRepository>(),
                         It.IsAny<ISmartContractState>(),
+                        It.IsAny<RuntimeObserver.IGasMeter>(),
                         It.IsAny<byte[]>(),
                         It.IsAny<object[]>(),
                         It.IsAny<string>()))
@@ -358,12 +359,13 @@ namespace Stratis.SmartContracts.CLR.Tests
 
             StateTransitionResult result = stateProcessor.Apply(state.Object, internalCreateMessage);
         
-            state.Verify(s => s.CreateSmartContractState(state.Object, It.IsAny<GasMeter>(), newContractAddress, internalCreateMessage, this.contractStateRoot.Object));
+            state.Verify(s => s.CreateSmartContractState(state.Object, It.IsAny<RuntimeObserver.IGasMeter>(), newContractAddress, internalCreateMessage, this.contractStateRoot.Object));
 
             this.vm.Verify(
                 v => v.Create(
                     this.contractStateRoot.Object,
-                    It.IsAny<ISmartContractState>(), 
+                    It.IsAny<ISmartContractState>(),
+                    It.IsAny<RuntimeObserver.IGasMeter>(),
                     code,
                     internalCreateMessage.Parameters,
                     internalCreateMessage.Type),
@@ -384,7 +386,7 @@ namespace Stratis.SmartContracts.CLR.Tests
             var internalCreateMessage = new InternalCreateMessage(
                 uint160.Zero,
                 10,
-                (Gas)(GasPriceList.BaseCost + 100000),
+                (RuntimeObserver.Gas)(GasPriceList.BaseCost + 100000),
                 new object[] { },
                 typeName
             );
@@ -405,7 +407,7 @@ namespace Stratis.SmartContracts.CLR.Tests
             Assert.NotNull(result.Error);
             Assert.Null(result.Error.VmError);
             Assert.Equal(StateTransitionErrorKind.InsufficientBalance, result.Error.Kind);
-            Assert.Equal((Gas)0, result.GasConsumed);
+            Assert.Equal((RuntimeObserver.Gas)0, result.GasConsumed);
         }
 
         [Fact]
@@ -417,12 +419,12 @@ namespace Stratis.SmartContracts.CLR.Tests
             var createMessage = new ExternalCreateMessage(
                 uint160.Zero,
                 10,
-                (Gas)(GasPriceList.BaseCost + 100000),
+                (RuntimeObserver.Gas)(GasPriceList.BaseCost + 100000),
                 new byte[0],
                 null
             );
 
-            this.vm.Setup(v => v.Create(this.contractStateRoot.Object, It.IsAny<ISmartContractState>(), createMessage.Code, createMessage.Parameters, null))
+            this.vm.Setup(v => v.Create(this.contractStateRoot.Object, It.IsAny<ISmartContractState>(), It.IsAny<RuntimeObserver.IGasMeter>(), createMessage.Code, createMessage.Parameters, null))
                 .Returns(vmExecutionResult);
 
             var state = new Mock<IState>();
@@ -437,7 +439,7 @@ namespace Stratis.SmartContracts.CLR.Tests
 
             this.contractStateRoot.Verify(ts => ts.CreateAccount(newContractAddress), Times.Once);
 
-            this.vm.Verify(v => v.Create(this.contractStateRoot.Object, It.IsAny<ISmartContractState>(), createMessage.Code, createMessage.Parameters, null), Times.Once);
+            this.vm.Verify(v => v.Create(this.contractStateRoot.Object, It.IsAny<ISmartContractState>(), It.IsAny<RuntimeObserver.IGasMeter>(), createMessage.Code, createMessage.Parameters, null), Times.Once);
 
             Assert.False(result.IsSuccess);
             Assert.True(result.IsFailure);
@@ -461,7 +463,7 @@ namespace Stratis.SmartContracts.CLR.Tests
                 uint160.One,
                 uint160.Zero,
                 10,
-                (Gas)(GasPriceList.BaseCost + 100000),
+                (RuntimeObserver.Gas)(GasPriceList.BaseCost + 100000),
                 new MethodCall("Test", new object[] {})
             );
 
@@ -473,7 +475,7 @@ namespace Stratis.SmartContracts.CLR.Tests
                 .Setup(sr => sr.GetContractType(internalCallMessage.To))
                 .Returns(typeName);
 
-            this.vm.Setup(v => v.ExecuteMethod(It.IsAny<ISmartContractState>(), internalCallMessage.Method, code, typeName))
+            this.vm.Setup(v => v.ExecuteMethod(It.IsAny<ISmartContractState>(), It.IsAny<RuntimeObserver.IGasMeter>(), internalCallMessage.Method, code, typeName))
                 .Returns(vmExecutionResult);
 
             var state = new Mock<IState>();
@@ -494,10 +496,10 @@ namespace Stratis.SmartContracts.CLR.Tests
             this.contractStateRoot.Verify(s => s.GetCode(internalCallMessage.To), Times.Once);
 
             // Verify we set up the smart contract state
-            state.Verify(s => s.CreateSmartContractState(state.Object, It.IsAny<GasMeter>(), internalCallMessage.To, internalCallMessage, this.contractStateRoot.Object));
+            state.Verify(s => s.CreateSmartContractState(state.Object, It.IsAny<RuntimeObserver.IGasMeter>(), internalCallMessage.To, internalCallMessage, this.contractStateRoot.Object));
 
             // Verify the VM was invoked
-            this.vm.Verify(v => v.ExecuteMethod(It.IsAny<ISmartContractState>(), internalCallMessage.Method, code, typeName), Times.Once);
+            this.vm.Verify(v => v.ExecuteMethod(It.IsAny<ISmartContractState>(), It.IsAny<RuntimeObserver.IGasMeter>(), internalCallMessage.Method, code, typeName), Times.Once);
 
             // Verify the value was added to the internal transfer list
             state.Verify(s => s.AddInternalTransfer(It.Is<TransferInfo>(t => t.From == internalCallMessage.From
@@ -524,12 +526,13 @@ namespace Stratis.SmartContracts.CLR.Tests
                 uint160.One,
                 uint160.Zero,
                 10,
-                (Gas)(GasPriceList.BaseCost + 100000),
+                (RuntimeObserver.Gas)(GasPriceList.BaseCost + 100000),
                 new MethodCall("Test", new object[] { })
             );
 
             this.vm.Setup(v => v.ExecuteMethod(
                     It.IsAny<ISmartContractState>(),
+                    It.IsAny<RuntimeObserver.IGasMeter>(),
                     internalCallMessage.Method,
                     code,
                     typeName))
@@ -552,11 +555,12 @@ namespace Stratis.SmartContracts.CLR.Tests
 
             StateTransitionResult result = stateProcessor.Apply(state.Object, internalCallMessage);
 
-            state.Verify(s => s.CreateSmartContractState(state.Object, It.IsAny<GasMeter>(), internalCallMessage.To, internalCallMessage, this.contractStateRoot.Object));
+            state.Verify(s => s.CreateSmartContractState(state.Object, It.IsAny<RuntimeObserver.IGasMeter>(), internalCallMessage.To, internalCallMessage, this.contractStateRoot.Object));
 
             this.vm.Verify(
                 v => v.ExecuteMethod(
                     It.IsAny<ISmartContractState>(),
+                    It.IsAny<RuntimeObserver.IGasMeter>(),
                     internalCallMessage.Method,
                     code,
                     typeName),
@@ -576,7 +580,7 @@ namespace Stratis.SmartContracts.CLR.Tests
                 uint160.One,
                 uint160.Zero,
                 10,
-                (Gas)(GasPriceList.BaseCost + 100000),
+                (RuntimeObserver.Gas)(GasPriceList.BaseCost + 100000),
                 new MethodCall("Test", new object[] { })
             );
 
@@ -596,7 +600,7 @@ namespace Stratis.SmartContracts.CLR.Tests
             Assert.NotNull(result.Error);
             Assert.Null(result.Error.VmError);
             Assert.Equal(StateTransitionErrorKind.InsufficientBalance, result.Error.Kind);
-            Assert.Equal((Gas) 0, result.GasConsumed);
+            Assert.Equal((RuntimeObserver.Gas) 0, result.GasConsumed);
         }
 
         [Fact]
@@ -606,7 +610,7 @@ namespace Stratis.SmartContracts.CLR.Tests
                 uint160.One,
                 uint160.Zero,
                 10,
-                (Gas)(GasPriceList.BaseCost + 100000),
+                (RuntimeObserver.Gas)(GasPriceList.BaseCost + 100000),
                 new MethodCall("Test", new object[] { })
             );
 
@@ -629,7 +633,7 @@ namespace Stratis.SmartContracts.CLR.Tests
             Assert.NotNull(result.Error);
             Assert.Null(result.Error.VmError);
             Assert.Equal(StateTransitionErrorKind.NoCode, result.Error.Kind);
-            Assert.Equal((Gas) GasPriceList.BaseCost, result.GasConsumed);
+            Assert.Equal((RuntimeObserver.Gas) GasPriceList.BaseCost, result.GasConsumed);
         }
 
         [Fact]
@@ -644,12 +648,13 @@ namespace Stratis.SmartContracts.CLR.Tests
                 uint160.One,
                 uint160.Zero,
                 10,
-                (Gas)(GasPriceList.BaseCost + 100000),
+                (RuntimeObserver.Gas)(GasPriceList.BaseCost + 100000),
                 new MethodCall("Test", new object[] { })
             );
 
             this.vm.Setup(v => v.ExecuteMethod(
                     It.IsAny<ISmartContractState>(),
+                    It.IsAny<RuntimeObserver.IGasMeter>(),
                     callMessage.Method,
                     code,
                     null))
@@ -668,11 +673,12 @@ namespace Stratis.SmartContracts.CLR.Tests
 
             StateTransitionResult result = stateProcessor.Apply(state.Object, callMessage);
 
-            state.Verify(s => s.CreateSmartContractState(state.Object, It.IsAny<GasMeter>(), callMessage.To, callMessage, this.contractStateRoot.Object));
+            state.Verify(s => s.CreateSmartContractState(state.Object, It.IsAny<RuntimeObserver.IGasMeter>(), callMessage.To, callMessage, this.contractStateRoot.Object));
 
             this.vm.Verify(
                 v => v.ExecuteMethod(
                     It.IsAny<ISmartContractState>(),
+                    It.IsAny<RuntimeObserver.IGasMeter>(),
                     callMessage.Method,
                     code,
                     null),
@@ -696,7 +702,7 @@ namespace Stratis.SmartContracts.CLR.Tests
                 uint160.One,
                 uint160.Zero,
                 10,
-                (Gas)(GasPriceList.BaseCost + 100000)
+                (RuntimeObserver.Gas)(GasPriceList.BaseCost + 100000)
             );
 
             // Code must be returned for this test to ensure we apply the call.
@@ -708,7 +714,7 @@ namespace Stratis.SmartContracts.CLR.Tests
                 .Setup(sr => sr.GetContractType(contractTransferMessage.To))
                 .Returns(typeName);
 
-            this.vm.Setup(v => v.ExecuteMethod(It.IsAny<ISmartContractState>(), contractTransferMessage.Method, code, typeName))
+            this.vm.Setup(v => v.ExecuteMethod(It.IsAny<ISmartContractState>(), It.IsAny<RuntimeObserver.IGasMeter>(),contractTransferMessage.Method, code, typeName))
                 .Returns(vmExecutionResult);
 
             var state = new Mock<IState>();
@@ -729,10 +735,10 @@ namespace Stratis.SmartContracts.CLR.Tests
             this.contractStateRoot.Verify(s => s.GetCode(contractTransferMessage.To), Times.Once);
 
             // Verify we set up the smart contract state
-            state.Verify(s => s.CreateSmartContractState(state.Object, It.IsAny<GasMeter>(), contractTransferMessage.To, contractTransferMessage, this.contractStateRoot.Object));
+            state.Verify(s => s.CreateSmartContractState(state.Object, It.IsAny<RuntimeObserver.IGasMeter>(), contractTransferMessage.To, contractTransferMessage, this.contractStateRoot.Object));
 
             // Verify the VM was invoked
-            this.vm.Verify(v => v.ExecuteMethod(It.IsAny<ISmartContractState>(), contractTransferMessage.Method, code, typeName), Times.Once);
+            this.vm.Verify(v => v.ExecuteMethod(It.IsAny<ISmartContractState>(), It.IsAny<RuntimeObserver.IGasMeter>(), contractTransferMessage.Method, code, typeName), Times.Once);
 
             // Verify the value was added to the internal transfer list
             state.Verify(s => s.AddInternalTransfer(It.Is<TransferInfo>(t => t.From == contractTransferMessage.From
@@ -759,11 +765,12 @@ namespace Stratis.SmartContracts.CLR.Tests
                 uint160.One,
                 uint160.Zero,
                 10,
-                (Gas)(GasPriceList.BaseCost + 100000)
+                (RuntimeObserver.Gas)(GasPriceList.BaseCost + 100000)
             );
 
             this.vm.Setup(v => v.ExecuteMethod(
                     It.IsAny<ISmartContractState>(),
+                    It.IsAny<RuntimeObserver.IGasMeter>(),
                     contractTransferMessage.Method,
                     code,
                     typeName))
@@ -786,11 +793,12 @@ namespace Stratis.SmartContracts.CLR.Tests
 
             StateTransitionResult result = stateProcessor.Apply(state.Object, contractTransferMessage);
 
-            state.Verify(s => s.CreateSmartContractState(state.Object, It.IsAny<GasMeter>(), contractTransferMessage.To, contractTransferMessage, this.contractStateRoot.Object));
+            state.Verify(s => s.CreateSmartContractState(state.Object, It.IsAny<RuntimeObserver.IGasMeter>(), contractTransferMessage.To, contractTransferMessage, this.contractStateRoot.Object));
 
             this.vm.Verify(
                 v => v.ExecuteMethod(
                     It.IsAny<ISmartContractState>(),
+                    It.IsAny<RuntimeObserver.IGasMeter>(),
                     contractTransferMessage.Method,
                     code,
                     typeName),
@@ -810,7 +818,7 @@ namespace Stratis.SmartContracts.CLR.Tests
                 uint160.One,
                 uint160.Zero,
                 10,
-                (Gas)(GasPriceList.BaseCost + 100000)
+                (RuntimeObserver.Gas)(GasPriceList.BaseCost + 100000)
             );
 
             var state = new Mock<IState>();
@@ -829,7 +837,7 @@ namespace Stratis.SmartContracts.CLR.Tests
             Assert.NotNull(result.Error);
             Assert.Null(result.Error.VmError);
             Assert.Equal(StateTransitionErrorKind.InsufficientBalance, result.Error.Kind);
-            Assert.Equal((Gas)0, result.GasConsumed);
+            Assert.Equal((RuntimeObserver.Gas)0, result.GasConsumed);
         }
 
         [Fact]
@@ -842,7 +850,7 @@ namespace Stratis.SmartContracts.CLR.Tests
                 uint160.One,
                 uint160.Zero,
                 10,
-                (Gas)(GasPriceList.BaseCost + 100000)
+                (RuntimeObserver.Gas)(GasPriceList.BaseCost + 100000)
             );
 
             // No code should be returned
@@ -868,7 +876,7 @@ namespace Stratis.SmartContracts.CLR.Tests
             this.contractStateRoot.Verify(s => s.GetCode(contractTransferMessage.To), Times.Once);
 
             // Verify the VM was NOT invoked
-            this.vm.Verify(v => v.ExecuteMethod(It.IsAny<ISmartContractState>(), It.IsAny<MethodCall>(), It.IsAny<byte[]>(), It.IsAny<string>()), Times.Never);
+            this.vm.Verify(v => v.ExecuteMethod(It.IsAny<ISmartContractState>(), It.IsAny<RuntimeObserver.IGasMeter>(), It.IsAny<MethodCall>(), It.IsAny<byte[]>(), It.IsAny<string>()), Times.Never);
 
             // Verify the value was added to the internal transfer list
             state.Verify(s => s.AddInternalTransfer(It.Is<TransferInfo>(t => t.From == contractTransferMessage.From
@@ -881,7 +889,7 @@ namespace Stratis.SmartContracts.CLR.Tests
             Assert.Null(result.Success.ExecutionResult);
 
             // No gas is consumed
-            Assert.Equal((Gas) GasPriceList.TransferCost, result.GasConsumed);
+            Assert.Equal((RuntimeObserver.Gas) GasPriceList.TransferCost, result.GasConsumed);
         }
     }
 }

--- a/src/Stratis.SmartContracts.CLR/BaseMessage.cs
+++ b/src/Stratis.SmartContracts.CLR/BaseMessage.cs
@@ -4,7 +4,7 @@ namespace Stratis.SmartContracts.CLR
 {
     public abstract class BaseMessage
     {
-        protected BaseMessage(uint160 from, ulong amount, Gas gasLimit)
+        protected BaseMessage(uint160 from, ulong amount, RuntimeObserver.Gas gasLimit)
         {
             this.From = from;
             this.Amount = amount;
@@ -24,6 +24,6 @@ namespace Stratis.SmartContracts.CLR
         /// <summary>
         /// The maximum amount of gas that can be expended while executing the message.
         /// </summary>
-        public Gas GasLimit { get; }
+        public RuntimeObserver.Gas GasLimit { get; }
     }
 }

--- a/src/Stratis.SmartContracts.CLR/CallDataSerializer.cs
+++ b/src/Stratis.SmartContracts.CLR/CallDataSerializer.cs
@@ -39,7 +39,7 @@ namespace Stratis.SmartContracts.CLR
                 
                 var vmVersion = this.primitiveSerializer.Deserialize<int>(vmVersionBytes);
                 var gasPrice = this.primitiveSerializer.Deserialize<ulong>(gasPriceBytes);
-                var gasLimit = (Gas) this.primitiveSerializer.Deserialize<ulong>(gasLimitBytes);
+                var gasLimit = (RuntimeObserver.Gas) this.primitiveSerializer.Deserialize<ulong>(gasLimitBytes);
 
                 return IsCallContract(type) 
                     ? this.SerializeCallContract(smartContractBytes, vmVersion, gasPrice, gasLimit)
@@ -53,7 +53,7 @@ namespace Stratis.SmartContracts.CLR
             }
         }
 
-        private Result<ContractTxData> SerializeCreateContract(byte[] smartContractBytes, int vmVersion, ulong gasPrice, Gas gasLimit)
+        private Result<ContractTxData> SerializeCreateContract(byte[] smartContractBytes, int vmVersion, ulong gasPrice, RuntimeObserver.Gas gasLimit)
         {
             var remaining = smartContractBytes.Slice(PrefixSize, (uint) (smartContractBytes.Length - PrefixSize));
 
@@ -66,7 +66,7 @@ namespace Stratis.SmartContracts.CLR
             return Result.Ok(callData);
         }
 
-        private Result<ContractTxData> SerializeCallContract(byte[] smartContractBytes, int vmVersion, ulong gasPrice, Gas gasLimit)
+        private Result<ContractTxData> SerializeCallContract(byte[] smartContractBytes, int vmVersion, ulong gasPrice, RuntimeObserver.Gas gasLimit)
         {
             var contractAddressBytes = smartContractBytes.Slice(PrefixSize, AddressSize);
             var contractAddress = new uint160(contractAddressBytes);

--- a/src/Stratis.SmartContracts.CLR/CallMessage.cs
+++ b/src/Stratis.SmartContracts.CLR/CallMessage.cs
@@ -7,7 +7,7 @@ namespace Stratis.SmartContracts.CLR
     /// </summary>
     public abstract class CallMessage : BaseMessage
     {
-        protected CallMessage(uint160 to, uint160 from, ulong amount, Gas gasLimit, MethodCall methodCall)
+        protected CallMessage(uint160 to, uint160 from, ulong amount, RuntimeObserver.Gas gasLimit, MethodCall methodCall)
             : base(from, amount, gasLimit)
         {
             this.To = to;

--- a/src/Stratis.SmartContracts.CLR/ContractExecutor.cs
+++ b/src/Stratis.SmartContracts.CLR/ContractExecutor.cs
@@ -13,7 +13,6 @@ namespace Stratis.SmartContracts.CLR
     /// </summary>
     public class ContractExecutor : IContractExecutor
     {
-        private readonly ILogger logger;
         private readonly IStateRepository stateRoot;
         private readonly IContractRefundProcessor refundProcessor;
         private readonly IContractTransferProcessor transferProcessor;
@@ -22,7 +21,7 @@ namespace Stratis.SmartContracts.CLR
         private readonly IStateProcessor stateProcessor;
         private readonly IContractPrimitiveSerializer contractPrimitiveSerializer;
 
-        public ContractExecutor(ILoggerFactory loggerFactory,
+        public ContractExecutor(
             ICallDataSerializer serializer,
             IStateRepository stateRoot,
             IContractRefundProcessor refundProcessor,
@@ -31,7 +30,6 @@ namespace Stratis.SmartContracts.CLR
             IStateProcessor stateProcessor,
             IContractPrimitiveSerializer contractPrimitiveSerializer)
         {
-            this.logger = loggerFactory.CreateLogger(this.GetType());
             this.stateRoot = stateRoot;
             this.refundProcessor = refundProcessor;
             this.transferProcessor = transferProcessor;

--- a/src/Stratis.SmartContracts.CLR/ContractLogging/MeteredContractLogger.cs
+++ b/src/Stratis.SmartContracts.CLR/ContractLogging/MeteredContractLogger.cs
@@ -9,11 +9,11 @@ namespace Stratis.SmartContracts.CLR.ContractLogging
     /// </summary>
     public class MeteredContractLogger : IContractLogger
     {
-        private readonly IGasMeter gasMeter;
+        private readonly RuntimeObserver.IGasMeter gasMeter;
         private readonly IContractLogger logger;
         private readonly IContractPrimitiveSerializer serializer;
 
-        public MeteredContractLogger(IGasMeter gasMeter, IContractLogger logger, IContractPrimitiveSerializer serializer)
+        public MeteredContractLogger(RuntimeObserver.IGasMeter gasMeter, IContractLogger logger, IContractPrimitiveSerializer serializer)
         {
             this.gasMeter = gasMeter;
             this.logger = logger;

--- a/src/Stratis.SmartContracts.CLR/ContractTransferMessage.cs
+++ b/src/Stratis.SmartContracts.CLR/ContractTransferMessage.cs
@@ -10,7 +10,7 @@ namespace Stratis.SmartContracts.CLR
     /// </summary>
     public class ContractTransferMessage : InternalCallMessage
     {
-        public ContractTransferMessage(uint160 to, uint160 from, ulong amount, Gas gasLimit) 
+        public ContractTransferMessage(uint160 to, uint160 from, ulong amount, RuntimeObserver.Gas gasLimit) 
             : base(to, from, amount, gasLimit, MethodCall.Receive())
         {
         }

--- a/src/Stratis.SmartContracts.CLR/ContractTxData.cs
+++ b/src/Stratis.SmartContracts.CLR/ContractTxData.cs
@@ -11,7 +11,7 @@ namespace Stratis.SmartContracts.CLR
         /// <summary>
         /// Creates a ContractTxData object for a method invocation
         /// </summary>
-        public ContractTxData(int vmVersion, ulong gasPrice, Gas gasLimit, uint160 contractAddress,
+        public ContractTxData(int vmVersion, ulong gasPrice, RuntimeObserver.Gas gasLimit, uint160 contractAddress,
             string method, object[] methodParameters = null)
         {
             this.OpCodeType = (byte) ScOpcodeType.OP_CALLCONTRACT;
@@ -27,7 +27,7 @@ namespace Stratis.SmartContracts.CLR
         /// <summary>
         /// Creates a ContractTxData for contract creation
         /// </summary>
-        public ContractTxData(int vmVersion, ulong gasPrice, Gas gasLimit, byte[] code,
+        public ContractTxData(int vmVersion, ulong gasPrice, RuntimeObserver.Gas gasLimit, byte[] code,
             object[] methodParameters = null)
         {
             this.OpCodeType = (byte)ScOpcodeType.OP_CREATECONTRACT;
@@ -48,7 +48,7 @@ namespace Stratis.SmartContracts.CLR
         public uint160 ContractAddress { get; }
 
         /// <summary>The maximum amount of gas units that can spent to execute this contract.</summary>
-        public Gas GasLimit { get; }
+        public RuntimeObserver.Gas GasLimit { get; }
 
         /// <summary>The amount it costs per unit of gas to execute the contract.</summary>
         public ulong GasPrice { get; }

--- a/src/Stratis.SmartContracts.CLR/ExternalCallMessage.cs
+++ b/src/Stratis.SmartContracts.CLR/ExternalCallMessage.cs
@@ -7,7 +7,7 @@ namespace Stratis.SmartContracts.CLR
     /// </summary>
     public class ExternalCallMessage : CallMessage
     {
-        public ExternalCallMessage(uint160 to, uint160 from, ulong amount, Gas gasLimit, MethodCall methodCall) 
+        public ExternalCallMessage(uint160 to, uint160 from, ulong amount, RuntimeObserver.Gas gasLimit, MethodCall methodCall) 
             : base(to, from, amount, gasLimit, methodCall)
         {
         }

--- a/src/Stratis.SmartContracts.CLR/ExternalCreateMessage.cs
+++ b/src/Stratis.SmartContracts.CLR/ExternalCreateMessage.cs
@@ -7,7 +7,7 @@ namespace Stratis.SmartContracts.CLR
     /// </summary>
     public class ExternalCreateMessage : BaseMessage
     {
-        public ExternalCreateMessage(uint160 from, ulong amount, Gas gasLimit, byte[] code, object[] parameters)
+        public ExternalCreateMessage(uint160 from, ulong amount, RuntimeObserver.Gas gasLimit, byte[] code, object[] parameters)
             : base(from, amount, gasLimit)
         {
             this.Code = code;

--- a/src/Stratis.SmartContracts.CLR/GasPriceList.cs
+++ b/src/Stratis.SmartContracts.CLR/GasPriceList.cs
@@ -30,15 +30,15 @@ namespace Stratis.SmartContracts.CLR
         /// <summary>
         /// Get the gas cost for a specific instruction. For v1 all instructions are priced equally.
         /// </summary>
-        public static Gas InstructionOperationCost(Instruction instruction)
+        public static RuntimeObserver.Gas InstructionOperationCost(Instruction instruction)
         {
             OpCode opcode = instruction.OpCode;
-            Gas cost;
+            RuntimeObserver.Gas cost;
 
             switch (opcode.Name)
             {
                 default:
-                    cost = (Gas)InstructionGasCost;
+                    cost = (RuntimeObserver.Gas)InstructionGasCost;
                     break;
             }
 
@@ -48,44 +48,43 @@ namespace Stratis.SmartContracts.CLR
         /// <summary>
         /// Gas cost to log an event inside a contract.
         /// </summary>
-        public static Gas LogOperationCost(IEnumerable<byte[]> topics, byte[] data)
+        public static RuntimeObserver.Gas LogOperationCost(IEnumerable<byte[]> topics, byte[] data)
         {
             int topicCost = topics.Select(x => x.Length * LogPerTopicByteCost).Sum();
             int dataCost = data.Length * LogPerByteCost;
-            return (Gas)(ulong) (topicCost + dataCost);
+            return (RuntimeObserver.Gas)(ulong) (topicCost + dataCost);
         }
 
         /// <summary>
         /// Get cost to store this key and value.
         /// </summary>
-        public static Gas StorageSaveOperationCost(byte[] keyBytes, byte[] valueBytes)
+        public static RuntimeObserver.Gas StorageSaveOperationCost(byte[] keyBytes, byte[] valueBytes)
         {
             int keyLen = keyBytes != null ? keyBytes.Length : 0;
             int valueLen = valueBytes != null ? valueBytes.Length : 0;
 
-            Gas cost = (Gas)(ulong)(StoragePerByteSavedGasCost * keyLen + StoragePerByteSavedGasCost * valueLen);
+            var cost = (RuntimeObserver.Gas)(ulong)(StoragePerByteSavedGasCost * keyLen + StoragePerByteSavedGasCost * valueLen);
             return cost;
         }
 
         /// <summary>
         /// Get cost to retrieve this value via key.
         /// </summary>
-        public static Gas StorageRetrieveOperationCost(byte[] keyBytes, byte[] valueBytes)
+        public static RuntimeObserver.Gas StorageRetrieveOperationCost(byte[] keyBytes, byte[] valueBytes)
         {
             int keyLen = keyBytes != null ? keyBytes.Length : 0;
             int valueLen = valueBytes != null ? valueBytes.Length : 0;
 
-            Gas cost = (Gas)(ulong)(StoragePerByteRetrievedGasCost * keyLen + StoragePerByteRetrievedGasCost * valueLen);
+            var cost = (RuntimeObserver.Gas)(ulong)(StoragePerByteRetrievedGasCost * keyLen + StoragePerByteRetrievedGasCost * valueLen);
             return cost;
         }
 
         /// <summary>
         /// TODO - Add actual costs
         /// </summary>
-        /// <param name="methodToCall"></param>
-        public static Gas MethodCallCost(MethodReference methodToCall)
+        public static RuntimeObserver.Gas MethodCallCost(MethodReference methodToCall)
         {
-            return (Gas)MethodCallGasCost;
+            return (RuntimeObserver.Gas)MethodCallGasCost;
         }
     }
 }

--- a/src/Stratis.SmartContracts.CLR/IInternalExecutorFactory.cs
+++ b/src/Stratis.SmartContracts.CLR/IInternalExecutorFactory.cs
@@ -2,6 +2,6 @@
 {
     public interface IInternalExecutorFactory
     {
-        IInternalTransactionExecutor Create(IState state);
+        IInternalTransactionExecutor Create(RuntimeObserver.IGasMeter gasMeter, IState state);
     }
 }

--- a/src/Stratis.SmartContracts.CLR/ILRewrite/CodeSegment.cs
+++ b/src/Stratis.SmartContracts.CLR/ILRewrite/CodeSegment.cs
@@ -28,14 +28,14 @@ namespace Stratis.SmartContracts.CLR.ILRewrite
         /// <summary>
         /// Total gas cost to execute the instructions in this segment.
         /// </summary>
-        public Gas CalculateGasCost()
+        public RuntimeObserver.Gas CalculateGasCost()
         {
-            Gas gasTally = (Gas) 0;
+            RuntimeObserver.Gas gasTally = (RuntimeObserver.Gas) 0;
 
             foreach (Instruction instruction in this.Instructions)
             {
-                Gas instructionCost = GasPriceList.InstructionOperationCost(instruction);
-                gasTally = (Gas)(gasTally + instructionCost);
+                RuntimeObserver.Gas instructionCost = GasPriceList.InstructionOperationCost(instruction);
+                gasTally = (RuntimeObserver.Gas)(gasTally + instructionCost);
 
                 if (instruction.IsMethodCall())
                 {
@@ -44,8 +44,8 @@ namespace Stratis.SmartContracts.CLR.ILRewrite
                     // If it's a method outside this contract then we will add some cost.
                     if (this.methodDefinition.DeclaringType != methodToCall.DeclaringType)
                     {
-                        Gas methodCallCost = GasPriceList.MethodCallCost(methodToCall);
-                        gasTally = (Gas)(gasTally + methodCallCost);
+                        RuntimeObserver.Gas methodCallCost = GasPriceList.MethodCallCost(methodToCall);
+                        gasTally = (RuntimeObserver.Gas)(gasTally + methodCallCost);
                     }
                 }
             }

--- a/src/Stratis.SmartContracts.CLR/ISmartContractStateFactory.cs
+++ b/src/Stratis.SmartContracts.CLR/ISmartContractStateFactory.cs
@@ -8,7 +8,7 @@ namespace Stratis.SmartContracts.CLR
         /// <summary>
         /// Sets up a new <see cref="ISmartContractState"/> based on the current state.
         /// </summary>        
-        ISmartContractState Create(IState state, IGasMeter gasMeter, uint160 address, BaseMessage message,
+        ISmartContractState Create(IState state, RuntimeObserver.IGasMeter gasMeter, uint160 address, BaseMessage message,
             IStateRepository repository);
     }
 }

--- a/src/Stratis.SmartContracts.CLR/IState.cs
+++ b/src/Stratis.SmartContracts.CLR/IState.cs
@@ -22,7 +22,7 @@ namespace Stratis.SmartContracts.CLR
         void AddInternalTransfer(TransferInfo transferInfo);
         ulong GetBalance(uint160 address);
         uint160 GenerateAddress(IAddressGenerator addressGenerator);
-        ISmartContractState CreateSmartContractState(IState state, IGasMeter gasMeter, uint160 address, BaseMessage message, IStateRepository repository);
+        ISmartContractState CreateSmartContractState(IState state, RuntimeObserver.IGasMeter gasMeter, uint160 address, BaseMessage message, IStateRepository repository);
         void AddInitialTransfer(TransferInfo initialTransfer);
     }
 }

--- a/src/Stratis.SmartContracts.CLR/IVirtualMachine.cs
+++ b/src/Stratis.SmartContracts.CLR/IVirtualMachine.cs
@@ -1,15 +1,20 @@
 ﻿using Stratis.SmartContracts.Core.State;
+using Stratis.SmartContracts.RuntimeObserver;
 
 namespace Stratis.SmartContracts.CLR
 {
     public interface IVirtualMachine
     {
-        VmExecutionResult Create(IStateRepository repository, ISmartContractState contractState,
+        VmExecutionResult Create(IStateRepository repository, 
+            ISmartContractState contractState,
+            RuntimeObserver.IGasMeter gasMeter,
             byte[] contractCode,
             object[] parameters,
             string typeName = null);
 
-        VmExecutionResult ExecuteMethod(ISmartContractState contractState, MethodCall methodCall,
+        VmExecutionResult ExecuteMethod(ISmartContractState contractState, 
+            RuntimeObserver.IGasMeter gasMeter,
+            MethodCall methodCall,
             byte[] contractCode, string typeName);
     }
 }

--- a/src/Stratis.SmartContracts.CLR/InternalCallMessage.cs
+++ b/src/Stratis.SmartContracts.CLR/InternalCallMessage.cs
@@ -8,7 +8,7 @@ namespace Stratis.SmartContracts.CLR
     /// </summary>
     public class InternalCallMessage : CallMessage
     {
-        public InternalCallMessage(uint160 to, uint160 from, ulong amount, Gas gasLimit, MethodCall methodCall)
+        public InternalCallMessage(uint160 to, uint160 from, ulong amount, RuntimeObserver.Gas gasLimit, MethodCall methodCall)
             : base(to, from, amount, gasLimit, methodCall)
         {
         }

--- a/src/Stratis.SmartContracts.CLR/InternalCreateMessage.cs
+++ b/src/Stratis.SmartContracts.CLR/InternalCreateMessage.cs
@@ -8,7 +8,7 @@ namespace Stratis.SmartContracts.CLR
     /// </summary>
     public class InternalCreateMessage : BaseMessage
     {
-        public InternalCreateMessage(uint160 from, ulong amount, Gas gasLimit, object[] parameters, string typeName)
+        public InternalCreateMessage(uint160 from, ulong amount, RuntimeObserver.Gas gasLimit, object[] parameters, string typeName)
             : base(from, amount, gasLimit)
         {
             this.Parameters = parameters;

--- a/src/Stratis.SmartContracts.CLR/InternalExecutor.cs
+++ b/src/Stratis.SmartContracts.CLR/InternalExecutor.cs
@@ -8,16 +8,15 @@ namespace Stratis.SmartContracts.CLR
     {
         public const ulong DefaultGasLimit = GasPriceList.BaseCost * 2 - 1;
 
-        private readonly ILogger logger;
-        private readonly ILoggerFactory loggerFactory;
         private readonly IState state;
         private readonly IStateProcessor stateProcessor;
+        private readonly RuntimeObserver.IGasMeter gasMeter;
 
-        public InternalExecutor(ILoggerFactory loggerFactory, IState state,
+        public InternalExecutor(RuntimeObserver.IGasMeter gasMeter,
+            IState state,
             IStateProcessor stateProcessor)
         {
-            this.loggerFactory = loggerFactory;
-            this.logger = loggerFactory.CreateLogger(this.GetType());
+            this.gasMeter = gasMeter;
             this.state = state;
             this.stateProcessor = stateProcessor;
         }
@@ -28,7 +27,7 @@ namespace Stratis.SmartContracts.CLR
             object[] parameters,
             ulong gasLimit = 0)
         {
-            Gas gasRemaining = smartContractState.GasMeter.GasAvailable;
+            RuntimeObserver.Gas gasRemaining = this.gasMeter.GasAvailable;
 
             // For a method call, send all the gas unless an amount was selected.Should only call trusted methods so re - entrance is less problematic.
             ulong gasBudget = (gasLimit != 0) ? gasLimit : gasRemaining;
@@ -41,7 +40,7 @@ namespace Stratis.SmartContracts.CLR
             var message = new InternalCreateMessage(
                 smartContractState.Message.ContractAddress.ToUint160(),
                 amountToTransfer,
-                (Gas) gasBudget,
+                (RuntimeObserver.Gas) gasBudget,
                 parameters,
                 typeof(T).Name
             );
@@ -56,7 +55,7 @@ namespace Stratis.SmartContracts.CLR
             if (result.IsSuccess)
                 this.state.TransitionTo(newState);
 
-            smartContractState.GasMeter.Spend(result.GasConsumed);
+            this.gasMeter.Spend(result.GasConsumed);
 
             return result.IsSuccess
                 ? CreateResult.Succeeded(result.Success.ContractAddress.ToAddress())
@@ -72,7 +71,7 @@ namespace Stratis.SmartContracts.CLR
             object[] parameters,
             ulong gasLimit = 0)
         {
-            Gas gasRemaining = smartContractState.GasMeter.GasAvailable;
+            RuntimeObserver.Gas gasRemaining = this.gasMeter.GasAvailable;
 
             // For a method call, send all the gas unless an amount was selected.Should only call trusted methods so re - entrance is less problematic.
             ulong gasBudget = (gasLimit != 0) ? gasLimit : gasRemaining;
@@ -84,7 +83,7 @@ namespace Stratis.SmartContracts.CLR
                 addressTo.ToUint160(),
                 smartContractState.Message.ContractAddress.ToUint160(),
                 amountToTransfer,
-                (Gas) gasBudget,
+                (RuntimeObserver.Gas) gasBudget,
                 new MethodCall(methodName, parameters)
             );
 
@@ -98,7 +97,7 @@ namespace Stratis.SmartContracts.CLR
             if (result.IsSuccess)
                 this.state.TransitionTo(newState);
 
-            smartContractState.GasMeter.Spend(result.GasConsumed);
+            this.gasMeter.Spend(result.GasConsumed);
 
             return result.IsSuccess
                 ? TransferResult.Transferred(result.Success.ExecutionResult)
@@ -108,7 +107,7 @@ namespace Stratis.SmartContracts.CLR
         ///<inheritdoc />
         public ITransferResult Transfer(ISmartContractState smartContractState, Address addressTo, ulong amountToTransfer)
         {
-            Gas gasRemaining = smartContractState.GasMeter.GasAvailable;
+            RuntimeObserver.Gas gasRemaining = this.gasMeter.GasAvailable;
 
             if (gasRemaining < GasPriceList.TransferCost)
                 return TransferResult.Failed();
@@ -121,7 +120,7 @@ namespace Stratis.SmartContracts.CLR
                 addressTo.ToUint160(),
                 smartContractState.Message.ContractAddress.ToUint160(),
                 amountToTransfer,
-                (Gas) gasBudget
+                (RuntimeObserver.Gas) gasBudget
             );
 
             // Create a snapshot of the current state
@@ -134,7 +133,7 @@ namespace Stratis.SmartContracts.CLR
             if (result.IsSuccess)
                 this.state.TransitionTo(newState);
 
-            smartContractState.GasMeter.Spend(result.GasConsumed);
+            this.gasMeter.Spend(result.GasConsumed);
 
             return result.IsSuccess
                 ? TransferResult.Empty()

--- a/src/Stratis.SmartContracts.CLR/InternalExecutorFactory.cs
+++ b/src/Stratis.SmartContracts.CLR/InternalExecutorFactory.cs
@@ -7,18 +7,16 @@ namespace Stratis.SmartContracts.CLR
     /// </summary>
     public sealed class InternalExecutorFactory : IInternalExecutorFactory
     {
-        private readonly ILoggerFactory loggerFactory;
         private readonly IStateProcessor stateProcessor;
 
         public InternalExecutorFactory(ILoggerFactory loggerFactory, IStateProcessor stateProcessor)
         {
-            this.loggerFactory = loggerFactory;
             this.stateProcessor = stateProcessor;
         }
 
-        public IInternalTransactionExecutor Create(IState state)
+        public IInternalTransactionExecutor Create(RuntimeObserver.IGasMeter gasMeter, IState state)
         {
-            return new InternalExecutor(this.loggerFactory, state, this.stateProcessor);
+            return new InternalExecutor(gasMeter, state, this.stateProcessor);
         }
     }
 }

--- a/src/Stratis.SmartContracts.CLR/Local/ILocalExecutionResult.cs
+++ b/src/Stratis.SmartContracts.CLR/Local/ILocalExecutionResult.cs
@@ -8,7 +8,7 @@ namespace Stratis.SmartContracts.CLR.Local
     public interface ILocalExecutionResult
     {
         IReadOnlyList<TransferInfo> InternalTransfers { get; }
-        Gas GasConsumed { get; }
+        RuntimeObserver.Gas GasConsumed { get; }
         bool Revert { get; }
         ContractErrorMessage ErrorMessage { get; }
         object Return { get; }

--- a/src/Stratis.SmartContracts.CLR/Local/LocalExecutionResult.cs
+++ b/src/Stratis.SmartContracts.CLR/Local/LocalExecutionResult.cs
@@ -8,7 +8,7 @@ namespace Stratis.SmartContracts.CLR.Local
     public class LocalExecutionResult : ILocalExecutionResult
     {
         public IReadOnlyList<TransferInfo> InternalTransfers { get; set; }
-        public Gas GasConsumed { get; set; }
+        public RuntimeObserver.Gas GasConsumed { get; set; }
         public bool Revert { get; set; }
         public ContractErrorMessage ErrorMessage { get; set; }
         public object Return { get; set; }

--- a/src/Stratis.SmartContracts.CLR/MeteredPersistenceStrategy.cs
+++ b/src/Stratis.SmartContracts.CLR/MeteredPersistenceStrategy.cs
@@ -11,10 +11,10 @@ namespace Stratis.SmartContracts.CLR
     public class MeteredPersistenceStrategy : IPersistenceStrategy
     {
         private readonly IStateRepository stateDb;
-        private readonly IGasMeter gasMeter;
+        private readonly RuntimeObserver.IGasMeter gasMeter;
         private readonly IKeyEncodingStrategy keyEncodingStrategy;
 
-        public MeteredPersistenceStrategy(IStateRepository stateDb, IGasMeter gasMeter, IKeyEncodingStrategy keyEncodingStrategy)
+        public MeteredPersistenceStrategy(IStateRepository stateDb, RuntimeObserver.IGasMeter gasMeter, IKeyEncodingStrategy keyEncodingStrategy)
         {
             Guard.NotNull(stateDb, nameof(stateDb));
             Guard.NotNull(gasMeter, nameof(gasMeter));
@@ -27,7 +27,7 @@ namespace Stratis.SmartContracts.CLR
 
         public bool ContractExists(uint160 address)
         {
-            this.gasMeter.Spend((Gas)GasPriceList.StorageCheckContractExistsCost);
+            this.gasMeter.Spend((RuntimeObserver.Gas)GasPriceList.StorageCheckContractExistsCost);
 
             return this.stateDb.IsExist(address);
         }
@@ -37,7 +37,7 @@ namespace Stratis.SmartContracts.CLR
             byte[] encodedKey = this.keyEncodingStrategy.GetBytes(key);
             byte[] value = this.stateDb.GetStorageValue(address, encodedKey);
 
-            Gas operationCost = GasPriceList.StorageRetrieveOperationCost(encodedKey, value);
+            RuntimeObserver.Gas operationCost = GasPriceList.StorageRetrieveOperationCost(encodedKey, value);
             this.gasMeter.Spend(operationCost);
 
             return value;
@@ -46,7 +46,7 @@ namespace Stratis.SmartContracts.CLR
         public void StoreBytes(uint160 address, byte[] key, byte[] value)
         {
             byte[] encodedKey = this.keyEncodingStrategy.GetBytes(key);
-            Gas operationCost = GasPriceList.StorageSaveOperationCost(
+            RuntimeObserver.Gas operationCost = GasPriceList.StorageSaveOperationCost(
                 encodedKey,
                 value);
 

--- a/src/Stratis.SmartContracts.CLR/Metering/GasMeter.cs
+++ b/src/Stratis.SmartContracts.CLR/Metering/GasMeter.cs
@@ -1,31 +1,30 @@
 ﻿using Stratis.SmartContracts.CLR.Exceptions;
 
-namespace Stratis.SmartContracts.CLR
+namespace Stratis.SmartContracts.CLR.Metering
 {
     /// <inheritdoc/>
-    public sealed class GasMeter : IGasMeter
+    public sealed class GasMeter : RuntimeObserver.IGasMeter
     {
         /// <inheritdoc/>
-        public Gas GasAvailable { get; private set; }
+        public RuntimeObserver.Gas GasAvailable { get; private set; }
 
         /// <inheritdoc/>
-        public Gas GasConsumed
+        public RuntimeObserver.Gas GasConsumed
         {
-            get { return (Gas)(this.GasLimit - this.GasAvailable); }
+            get { return (RuntimeObserver.Gas)(this.GasLimit - this.GasAvailable); }
         }
 
         /// <inheritdoc/>
-        public Gas GasLimit { get; }
+        public RuntimeObserver.Gas GasLimit { get; }
 
-        public GasMeter(Gas gasAvailable)
+        public GasMeter(RuntimeObserver.Gas gasAvailable)
         {
             this.GasAvailable = gasAvailable;
             this.GasLimit = gasAvailable;
         }
 
         /// <inheritdoc/>
-        /// <remarks>TODO Can we make it more obvious when program execution will be interrupted?</remarks>
-        public void Spend(Gas gasToSpend)
+        public void Spend(RuntimeObserver.Gas gasToSpend)
         {
             if (this.GasAvailable >= gasToSpend)
             {
@@ -33,7 +32,7 @@ namespace Stratis.SmartContracts.CLR
                 return;
             }
 
-            this.GasAvailable = (Gas)0;
+            this.GasAvailable = (RuntimeObserver.Gas)0;
 
             throw new OutOfGasException("Went over gas limit of " + this.GasLimit);
         }

--- a/src/Stratis.SmartContracts.CLR/Metering/MemoryMeter.cs
+++ b/src/Stratis.SmartContracts.CLR/Metering/MemoryMeter.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Stratis.SmartContracts.CLR.Exceptions;
+using Stratis.SmartContracts.RuntimeObserver;
+
+namespace Stratis.SmartContracts.CLR.Metering
+{
+    public class MemoryMeter : IMemoryMeter
+    {
+        public ulong MemoryAvailable { get; private set; }
+
+        public ulong MemoryConsumed => this.MemoryLimit - this.MemoryAvailable;
+
+        public ulong MemoryLimit { get; private set; }
+
+        public MemoryMeter(ulong available)
+        {
+            this.MemoryLimit = available;
+            this.MemoryAvailable = available;
+        }
+
+        public void Spend(ulong toSpend)
+        {
+            if (this.MemoryAvailable >= toSpend)
+            {
+                this.MemoryAvailable -= toSpend;
+                return;
+            }
+
+            this.MemoryAvailable = 0;
+
+            throw new MemoryConsumptionException($"Smart contract has allocated too much memory. Spent more than {this.MemoryLimit} memory units when allocating strings or arrays.");
+        }
+    }
+}

--- a/src/Stratis.SmartContracts.CLR/ReflectionExecutorFactory.cs
+++ b/src/Stratis.SmartContracts.CLR/ReflectionExecutorFactory.cs
@@ -46,8 +46,7 @@ namespace Stratis.SmartContracts.CLR
             IStateRepositoryRoot stateRepository,
             IContractTransactionContext transactionContext)
         {
-            return new ContractExecutor(this.loggerFactory, this.serializer, 
-                    stateRepository, this.refundProcessor, this.transferProcessor, this.stateFactory, this.stateProcessor, this.contractPrimitiveSerializer);
+            return new ContractExecutor(this.serializer, stateRepository, this.refundProcessor, this.transferProcessor, this.stateFactory, this.stateProcessor, this.contractPrimitiveSerializer);
         }
     }
 }

--- a/src/Stratis.SmartContracts.CLR/ResultProcessors/ContractRefundProcessor.cs
+++ b/src/Stratis.SmartContracts.CLR/ResultProcessors/ContractRefundProcessor.cs
@@ -17,8 +17,9 @@ namespace Stratis.SmartContracts.CLR.ResultProcessors
         }
 
         public (Money, TxOut) Process(ContractTxData contractTxData,
-            ulong mempoolFee, uint160 sender,
-            Gas gasConsumed,
+            ulong mempoolFee,
+            uint160 sender,
+            RuntimeObserver.Gas gasConsumed,
             bool outOfGas)
         {
 

--- a/src/Stratis.SmartContracts.CLR/ResultProcessors/IContractRefundProcessor.cs
+++ b/src/Stratis.SmartContracts.CLR/ResultProcessors/IContractRefundProcessor.cs
@@ -11,8 +11,9 @@ namespace Stratis.SmartContracts.CLR.ResultProcessors
         /// Returns the fee and refund transactions to account for gas refunds after contract execution.
         /// </summary>
         (Money, TxOut) Process(ContractTxData contractTxData,
-            ulong mempoolFee, uint160 sender,
-            Gas gasConsumed,
+            ulong mempoolFee, 
+            uint160 sender,
+            RuntimeObserver.Gas gasConsumed,
             bool outOfGas);
     }
 }

--- a/src/Stratis.SmartContracts.CLR/SmartContractState.cs
+++ b/src/Stratis.SmartContracts.CLR/SmartContractState.cs
@@ -12,7 +12,6 @@ namespace Stratis.SmartContracts.CLR
             IMessage message,
             IPersistentState persistentState,
             ISerializer serializer,
-            IGasMeter gasMeter,
             IContractLogger contractLogger,
             IInternalTransactionExecutor internalTransactionExecutor,
             IInternalHashHelper internalHashHelper,
@@ -22,7 +21,6 @@ namespace Stratis.SmartContracts.CLR
             this.Message = message;
             this.PersistentState = persistentState;
             this.Serializer = serializer;
-            this.GasMeter = gasMeter;
             this.ContractLogger = contractLogger;
             this.InternalTransactionExecutor = internalTransactionExecutor;
             this.InternalHashHelper = internalHashHelper;
@@ -37,6 +35,7 @@ namespace Stratis.SmartContracts.CLR
 
         public ISerializer Serializer { get; }
 
+        [Obsolete]
         public IGasMeter GasMeter { get; }
 
         public IContractLogger ContractLogger { get; }

--- a/src/Stratis.SmartContracts.CLR/SmartContractStateFactory.cs
+++ b/src/Stratis.SmartContracts.CLR/SmartContractStateFactory.cs
@@ -24,7 +24,7 @@ namespace Stratis.SmartContracts.CLR
         /// <summary>
         /// Sets up a new <see cref="ISmartContractState"/> based on the current state.
         /// </summary>        
-        public ISmartContractState Create(IState state, IGasMeter gasMeter, uint160 address, BaseMessage message, IStateRepository repository)
+        public ISmartContractState Create(IState state, RuntimeObserver.IGasMeter gasMeter, uint160 address, BaseMessage message, IStateRepository repository)
         {
             IPersistenceStrategy persistenceStrategy = new MeteredPersistenceStrategy(repository, gasMeter, new BasicKeyEncodingStrategy());
 
@@ -41,9 +41,8 @@ namespace Stratis.SmartContracts.CLR
                 ),
                 persistentState,
                 this.serializer,
-                gasMeter,
                 contractLogger,
-                this.InternalTransactionExecutorFactory.Create(state),
+                this.InternalTransactionExecutorFactory.Create(gasMeter, state),
                 new InternalHashHelper(),
                 () => state.GetBalance(address));
 

--- a/src/Stratis.SmartContracts.CLR/State.cs
+++ b/src/Stratis.SmartContracts.CLR/State.cs
@@ -83,7 +83,7 @@ namespace Stratis.SmartContracts.CLR
         /// <summary>
         /// Sets up a new <see cref="ISmartContractState"/> based on the current state.
         /// </summary>
-        public ISmartContractState CreateSmartContractState(IState state, IGasMeter gasMeter, uint160 address, BaseMessage message, IStateRepository repository) 
+        public ISmartContractState CreateSmartContractState(IState state, RuntimeObserver.IGasMeter gasMeter, uint160 address, BaseMessage message, IStateRepository repository) 
         {
             return this.smartContractStateFactory.Create(state, gasMeter, address, message, repository);
         }

--- a/src/Stratis.SmartContracts.CLR/StateTransitionResult.cs
+++ b/src/Stratis.SmartContracts.CLR/StateTransitionResult.cs
@@ -46,7 +46,7 @@ namespace Stratis.SmartContracts.CLR
     public class StateTransitionSuccess
     {
         public StateTransitionSuccess(
-            Gas gasConsumed,
+            RuntimeObserver.Gas gasConsumed,
             uint160 contractAddress,
             object result = null)
         {
@@ -63,7 +63,7 @@ namespace Stratis.SmartContracts.CLR
         /// <summary>
         /// Gas consumed during execution.
         /// </summary>
-        public Gas GasConsumed { get; }
+        public RuntimeObserver.Gas GasConsumed { get; }
 
         /// <summary>
         /// The receiving contract's address.
@@ -77,7 +77,7 @@ namespace Stratis.SmartContracts.CLR
     /// </summary>
     public class StateTransitionError
     {
-        public StateTransitionError(Gas gasConsumed, StateTransitionErrorKind kind, ContractErrorMessage vmError)
+        public StateTransitionError(RuntimeObserver.Gas gasConsumed, StateTransitionErrorKind kind, ContractErrorMessage vmError)
         {
             this.Kind = kind;
             this.GasConsumed = gasConsumed;
@@ -98,7 +98,7 @@ namespace Stratis.SmartContracts.CLR
         /// <summary>
         /// The gas consumed during execution.
         /// </summary>
-        public Gas GasConsumed { get; }
+        public RuntimeObserver.Gas GasConsumed { get; }
 
         public ContractErrorMessage GetErrorMessage()
         {
@@ -142,7 +142,7 @@ namespace Stratis.SmartContracts.CLR
         /// <summary>
         /// The gas consumed during the state transition.
         /// </summary>
-        public Gas GasConsumed => this.IsSuccess ? this.Success.GasConsumed : this.Error.GasConsumed;
+        public RuntimeObserver.Gas GasConsumed => this.IsSuccess ? this.Success.GasConsumed : this.Error.GasConsumed;
 
         public bool IsSuccess { get; }
 
@@ -163,7 +163,7 @@ namespace Stratis.SmartContracts.CLR
         /// <summary>
         /// Creates a new result for a successful state transition.
         /// </summary>
-        public static StateTransitionResult Ok(Gas gasConsumed,
+        public static StateTransitionResult Ok(RuntimeObserver.Gas gasConsumed,
             uint160 contractAddress,
             object result = null)
         {
@@ -174,7 +174,7 @@ namespace Stratis.SmartContracts.CLR
         /// <summary>
         /// Creates a new result for a failed state transition due to a VM exception.
         /// </summary>
-        public static StateTransitionResult Fail(Gas gasConsumed, VmExecutionError vmError)
+        public static StateTransitionResult Fail(RuntimeObserver.Gas gasConsumed, VmExecutionError vmError)
         {
             // If VM execution ran out of gas we return a different kind of state transition error.
             StateTransitionErrorKind errorKind = vmError.ErrorKind == VmExecutionErrorKind.OutOfGas
@@ -187,7 +187,7 @@ namespace Stratis.SmartContracts.CLR
         /// <summary>
         /// Creates a new result for a failed state transition.
         /// </summary>
-        public static StateTransitionResult Fail(Gas gasConsumed, StateTransitionErrorKind kind)
+        public static StateTransitionResult Fail(RuntimeObserver.Gas gasConsumed, StateTransitionErrorKind kind)
         {
             return new StateTransitionResult(new StateTransitionError(gasConsumed, kind, null));
         }

--- a/src/Stratis.SmartContracts.IntegrationTests/ContractExecutionFailureTests.cs
+++ b/src/Stratis.SmartContracts.IntegrationTests/ContractExecutionFailureTests.cs
@@ -44,7 +44,7 @@ namespace Stratis.SmartContracts.IntegrationTests
             var serializer =
                 new CallDataSerializer(new ContractPrimitiveSerializer(this.node1.CoreNode.FullNode.Network));
 
-            var txData = serializer.Serialize(new ContractTxData(1, 1, (Gas)(GasPriceList.BaseCost + 1), new uint160(1), "Test"));
+            var txData = serializer.Serialize(new ContractTxData(1, 1, (RuntimeObserver.Gas)(GasPriceList.BaseCost + 1), new uint160(1), "Test"));
 
             var random = new Random();
             byte[] bytes = new byte[101];

--- a/src/Stratis.SmartContracts.IntegrationTests/PoW/SmartContractMemoryPoolTests.cs
+++ b/src/Stratis.SmartContracts.IntegrationTests/PoW/SmartContractMemoryPoolTests.cs
@@ -59,7 +59,7 @@ namespace Stratis.SmartContracts.IntegrationTests.PoW
                 // Gas higher than allowed limit
                 var tx = stratisNodeSync.FullNode.Network.CreateTransaction();
                 tx.AddInput(new TxIn(new OutPoint(prevTrx.GetHash(), 0), PayToPubkeyHashTemplate.Instance.GenerateScriptPubKey(stratisNodeSync.MinerSecret.PubKey)));
-                var contractTxData = new ContractTxData(1, 100, new Gas(10_000_000), new uint160(0), "Test");
+                var contractTxData = new ContractTxData(1, 100, new RuntimeObserver.Gas(10_000_000), new uint160(0), "Test");
                 tx.AddOutput(new TxOut(1, new Script(callDataSerializer.Serialize(contractTxData))));
                 tx.Sign(stratisNodeSync.FullNode.Network, stratisNodeSync.MinerSecret, false);
                 stratisNodeSync.Broadcast(tx);
@@ -92,7 +92,7 @@ namespace Stratis.SmartContracts.IntegrationTests.PoW
                 // Gas price lower than minimum
                 tx = stratisNodeSync.FullNode.Network.CreateTransaction();
                 tx.AddInput(new TxIn(new OutPoint(prevTrx.GetHash(), 0), PayToPubkeyHashTemplate.Instance.GenerateScriptPubKey(stratisNodeSync.MinerSecret.PubKey)));
-                var lowGasPriceContractTxData = new ContractTxData(1, SmartContractMempoolValidator.MinGasPrice - 1, new Gas(SmartContractFormatRule.GasLimitMaximum), new uint160(0), "Test");
+                var lowGasPriceContractTxData = new ContractTxData(1, SmartContractMempoolValidator.MinGasPrice - 1, new RuntimeObserver.Gas(SmartContractFormatRule.GasLimitMaximum), new uint160(0), "Test");
                 tx.AddOutput(new TxOut(1, new Script(callDataSerializer.Serialize(lowGasPriceContractTxData))));
                 tx.Sign(stratisNodeSync.FullNode.Network, stratisNodeSync.MinerSecret, false);
                 stratisNodeSync.Broadcast(tx);

--- a/src/Stratis.SmartContracts.IntegrationTests/PoW/SmartContractMinerTests.cs
+++ b/src/Stratis.SmartContracts.IntegrationTests/PoW/SmartContractMinerTests.cs
@@ -330,7 +330,7 @@ namespace Stratis.SmartContracts.IntegrationTests.PoW
             await context.InitializeAsync();
 
             ulong gasPrice = 1;
-            Gas gasLimit = (Gas) SmartContractFormatRule.GasLimitMaximum;
+            var gasLimit = (RuntimeObserver.Gas) SmartContractFormatRule.GasLimitMaximum;
             var gasBudget = gasPrice * gasLimit;
 
             ContractCompilationResult compilationResult = ContractCompiler.CompileFile("SmartContracts/Token.cs");
@@ -357,7 +357,7 @@ namespace Stratis.SmartContracts.IntegrationTests.PoW
             await context.InitializeAsync();
 
             ulong gasPrice = 1;
-            Gas gasLimit = (Gas)SmartContractFormatRule.GasLimitMaximum;
+            var gasLimit = (RuntimeObserver.Gas)SmartContractFormatRule.GasLimitMaximum;
             var gasBudget = gasPrice * gasLimit;
 
             ContractCompilationResult compilationResult = ContractCompiler.CompileFile("SmartContracts/TransferTest.cs");
@@ -419,7 +419,7 @@ namespace Stratis.SmartContracts.IntegrationTests.PoW
             await context.InitializeAsync();
 
             ulong gasPrice = 1;
-            Gas gasLimit = (Gas)SmartContractFormatRule.GasLimitMaximum;
+            var gasLimit = (RuntimeObserver.Gas)SmartContractFormatRule.GasLimitMaximum;
             var gasBudget = gasPrice * gasLimit;
 
             ContractCompilationResult compilationResult = ContractCompiler.CompileFile("SmartContracts/TransferTest.cs");
@@ -471,7 +471,7 @@ namespace Stratis.SmartContracts.IntegrationTests.PoW
             await context.InitializeAsync();
 
             ulong gasPrice = 1;
-            Gas gasLimit = (Gas) SmartContractFormatRule.GasLimitMaximum;
+            var gasLimit = (RuntimeObserver.Gas) SmartContractFormatRule.GasLimitMaximum;
             var gasBudget = gasPrice * gasLimit;
 
             ContractCompilationResult compilationResult = ContractCompiler.CompileFile("SmartContracts/StorageDemo.cs");
@@ -497,7 +497,7 @@ namespace Stratis.SmartContracts.IntegrationTests.PoW
             await context.InitializeAsync();
 
             ulong gasPrice = 1;
-            Gas gasLimit = (Gas)SmartContractFormatRule.GasLimitMaximum;
+            var gasLimit = (RuntimeObserver.Gas)SmartContractFormatRule.GasLimitMaximum;
             var gasBudget = gasPrice * gasLimit;
 
             ContractCompilationResult compilationResult = ContractCompiler.CompileFile("SmartContracts/TransferTest.cs");
@@ -551,7 +551,7 @@ namespace Stratis.SmartContracts.IntegrationTests.PoW
             await context.InitializeAsync();
 
             ulong gasPrice = 1;
-            Gas gasLimit = (Gas) SmartContractFormatRule.GasLimitMaximum;
+            var gasLimit = (RuntimeObserver.Gas) SmartContractFormatRule.GasLimitMaximum;
             var gasBudget = gasPrice * gasLimit;
 
             ContractCompilationResult compilationResult = ContractCompiler.CompileFile("SmartContracts/TransferTest.cs");
@@ -581,7 +581,7 @@ namespace Stratis.SmartContracts.IntegrationTests.PoW
             await context.InitializeAsync();
 
             ulong gasPrice = 1;
-            Gas gasLimit = (Gas)SmartContractFormatRule.GasLimitMaximum;
+            var gasLimit = (RuntimeObserver.Gas)SmartContractFormatRule.GasLimitMaximum;
             var gasBudget = gasPrice * gasLimit;
 
             ContractCompilationResult compilationResult = ContractCompiler.CompileFile("SmartContracts/TransferTest.cs");
@@ -626,7 +626,7 @@ namespace Stratis.SmartContracts.IntegrationTests.PoW
 
             ulong gasPrice = 1;
             // This uses a lot of gas
-            Gas gasLimit = (Gas)SmartContractFormatRule.GasLimitMaximum;
+            var gasLimit = (RuntimeObserver.Gas)SmartContractFormatRule.GasLimitMaximum;
             var gasBudget = gasPrice * gasLimit;
 
             ContractCompilationResult compilationResult = ContractCompiler.CompileFile("SmartContracts/TransferTest.cs");
@@ -662,7 +662,7 @@ namespace Stratis.SmartContracts.IntegrationTests.PoW
 
             ulong gasPrice = 1;
             // This uses a lot of gas
-            Gas gasLimit = (Gas)SmartContractFormatRule.GasLimitMaximum;
+            var gasLimit = (RuntimeObserver.Gas)SmartContractFormatRule.GasLimitMaximum;
             var gasBudget = gasPrice * gasLimit;
 
             ContractCompilationResult compilationResult = ContractCompiler.CompileFile("SmartContracts/InterContract1.cs");
@@ -719,7 +719,7 @@ namespace Stratis.SmartContracts.IntegrationTests.PoW
 
             ulong gasPrice = 1;
             // This uses a lot of gas
-            Gas gasLimit = (Gas) SmartContractFormatRule.GasLimitMaximum;
+            var gasLimit = (RuntimeObserver.Gas) SmartContractFormatRule.GasLimitMaximum;
             var gasBudget = gasPrice * gasLimit;
 
             var compilationResult = ContractCompiler.CompileFile("SmartContracts/CountContract.cs");
@@ -760,7 +760,7 @@ namespace Stratis.SmartContracts.IntegrationTests.PoW
 
             ulong gasPrice = 1;
             // This uses a lot of gas
-            Gas gasLimit = (Gas)SmartContractFormatRule.GasLimitMaximum;
+            var gasLimit = (RuntimeObserver.Gas)SmartContractFormatRule.GasLimitMaximum;
             var gasBudget = gasPrice * gasLimit;
 
             ContractCompilationResult compilationResult = ContractCompiler.CompileFile("SmartContracts/InterContract1.cs");
@@ -824,7 +824,7 @@ namespace Stratis.SmartContracts.IntegrationTests.PoW
 
             // Add the smart contract transaction to the mempool and mine as normal.
             ulong gasPrice = 1;
-            Gas gasLimit = (Gas)1000000;
+            var gasLimit = (RuntimeObserver.Gas)1000000;
             var gasBudget = gasPrice * gasLimit;
             ContractCompilationResult compilationResult = ContractCompiler.CompileFile("SmartContracts/InterContract1.cs");
             Assert.True(compilationResult.Success);
@@ -847,7 +847,7 @@ namespace Stratis.SmartContracts.IntegrationTests.PoW
             await context.InitializeAsync();
 
             ulong gasPrice = 1;
-            Gas gasLimit = (Gas)SmartContractFormatRule.GasLimitMaximum;
+            var gasLimit = (RuntimeObserver.Gas)SmartContractFormatRule.GasLimitMaximum;
             var gasBudget = gasPrice * gasLimit;
 
             var receiveContract = Path.Combine("SmartContracts", "ReceiveHandlerContract.cs");

--- a/src/Stratis.SmartContracts.IntegrationTests/PoW/SmartContractWalletOnPosNetworkTests.cs
+++ b/src/Stratis.SmartContracts.IntegrationTests/PoW/SmartContractWalletOnPosNetworkTests.cs
@@ -41,7 +41,7 @@ namespace Stratis.SmartContracts.IntegrationTests.PoW
                 // Create a token contract
                 ulong gasPrice = 1;
                 int vmVersion = 1;
-                Gas gasLimit = (Gas)5000;
+                var gasLimit = (RuntimeObserver.Gas)5000;
                 ContractCompilationResult compilationResult = ContractCompiler.CompileFile("SmartContracts/TransferTestPos.cs");
                 Assert.True(compilationResult.Success);
 

--- a/src/Stratis.SmartContracts.IntegrationTests/PoW/SmartContractWalletTests.cs
+++ b/src/Stratis.SmartContracts.IntegrationTests/PoW/SmartContractWalletTests.cs
@@ -94,7 +94,7 @@ namespace Stratis.SmartContracts.IntegrationTests.PoW
                 // Create a token contract.
                 ulong gasPrice = SmartContractMempoolValidator.MinGasPrice;
                 int vmVersion = 1;
-                Gas gasLimit = (Gas)(SmartContractFormatRule.GasLimitMaximum / 2);
+                var gasLimit = (RuntimeObserver.Gas)(SmartContractFormatRule.GasLimitMaximum / 2);
                 ContractCompilationResult compilationResult = ContractCompiler.CompileFile("SmartContracts/TransferTest.cs");
                 Assert.True(compilationResult.Success);
 

--- a/src/Stratis.SmartContracts.RuntimeObserver/Gas.cs
+++ b/src/Stratis.SmartContracts.RuntimeObserver/Gas.cs
@@ -1,0 +1,51 @@
+﻿namespace Stratis.SmartContracts.RuntimeObserver
+{
+    /// <summary>
+    /// Value type representing an amount of Gas. Use this to avoid confusion with many other ulong values.
+    /// </summary>
+    public struct Gas
+    {
+        public Gas(ulong value)
+        {
+            this.Value = value;
+        }
+
+        public static Gas None = (Gas)0;
+
+        public readonly ulong Value;
+
+        /// <summary>
+        /// Values of type ulong must be explicitly cast to Gas to ensure developer's intention.
+        /// <para>
+        /// ulong u = 10000;
+        /// Gas g = (Gas)u;
+        /// </para>
+        /// </summary>
+        public static explicit operator Gas(ulong value)
+        {
+            return new Gas(value);
+        }
+
+        public static explicit operator Gas(int value)
+        {
+            return new Gas((ulong)value);
+        }
+
+        /// <summary>
+        /// Ensures we can implicitly treat Gas as an ulong.
+        /// <para>
+        /// Gas g = new Gas(10000);
+        /// ulong u = g;
+        /// </para>
+        /// </summary>
+        public static implicit operator ulong(Gas gas)
+        {
+            return gas.Value;
+        }
+
+        public override string ToString()
+        {
+            return this.Value.ToString();
+        }
+    }
+}

--- a/src/Stratis.SmartContracts.RuntimeObserver/IGasMeter.cs
+++ b/src/Stratis.SmartContracts.RuntimeObserver/IGasMeter.cs
@@ -1,0 +1,20 @@
+﻿namespace Stratis.SmartContracts.RuntimeObserver
+{
+    /// <summary>
+    /// Contract that defines how gas is spent.
+    /// </summary>
+    public interface IGasMeter
+    {
+        /// <summary>The amount of gas left that the contract can spend.</summary>
+        Gas GasAvailable { get; }
+
+        /// <summary>The amount of gas already used by the contract.</summary>
+        Gas GasConsumed { get; }
+
+        /// <summary>The maximum amount of gas that can be spent by the contract.</summary>
+        Gas GasLimit { get; }
+
+        /// <summary>Spends the gas used by the contract.</summary>
+        void Spend(Gas spend);
+    }
+}

--- a/src/Stratis.SmartContracts.RuntimeObserver/IMemoryMeter.cs
+++ b/src/Stratis.SmartContracts.RuntimeObserver/IMemoryMeter.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Stratis.SmartContracts.RuntimeObserver
+{
+    public interface IMemoryMeter
+    {
+        ulong MemoryAvailable { get; }
+
+        ulong MemoryConsumed { get; }
+
+        ulong MemoryLimit { get; }
+
+        void Spend(ulong toSpend);
+    }
+}

--- a/src/Stratis.SmartContracts.RuntimeObserver/Observer.cs
+++ b/src/Stratis.SmartContracts.RuntimeObserver/Observer.cs
@@ -1,4 +1,6 @@
-﻿namespace Stratis.SmartContracts.RuntimeObserver
+﻿using System.Buffers;
+
+namespace Stratis.SmartContracts.RuntimeObserver
 {
     /// <summary>
     /// Is able to hold metrics about the current runtime.
@@ -6,28 +8,14 @@
     /// </summary>
     public class Observer
     {
-        /// <summary>
-        /// The limit for 'memory units'.
-        /// 
-        /// A 'memory unit' is spent for any operation that reserves a significant chunk of memory. 
-        /// 
-        /// Standard allocations for primitives aren't counted as memory units as they are trivially small
-        /// and the instructions that cause them will run the contract out of gas eventually.
-        /// 
-        /// String primitives and method parameters are always limited by the size of transactions and will be costly.
-        /// 
-        /// So 'memory units' are spent when allocating arrays or performing string concatenations.
-        /// </summary>
-        private readonly long memoryLimit;
+        public IMemoryMeter MemoryMeter { get; private set; }
 
-        public IGasMeter GasMeter { get; }
+        public IGasMeter GasMeter { get; private set; }
 
-        public long MemoryConsumed { get; private set; }
-
-        public Observer(IGasMeter gasMeter, long memoryLimit)
+        public Observer(IGasMeter gasMeter, IMemoryMeter memoryMeter)
         {
             this.GasMeter = gasMeter;
-            this.memoryLimit = memoryLimit;
+            this.MemoryMeter = memoryMeter;
         }
 
         /// <summary>
@@ -35,18 +23,15 @@
         /// </summary>
         public void SpendGas(long gas)
         {
-            this.GasMeter.Spend((Gas) gas);
+            this.GasMeter.Spend((Gas)gas);
         }
 
         /// <summary>
-        /// Register that some amount of memory has been reserved. If it goes over the allowed limit, throw an exception.
+        /// Register that some amount of memory has been reserved.
         /// </summary>
         public void SpendMemory(long memory)
         {
-            this.MemoryConsumed += memory;
-
-            if (this.MemoryConsumed > this.memoryLimit)
-                throw new MemoryConsumptionException($"Smart contract has allocated too much memory. Spent more than {this.memoryLimit} memory units when allocating strings or arrays.");
+            this.MemoryMeter.Spend((ulong)memory);
         }
 
         /// <summary>

--- a/src/Stratis.SmartContracts.RuntimeObserver/Stratis.SmartContracts.RuntimeObserver.csproj
+++ b/src/Stratis.SmartContracts.RuntimeObserver/Stratis.SmartContracts.RuntimeObserver.csproj
@@ -5,8 +5,4 @@
     <Version>0.0.1-beta</Version>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Stratis.SmartContracts" Version="1.1.0" />
-  </ItemGroup>
-
 </Project>


### PR DESCRIPTION
- IMemoryMeter now allows CLR to decide how to handle memory limits.
- Gas and IGasMeter now part of RuntimeObserver.
- Replaced all of the references to Stratis.SmartContracts.IGasMeter with RuntimeObserver.GasMeter and all references to Gas with RuntimeObserver.Gas