### PR TITLE
PoA_DynamicFederationMembers_2

### DIFF
--- a/src/Stratis.Bitcoin.Features.PoA.Tests/Rules/PoARulesTestsBase.cs
+++ b/src/Stratis.Bitcoin.Features.PoA.Tests/Rules/PoARulesTestsBase.cs
@@ -5,6 +5,7 @@ using System.Text;
 using Microsoft.Extensions.Logging;
 using Moq;
 using NBitcoin;
+using NBitcoin.Protocol;
 using Stratis.Bitcoin.Base;
 using Stratis.Bitcoin.Base.Deployments;
 using Stratis.Bitcoin.Configuration;
@@ -29,6 +30,7 @@ namespace Stratis.Bitcoin.Features.PoA.Tests.Rules
         protected readonly SlotsManager slotsManager;
         protected readonly ConsensusSettings consensusSettings;
         protected readonly ConcurrentChain chain;
+        protected readonly FederationManager federationManager;
 
         public PoARulesTestsBase(PoANetwork network = null)
         {
@@ -43,7 +45,11 @@ namespace Stratis.Bitcoin.Features.PoA.Tests.Rules
             string dir = TestBase.CreateTestDir(this);
             var keyValueRepo = new KeyValueRepository(dir, new DBreezeSerializer(this.network));
 
-            this.slotsManager = new SlotsManager(this.network, new FederationManager(NodeSettings.Default(this.network), this.network, this.loggerFactory, keyValueRepo), this.loggerFactory);
+            var settings = new NodeSettings(this.network, args: new string[] { $"-datadir={dir}"});
+            this.federationManager = new FederationManager(settings, this.network, this.loggerFactory, keyValueRepo);
+            this.federationManager.Initialize();
+
+            this.slotsManager = new SlotsManager(this.network, this.federationManager, this.loggerFactory);
 
             this.poaHeaderValidator = new PoABlockHeaderValidator(this.loggerFactory);
 

--- a/src/Stratis.Bitcoin.Features.PoA.Tests/Rules/PoARulesTestsBase.cs
+++ b/src/Stratis.Bitcoin.Features.PoA.Tests/Rules/PoARulesTestsBase.cs
@@ -40,7 +40,10 @@ namespace Stratis.Bitcoin.Features.PoA.Tests.Rules
             IDateTimeProvider timeProvider = new DateTimeProvider();
             this.consensusSettings = new ConsensusSettings(NodeSettings.Default(this.network));
 
-            this.slotsManager = new SlotsManager(this.network, new FederationManager(NodeSettings.Default(this.network), this.network, this.loggerFactory), this.loggerFactory);
+            string dir = TestBase.CreateTestDir(this);
+            var keyValueRepo = new KeyValueRepository(dir, new DBreezeSerializer(this.network));
+
+            this.slotsManager = new SlotsManager(this.network, new FederationManager(NodeSettings.Default(this.network), this.network, this.loggerFactory, keyValueRepo), this.loggerFactory);
 
             this.poaHeaderValidator = new PoABlockHeaderValidator(this.loggerFactory);
 

--- a/src/Stratis.Bitcoin.Features.PoA.Tests/SlotsManagerTests.cs
+++ b/src/Stratis.Bitcoin.Features.PoA.Tests/SlotsManagerTests.cs
@@ -14,14 +14,15 @@ namespace Stratis.Bitcoin.Features.PoA.Tests
         private SlotsManager slotsManager;
         private PoANetwork network;
         private PoAConsensusOptions consensusOptions;
+        private FederationManager federationManager;
 
         public SlotsManagerTests()
         {
             this.network = new TestPoANetwork();
             this.consensusOptions = this.network.ConsensusOptions;
 
-            var fedManager = new FederationManager(NodeSettings.Default(this.network), this.network, new LoggerFactory());
-            this.slotsManager = new SlotsManager(this.network, fedManager, new LoggerFactory());
+            this.federationManager = new FederationManager(NodeSettings.Default(this.network), this.network, new LoggerFactory());
+            this.slotsManager = new SlotsManager(this.network, this.federationManager, new LoggerFactory());
         }
 
         [Fact]
@@ -38,7 +39,7 @@ namespace Stratis.Bitcoin.Features.PoA.Tests
         [Fact]
         public void ValidSlotAssigned()
         {
-            List<PubKey> fedKeys = this.network.ConsensusOptions.FederationPublicKeys;
+            List<PubKey> fedKeys = this.federationManager.GetFederationMembers();
             uint roundStart = this.consensusOptions.TargetSpacingSeconds * (uint)fedKeys.Count * 5;
 
             Assert.Equal(fedKeys[0], this.slotsManager.GetPubKeyForTimestamp(roundStart));
@@ -61,7 +62,7 @@ namespace Stratis.Bitcoin.Features.PoA.Tests
             var fedManager = new FederationManager(NodeSettings.Default(this.network), this.network, new LoggerFactory());
             this.slotsManager = new SlotsManager(this.network, fedManager, new LoggerFactory());
 
-            List<PubKey> fedKeys = this.consensusOptions.FederationPublicKeys;
+            List<PubKey> fedKeys = this.federationManager.GetFederationMembers();
             uint roundStart = this.consensusOptions.TargetSpacingSeconds * (uint)fedKeys.Count * 5;
 
             fedManager.SetPrivatePropertyValue(nameof(FederationManager.IsFederationMember), true);

--- a/src/Stratis.Bitcoin.Features.PoA.Tests/SlotsManagerTests.cs
+++ b/src/Stratis.Bitcoin.Features.PoA.Tests/SlotsManagerTests.cs
@@ -26,7 +26,10 @@ namespace Stratis.Bitcoin.Features.PoA.Tests
             string dir = TestBase.CreateTestDir(this);
             this.keyValueRepository = new KeyValueRepository(dir, new DBreezeSerializer(this.network));
 
-            this.federationManager = new FederationManager(NodeSettings.Default(this.network), this.network, new LoggerFactory(), this.keyValueRepository);
+            var settings = new NodeSettings(this.network, args: new string[] { $"-datadir={dir}" });
+
+            this.federationManager = new FederationManager(settings, this.network, new LoggerFactory(), this.keyValueRepository);
+            this.federationManager.Initialize();
             this.slotsManager = new SlotsManager(this.network, this.federationManager, new LoggerFactory());
         }
 
@@ -64,7 +67,12 @@ namespace Stratis.Bitcoin.Features.PoA.Tests
             Key key = tool.GeneratePrivateKey();
             this.network = new TestPoANetwork(new List<PubKey>() { tool.GeneratePrivateKey().PubKey, key.PubKey, tool.GeneratePrivateKey().PubKey});
 
-            var fedManager = new FederationManager(NodeSettings.Default(this.network), this.network, new LoggerFactory(), this.keyValueRepository);
+            string dir = TestBase.CreateTestDir(this);
+            this.keyValueRepository = new KeyValueRepository(dir, new DBreezeSerializer(this.network));
+            var settings = new NodeSettings(this.network, args: new string[] { $"-datadir={dir}" });
+
+            var fedManager = new FederationManager(settings, this.network, new LoggerFactory(), this.keyValueRepository);
+            fedManager.Initialize();
             this.slotsManager = new SlotsManager(this.network, fedManager, new LoggerFactory());
 
             List<PubKey> fedKeys = this.federationManager.GetFederationMembers();

--- a/src/Stratis.Bitcoin.Features.PoA.Tests/SlotsManagerTests.cs
+++ b/src/Stratis.Bitcoin.Features.PoA.Tests/SlotsManagerTests.cs
@@ -5,6 +5,7 @@ using NBitcoin;
 using Stratis.Bitcoin.Configuration;
 using Stratis.Bitcoin.Features.PoA.Tests.Rules;
 using Stratis.Bitcoin.Tests.Common;
+using Stratis.Bitcoin.Utilities;
 using Xunit;
 
 namespace Stratis.Bitcoin.Features.PoA.Tests
@@ -15,13 +16,17 @@ namespace Stratis.Bitcoin.Features.PoA.Tests
         private PoANetwork network;
         private PoAConsensusOptions consensusOptions;
         private FederationManager federationManager;
+        private KeyValueRepository keyValueRepository;
 
         public SlotsManagerTests()
         {
             this.network = new TestPoANetwork();
             this.consensusOptions = this.network.ConsensusOptions;
 
-            this.federationManager = new FederationManager(NodeSettings.Default(this.network), this.network, new LoggerFactory());
+            string dir = TestBase.CreateTestDir(this);
+            this.keyValueRepository = new KeyValueRepository(dir, new DBreezeSerializer(this.network));
+
+            this.federationManager = new FederationManager(NodeSettings.Default(this.network), this.network, new LoggerFactory(), this.keyValueRepository);
             this.slotsManager = new SlotsManager(this.network, this.federationManager, new LoggerFactory());
         }
 
@@ -59,7 +64,7 @@ namespace Stratis.Bitcoin.Features.PoA.Tests
             Key key = tool.GeneratePrivateKey();
             this.network = new TestPoANetwork(new List<PubKey>() { tool.GeneratePrivateKey().PubKey, key.PubKey, tool.GeneratePrivateKey().PubKey});
 
-            var fedManager = new FederationManager(NodeSettings.Default(this.network), this.network, new LoggerFactory());
+            var fedManager = new FederationManager(NodeSettings.Default(this.network), this.network, new LoggerFactory(), this.keyValueRepository);
             this.slotsManager = new SlotsManager(this.network, fedManager, new LoggerFactory());
 
             List<PubKey> fedKeys = this.federationManager.GetFederationMembers();

--- a/src/Stratis.Bitcoin.Features.PoA.Tests/VotingDataEncoderTests.cs
+++ b/src/Stratis.Bitcoin.Features.PoA.Tests/VotingDataEncoderTests.cs
@@ -84,6 +84,28 @@ namespace Stratis.Bitcoin.Features.PoA.Tests
         }
 
         [Fact]
