### PR TITLE
[Wallet] Remove transactions from date

### DIFF
--- a/src/Stratis.Bitcoin.Features.Wallet/Controllers/WalletController.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Controllers/WalletController.cs
@@ -1059,15 +1059,18 @@ namespace Stratis.Bitcoin.Features.Wallet.Controllers
                 {
                     result = this.walletManager.RemoveAllTransactions(request.WalletName);
                 }
-                else
+                else if (request.FromDate != default(DateTime))
                 {
-                    if (request.TransactionsIds == null || request.TransactionsIds.Any(trx => trx == null))
-                    {
-                        throw new WalletException("Transaction ids need to be specified if the 'all' flag is not set.");
-                    }
-
+                    result = this.walletManager.RemoveTransactionsFromDate(request.WalletName, request.FromDate);
+                }
+                else if(request.TransactionsIds != null)
+                {
                     IEnumerable<uint256> ids = request.TransactionsIds.Select(uint256.Parse);
                     result = this.walletManager.RemoveTransactionsByIdsLocked(request.WalletName, ids);
+                }
+                else
+                {
+                    throw new WalletException("A filter specifying what transactions to remove must be set.");
                 }
 
                 // If the user chose to resync the wallet after removing transactions.

--- a/src/Stratis.Bitcoin.Features.Wallet/Interfaces/IWalletManager.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Interfaces/IWalletManager.cs
@@ -315,5 +315,13 @@ namespace Stratis.Bitcoin.Features.Wallet.Interfaces
         /// <param name="walletName">The name of the wallet to remove transactions from.</param>
         /// <returns>A list of objects made up of a transactions ID along with the time at which they were created.</returns>
         HashSet<(uint256, DateTimeOffset)> RemoveAllTransactions(string walletName);
+
+        /// <summary>
+        /// Removes all the transactions that occurred after a certain date.
+        /// </summary>
+        /// <param name="walletName">The name of the wallet to remove transactions from.</param>
+        /// <param name="fromDate">The date after which the transactions should be removed.</param>
+        /// <returns>A list of objects made up of a transactions ID along with the time at which they were created.</returns>
+        HashSet<(uint256, DateTimeOffset)> RemoveTransactionsFromDate(string walletName, DateTimeOffset fromDate);
     }
 }

--- a/src/Stratis.Bitcoin.Features.Wallet/Models/RequestModels.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Models/RequestModels.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using System.Linq;
 using Microsoft.AspNetCore.Mvc;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
@@ -268,7 +269,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Models
     /// Model object to use as input to the Api request for removing transactions from a wallet.
     /// </summary>
     /// <seealso cref="RequestModel" />
-    public class RemoveTransactionsModel : RequestModel
+    public class RemoveTransactionsModel : RequestModel, IValidatableObject
     {
         [Required(ErrorMessage = "The name of the wallet is required.")]
         public string WalletName { get; set; }
@@ -276,11 +277,45 @@ namespace Stratis.Bitcoin.Features.Wallet.Models
         [FromQuery(Name = "ids")]
         public IEnumerable<string> TransactionsIds { get; set; }
 
+        [JsonConverter(typeof(IsoDateTimeConverter))]
+        [FromQuery(Name = "fromDate")]
+        public DateTime FromDate { get; set; }
+
         [FromQuery(Name = "all")]
         public bool DeleteAll { get; set; }
 
         [JsonProperty(PropertyName = "reSync")]
         public bool ReSync { get; set; }
+
+        /// <inheritdoc />
+        public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+        {
+            // Check that one of the filters is set.
+            if (!this.DeleteAll && (this.TransactionsIds == null || !this.TransactionsIds.Any()) && this.FromDate == default(DateTime))
+            {
+                yield return new ValidationResult(
+                    $"One of the query parameters '{nameof(this.DeleteAll)}', '{nameof(this.TransactionsIds)}' or '{nameof(this.FromDate)}' must be set.",
+                    new[] { $"{nameof(this.DeleteAll)}" });
+            }
+
+            // Check that only one of the filters is set.
+            if ((this.DeleteAll && this.TransactionsIds != null) 
+                || (this.DeleteAll && this.FromDate != default(DateTime))
+                || (this.TransactionsIds != null && this.FromDate != default(DateTime)))
+            {
+                yield return new ValidationResult(
+                    $"Only one out of the query parameters '{nameof(this.DeleteAll)}', '{nameof(this.TransactionsIds)}' or '{nameof(this.FromDate)}' can be set.",
+                    new[] { $"{nameof(this.DeleteAll)}" });
+            }
+
+            // Check that transaction ids doesn't contain empty elements.
+            if (this.TransactionsIds != null && this.TransactionsIds.Any(trx => trx == null))
+            {
+                yield return new ValidationResult(
+                    $"'{nameof(this.TransactionsIds)}' must not contain any null ids.",
+                    new[] { $"{nameof(this.TransactionsIds)}" });
+            }
+        }
     }
 
     public class ListAccountsModel : RequestModel

