### PR TITLE
Ensure Consensus Manager Integration tests run more accurately

### DIFF
--- a/src/Stratis.Bitcoin.IntegrationTests.Common/BlockObserverFeature.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests.Common/BlockObserverFeature.cs
@@ -28,18 +28,12 @@ namespace Stratis.Bitcoin.IntegrationTests.Common
         /// Adds a feature to the node that will observe when blocks are connected or disconnected.
         /// </summary>
         /// <param name="fullNodeBuilder">The object used to build the current node.</param>
-        /// <param name="interceptor">Callback routine to be called when a certain block has been disconnected.</param>
         /// <returns>The full node builder, enriched with the new component.</returns>
-        public static IFullNodeBuilder InterceptBlockDisconnected(this IFullNodeBuilder fullNodeBuilder, Func<ChainedHeaderBlock, bool> interceptor)
+        public static IFullNodeBuilder AddBlockObserverFeature(this IFullNodeBuilder fullNodeBuilder)
         {
             fullNodeBuilder.ConfigureFeature(features =>
             {
-                features
-                    .AddFeature<BlockObserverFeature>()
-                    .FeatureServices(services =>
-                    {
-                        services.AddSingleton(service => new InterceptBlockDisconnected(service.GetService<Signals.Signals>(), interceptor));
-                    });
+                features.AddFeature<BlockObserverFeature>();
             });
 
             return fullNodeBuilder;
@@ -51,21 +45,31 @@ namespace Stratis.Bitcoin.IntegrationTests.Common
         /// <param name="fullNodeBuilder">The object used to build the current node.</param>
         /// <param name="interceptor">Callback routine to be called when a certain block has been disconnected.</param>
         /// <returns>The full node builder, enriched with the new component.</returns>
-        public static IFullNodeBuilder InterceptBlockConnected(this IFullNodeBuilder fullNodeBuilder, Func<ChainedHeaderBlock, bool> interceptor)
+        public static IFullNodeBuilder UseBlockDisconnectedInterceptor(this IFullNodeBuilder fullNodeBuilder, Func<ChainedHeaderBlock, bool> interceptor)
         {
-            fullNodeBuilder.ConfigureFeature(features =>
+            fullNodeBuilder.ConfigureServices(services =>
             {
-                features
-                    .AddFeature<BlockObserverFeature>()
-                    .FeatureServices(services =>
-                    {
-                        services.AddSingleton(service => new InterceptBlockConnected(service.GetService<Signals.Signals>(), interceptor));
-                    });
+                services.AddSingleton(service => new InterceptBlockDisconnected(service.GetService<Signals.Signals>(), interceptor));
             });
 
             return fullNodeBuilder;
         }
 
+        /// <summary>
+        /// Adds a feature to the node that will observe when blocks are connected or disconnected.
+        /// </summary>
+        /// <param name="fullNodeBuilder">The object used to build the current node.</param>
+        /// <param name="interceptor">Callback routine to be called when a certain block has been disconnected.</param>
+        /// <returns>The full node builder, enriched with the new component.</returns>
+        public static IFullNodeBuilder UseBlockConnectedInterceptor(this IFullNodeBuilder fullNodeBuilder, Func<ChainedHeaderBlock, bool> interceptor)
+        {
+            fullNodeBuilder.ConfigureServices(services =>
+            {
+                services.AddSingleton(service => new InterceptBlockConnected(service.GetService<Signals.Signals>(), interceptor));
+            });
+
+            return fullNodeBuilder;
+        }
     }
 
     /// <summary>

--- a/src/Stratis.Bitcoin.IntegrationTests.Common/BlockObserverFeature.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests.Common/BlockObserverFeature.cs
@@ -45,23 +45,7 @@ namespace Stratis.Bitcoin.IntegrationTests.Common
         /// <param name="fullNodeBuilder">The object used to build the current node.</param>
         /// <param name="interceptor">Callback routine to be called when a certain block has been disconnected.</param>
         /// <returns>The full node builder, enriched with the new component.</returns>
-        public static IFullNodeBuilder UseBlockDisconnectedInterceptor(this IFullNodeBuilder fullNodeBuilder, Action<ChainedHeaderBlock> interceptor)
-        {
-            fullNodeBuilder.ConfigureServices(services =>
-            {
-                services.AddSingleton(service => new InterceptBlockDisconnected(service.GetService<Signals.Signals>(), interceptor));
-            });
-
-            return fullNodeBuilder;
-        }
-
-        /// <summary>
-        /// Adds a feature to the node that will observe when blocks are connected or disconnected.
-        /// </summary>
-        /// <param name="fullNodeBuilder">The object used to build the current node.</param>
-        /// <param name="interceptor">Callback routine that will only be called once when a certain block has been disconnected.</param>
-        /// <returns>The full node builder, enriched with the new component.</returns>
-        public static IFullNodeBuilder UseBlockDisconnectedInterceptorOnce(this IFullNodeBuilder fullNodeBuilder, Func<ChainedHeaderBlock, bool> interceptor)
+        public static IFullNodeBuilder UseDisconnectedInterceptor(this IFullNodeBuilder fullNodeBuilder, Action<ChainedHeaderBlock> interceptor)
         {
             fullNodeBuilder.ConfigureServices(services =>
             {
@@ -77,23 +61,7 @@ namespace Stratis.Bitcoin.IntegrationTests.Common
         /// <param name="fullNodeBuilder">The object used to build the current node.</param>
         /// <param name="interceptor">Callback routine to be called when a certain block has been disconnected.</param>
         /// <returns>The full node builder, enriched with the new component.</returns>
-        public static IFullNodeBuilder UseBlockConnectedInterceptor(this IFullNodeBuilder fullNodeBuilder, Action<ChainedHeaderBlock> interceptor)
-        {
-            fullNodeBuilder.ConfigureServices(services =>
-            {
-                services.AddSingleton(service => new InterceptBlockConnected(service.GetService<Signals.Signals>(), interceptor));
-            });
-
-            return fullNodeBuilder;
-        }
-
-        /// <summary>
-        /// Adds a feature to the node that will observe when blocks are connected or disconnected.
-        /// </summary>
-        /// <param name="fullNodeBuilder">The object used to build the current node.</param>
-        /// <param name="interceptor">Callback routine to be called only once when a certain block has been disconnected.</param>
-        /// <returns>The full node builder, enriched with the new component.</returns>
-        public static IFullNodeBuilder UseBlockConnectedInterceptorOnce(this IFullNodeBuilder fullNodeBuilder, Func<ChainedHeaderBlock, bool> interceptor)
+        public static IFullNodeBuilder UseConnectedInterceptor(this IFullNodeBuilder fullNodeBuilder, Action<ChainedHeaderBlock> interceptor)
         {
             fullNodeBuilder.ConfigureServices(services =>
             {
@@ -109,21 +77,12 @@ namespace Stratis.Bitcoin.IntegrationTests.Common
     /// </summary>
     public sealed class InterceptBlockDisconnected : SignalObserver<ChainedHeaderBlock>
     {
-        private readonly Action<ChainedHeaderBlock> executeInterceptor;
-        private readonly Func<ChainedHeaderBlock, bool> executeInterceptorOnce;
-
-        private bool interceptorExecuted = false;
+        private readonly Action<ChainedHeaderBlock> interceptor;
 
         public InterceptBlockDisconnected(Signals.Signals signals, Action<ChainedHeaderBlock> interceptor)
         {
             signals.SubscribeForBlocksDisconnected(this);
-            this.executeInterceptor = interceptor;
-        }
-
-        public InterceptBlockDisconnected(Signals.Signals signals, Func<ChainedHeaderBlock, bool> interceptor)
-        {
-            signals.SubscribeForBlocksDisconnected(this);
-            this.executeInterceptorOnce = interceptor;
+            this.interceptor = interceptor;
         }
 
         /// <summary>
@@ -131,14 +90,7 @@ namespace Stratis.Bitcoin.IntegrationTests.Common
         /// </summary>
         protected override void OnNextCore(ChainedHeaderBlock chainedHeaderBlock)
         {
-            if (this.executeInterceptor != null)
-            {
-                this.executeInterceptor(chainedHeaderBlock);
-                return;
-            }
-
-            if (!this.interceptorExecuted)
-                this.interceptorExecuted = this.executeInterceptorOnce(chainedHeaderBlock);
+            this.interceptor?.Invoke(chainedHeaderBlock);
         }
     }
 
@@ -147,21 +99,12 @@ namespace Stratis.Bitcoin.IntegrationTests.Common
     /// </summary>
     public sealed class InterceptBlockConnected : SignalObserver<ChainedHeaderBlock>
     {
-        private readonly Action<ChainedHeaderBlock> executeInterceptor;
-        private readonly Func<ChainedHeaderBlock, bool> executeInterceptorOnce;
-
-        private bool interceptorExecuted = false;
+        private readonly Action<ChainedHeaderBlock> interceptor;
 
         public InterceptBlockConnected(Signals.Signals signals, Action<ChainedHeaderBlock> interceptor)
         {
             signals.SubscribeForBlocksConnected(this);
-            this.executeInterceptor = interceptor;
-        }
-
-        public InterceptBlockConnected(Signals.Signals signals, Func<ChainedHeaderBlock, bool> interceptor)
-        {
-            signals.SubscribeForBlocksConnected(this);
-            this.executeInterceptorOnce = interceptor;
+            this.interceptor = interceptor;
         }
 
         /// <summary>
@@ -169,14 +112,7 @@ namespace Stratis.Bitcoin.IntegrationTests.Common
         /// </summary>
         protected override void OnNextCore(ChainedHeaderBlock chainedHeaderBlock)
         {
-            if (this.executeInterceptor != null)
-            {
-                this.executeInterceptor(chainedHeaderBlock);
-                return;
-            }
-
-            if (!this.interceptorExecuted)
-                this.interceptorExecuted = this.executeInterceptorOnce(chainedHeaderBlock);
+            this.interceptor?.Invoke(chainedHeaderBlock);
         }
     }
 }

--- a/src/Stratis.Bitcoin.IntegrationTests.Common/BlockObserverFeature.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests.Common/BlockObserverFeature.cs
@@ -45,7 +45,23 @@ namespace Stratis.Bitcoin.IntegrationTests.Common
         /// <param name="fullNodeBuilder">The object used to build the current node.</param>
         /// <param name="interceptor">Callback routine to be called when a certain block has been disconnected.</param>
         /// <returns>The full node builder, enriched with the new component.</returns>
-        public static IFullNodeBuilder UseBlockDisconnectedInterceptor(this IFullNodeBuilder fullNodeBuilder, Func<ChainedHeaderBlock, bool> interceptor)
+        public static IFullNodeBuilder UseBlockDisconnectedInterceptor(this IFullNodeBuilder fullNodeBuilder, Action<ChainedHeaderBlock> interceptor)
+        {
+            fullNodeBuilder.ConfigureServices(services =>
+            {
+                services.AddSingleton(service => new InterceptBlockDisconnected(service.GetService<Signals.Signals>(), interceptor));
+            });
+
+            return fullNodeBuilder;
+        }
+
+        /// <summary>
+        /// Adds a feature to the node that will observe when blocks are connected or disconnected.
+        /// </summary>
+        /// <param name="fullNodeBuilder">The object used to build the current node.</param>
+        /// <param name="interceptor">Callback routine that will only be called once when a certain block has been disconnected.</param>
+        /// <returns>The full node builder, enriched with the new component.</returns>
+        public static IFullNodeBuilder UseBlockDisconnectedInterceptorOnce(this IFullNodeBuilder fullNodeBuilder, Func<ChainedHeaderBlock, bool> interceptor)
         {
             fullNodeBuilder.ConfigureServices(services =>
             {
@@ -61,7 +77,23 @@ namespace Stratis.Bitcoin.IntegrationTests.Common
         /// <param name="fullNodeBuilder">The object used to build the current node.</param>
         /// <param name="interceptor">Callback routine to be called when a certain block has been disconnected.</param>
         /// <returns>The full node builder, enriched with the new component.</returns>
-        public static IFullNodeBuilder UseBlockConnectedInterceptor(this IFullNodeBuilder fullNodeBuilder, Func<ChainedHeaderBlock, bool> interceptor)
+        public static IFullNodeBuilder UseBlockConnectedInterceptor(this IFullNodeBuilder fullNodeBuilder, Action<ChainedHeaderBlock> interceptor)
+        {
+            fullNodeBuilder.ConfigureServices(services =>
+            {
+                services.AddSingleton(service => new InterceptBlockConnected(service.GetService<Signals.Signals>(), interceptor));
+            });
+
+            return fullNodeBuilder;
+        }
+
+        /// <summary>
+        /// Adds a feature to the node that will observe when blocks are connected or disconnected.
+        /// </summary>
+        /// <param name="fullNodeBuilder">The object used to build the current node.</param>
+        /// <param name="interceptor">Callback routine to be called only once when a certain block has been disconnected.</param>
+        /// <returns>The full node builder, enriched with the new component.</returns>
+        public static IFullNodeBuilder UseBlockConnectedInterceptorOnce(this IFullNodeBuilder fullNodeBuilder, Func<ChainedHeaderBlock, bool> interceptor)
         {
             fullNodeBuilder.ConfigureServices(services =>
             {
@@ -77,13 +109,21 @@ namespace Stratis.Bitcoin.IntegrationTests.Common
     /// </summary>
     public sealed class InterceptBlockDisconnected : SignalObserver<ChainedHeaderBlock>
     {
-        private readonly Func<ChainedHeaderBlock, bool> interceptor;
+        private readonly Action<ChainedHeaderBlock> executeInterceptor;
+        private readonly Func<ChainedHeaderBlock, bool> executeInterceptorOnce;
+
         private bool interceptorExecuted = false;
+
+        public InterceptBlockDisconnected(Signals.Signals signals, Action<ChainedHeaderBlock> interceptor)
+        {
+            signals.SubscribeForBlocksDisconnected(this);
+            this.executeInterceptor = interceptor;
+        }
 
         public InterceptBlockDisconnected(Signals.Signals signals, Func<ChainedHeaderBlock, bool> interceptor)
         {
             signals.SubscribeForBlocksDisconnected(this);
-            this.interceptor = interceptor;
+            this.executeInterceptorOnce = interceptor;
         }
 
         /// <summary>
@@ -91,8 +131,14 @@ namespace Stratis.Bitcoin.IntegrationTests.Common
         /// </summary>
         protected override void OnNextCore(ChainedHeaderBlock chainedHeaderBlock)
         {
+            if (this.executeInterceptor != null)
+            {
+                this.executeInterceptor(chainedHeaderBlock);
+                return;
+            }
+
             if (!this.interceptorExecuted)
-                this.interceptorExecuted = this.interceptor(chainedHeaderBlock);
+                this.interceptorExecuted = this.executeInterceptorOnce(chainedHeaderBlock);
         }
     }
 
@@ -101,13 +147,21 @@ namespace Stratis.Bitcoin.IntegrationTests.Common
     /// </summary>
     public sealed class InterceptBlockConnected : SignalObserver<ChainedHeaderBlock>
     {
-        private readonly Func<ChainedHeaderBlock, bool> interceptor;
+        private readonly Action<ChainedHeaderBlock> executeInterceptor;
+        private readonly Func<ChainedHeaderBlock, bool> executeInterceptorOnce;
+
         private bool interceptorExecuted = false;
+
+        public InterceptBlockConnected(Signals.Signals signals, Action<ChainedHeaderBlock> interceptor)
+        {
+            signals.SubscribeForBlocksConnected(this);
+            this.executeInterceptor = interceptor;
+        }
 
         public InterceptBlockConnected(Signals.Signals signals, Func<ChainedHeaderBlock, bool> interceptor)
         {
             signals.SubscribeForBlocksConnected(this);
-            this.interceptor = interceptor;
+            this.executeInterceptorOnce = interceptor;
         }
 
         /// <summary>
@@ -115,9 +169,14 @@ namespace Stratis.Bitcoin.IntegrationTests.Common
         /// </summary>
         protected override void OnNextCore(ChainedHeaderBlock chainedHeaderBlock)
         {
+            if (this.executeInterceptor != null)
+            {
+                this.executeInterceptor(chainedHeaderBlock);
+                return;
+            }
+
             if (!this.interceptorExecuted)
-                this.interceptorExecuted = this.interceptor(chainedHeaderBlock);
+                this.interceptorExecuted = this.executeInterceptorOnce(chainedHeaderBlock);
         }
     }
-
 }

--- a/src/Stratis.Bitcoin.IntegrationTests.Common/EnvironmentMockUpHelpers/BlockBuilder.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests.Common/EnvironmentMockUpHelpers/BlockBuilder.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 using NBitcoin;
 using Stratis.Bitcoin.Consensus;
 using Stratis.Bitcoin.Utilities;
@@ -52,7 +53,7 @@ namespace Stratis.Bitcoin.IntegrationTests.Common.EnvironmentMockUpHelpers
         /// Each block will also be submitted to consensus.
         /// </para>
         /// </summary>
-        public async void BuildAsync()
+        public async Task<ChainedHeader> BuildAsync()
         {
             var chainTip = this.coreNode.FullNode.ConsensusManager().Tip;
             var chainTipHeight = chainTip.Height;
@@ -92,6 +93,8 @@ namespace Stratis.Bitcoin.IntegrationTests.Common.EnvironmentMockUpHelpers
 
                 chainTip = this.coreNode.FullNode.ConsensusManager().Tip;
             }
+
+            return chainTip;
         }
 
         /// <summary>

--- a/src/Stratis.Bitcoin.IntegrationTests.Common/EnvironmentMockUpHelpers/CoreNode.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests.Common/EnvironmentMockUpHelpers/CoreNode.cs
@@ -58,11 +58,8 @@ namespace Stratis.Bitcoin.IntegrationTests.Common.EnvironmentMockUpHelpers
 
         public Mnemonic Mnemonic { get; set; }
 
-        private Action<ChainedHeaderBlock> builderDisconnectInterceptor;
-        private Func<ChainedHeaderBlock, bool> builderDisconnectInterceptorOnce;
-
         private Action<ChainedHeaderBlock> builderConnectInterceptor;
-        private Func<ChainedHeaderBlock, bool> builderConnectInterceptorOnce;
+        private Action<ChainedHeaderBlock> builderDisconnectInterceptor;
 
         private bool builderEnablePeerDiscovery;
         private bool builderNoValidation;
@@ -116,28 +113,6 @@ namespace Stratis.Bitcoin.IntegrationTests.Common.EnvironmentMockUpHelpers
         }
 
         /// <summary>
-        /// Executes a function when a block has disconnected.
-        /// </summary>
-        /// <param name="interceptor">A function that is called when a block disconnects.</param>
-        /// <returns>This node.</returns>
-        public CoreNode SetDisconnectInterceptor(Action<ChainedHeaderBlock> interceptor)
-        {
-            this.builderDisconnectInterceptor = interceptor;
-            return this;
-        }
-
-        /// <summary>
-        /// Executes a function when a block has disconnected.
-        /// </summary>
-        /// <param name="interceptor">A function that is called when a block disconnects, it will return true if it executed.</param>
-        /// <returns>This node.</returns>
-        public CoreNode SetDisconnectInterceptorOnce(Func<ChainedHeaderBlock, bool> interceptor)
-        {
-            this.builderDisconnectInterceptorOnce = interceptor;
-            return this;
-        }
-
-        /// <summary>
         /// Executes a function when a block has connected.
         /// </summary>
         /// <param name="interceptor">A function that is called everytime a block connects.</param>
@@ -149,13 +124,13 @@ namespace Stratis.Bitcoin.IntegrationTests.Common.EnvironmentMockUpHelpers
         }
 
         /// <summary>
-        /// Executes a function when a block has connected.
+        /// Executes a function when a block has disconnected.
         /// </summary>
-        /// <param name="interceptor">A function that is called when a block connects, it will return true if it executed.</param>
+        /// <param name="interceptor">A function that is called when a block disconnects.</param>
         /// <returns>This node.</returns>
-        public CoreNode SetConnectInterceptorOnce(Func<ChainedHeaderBlock, bool> interceptor)
+        public CoreNode SetDisconnectInterceptor(Action<ChainedHeaderBlock> interceptor)
         {
-            this.builderConnectInterceptorOnce = interceptor;
+            this.builderDisconnectInterceptor = interceptor;
             return this;
         }
 
@@ -276,14 +251,9 @@ namespace Stratis.Bitcoin.IntegrationTests.Common.EnvironmentMockUpHelpers
                 this.runner.EnablePeerDiscovery = this.builderEnablePeerDiscovery;
                 this.runner.OverrideDateTimeProvider = this.builderOverrideDateTimeProvider;
 
-                // Connect interceptors------------------------------
-                this.runner.InterceptorConnect = this.builderConnectInterceptor;
-                this.runner.InterceptorConnectOnce = this.builderConnectInterceptorOnce;
-                // --------------------------------------------------
-
-                // Disconnect interceptors---------------------------
-                this.runner.InterceptorDisconnect = this.builderDisconnectInterceptor;
-                this.runner.InterceptorDisconnectOnce = this.builderDisconnectInterceptorOnce;
+                // Interceptors--------------------------------------
+                this.runner.ConnectInterceptor = this.builderConnectInterceptor;
+                this.runner.DisconnectInterceptor = this.builderDisconnectInterceptor;
                 // --------------------------------------------------
 
                 this.runner.BuildNode();

--- a/src/Stratis.Bitcoin.IntegrationTests.Common/EnvironmentMockUpHelpers/CoreNode.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests.Common/EnvironmentMockUpHelpers/CoreNode.cs
@@ -58,11 +58,11 @@ namespace Stratis.Bitcoin.IntegrationTests.Common.EnvironmentMockUpHelpers
 
         public Mnemonic Mnemonic { get; set; }
 
-        private Action<ChainedHeaderBlock> builderExecuteDisconnectInterceptor;
-        private Func<ChainedHeaderBlock, bool> builderExecuteDisconnectInterceptorOnce;
+        private Action<ChainedHeaderBlock> builderDisconnectInterceptor;
+        private Func<ChainedHeaderBlock, bool> builderDisconnectInterceptorOnce;
 
-        private Action<ChainedHeaderBlock> builderExecuteBlockConnectInterceptor;
-        private Func<ChainedHeaderBlock, bool> builderExecuteConnectInterceptorOnce;
+        private Action<ChainedHeaderBlock> builderConnectInterceptor;
+        private Func<ChainedHeaderBlock, bool> builderConnectInterceptorOnce;
 
         private bool builderEnablePeerDiscovery;
         private bool builderNoValidation;
@@ -120,9 +120,9 @@ namespace Stratis.Bitcoin.IntegrationTests.Common.EnvironmentMockUpHelpers
         /// </summary>
         /// <param name="interceptor">A function that is called when a block disconnects.</param>
         /// <returns>This node.</returns>
-        public CoreNode ExecuteDisconnectInterceptor(Action<ChainedHeaderBlock> interceptor)
+        public CoreNode SetDisconnectInterceptor(Action<ChainedHeaderBlock> interceptor)
         {
-            this.builderExecuteDisconnectInterceptor = interceptor;
+            this.builderDisconnectInterceptor = interceptor;
             return this;
         }
 
@@ -131,9 +131,9 @@ namespace Stratis.Bitcoin.IntegrationTests.Common.EnvironmentMockUpHelpers
         /// </summary>
         /// <param name="interceptor">A function that is called when a block disconnects, it will return true if it executed.</param>
         /// <returns>This node.</returns>
-        public CoreNode ExecuteDisconnectInterceptorOnce(Func<ChainedHeaderBlock, bool> interceptor)
+        public CoreNode SetDisconnectInterceptorOnce(Func<ChainedHeaderBlock, bool> interceptor)
         {
-            this.builderExecuteDisconnectInterceptorOnce = interceptor;
+            this.builderDisconnectInterceptorOnce = interceptor;
             return this;
         }
 
@@ -142,9 +142,9 @@ namespace Stratis.Bitcoin.IntegrationTests.Common.EnvironmentMockUpHelpers
         /// </summary>
         /// <param name="interceptor">A function that is called everytime a block connects.</param>
         /// <returns>This node.</returns>
-        public CoreNode ExecuteConnectInterceptor(Action<ChainedHeaderBlock> interceptor)
+        public CoreNode SetConnectInterceptor(Action<ChainedHeaderBlock> interceptor)
         {
-            this.builderExecuteBlockConnectInterceptor = interceptor;
+            this.builderConnectInterceptor = interceptor;
             return this;
         }
 
@@ -153,9 +153,9 @@ namespace Stratis.Bitcoin.IntegrationTests.Common.EnvironmentMockUpHelpers
         /// </summary>
         /// <param name="interceptor">A function that is called when a block connects, it will return true if it executed.</param>
         /// <returns>This node.</returns>
-        public CoreNode ExecuteConnectInterceptorOnce(Func<ChainedHeaderBlock, bool> interceptor)
+        public CoreNode SetConnectInterceptorOnce(Func<ChainedHeaderBlock, bool> interceptor)
         {
-            this.builderExecuteConnectInterceptorOnce = interceptor;
+            this.builderConnectInterceptorOnce = interceptor;
             return this;
         }
 
@@ -277,13 +277,13 @@ namespace Stratis.Bitcoin.IntegrationTests.Common.EnvironmentMockUpHelpers
                 this.runner.OverrideDateTimeProvider = this.builderOverrideDateTimeProvider;
 
                 // Connect interceptors------------------------------
-                this.runner.InterceptorConnect = this.builderExecuteBlockConnectInterceptor;
-                this.runner.InterceptorConnectOnce = this.builderExecuteConnectInterceptorOnce;
+                this.runner.InterceptorConnect = this.builderConnectInterceptor;
+                this.runner.InterceptorConnectOnce = this.builderConnectInterceptorOnce;
                 // --------------------------------------------------
 
                 // Disconnect interceptors---------------------------
-                this.runner.InterceptorDisconnect = this.builderExecuteDisconnectInterceptor;
-                this.runner.InterceptorDisconnectOnce = this.builderExecuteDisconnectInterceptorOnce;
+                this.runner.InterceptorDisconnect = this.builderDisconnectInterceptor;
+                this.runner.InterceptorDisconnectOnce = this.builderDisconnectInterceptorOnce;
                 // --------------------------------------------------
 
                 this.runner.BuildNode();

--- a/src/Stratis.Bitcoin.IntegrationTests.Common/Runners/NodeRunner.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests.Common/Runners/NodeRunner.cs
@@ -23,11 +23,8 @@ namespace Stratis.Bitcoin.IntegrationTests.Common.Runners
         public bool EnablePeerDiscovery { get; internal set; }
         public FullNode FullNode { get; set; }
 
-        public Action<ChainedHeaderBlock> InterceptorDisconnect { get; internal set; }
-        public Func<ChainedHeaderBlock, bool> InterceptorDisconnectOnce { get; internal set; }
-
-        public Action<ChainedHeaderBlock> InterceptorConnect { get; internal set; }
-        public Func<ChainedHeaderBlock, bool> InterceptorConnectOnce { get; internal set; }
+        public Action<ChainedHeaderBlock> ConnectInterceptor { get; internal set; }
+        public Action<ChainedHeaderBlock> DisconnectInterceptor { get; internal set; }
 
         public Network Network { set; get; }
         public bool OverrideDateTimeProvider { get; internal set; }
@@ -68,17 +65,11 @@ namespace Stratis.Bitcoin.IntegrationTests.Common.Runners
 
             builder = builder.AddBlockObserverFeature();
 
-            if (this.InterceptorConnect != null)
-                builder = builder.UseBlockConnectedInterceptor(this.InterceptorConnect);
+            if (this.ConnectInterceptor != null)
+                builder = builder.UseConnectedInterceptor(this.ConnectInterceptor);
 
-            if (this.InterceptorConnectOnce != null)
-                builder = builder.UseBlockConnectedInterceptorOnce(this.InterceptorConnectOnce);
-
-            if (this.InterceptorDisconnect != null)
-                builder = builder.UseBlockDisconnectedInterceptor(this.InterceptorDisconnect);
-
-            if (this.InterceptorDisconnectOnce != null)
-                builder = builder.UseBlockDisconnectedInterceptorOnce(this.InterceptorDisconnectOnce);
+            if (this.DisconnectInterceptor != null)
+                builder = builder.UseDisconnectedInterceptor(this.DisconnectInterceptor);
         }
     }
 }

--- a/src/Stratis.Bitcoin.IntegrationTests.Common/Runners/NodeRunner.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests.Common/Runners/NodeRunner.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Microsoft.Extensions.DependencyInjection;
 using NBitcoin;
+using Stratis.Bitcoin.Builder;
 using Stratis.Bitcoin.Primitives;
 
 namespace Stratis.Bitcoin.IntegrationTests.Common.Runners
@@ -53,6 +54,20 @@ namespace Stratis.Bitcoin.IntegrationTests.Common.Runners
             }
 
             this.FullNode = null;
+        }
+
+        protected void ConfigureInterceptors(IFullNodeBuilder builder)
+        {
+            if (this is BitcoinCoreRunner)
+                return;
+
+            builder = builder.AddBlockObserverFeature();
+
+            if (this.InterceptorConnect != null)
+                builder = builder.UseBlockConnectedInterceptor(this.InterceptorConnect);
+
+            if (this.InterceptorDisconnect != null)
+                builder = builder.UseBlockDisconnectedInterceptor(this.InterceptorDisconnect);
         }
     }
 }

--- a/src/Stratis.Bitcoin.IntegrationTests.Common/Runners/NodeRunner.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests.Common/Runners/NodeRunner.cs
@@ -22,8 +22,13 @@ namespace Stratis.Bitcoin.IntegrationTests.Common.Runners
 
         public bool EnablePeerDiscovery { get; internal set; }
         public FullNode FullNode { get; set; }
-        public Func<ChainedHeaderBlock, bool> InterceptorDisconnect { get; internal set; }
-        public Func<ChainedHeaderBlock, bool> InterceptorConnect { get; internal set; }
+
+        public Action<ChainedHeaderBlock> InterceptorDisconnect { get; internal set; }
+        public Func<ChainedHeaderBlock, bool> InterceptorDisconnectOnce { get; internal set; }
+
+        public Action<ChainedHeaderBlock> InterceptorConnect { get; internal set; }
+        public Func<ChainedHeaderBlock, bool> InterceptorConnectOnce { get; internal set; }
+
         public Network Network { set; get; }
         public bool OverrideDateTimeProvider { get; internal set; }
         public Action<IServiceCollection> ServiceToOverride { get; internal set; }
@@ -66,8 +71,14 @@ namespace Stratis.Bitcoin.IntegrationTests.Common.Runners
             if (this.InterceptorConnect != null)
                 builder = builder.UseBlockConnectedInterceptor(this.InterceptorConnect);
 
+            if (this.InterceptorConnectOnce != null)
+                builder = builder.UseBlockConnectedInterceptorOnce(this.InterceptorConnectOnce);
+
             if (this.InterceptorDisconnect != null)
                 builder = builder.UseBlockDisconnectedInterceptor(this.InterceptorDisconnect);
+
+            if (this.InterceptorDisconnectOnce != null)
+                builder = builder.UseBlockDisconnectedInterceptorOnce(this.InterceptorDisconnectOnce);
         }
     }
 }