+        public void CanEncodeAndDecodeLargeAmountsOfData()
+        {
+            var dataList = new List<VotingData>();
+
+            for (int i = 0; i < 2000; i++)
+            {
+                dataList.Add(new VotingData()
+                {
+                    Key = VoteKey.AddFederationMember,
+                    Data = RandomUtils.GetBytes(25)
+                });
+            }
+
+            byte[] encodedBytes = this.encoder.Encode(dataList);
+
+            List<VotingData> decoded = this.encoder.Decode(encodedBytes);
+
+            byte[] encodedBytes2 = this.encoder.Encode(decoded);
+            Assert.True(encodedBytes.SequenceEqual(encodedBytes2));
+        }
+
+        [Fact]
         public void DecodeRandomData()
         {
             Assert.Throws<ConsensusErrorException>(() => this.encoder.Decode(new byte[] { 123, 55, 77, 14, 98, 12, 56, 0, 12 }));

--- a/src/Stratis.Bitcoin.Features.PoA/FederationManager.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/FederationManager.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Security.Cryptography.X509Certificates;
 using Microsoft.Extensions.Logging;
 using NBitcoin;
 using Stratis.Bitcoin.Configuration;
@@ -30,9 +32,12 @@ namespace Stratis.Bitcoin.Features.PoA
 
         public void Initialize()
         {
+            // Load federation from the db.
+            // TODO
+
             // Display federation.
             this.logger.LogInformation("Federation contains {0} members. Their public keys are: {1}",
-                this.network.ConsensusOptions.FederationPublicKeys.Count, Environment.NewLine + string.Join(Environment.NewLine, this.network.ConsensusOptions.FederationPublicKeys));
+                this.network.ConsensusOptions.GenesisFederationPublicKeys.Count, Environment.NewLine + string.Join(Environment.NewLine, this.network.ConsensusOptions.GenesisFederationPublicKeys));
 
             // Load key.
             Key key = new KeyTool(this.settings.DataFolder).LoadPrivateKey();
@@ -47,7 +52,7 @@ namespace Stratis.Bitcoin.Features.PoA
             }
 
             // Loaded key has to be a key for current federation.