--- a/src/Stratis.Bitcoin.IntegrationTests/Wallet/WalletPostOperationsTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/Wallet/WalletPostOperationsTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net;
+using System.Net.Http;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Flurl;
@@ -269,7 +270,7 @@ namespace Stratis.Bitcoin.IntegrationTests.Wallet
         }
 
         [Fact]
-        public async Task RemoveTransactionsWithoutIdsOrAllFlagFromWallet()
+        public async Task RemoveTransactionsFromWalletWithoutFilters()
         {
             using (NodeBuilder builder = NodeBuilder.Create(this))
             {
@@ -303,10 +304,85 @@ namespace Stratis.Bitcoin.IntegrationTests.Wallet
 
                 response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
                 errors.Should().ContainSingle();
-                errors.First().Message.Should().Be("Transaction ids need to be specified if the 'all' flag is not set.");
+                errors.First().Message.Should().Be($"One of the query parameters '{nameof(RemoveTransactionsModel.DeleteAll)}', '{nameof(RemoveTransactionsModel.TransactionsIds)}' or '{nameof(RemoveTransactionsModel.FromDate)}' must be set.");
             }
         }
 
+        [Fact]
+        public async Task RemoveTransactionsFromWalletCalledWithMoreThanOneFilter()
+        {
+            using (NodeBuilder builder = NodeBuilder.Create(this))
+            {
+                // Arrange.
+                CoreNode node = builder.CreateStratisPosNode(this.network).Start();
+
+                this.AddAndLoadWalletFileToWalletFolder(node);
+
+                // Make sure the account is used, i.e, it has transactions.
+                WalletHistoryModel history = await $"http://localhost:{node.ApiPort}/api"
+                .AppendPathSegment("wallet/history")
+                .SetQueryParams(new { walletName = this.walletWithFundsName, accountName = "account 0" })
+                .GetJsonAsync<WalletHistoryModel>();
+
+                history.AccountsHistoryModel.Should().NotBeEmpty();
+                history.AccountsHistoryModel.First().TransactionsHistory.Should().NotBeEmpty();
+
+                // Act.
+                Func<Task> act1 = async () => await $"http://localhost:{node.ApiPort}/api"
+                    .AppendPathSegment("wallet/remove-transactions")
+                    .SetQueryParams(new { walletName = this.walletWithFundsName, all = true, ids = new[] { "3ccdfdce538eabe4d18efd2ee8fdc2554dc95cae6ce082aa4b5c7b9074b2e0a3" } })
+                    .DeleteAsync()
+                    .ReceiveJson<HashSet<(uint256 transactionId, DateTimeOffset creationTime)>>();
+
+                Func<Task> act2 = async () => await $"http://localhost:{node.ApiPort}/api"
+                    .AppendPathSegment("wallet/remove-transactions")
+                    .SetQueryParams(new { walletName = this.walletWithFundsName, fromDate = "06/06/2018", ids = new[] { "3ccdfdce538eabe4d18efd2ee8fdc2554dc95cae6ce082aa4b5c7b9074b2e0a3" } })
+                    .DeleteAsync()
+                    .ReceiveJson<HashSet<(uint256 transactionId, DateTimeOffset creationTime)>>();
+
+                Func<Task> act3 = async () => await $"http://localhost:{node.ApiPort}/api"
+                    .AppendPathSegment("wallet/remove-transactions")
+                    .SetQueryParams(new { walletName = this.walletWithFundsName, fromDate = "06/06/2018", all = true })
+                    .DeleteAsync()
+                    .ReceiveJson<HashSet<(uint256 transactionId, DateTimeOffset creationTime)>>();
+
+                Func<Task> act4 = async () => await $"http://localhost:{node.ApiPort}/api"
+                    .AppendPathSegment("wallet/remove-transactions")
+                    .SetQueryParams(new { walletName = this.walletWithFundsName, fromDate = "06/06/2018", all = true, ids = new[] { "3ccdfdce538eabe4d18efd2ee8fdc2554dc95cae6ce082aa4b5c7b9074b2e0a3" } })
+                    .DeleteAsync()
+                    .ReceiveJson<HashSet<(uint256 transactionId, DateTimeOffset creationTime)>>();
+
+                // Assert.
+                FlurlHttpException exception1 = act1.Should().Throw<FlurlHttpException>().Which;
+                HttpResponseMessage response1 = exception1.Call.Response;
+
+                FlurlHttpException exception2 = act2.Should().Throw<FlurlHttpException>().Which;
+                HttpResponseMessage response2 = exception2.Call.Response;
+
+                FlurlHttpException exception3 = act3.Should().Throw<FlurlHttpException>().Which;
+                HttpResponseMessage response3 = exception3.Call.Response;
+
+                FlurlHttpException exception4 = act4.Should().Throw<FlurlHttpException>().Which;
+                HttpResponseMessage response4 = exception4.Call.Response;
+
+                ErrorResponse errorResponse1 = JsonConvert.DeserializeObject<ErrorResponse>(await response1.Content.ReadAsStringAsync());
+                ErrorResponse errorResponse2 = JsonConvert.DeserializeObject<ErrorResponse>(await response2.Content.ReadAsStringAsync());
+                ErrorResponse errorResponse3 = JsonConvert.DeserializeObject<ErrorResponse>(await response3.Content.ReadAsStringAsync());
+                ErrorResponse errorResponse4 = JsonConvert.DeserializeObject<ErrorResponse>(await response4.Content.ReadAsStringAsync());
+
+                response1.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+                response1.StatusCode.Should().Be(response2.StatusCode);
+                response2.StatusCode.Should().Be(response3.StatusCode);
+                response3.StatusCode.Should().Be(response4.StatusCode);
+
+                List<ErrorModel> errors = errorResponse1.Errors;
+                errors.Should().ContainSingle();
+                errors.First().Message.Should().Be($"Only one out of the query parameters '{nameof(RemoveTransactionsModel.DeleteAll)}', '{nameof(RemoveTransactionsModel.TransactionsIds)}' or '{nameof(RemoveTransactionsModel.FromDate)}' can be set.");
+                errorResponse1.Should().BeEquivalentTo(errorResponse2);
+                errorResponse2.Should().BeEquivalentTo(errorResponse3);
+                errorResponse3.Should().BeEquivalentTo(errorResponse4);
+            }
+        }
 
         [Fact]
         public async Task GetSpendableTransactionsInAccountAllowUnconfirmed()


### PR DESCRIPTION
When the wallet gets out of sync, we already had the ability to completely clean it from transactions and resync. But for big wallets, this may mean resyncing 18 months of transactions.
In this PR we have the ability to specify a date after which back to which we want the wallet to "roll-back".
This useful will need some UI in StratisCore but an API endpoint is exposed.