--- a/src/Stratis.Bitcoin.IntegrationTests.Common/Runners/StratisBitcoinPosRunner.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests.Common/Runners/StratisBitcoinPosRunner.cs
@@ -41,16 +41,13 @@ namespace Stratis.Bitcoin.IntegrationTests.Common.Runners
             if (this.OverrideDateTimeProvider)
                 builder.OverrideDateTimeProviderFor<MiningFeature>();
 
-            if (this.InterceptorConnect != null || this.InterceptorDisconnect != null)
-            {
-                builder = builder.AddBlockObserverFeature();
+            builder = builder.AddBlockObserverFeature();
 
-                if (this.InterceptorConnect != null)
-                    builder = builder.UseBlockConnectedInterceptor(this.InterceptorConnect);
+            if (this.InterceptorConnect != null)
+                builder = builder.UseBlockConnectedInterceptor(this.InterceptorConnect);
 
-                if (this.InterceptorDisconnect != null)
-                    builder = builder.UseBlockDisconnectedInterceptor(this.InterceptorDisconnect);
-            }
+            if (this.InterceptorDisconnect != null)
+                builder = builder.UseBlockDisconnectedInterceptor(this.InterceptorDisconnect);
 
             if (!this.EnablePeerDiscovery)
             {

--- a/src/Stratis.Bitcoin.IntegrationTests.Common/Runners/StratisBitcoinPosRunner.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests.Common/Runners/StratisBitcoinPosRunner.cs
@@ -41,11 +41,16 @@ namespace Stratis.Bitcoin.IntegrationTests.Common.Runners
             if (this.OverrideDateTimeProvider)
                 builder.OverrideDateTimeProviderFor<MiningFeature>();
 
-            if (this.InterceptorDisconnect != null)
-                builder = builder.InterceptBlockDisconnected(this.InterceptorDisconnect);
+            if (this.InterceptorConnect != null || this.InterceptorDisconnect != null)
+            {
+                builder = builder.AddBlockObserverFeature();
 
-            if (this.InterceptorConnect != null)
-                builder = builder.InterceptBlockConnected(this.InterceptorConnect);
+                if (this.InterceptorConnect != null)
+                    builder = builder.UseBlockConnectedInterceptor(this.InterceptorConnect);
+
+                if (this.InterceptorDisconnect != null)
+                    builder = builder.UseBlockDisconnectedInterceptor(this.InterceptorDisconnect);
+            }
 
             if (!this.EnablePeerDiscovery)
             {

--- a/src/Stratis.Bitcoin.IntegrationTests.Common/Runners/StratisBitcoinPosRunner.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests.Common/Runners/StratisBitcoinPosRunner.cs
@@ -41,13 +41,7 @@ namespace Stratis.Bitcoin.IntegrationTests.Common.Runners
             if (this.OverrideDateTimeProvider)
                 builder.OverrideDateTimeProviderFor<MiningFeature>();
 
-            builder = builder.AddBlockObserverFeature();
-
-            if (this.InterceptorConnect != null)
-                builder = builder.UseBlockConnectedInterceptor(this.InterceptorConnect);
-
-            if (this.InterceptorDisconnect != null)
-                builder = builder.UseBlockDisconnectedInterceptor(this.InterceptorDisconnect);
+            ConfigureInterceptors(builder);
 
             if (!this.EnablePeerDiscovery)
             {

--- a/src/Stratis.Bitcoin.IntegrationTests.Common/Runners/StratisBitcoinPowRunner.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests.Common/Runners/StratisBitcoinPowRunner.cs
@@ -43,8 +43,16 @@ namespace Stratis.Bitcoin.IntegrationTests.Common.Runners
                             .UseTestChainedHeaderTree()
                             .MockIBD();
 
-            if (this.InterceptorDisconnect != null)
-                builder = builder.InterceptBlockDisconnected(this.InterceptorDisconnect);
+            if (this.InterceptorConnect != null || this.InterceptorDisconnect != null)
+            {
+                builder = builder.AddBlockObserverFeature();
+
+                if (this.InterceptorConnect != null)
+                    builder = builder.UseBlockConnectedInterceptor(this.InterceptorConnect);
+
+                if (this.InterceptorDisconnect != null)
+                    builder = builder.UseBlockDisconnectedInterceptor(this.InterceptorDisconnect);
+            }
 
             if (this.ServiceToOverride != null)
                 builder.OverrideService<BaseFeature>(this.ServiceToOverride);

--- a/src/Stratis.Bitcoin.IntegrationTests.Common/Runners/StratisBitcoinPowRunner.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests.Common/Runners/StratisBitcoinPowRunner.cs
@@ -43,13 +43,7 @@ namespace Stratis.Bitcoin.IntegrationTests.Common.Runners
                             .UseTestChainedHeaderTree()
                             .MockIBD();
 
-            builder = builder.AddBlockObserverFeature();
-
-            if (this.InterceptorConnect != null)
-                builder = builder.UseBlockConnectedInterceptor(this.InterceptorConnect);
-
-            if (this.InterceptorDisconnect != null)
-                builder = builder.UseBlockDisconnectedInterceptor(this.InterceptorDisconnect);
+            ConfigureInterceptors(builder);
 
             if (this.ServiceToOverride != null)
                 builder.OverrideService<BaseFeature>(this.ServiceToOverride);

--- a/src/Stratis.Bitcoin.IntegrationTests.Common/Runners/StratisBitcoinPowRunner.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests.Common/Runners/StratisBitcoinPowRunner.cs
@@ -43,16 +43,13 @@ namespace Stratis.Bitcoin.IntegrationTests.Common.Runners
                             .UseTestChainedHeaderTree()
                             .MockIBD();
 
-            if (this.InterceptorConnect != null || this.InterceptorDisconnect != null)
-            {
-                builder = builder.AddBlockObserverFeature();
+            builder = builder.AddBlockObserverFeature();
 
-                if (this.InterceptorConnect != null)
-                    builder = builder.UseBlockConnectedInterceptor(this.InterceptorConnect);
+            if (this.InterceptorConnect != null)
+                builder = builder.UseBlockConnectedInterceptor(this.InterceptorConnect);
 
-                if (this.InterceptorDisconnect != null)
-                    builder = builder.UseBlockDisconnectedInterceptor(this.InterceptorDisconnect);
-            }
+            if (this.InterceptorDisconnect != null)
+                builder = builder.UseBlockDisconnectedInterceptor(this.InterceptorDisconnect);
 
             if (this.ServiceToOverride != null)
                 builder.OverrideService<BaseFeature>(this.ServiceToOverride);

--- a/src/Stratis.Bitcoin.IntegrationTests/ConsensusManagerFailedReorgTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/ConsensusManagerFailedReorgTests.cs
@@ -1,8 +1,11 @@
-﻿using NBitcoin;
+﻿using System.Threading.Tasks;
+using NBitcoin;
 using Stratis.Bitcoin.IntegrationTests.Common;
 using Stratis.Bitcoin.IntegrationTests.Common.EnvironmentMockUpHelpers;
+using Stratis.Bitcoin.IntegrationTests.Common.ReadyData;
 using Stratis.Bitcoin.IntegrationTests.Common.TestNetworks;
 using Stratis.Bitcoin.Networks;
+using Stratis.Bitcoin.Primitives;
 using Xunit;
 
 namespace Stratis.Bitcoin.IntegrationTests
@@ -19,46 +22,112 @@ namespace Stratis.Bitcoin.IntegrationTests
         }
 
         [Fact]
-        public void ReorgChain_FailsFullValidation_Reconnect_OldChain_Nodes_Connected()
+        public async Task ReorgChain_FailsFullValidation_Reconnect_OldChain_Nodes_ConnectedAsync()
         {
             using (var builder = NodeBuilder.Create(this))
             {
                 var bitcoinNoValidationRulesNetwork = new BitcoinRegTestNoValidationRules();
 
-                var minerA = builder.CreateStratisPowNode(this.powNetwork).WithDummyWallet().Start();
+                var minerA = builder.CreateStratisPowNode(this.powNetwork).WithDummyWallet().WithReadyBlockchainData(ReadyBlockchain.BitcoinRegTest10Miner).Start();
                 var minerB = builder.CreateStratisPowNode(bitcoinNoValidationRulesNetwork).NoValidation().WithDummyWallet().Start();
 
-                // MinerA mines 5 blocks
-                TestHelper.MineBlocks(minerA, 5);
+                // Miner A mines 5 blocks
+                //TestHelper.MineBlocks(minerA, 5);
 
-                // MinerB syncs with MinerA
+                // Miner B syncs with Miner A
                 TestHelper.ConnectAndSync(minerB, minerA);
 
-                // Disable syncer from sending blocks to miner B
+                // Disable Miner A from sending blocks to Miner B
                 TestHelper.DisableBlockPropagation(minerA, minerB);
 
-                // Miner A continues to mine to height 9
+                // Miner A continues to mine to height 14
                 TestHelper.MineBlocks(minerA, 4);
-                TestHelper.WaitLoop(() => minerA.FullNode.ConsensusManager().Tip.Height == 9);
+                TestHelper.WaitLoop(() => minerA.FullNode.ConsensusManager().Tip.Height == 14);
+                Assert.Equal(10, minerB.FullNode.ConsensusManager().Tip.Height);
 
-                // MinerB mines 5 more blocks:
+                // Disable Miner B from sending blocks to miner A
+                TestHelper.DisableBlockPropagation(minerB, minerA);
+
+                // Miner B mines 5 more blocks:
                 // Block 6,7,9,10 = valid
                 // Block 8 = invalid
-                TestHelper.BuildBlocks.OnNode(minerB).Amount(5).Invalid(8, (coreNode, block) => BlockBuilder.InvalidCoinbaseReward(coreNode, block)).BuildAsync();
+                var minerBChainTip = await TestHelper.BuildBlocks.OnNode(minerB).Amount(5).Invalid(13, (coreNode, block) => BlockBuilder.InvalidCoinbaseReward(coreNode, block)).BuildAsync();
+                Assert.Equal(15, minerBChainTip.Height);
+                Assert.Equal(15, minerB.FullNode.ConsensusManager().Tip.Height);
 
-                // On mining the following will happen: 
-                // Reorg from blocks 9 to 5.
-                // Connect blocks 5 to 10
-                // Block 8 fails.
-                // Reorg from 7 to 5
-                // Reconnect blocks 6 to 9
-                TestHelper.WaitLoop(() => minerA.FullNode.ConsensusManager().Tip.Height == 9);
-                TestHelper.WaitLoop(() => minerB.FullNode.ConsensusManager().Tip.Height == 10);
+                bool minerA_Disconnected_ItsOwnChain_ToConnectTo_MinerBs_LongerChain = false;
+                bool minerA_IsConnecting_To_MinerBChain = false;
+                bool minerA_Disconnected_MinerBsChain = false;
+                bool minerA_Reconnected_Its_OwnChain = false;
+
+                // Configure the interceptor to intercept when Miner A connects Miner B's chain.
+                bool interceptorConnect(ChainedHeaderBlock chainedHeaderBlock)
+                {
+                    if (minerA_IsConnecting_To_MinerBChain == false)
+                    {
+                        if (chainedHeaderBlock.ChainedHeader.Height == 12)
+                            minerA_IsConnecting_To_MinerBChain = minerA.FullNode.ConsensusManager().Tip.HashBlock == minerBChainTip.GetAncestor(12).HashBlock;
+
+                        return false;
+                    }
+
+                    if (minerA_Reconnected_Its_OwnChain == false)
+                    {
+                        if (chainedHeaderBlock.ChainedHeader.Height == 14)
+                            minerA_Reconnected_Its_OwnChain = true;
+
+                        return false;
+                    }
+
+                    return false;
+                }
+
+                // Configure the interceptor to intercept when Miner A disconnects Miner B's chain after the reorg.
+                bool interceptorDisconnect(ChainedHeaderBlock chainedHeaderBlock)
+                {
+                    if (minerA_Disconnected_ItsOwnChain_ToConnectTo_MinerBs_LongerChain == false)
+                    {
+                        if (minerA.FullNode.ConsensusManager().Tip.Height == 10)
+                            minerA_Disconnected_ItsOwnChain_ToConnectTo_MinerBs_LongerChain = true;
+
+                        return false;
+                    }
+                    else
+
+                    if (minerA_Disconnected_MinerBsChain == false)
+                    {
+                        if (minerA.FullNode.ConsensusManager().Tip.Height == 10)
+                            minerA_Disconnected_MinerBsChain = true;
+
+                        return false;
+                    }
+
+                    return false;
+                }
+
+                minerA.BlockConnectInterceptor(interceptorConnect);
+                minerA.BlockDisconnectInterceptor(interceptorDisconnect);
+                minerA.Restart();
+
+                TestHelper.Connect(minerA, minerB);
+
+                // Wait until Miner A disconnected its own chain so that it can connect to
+                // Miner B's longer chain.
+                TestHelper.WaitLoop(() => minerA_Disconnected_ItsOwnChain_ToConnectTo_MinerBs_LongerChain);
+
+                // Wait until Miner A has connected Miner B's chain (but failed)
+                TestHelper.WaitLoop(() => minerA_IsConnecting_To_MinerBChain);
+
+                // Wait until Miner A has disconnected Miner B's invalid chain.
+                TestHelper.WaitLoop(() => minerA_Disconnected_MinerBsChain);
+
+                // Wait until Miner A has reconnected its own chain.
+                TestHelper.WaitLoop(() => minerA_Reconnected_Its_OwnChain);
             }
         }
 
         [Fact]
-        public void ReorgChain_FailsFullValidation_Reconnect_OldChain_Nodes_Disconnected()
+        public async Task ReorgChain_FailsFullValidation_Reconnect_OldChain_Nodes_DisconnectedAsync()
         {
             using (var builder = NodeBuilder.Create(this))
             {
@@ -83,14 +152,14 @@ namespace Stratis.Bitcoin.IntegrationTests
                 // MinerB mines 5 more blocks:
                 // Block 6,7,9,10 = valid
                 // Block 8 = invalid
-                TestHelper.BuildBlocks.OnNode(minerB).Amount(5).Invalid(8, (coreNode, block) => BlockBuilder.InvalidCoinbaseReward(coreNode, block)).BuildAsync();
+                await TestHelper.BuildBlocks.OnNode(minerB).Amount(5).Invalid(8, (coreNode, block) => BlockBuilder.InvalidCoinbaseReward(coreNode, block)).BuildAsync();
 
                 // Reconnect minerA to minerB causing the following to happen: 
                 // Reorg from blocks 9 to 5.
                 // Connect blocks 5 to 10
                 // Block 8 fails.
                 // Reorg from 7 to 5
-                // Reconnect blocks 6 to 9
+                // Reconnect blocks 6 to  
                 TestHelper.Connect(minerA, minerB);
 
                 TestHelper.WaitLoop(() => minerA.FullNode.ConsensusManager().Tip.Height == 9);
@@ -99,7 +168,7 @@ namespace Stratis.Bitcoin.IntegrationTests
         }
 
         [Fact]
-        public void ReorgChain_FailsFullValidation_Reconnect_OldChain_FromSecondMiner_Disconnected()
+        public async Task ReorgChain_FailsFullValidation_Reconnect_OldChain_FromSecondMiner_DisconnectedAsync()
         {
             using (var builder = NodeBuilder.Create(this))
             {
@@ -133,7 +202,7 @@ namespace Stratis.Bitcoin.IntegrationTests
                 // MinerB mines 5 more blocks:
                 // Block 6,7,9,10 = valid
                 // Block 8 = invalid
-                TestHelper.BuildBlocks.OnNode(minerB).Amount(5).Invalid(8, (coreNode, block) => BlockBuilder.InvalidCoinbaseReward(coreNode, block)).BuildAsync();
+                await TestHelper.BuildBlocks.OnNode(minerB).Amount(5).Invalid(8, (coreNode, block) => BlockBuilder.InvalidCoinbaseReward(coreNode, block)).BuildAsync();
 
                 // Reconnect syncer to minerB causing the following to happen: 
                 // Reorg from blocks 9 to 5.
@@ -152,7 +221,7 @@ namespace Stratis.Bitcoin.IntegrationTests
         }
 
         [Fact]
-        public void ReorgChain_FailsPartialValidation_Nodes_Connected()
+        public async Task ReorgChain_FailsPartialValidation_Nodes_ConnectedAsync()
         {
             using (var builder = NodeBuilder.Create(this))
             {
@@ -177,7 +246,7 @@ namespace Stratis.Bitcoin.IntegrationTests
                 // MinerB mines 5 more blocks:
                 // Block 6,7,9,10 = valid
                 // Block 8 = invalid
-                TestHelper.BuildBlocks.OnNode(minerB).Amount(5).Invalid(8, (coreNode, block) => BlockBuilder.InvalidDuplicateCoinbase(coreNode, block)).BuildAsync();
+                await TestHelper.BuildBlocks.OnNode(minerB).Amount(5).Invalid(8, (coreNode, block) => BlockBuilder.InvalidDuplicateCoinbase(coreNode, block)).BuildAsync();
 
                 // Reconnect minerA to minerB.
                 // This will cause the reorg chain to fail at block 8 and roll back any changes.
@@ -187,7 +256,7 @@ namespace Stratis.Bitcoin.IntegrationTests
         }
 
         [Fact]
-        public void ReorgChain_FailsPartialValidation_Nodes_Disconnected()
+        public async Task ReorgChain_FailsPartialValidation_Nodes_DisconnectedAsync()
         {
             using (var builder = NodeBuilder.Create(this))
             {
@@ -212,7 +281,7 @@ namespace Stratis.Bitcoin.IntegrationTests
                 // MinerB mines 5 more blocks:
                 // Block 6,7,9,10 = valid
                 // Block 8 = invalid
-                TestHelper.BuildBlocks.OnNode(minerB).Amount(5).Invalid(8, (coreNode, block) => BlockBuilder.InvalidDuplicateCoinbase(coreNode, block)).BuildAsync();
+                await TestHelper.BuildBlocks.OnNode(minerB).Amount(5).Invalid(8, (coreNode, block) => BlockBuilder.InvalidDuplicateCoinbase(coreNode, block)).BuildAsync();
 
                 // Reconnect minerA to minerB.
                 // This will cause the reorg chain to fail at block 8 and roll back any changes.
@@ -236,7 +305,7 @@ namespace Stratis.Bitcoin.IntegrationTests
         /// 13 -> Header Only
         /// </summary>
         [Fact]
-        public void ReorgChain_FailsFullValidation_ChainHasBlocksAndHeadersOnly_NodesDisconnected()
+        public async Task ReorgChain_FailsFullValidation_ChainHasBlocksAndHeadersOnly_NodesDisconnectedAsync()
         {
             using (var builder = NodeBuilder.Create(this))
             {
@@ -271,7 +340,7 @@ namespace Stratis.Bitcoin.IntegrationTests
                 // MinerB mines 5 more blocks:
                 // Block 6,7,9,10 = valid
                 // Block 8 = invalid
-                TestHelper.BuildBlocks.OnNode(minerC).Amount(5).Invalid(8, (coreNode, block) => BlockBuilder.InvalidCoinbaseReward(coreNode, block)).BuildAsync();
+                await TestHelper.BuildBlocks.OnNode(minerC).Amount(5).Invalid(8, (coreNode, block) => BlockBuilder.InvalidCoinbaseReward(coreNode, block)).BuildAsync();
 
                 // Reconnect MinerA to MinerC.
                 TestHelper.Connect(minerA, minerC);

--- a/src/Stratis.Bitcoin.IntegrationTests/ConsensusManagerFailedReorgTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/ConsensusManagerFailedReorgTests.cs
@@ -12,12 +12,10 @@ namespace Stratis.Bitcoin.IntegrationTests
 {
     public class ConsensusManagerFailedReorgTests
     {
-        private readonly Network posNetwork;
         private readonly Network powNetwork;
 
         public ConsensusManagerFailedReorgTests()
         {
-            this.posNetwork = new StratisRegTest();
             this.powNetwork = new BitcoinRegTest();
         }
 

--- a/src/Stratis.Bitcoin.IntegrationTests/ConsensusManagerFailedReorgTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/ConsensusManagerFailedReorgTests.cs
@@ -82,8 +82,8 @@ namespace Stratis.Bitcoin.IntegrationTests
                     }
                 }
 
-                minerA.ExecuteConnectInterceptor(interceptorConnect);
-                minerA.ExecuteDisconnectInterceptor(interceptorDisconnect);
+                minerA.SetConnectInterceptor(interceptorConnect);
+                minerA.SetDisconnectInterceptor(interceptorDisconnect);
                 minerA.Start();
 
                 // Miner B syncs with Miner A
@@ -161,7 +161,7 @@ namespace Stratis.Bitcoin.IntegrationTests
                 // Configure the interceptor to intercept when Miner A connects Miner B's chain.
                 void interceptorConnect(ChainedHeaderBlock chainedHeaderBlock)
                 {
-                    if (minerA_IsConnecting_To_MinerBChain == false)
+                    if (!minerA_IsConnecting_To_MinerBChain)
                     {
                         if (chainedHeaderBlock.ChainedHeader.Height == 12)
                             minerA_IsConnecting_To_MinerBChain = minerA.FullNode.ConsensusManager().Tip.HashBlock == minerBChainTip.GetAncestor(12).HashBlock;
@@ -169,7 +169,7 @@ namespace Stratis.Bitcoin.IntegrationTests
                         return;
                     }
 
-                    if (minerA_Reconnected_Its_OwnChain == false)
+                    if (!minerA_Reconnected_Its_OwnChain)
                     {
                         if (chainedHeaderBlock.ChainedHeader.Height == 14)
                             minerA_Reconnected_Its_OwnChain = true;
@@ -181,7 +181,7 @@ namespace Stratis.Bitcoin.IntegrationTests
                 // Configure the interceptor to intercept when Miner A disconnects Miner B's chain after the reorg.
                 void interceptorDisconnect(ChainedHeaderBlock chainedHeaderBlock)
                 {
-                    if (minerA_Disconnected_ItsOwnChain_ToConnectTo_MinerBs_LongerChain == false)
+                    if (!minerA_Disconnected_ItsOwnChain_ToConnectTo_MinerBs_LongerChain)
                     {
                         if (minerA.FullNode.ConsensusManager().Tip.Height == 10)
                             minerA_Disconnected_ItsOwnChain_ToConnectTo_MinerBs_LongerChain = true;
@@ -190,7 +190,7 @@ namespace Stratis.Bitcoin.IntegrationTests
                     }
                     else
 
-                    if (minerA_Disconnected_MinerBsChain == false)
+                    if (!minerA_Disconnected_MinerBsChain)
                     {
                         if (minerA.FullNode.ConsensusManager().Tip.Height == 10)
                             minerA_Disconnected_MinerBsChain = true;
@@ -199,8 +199,8 @@ namespace Stratis.Bitcoin.IntegrationTests
                     }
                 }
 
-                minerA.ExecuteConnectInterceptor(interceptorConnect);
-                minerA.ExecuteDisconnectInterceptor(interceptorDisconnect);
+                minerA.SetConnectInterceptor(interceptorConnect);
+                minerA.SetDisconnectInterceptor(interceptorDisconnect);
                 minerA.Restart();
 
                 TestHelper.Connect(minerA, minerB);

--- a/src/Stratis.Bitcoin.IntegrationTests/ConsensusManagerFailedReorgTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/ConsensusManagerFailedReorgTests.cs
@@ -37,17 +37,17 @@ namespace Stratis.Bitcoin.IntegrationTests
                 bool minerA_Reconnected_Its_OwnChain = false;
 
                 // Configure the interceptor to intercept when Miner A connects Miner B's chain.
-                bool interceptorConnect(ChainedHeaderBlock chainedHeaderBlock)
+                void interceptorConnect(ChainedHeaderBlock chainedHeaderBlock)
                 {
                     if (!interceptorsEnabled)
-                        return false;
+                        return;
 
                     if (!minerA_IsConnecting_To_MinerBChain)
                     {
                         if (chainedHeaderBlock.ChainedHeader.Height == 12)
                             minerA_IsConnecting_To_MinerBChain = minerA.FullNode.ConsensusManager().Tip.HashBlock == minerBChainTip.GetAncestor(12).HashBlock;
 
-                        return false;
+                        return;
                     }
 
                     if (!minerA_Reconnected_Its_OwnChain)
@@ -55,24 +55,22 @@ namespace Stratis.Bitcoin.IntegrationTests
                         if (chainedHeaderBlock.ChainedHeader.Height == 14)
                             minerA_Reconnected_Its_OwnChain = true;
 
-                        return false;
+                        return;
                     }
-
-                    return false;
                 }
 
                 // Configure the interceptor to intercept when Miner A disconnects Miner B's chain after the reorg.
-                bool interceptorDisconnect(ChainedHeaderBlock chainedHeaderBlock)
+                void interceptorDisconnect(ChainedHeaderBlock chainedHeaderBlock)
                 {
                     if (!interceptorsEnabled)
-                        return false;
+                        return;
 
                     if (!minerA_Disconnected_ItsOwnChain_ToConnectTo_MinerBs_LongerChain)
                     {
                         if (minerA.FullNode.ConsensusManager().Tip.Height == 10)
                             minerA_Disconnected_ItsOwnChain_ToConnectTo_MinerBs_LongerChain = true;
 
-                        return false;
+                        return;
                     }
 
                     if (!minerA_Disconnected_MinerBsChain)
@@ -80,14 +78,12 @@ namespace Stratis.Bitcoin.IntegrationTests
                         if (minerA.FullNode.ConsensusManager().Tip.Height == 10)
                             minerA_Disconnected_MinerBsChain = true;
 
-                        return false;
+                        return;
                     }
-
-                    return false;
                 }
 
-                minerA.BlockConnectInterceptor(interceptorConnect);
-                minerA.BlockDisconnectInterceptor(interceptorDisconnect);
+                minerA.ExecuteConnectInterceptor(interceptorConnect);
+                minerA.ExecuteDisconnectInterceptor(interceptorDisconnect);
                 minerA.Start();
 
                 // Miner B syncs with Miner A
@@ -163,14 +159,14 @@ namespace Stratis.Bitcoin.IntegrationTests
                 bool minerA_Reconnected_Its_OwnChain = false;
 
                 // Configure the interceptor to intercept when Miner A connects Miner B's chain.
-                bool interceptorConnect(ChainedHeaderBlock chainedHeaderBlock)
+                void interceptorConnect(ChainedHeaderBlock chainedHeaderBlock)
                 {
                     if (minerA_IsConnecting_To_MinerBChain == false)
                     {
                         if (chainedHeaderBlock.ChainedHeader.Height == 12)
                             minerA_IsConnecting_To_MinerBChain = minerA.FullNode.ConsensusManager().Tip.HashBlock == minerBChainTip.GetAncestor(12).HashBlock;
 
-                        return false;
+                        return;
                     }
 
                     if (minerA_Reconnected_Its_OwnChain == false)
@@ -178,21 +174,19 @@ namespace Stratis.Bitcoin.IntegrationTests
                         if (chainedHeaderBlock.ChainedHeader.Height == 14)
                             minerA_Reconnected_Its_OwnChain = true;
 
-                        return false;
+                        return;
                     }
-
-                    return false;
                 }
 
                 // Configure the interceptor to intercept when Miner A disconnects Miner B's chain after the reorg.
-                bool interceptorDisconnect(ChainedHeaderBlock chainedHeaderBlock)
+                void interceptorDisconnect(ChainedHeaderBlock chainedHeaderBlock)
                 {
                     if (minerA_Disconnected_ItsOwnChain_ToConnectTo_MinerBs_LongerChain == false)
                     {
                         if (minerA.FullNode.ConsensusManager().Tip.Height == 10)
                             minerA_Disconnected_ItsOwnChain_ToConnectTo_MinerBs_LongerChain = true;
 
-                        return false;
+                        return;
                     }
                     else
 
@@ -201,14 +195,12 @@ namespace Stratis.Bitcoin.IntegrationTests
                         if (minerA.FullNode.ConsensusManager().Tip.Height == 10)
                             minerA_Disconnected_MinerBsChain = true;
 
-                        return false;
+                        return;
                     }
-
-                    return false;
                 }
 
-                minerA.BlockConnectInterceptor(interceptorConnect);
-                minerA.BlockDisconnectInterceptor(interceptorDisconnect);
+                minerA.ExecuteConnectInterceptor(interceptorConnect);
+                minerA.ExecuteDisconnectInterceptor(interceptorDisconnect);
                 minerA.Restart();
 
                 TestHelper.Connect(minerA, minerB);

--- a/src/Stratis.Bitcoin.IntegrationTests/ConsensusManagerInterceptorTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/ConsensusManagerInterceptorTests.cs
@@ -37,7 +37,7 @@ namespace Stratis.Bitcoin.IntegrationTests
                     return false;
                 }
 
-                minerA.BlockDisconnectInterceptor(interceptor);
+                minerA.ExecuteDisconnectInterceptorOnce(interceptor);
 
                 // Start the nodes.
                 minerA.Start();
@@ -110,7 +110,7 @@ namespace Stratis.Bitcoin.IntegrationTests
                     return false;
                 }
 
-                minerA.BlockDisconnectInterceptor(interceptor);
+                minerA.ExecuteDisconnectInterceptorOnce(interceptor);
 
                 // Start the nodes.
                 minerA.Start();

--- a/src/Stratis.Bitcoin.IntegrationTests/ConsensusManagerInterceptorTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/ConsensusManagerInterceptorTests.cs
@@ -1,4 +1,5 @@
-﻿using Stratis.Bitcoin.IntegrationTests.Common;
+﻿using System.Threading.Tasks;
+using Stratis.Bitcoin.IntegrationTests.Common;
 using Stratis.Bitcoin.IntegrationTests.Common.EnvironmentMockUpHelpers;
 using Stratis.Bitcoin.Networks;
 using Stratis.Bitcoin.Primitives;
@@ -13,7 +14,7 @@ namespace Stratis.Bitcoin.IntegrationTests
         /// tries to connect to another chain with longer chain work but containing an invalid block.
         /// </summary>
         [Fact]
-        public void ReorgChain_AfterInitialRewind_ChainA_Extension_MinerC_Disconnects()
+        public async Task ReorgChain_AfterInitialRewind_ChainA_Extension_MinerC_DisconnectsAsync()
         {
             using (var builder = NodeBuilder.Create(this))
             {
@@ -23,21 +24,26 @@ namespace Stratis.Bitcoin.IntegrationTests
                 var minerB = builder.CreateStratisPowNode(network).NoValidation().WithDummyWallet();
                 var syncer = builder.CreateStratisPowNode(network).WithDummyWallet();
 
+                bool minerADisconnectedFromSyncer = false;
+
                 // Configure the interceptor to disconnect a node after a certain block has been disconnected (rewound).
-                bool interceptor(ChainedHeaderBlock chainedHeaderBlock)
+                void interceptor(ChainedHeaderBlock chainedHeaderBlock)
                 {
+                    if (minerADisconnectedFromSyncer)
+                        return;
+
                     if (chainedHeaderBlock.ChainedHeader.Previous.Height == 5)
                     {
                         // Ensure that minerA's tip has rewound to 5.
                         TestHelper.WaitLoop(() => TestHelper.IsNodeSyncedAtHeight(minerA, 5));
                         TestHelper.Disconnect(minerA, syncer);
-                        return true;
-                    }
+                        minerADisconnectedFromSyncer = true;
 
-                    return false;
+                        return;
+                    }
                 }
 
-                minerA.SetDisconnectInterceptorOnce(interceptor);
+                minerA.SetDisconnectInterceptor(interceptor);
 
                 // Start the nodes.
                 minerA.Start();
@@ -63,7 +69,7 @@ namespace Stratis.Bitcoin.IntegrationTests
                 // Block 6,7,9,10 = valid
                 // Block 8 = invalid
                 Assert.False(TestHelper.IsNodeConnected(minerB));
-                TestHelper.BuildBlocks.OnNode(minerB).Amount(5).Invalid(8, (node, block) => BlockBuilder.InvalidCoinbaseReward(node, block)).BuildAsync();
+                await TestHelper.BuildBlocks.OnNode(minerB).Amount(5).Invalid(8, (node, block) => BlockBuilder.InvalidCoinbaseReward(node, block)).BuildAsync();
 
                 // Reconnect minerA to minerB.
                 TestHelper.Connect(minerA, minerB);
@@ -96,21 +102,26 @@ namespace Stratis.Bitcoin.IntegrationTests
                 var minerB = builder.CreateStratisPowNode(network).WithDummyWallet();
                 var syncer = builder.CreateStratisPowNode(network).WithDummyWallet();
 
+                bool minerADisconnectedFromMinerB = false;
+
                 // Configure the interceptor to disconnect a node after a certain block has been disconnected (rewound).
-                bool interceptor(ChainedHeaderBlock chainedHeaderBlock)
+                void interceptor(ChainedHeaderBlock chainedHeaderBlock)
                 {
+                    if (minerADisconnectedFromMinerB)
+                        return;
+
                     if (chainedHeaderBlock.ChainedHeader.Previous.Height == 5)
                     {
                         // Ensure that minerA's tips has rewound to 5.
                         TestHelper.WaitLoop(() => TestHelper.IsNodeSyncedAtHeight(minerA, 5));
                         TestHelper.Disconnect(minerA, minerB);
-                        return true;
-                    }
+                        minerADisconnectedFromMinerB = true;
 
-                    return false;
+                        return;
+                    }
                 }
 
-                minerA.SetDisconnectInterceptorOnce(interceptor);
+                minerA.SetDisconnectInterceptor(interceptor);
 
                 // Start the nodes.
                 minerA.Start();

--- a/src/Stratis.Bitcoin.IntegrationTests/ConsensusManagerInterceptorTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/ConsensusManagerInterceptorTests.cs
@@ -37,7 +37,7 @@ namespace Stratis.Bitcoin.IntegrationTests
                     return false;
                 }
 
-                minerA.ExecuteDisconnectInterceptorOnce(interceptor);
+                minerA.SetDisconnectInterceptorOnce(interceptor);
 
                 // Start the nodes.
                 minerA.Start();
@@ -110,7 +110,7 @@ namespace Stratis.Bitcoin.IntegrationTests
                     return false;
                 }
 
-                minerA.ExecuteDisconnectInterceptorOnce(interceptor);
+                minerA.SetDisconnectInterceptorOnce(interceptor);
 
                 // Start the nodes.
                 minerA.Start();

--- a/src/Stratis.Bitcoin.IntegrationTests/Program.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/Program.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using Stratis.Bitcoin.IntegrationTests.Miners;
 using Stratis.Bitcoin.IntegrationTests.Wallet;
 using Xunit;
 


### PR DESCRIPTION
@dangershony noticed that some of the reconnect chain integration tests runs too quickly for the test too properly assert whether or the `Reconnect` chain methods in `ConsensusManager` was in fact called. This was purely due to the whole reconnect logic not being properly waited on to complete, thus the test completes whilst the node is still doing its thing.

I've extended the interceptors on those tests to be more robust and accurate. Now we can with precision "stop" the node at any point during the block connect and disconnect process and perform custom logic.