-            if (!this.network.ConsensusOptions.FederationPublicKeys.Contains(this.FederationMemberKey.PubKey))
+            if (!this.network.ConsensusOptions.GenesisFederationPublicKeys.Contains(this.FederationMemberKey.PubKey))
             {
                 string message = "Key provided is not registered on the network!";
 
@@ -56,6 +61,17 @@ namespace Stratis.Bitcoin.Features.PoA
             }
 
             this.logger.LogInformation("Federation key pair was successfully loaded. Your public key is: {0}.", this.FederationMemberKey.PubKey);
+        }
+
+        /// <summary>Provides up to date list of federation members.</summary>
+        /// <remarks>
+        /// Blocks that are not signed with private keys that correspond
+        /// to public keys from this list are considered to be invalid.
+        /// </remarks>
+        public List<PubKey> GetFederationMembers()
+        {
+            // TODO replace with actual list
+            return this.network.ConsensusOptions.GenesisFederationPublicKeys;
         }
     }
 }

--- a/src/Stratis.Bitcoin.Features.PoA/FederationManager.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/FederationManager.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Security.Cryptography.X509Certificates;
 using Microsoft.Extensions.Logging;
 using NBitcoin;
 using Stratis.Bitcoin.Configuration;

--- a/src/Stratis.Bitcoin.Features.PoA/FederationManager.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/FederationManager.cs
@@ -59,7 +59,7 @@ namespace Stratis.Bitcoin.Features.PoA
 
             // Display federation.
             this.logger.LogInformation("Federation contains {0} members. Their public keys are: {1}",
-                this.network.ConsensusOptions.GenesisFederationPublicKeys.Count, Environment.NewLine + string.Join(Environment.NewLine, this.network.ConsensusOptions.GenesisFederationPublicKeys));
+                this.federationMembers.Count, Environment.NewLine + string.Join(Environment.NewLine, this.federationMembers));
 
             // Load key.
             Key key = new KeyTool(this.settings.DataFolder).LoadPrivateKey();
