### PR TITLE
Fix RemoveNodeAddress to not both enumerate and modify the same collection

### DIFF
--- a/src/Stratis.Bitcoin.IntegrationTests/RPC/AddNodeActionTest.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/RPC/AddNodeActionTest.cs
@@ -18,7 +18,7 @@ namespace Stratis.Bitcoin.IntegrationTests.RPC
 
             var controller = fullNode.Services.ServiceProvider.GetService<ConnectionManagerController>();
 
-            Assert.ThrowsAny<SocketException>(() => { controller.AddNodeRPC("0.0.0.0", "onetry"); });
+            Assert.True(controller.AddNodeRPC("0.0.0.0", "add"));
             Assert.Throws<ArgumentException>(() => { controller.AddNodeRPC("0.0.0.0", "notarealcommand"); });
             Assert.ThrowsAny<SocketException>(() => { controller.AddNodeRPC("a.b.c.d", "onetry"); });
             Assert.True(controller.AddNodeRPC("0.0.0.0", "remove"));

--- a/src/Stratis.Bitcoin/Connection/ConnectionManager.cs
+++ b/src/Stratis.Bitcoin/Connection/ConnectionManager.cs
@@ -418,7 +418,9 @@ namespace Stratis.Bitcoin.Connection
             }
 
             this.peerAddressManager.RemovePeer(ipEndpoint);
-            IEnumerable<IPEndPoint> matchingAddNodes = this.ConnectionSettings.AddNode.Where(p => p.Match(ipEndpoint));
+
+            // Create a copy of the nodes to remove. This avoids errors due to both modifying the collection and iterating it.
+            List<IPEndPoint> matchingAddNodes = this.ConnectionSettings.AddNode.Where(p => p.Match(ipEndpoint)).ToList();
             foreach (IPEndPoint m in matchingAddNodes)
                 this.ConnectionSettings.AddNode.Remove(m);
         }


### PR DESCRIPTION
This PR:
- Fixes `RemoveNodeAddress` to not both enumerate and modify the same collection.
- Removes a test that provides different results for macOS and replaces it with a more useful / omitted test.