@@ -74,7 +74,7 @@ namespace Stratis.Bitcoin.Features.PoA
             }
 
             // Loaded key has to be a key for current federation.
-            if (!this.network.ConsensusOptions.GenesisFederationPublicKeys.Contains(this.FederationMemberKey.PubKey))
+            if (!this.federationMembers.Contains(this.FederationMemberKey.PubKey))
             {
                 string message = "Key provided is not registered on the network!";
 

--- a/src/Stratis.Bitcoin.Features.PoA/FederationManager.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/FederationManager.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using Microsoft.Extensions.Logging;
 using NBitcoin;
@@ -38,6 +37,11 @@ namespace Stratis.Bitcoin.Features.PoA
 
             this.logger = loggerFactory.CreateLogger(this.GetType().FullName);
         }
+
+        // TODO
+        /*
+         * Subscribe to VotingManager and track when new member is added or deleted. Update keys and then persist.
+         */
 
         public void Initialize()
         {

--- a/src/Stratis.Bitcoin.Features.PoA/FederationManager.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/FederationManager.cs
@@ -82,7 +82,7 @@ namespace Stratis.Bitcoin.Features.PoA
                 throw new Exception(message);
             }
 
-            this.logger.LogInformation("Federation key pair was successfully loaded. Your public key is: {0}.", this.FederationMemberKey.PubKey);
+            this.logger.LogInformation("Federation key pair was successfully loaded. Your public key is: '{0}'.", this.FederationMemberKey.PubKey);
         }
 
         /// <summary>Provides up to date list of federation members.</summary>
@@ -106,10 +106,7 @@ namespace Stratis.Bitcoin.Features.PoA
         {
             List<string> hexList = this.keyValueRepo.LoadValueJson<List<string>>(federationMembersDbKey);
 
-            if (hexList == null)
-                return null;
-
-            return hexList.Select(x => new PubKey(x)).ToList();
+            return hexList?.Select(x => new PubKey(x)).ToList();
         }
     }
 }

--- a/src/Stratis.Bitcoin.Features.PoA/FederationManager.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/FederationManager.cs
@@ -30,35 +30,32 @@ namespace Stratis.Bitcoin.Features.PoA
 
         public void Initialize()
         {
-            this.LoadKey();
-
-            if (this.FederationMemberKey != null)
-            {
-                // Loaded key has to be a key for current federation.
-                if (!this.network.ConsensusOptions.FederationPublicKeys.Contains(this.FederationMemberKey.PubKey))
-                {
-                    string message = "Key provided is not registered on the network!";
-
-                    this.logger.LogCritical(message);
-                    throw new Exception(message);
-                }
-
-                this.logger.LogInformation("Federation key pair was successfully loaded. Your public key is: {0}.", this.FederationMemberKey.PubKey);
-            }
-
+            // Display federation.
             this.logger.LogInformation("Federation contains {0} members. Their public keys are: {1}",
                 this.network.ConsensusOptions.FederationPublicKeys.Count, Environment.NewLine + string.Join(Environment.NewLine, this.network.ConsensusOptions.FederationPublicKeys));
-        }
 
-        /// <summary>Loads federation key if it exists.</summary>
-        private void LoadKey()
-        {
-            var keyTool = new KeyTool(this.settings.DataFolder);
-
-            Key key = keyTool.LoadPrivateKey();
+            // Load key.
+            Key key = new KeyTool(this.settings.DataFolder).LoadPrivateKey();
 
             this.IsFederationMember = key != null;
             this.FederationMemberKey = key;
+
+            if (this.FederationMemberKey == null)
+            {
+                this.logger.LogTrace("(-)[NOT_FED_MEMBER]");
+                return;
+            }
+
+            // Loaded key has to be a key for current federation.
+            if (!this.network.ConsensusOptions.FederationPublicKeys.Contains(this.FederationMemberKey.PubKey))
+            {
+                string message = "Key provided is not registered on the network!";
+
+                this.logger.LogCritical(message);
+                throw new Exception(message);
+            }
+
+            this.logger.LogInformation("Federation key pair was successfully loaded. Your public key is: {0}.", this.FederationMemberKey.PubKey);
         }
     }
 }

--- a/src/Stratis.Bitcoin.Features.PoA/KeyTool.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/KeyTool.cs
@@ -41,14 +41,18 @@ namespace Stratis.Bitcoin.Features.PoA
         /// <summary>Saves private key to default path.</summary>
         public void SavePrivateKey(Key privateKey)
         {
-            var ms = new MemoryStream();
-            var stream = new BitcoinStream(ms, true);
-            stream.ReadWrite(ref privateKey);
+            using (var ms = new MemoryStream())
+            {
+                var stream = new BitcoinStream(ms, true);
+                stream.ReadWrite(ref privateKey);
 
-            ms.Seek(0, SeekOrigin.Begin);
-            FileStream fileStream = File.Create(this.GetPrivateKeySavePath());
-            ms.CopyTo(fileStream);
-            fileStream.Close();
+                ms.Seek(0, SeekOrigin.Begin);
+
+                using (FileStream fileStream = File.Create(this.GetPrivateKeySavePath()))
+                {
+                    ms.CopyTo(fileStream);
+                }
+            }
         }
 
         /// <summary>Loads the private key from default path.</summary>
@@ -59,14 +63,14 @@ namespace Stratis.Bitcoin.Features.PoA
             if (!File.Exists(path))
                 return null;
 
-            FileStream readStream = File.OpenRead(path);
+            using (FileStream readStream = File.OpenRead(path))
+            {
+                var privateKey = new Key();
+                var stream = new BitcoinStream(readStream, false);
+                stream.ReadWrite(ref privateKey);
 
-            var privateKey = new Key();
-            var stream = new BitcoinStream(readStream, false);
-            stream.ReadWrite(ref privateKey);
-            readStream.Close();
-
-            return privateKey;
+                return privateKey;
+            }
         }
     }
 }

--- a/src/Stratis.Bitcoin.Features.PoA/PoAConsensusOptions.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/PoAConsensusOptions.cs
@@ -5,12 +5,14 @@ namespace Stratis.Bitcoin.Features.PoA
 {
     public class PoAConsensusOptions : ConsensusOptions
     {
-        /// <summary>Public keys of all federation members.</summary>
+        /// <summary>Public keys of all federation members at the start of the chain.</summary>
         /// <remarks>
-        /// Blocks that are not signed with private keys that correspond
-        /// to public keys from this list are considered to be invalid.
+        /// Do not use this list anywhere except for at the initialization of the chain.
+        /// Actual collection of the federation members can be changed with time.
+        /// Use <see cref="FederationManager.GetFederationMembers"/> as a source of
+        /// up to date federation keys.
         /// </remarks>
-        public List<PubKey> FederationPublicKeys { get; protected set; }
+        public List<PubKey> GenesisFederationPublicKeys { get; protected set; }
 
         public uint TargetSpacingSeconds { get; protected set; }
 
@@ -25,7 +27,7 @@ namespace Stratis.Bitcoin.Features.PoA
             uint targetSpacingSeconds)
                 : base(maxBlockBaseSize, maxStandardVersion, maxStandardTxWeight, maxBlockSigopsCost, maxStandardTxSigopsCost)
         {
-            this.FederationPublicKeys = federationPublicKeys;
+            this.GenesisFederationPublicKeys = federationPublicKeys;
             this.TargetSpacingSeconds = targetSpacingSeconds;
         }
     }

--- a/src/Stratis.Bitcoin.Features.PoA/PoANetwork.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/PoANetwork.cs
@@ -166,9 +166,9 @@ namespace Stratis.Bitcoin.Features.PoA
             Assert(this.Consensus.HashGenesisBlock == uint256.Parse("0x0621b88fb7a99c985d695be42e606cb913259bace2babe92970547fa033e4076"));
             Assert(this.Genesis.Header.HashMerkleRoot == uint256.Parse("0x9928b372fd9e4cf62a31638607344c03c48731ba06d24576342db9c8591e1432"));
 
-            if ((this.ConsensusOptions.FederationPublicKeys == null) || (this.ConsensusOptions.FederationPublicKeys.Count == 0))
+            if ((this.ConsensusOptions.GenesisFederationPublicKeys == null) || (this.ConsensusOptions.GenesisFederationPublicKeys.Count == 0))
             {
-                throw new Exception("No keys for federation members are configured!");
+                throw new Exception("No keys for initial federation are configured!");
             }
         }
 

--- a/src/Stratis.Bitcoin.Features.PoA/PoANetwork.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/PoANetwork.cs
@@ -71,9 +71,9 @@ namespace Stratis.Bitcoin.Features.PoA
             // and should be the same for all nodes operating on this network.
             var federationPublicKeys = new List<PubKey>()
             {
-                new PubKey("03e6f19ea3dc6c145d98a0e0838af952755798e5bc3950bbca4f9485aa23873d7f"),
-                new PubKey("02ddebcf18207072bdd172a25f85f2ea12e2de1d9d794f136722634aad08400fcb"),
-                new PubKey("02067b38d777690aaaf23a5b371a819e6ddc6d2aae734b0199fe59df28dc056dd7")
+                new PubKey("03025fcadedd28b12665de0542c8096f4cd5af8e01791a4d057f67e2866ca66ba7"),
+                new PubKey("027724a9ecc54417ff0250c3355d300cee008747b630f43e791cd02c2b35294d2f"),
+                new PubKey("022f8ad1799fd281fc9519814d20a407ed120ba84ec24cca8e869b811e6f6d4590")
             };
 
             var consensusOptions = new PoAConsensusOptions(

--- a/src/Stratis.Bitcoin.FullNode.sln
+++ b/src/Stratis.Bitcoin.FullNode.sln
@@ -150,9 +150,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Stratis.Bitcoin.Features.Po
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Stratis.SmartContracts.RuntimeObserver", "Stratis.SmartContracts.RuntimeObserver\Stratis.SmartContracts.RuntimeObserver.csproj", "{8FEFF18B-3546-4237-8FD1-9F184BC7B4C7}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Stratis.SmartContracts.CLR.Tests", "Stratis.SmartContracts.CLR.Tests\Stratis.SmartContracts.CLR.Tests.csproj", "{E98CB412-9684-4061-8E76-B6CD12A3C32A}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Stratis.SmartContracts.CLR.Tests", "Stratis.SmartContracts.CLR.Tests\Stratis.SmartContracts.CLR.Tests.csproj", "{E98CB412-9684-4061-8E76-B6CD12A3C32A}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Stratis.SmartContracts.Core.Tests", "Stratis.SmartContracts.Core.Tests\Stratis.SmartContracts.Core.Tests.csproj", "{A1CF9560-A6A0-4270-9569-0D117AFA799C}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Stratis.SmartContracts.Core.Tests", "Stratis.SmartContracts.Core.Tests\Stratis.SmartContracts.Core.Tests.csproj", "{A1CF9560-A6A0-4270-9569-0D117AFA799C}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/Stratis.Bitcoin.Tests/Utilities/DBreezeTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Utilities/DBreezeTest.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using DBreeze;
@@ -203,6 +204,24 @@ namespace Stratis.Bitcoin.Tests.Utilities
 
                 return data;
             }
+        }
+
+        [Fact]
+        public void IsAbleToSerializeAndDeserializeCollections()
+        {
+            var data = new List<uint256>
+            {
+                new uint256(3),
+                new uint256(2),
+                new uint256(5),
+                new uint256(10),
+            };
+
+            byte[] bytes1 = this.dbreezeSerializer.Serialize(data);
+            byte[] bytes2 = this.dbreezeSerializer.Serialize(data.ToArray());
+            Assert.True(bytes1.SequenceEqual(bytes2));
+
+            this.dbreezeSerializer.Serialize(data.ToHashSet());
         }
     }
 }

--- a/src/Stratis.Bitcoin.Tests/Utilities/DBreezeTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Utilities/DBreezeTest.cs
@@ -207,7 +207,7 @@ namespace Stratis.Bitcoin.Tests.Utilities
         }
 
         [Fact]
-        public void IsAbleToSerializeAndDeserializeCollections()
+        public void IsAbleToSerializeCollections()
         {
             var data = new List<uint256>
             {

--- a/src/Stratis.Bitcoin/Utilities/DBreezeSerializer.cs
+++ b/src/Stratis.Bitcoin/Utilities/DBreezeSerializer.cs
@@ -41,9 +41,9 @@ namespace Stratis.Bitcoin.Utilities
 
             if (obj is IEnumerable<object> collection)
             {
-                object[] array = collection.ToArray();
+                object[] array = obj as object[] ?? collection.ToArray();
 
-                var serializedItems = new byte[array.Count()][];
+                var serializedItems = new byte[array.Length][];
                 int itemIndex = 0;
                 foreach (object arrayObject in array)
                 {

--- a/src/Stratis.Bitcoin/Utilities/DBreezeSerializer.cs
+++ b/src/Stratis.Bitcoin/Utilities/DBreezeSerializer.cs
@@ -41,7 +41,7 @@ namespace Stratis.Bitcoin.Utilities
 
             if (obj is IEnumerable<object> collection)
             {
-                var array = collection.ToArray();
+                object[] array = collection.ToArray();
 
                 var serializedItems = new byte[array.Count()][];
                 int itemIndex = 0;

--- a/src/Stratis.Bitcoin/Utilities/DBreezeSerializer.cs
+++ b/src/Stratis.Bitcoin/Utilities/DBreezeSerializer.cs
@@ -1,4 +1,7 @@
 ﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using DBreeze.Utils;
 using NBitcoin;
@@ -24,28 +27,25 @@ namespace Stratis.Bitcoin.Utilities
         /// <returns>Binary data representing the serialized object.</returns>
         public byte[] Serialize(object obj)
         {
-            var serializable = obj as IBitcoinSerializable;
-            if (serializable != null)
+            if (obj is IBitcoinSerializable serializable)
                 return serializable.ToBytes(this.Network.Consensus.ConsensusFactory);
 
-            var u256 = obj as uint256;
-            if (u256 != null)
+            if (obj is uint256 u256)
                 return u256.ToBytes();
 
-            var u160 = obj as uint160;
-            if (u160 != null)
+            if (obj is uint160 u160)
                 return u160.ToBytes();
 
-            var u32 = obj as uint?;
-            if (u32 != null)
+            if (obj is uint u32)
                 return u32.ToBytes();
 
-            var arr = obj as object[];
-            if (arr != null)
+            if (obj is IEnumerable<object> collection)
             {
-                var serializedItems = new byte[arr.Length][];
+                var array = collection.ToArray();
+
+                var serializedItems = new byte[array.Count()][];
                 int itemIndex = 0;
-                foreach (object arrayObject in arr)
+                foreach (object arrayObject in array)
                 {
                     byte[] serializedObject = this.Serialize(arrayObject);
                     serializedItems[itemIndex] = serializedObject;

--- a/src/Stratis.Bitcoin/Utilities/KeyValueRepository.cs
+++ b/src/Stratis.Bitcoin/Utilities/KeyValueRepository.cs
@@ -10,9 +10,13 @@ namespace Stratis.Bitcoin.Utilities
     /// <summary>Allows saving and loading single values to and from key-value storage.</summary>
     public interface IKeyValueRepository : IDisposable
     {
+        void SaveBytes(string key, byte[] bytes);
+
         void SaveValue<T>(string key, T value);
 
         T LoadValue<T>(string key);
+
+        byte[] LoadBytes(string key);
     }
 
     public class KeyValueRepository : IKeyValueRepository
@@ -36,20 +40,26 @@ namespace Stratis.Bitcoin.Utilities
         }
 
         /// <inheritdoc />
-        public void SaveValue<T>(string key, T value)
+        public void SaveBytes(string key, byte[] bytes)
         {
             byte[] keyBytes = Encoding.ASCII.GetBytes(key);
 
             using (DBreeze.Transactions.Transaction transaction = this.dbreeze.GetTransaction())
             {
-                transaction.Insert<byte[], byte[]>(TableName, keyBytes, this.dBreezeSerializer.Serialize(value));
+                transaction.Insert<byte[], byte[]>(TableName, keyBytes, bytes);
 
                 transaction.Commit();
             }
         }
 
         /// <inheritdoc />
-        public T LoadValue<T>(string key)
+        public void SaveValue<T>(string key, T value)
+        {
+            this.SaveBytes(key, this.dBreezeSerializer.Serialize(value));
+        }
+
+        /// <inheritdoc />
+        public byte[] LoadBytes(string key)
         {
             byte[] keyBytes = Encoding.ASCII.GetBytes(key);
 
@@ -60,11 +70,22 @@ namespace Stratis.Bitcoin.Utilities
                 Row<byte[], byte[]> row = transaction.Select<byte[], byte[]>(TableName, keyBytes);
 
                 if (!row.Exists)
-                    return default(T);
+                    return null;
 
-                T value = this.dBreezeSerializer.Deserialize<T>(row.Value);
-                return value;
+                return row.Value;
             }
+        }
+
+        /// <inheritdoc />
+        public T LoadValue<T>(string key)
+        {
+            byte[] bytes = this.LoadBytes(key);
+
+            if (bytes == null)
+                return default(T);
+
+            T value = this.dBreezeSerializer.Deserialize<T>(bytes);
+            return value;
         }
 
         /// <inheritdoc />

--- a/src/Stratis.Bitcoin/Utilities/KeyValueRepository.cs
+++ b/src/Stratis.Bitcoin/Utilities/KeyValueRepository.cs
@@ -4,6 +4,7 @@ using System.Text;
 using DBreeze;
 using DBreeze.DataTypes;
 using Stratis.Bitcoin.Configuration;
+using Stratis.Bitcoin.Utilities.JsonConverters;
 
 namespace Stratis.Bitcoin.Utilities
 {
@@ -14,9 +15,13 @@ namespace Stratis.Bitcoin.Utilities
 
         void SaveValue<T>(string key, T value);
 
-        T LoadValue<T>(string key);
+        void SaveValueJson<T>(string key, T value);
 
         byte[] LoadBytes(string key);
+
+        T LoadValue<T>(string key);
+
+        T LoadValueJson<T>(string key);
     }
 
     public class KeyValueRepository : IKeyValueRepository
@@ -59,6 +64,15 @@ namespace Stratis.Bitcoin.Utilities
         }
 
         /// <inheritdoc />
+        public void SaveValueJson<T>(string key, T value)
+        {
+            string json = Serializer.ToString(value);
+            byte[] jsonBytes = Encoding.ASCII.GetBytes(json);
+
+            this.SaveBytes(key, jsonBytes);
+        }
+
+        /// <inheritdoc />
         public byte[] LoadBytes(string key)
         {
             byte[] keyBytes = Encoding.ASCII.GetBytes(key);
@@ -85,6 +99,21 @@ namespace Stratis.Bitcoin.Utilities
                 return default(T);
 
             T value = this.dBreezeSerializer.Deserialize<T>(bytes);
+            return value;
+        }
+
+        /// <inheritdoc />
+        public T LoadValueJson<T>(string key)
+        {
+            byte[] bytes = this.LoadBytes(key);
+
+            if (bytes == null)
+                return default(T);
+
+            string json = Encoding.ASCII.GetString(bytes);
+
+            T value = Serializer.ToObject<T>(json);
+
             return value;
         }
 


### PR DESCRIPTION
Refactoring, tests, ability to save and load federation member keys to db. 

This PR corresponds to `Keep list of active federation members inside of the FederationManager and use it instead of list from the network` item in the design doc