### PR TITLE
[P2P / Integation Tests] PeerConnector dispose exception

### DIFF
--- a/src/Stratis.Bitcoin/Configuration/Settings/ConnectionManagerSettings.cs
+++ b/src/Stratis.Bitcoin/Configuration/Settings/ConnectionManagerSettings.cs
@@ -150,7 +150,6 @@ namespace Stratis.Bitcoin.Configuration.Settings
             this.BanTimeSeconds = config.GetOrDefault<int>("bantime", nodeSettings.Network.IsTest() ? DefaultMisbehavingBantimeSecondsTestnet : DefaultMisbehavingBantimeSeconds, this.logger);
             this.MaxOutboundConnections = config.GetOrDefault<int>("maxoutboundconnections", nodeSettings.Network.DefaultMaxOutboundConnections, this.logger);
             this.MaxInboundConnections = config.GetOrDefault<int>("maxinboundconnections", nodeSettings.Network.DefaultMaxInboundConnections, this.logger);
-            this.BurstModeTargetConnections = config.GetOrDefault("burstModeTargetConnections", 1, this.logger);
             this.SyncTimeEnabled = config.GetOrDefault<bool>("synctime", true, this.logger);
             this.RelayTxes = !config.GetOrDefault("blocksonly", DefaultBlocksOnly, this.logger);
             this.IpRangeFiltering = config.GetOrDefault<bool>("IpRangeFiltering", true, this.logger);

--- a/src/Stratis.Bitcoin/Configuration/Settings/ConnectionManagerSettings.cs
+++ b/src/Stratis.Bitcoin/Configuration/Settings/ConnectionManagerSettings.cs
@@ -254,9 +254,6 @@ namespace Stratis.Bitcoin.Configuration.Settings
         /// <summary>Maximum number of inbound connections.</summary>
         public int MaxInboundConnections { get; internal set; }
 
-        /// <summary>Connections number after which burst connectivity mode (connection attempts with no delay in between) will be disabled.</summary>
-        public int BurstModeTargetConnections { get; internal set; }
-
         /// <summary><c>true</c> to sync time with other peers and calculate adjusted time, <c>false</c> to use our system clock only.</summary>
         public bool SyncTimeEnabled { get; private set; }
 

--- a/src/Stratis.Bitcoin/P2P/PeerConnector.cs
+++ b/src/Stratis.Bitcoin/P2P/PeerConnector.cs
@@ -128,8 +128,8 @@ namespace Stratis.Bitcoin.P2P
             this.selfEndpointTracker = selfEndpointTracker;
             this.Requirements = new NetworkPeerRequirement { MinVersion = nodeSettings.MinProtocolVersion ?? nodeSettings.ProtocolVersion };
 
-            this.defaultConnectionInterval = TimeSpans.Second;
-            this.burstConnectionInterval = TimeSpan.Zero;
+            this.defaultConnectionInterval = TimeSpans.FiveSeconds;
+            this.burstConnectionInterval = TimeSpans.Second;
         }
 
         /// <inheritdoc/>
@@ -206,10 +206,7 @@ namespace Stratis.Bitcoin.P2P
             this.asyncLoop = this.asyncLoopFactory.Run($"{this.GetType().Name}.{nameof(this.ConnectAsync)}", async token =>
             {
                 if (!this.peerAddressManager.Peers.Any() || (this.ConnectorPeers.Count >= this.MaxOutboundConnections))
-                {
-                    await Task.Delay(2000, this.nodeLifetime.ApplicationStopping).ConfigureAwait(false);
                     return;
-                }
 
                 await this.OnConnectAsync().ConfigureAwait(false);
             },
@@ -284,16 +281,8 @@ namespace Stratis.Bitcoin.P2P
         /// <inheritdoc/>
         public void Dispose()
         {
-            try
-            {
-                this.asyncLoop?.Dispose();
-                this.networkPeerDisposer.Dispose();
-            }
-            catch (Exception ex)
-            {
-                this.logger.LogInformation("{0}-{1}", this.GetType().Name, ex.ToString());
-                throw;
-            }
+            this.asyncLoop?.Dispose();
+            this.networkPeerDisposer.Dispose();
         }
     }
 }

--- a/src/Stratis.Bitcoin/P2P/PeerConnector.cs
+++ b/src/Stratis.Bitcoin/P2P/PeerConnector.cs
@@ -284,8 +284,16 @@ namespace Stratis.Bitcoin.P2P
         /// <inheritdoc/>
         public void Dispose()
         {
-            this.asyncLoop?.Dispose();
-            this.networkPeerDisposer.Dispose();
+            try
+            {
+                this.asyncLoop?.Dispose();
+                this.networkPeerDisposer.Dispose();
+            }
+            catch (Exception ex)
+            {
+                this.logger.LogInformation("{0}-{1}", this.GetType().Name, ex.ToString());
+                throw;
+            }
         }
     }
 }

--- a/src/Stratis.Bitcoin/P2P/PeerConnectorAddNode.cs
+++ b/src/Stratis.Bitcoin/P2P/PeerConnectorAddNode.cs
@@ -36,11 +36,6 @@ namespace Stratis.Bitcoin.P2P
         /// <inheritdoc/>
         public override void OnInitialize()
         {
-            // For the -addnode connector, effectively disable burst mode by preventing high frequency connection attempts.
-            // The initial -addnode list will all have their connection attempts made in parallel regardless, so this
-            // does not slow down the startup.
-            this.burstConnectionInterval = TimeSpans.Second;
-
             this.MaxOutboundConnections = this.ConnectionSettings.AddNode.Count;
 
             // Add the endpoints from the -addnode arg to the address manager.

--- a/src/Stratis.Bitcoin/P2P/PeerConnectorConnect.cs
+++ b/src/Stratis.Bitcoin/P2P/PeerConnectorConnect.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Linq;
+﻿using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -38,11 +37,6 @@ namespace Stratis.Bitcoin.P2P
         /// <inheritdoc/>
         public override void OnInitialize()
         {
-            // For the -connect connector, effectively disable burst mode by preventing high frequency connection attempts.
-            // The initial -connect list will all have their connection attempts made in parallel regardless, so this
-            // does not slow down the startup.
-            this.burstConnectionInterval = TimeSpans.Second;
-
             this.MaxOutboundConnections = this.ConnectionSettings.Connect.Count;
 
             // Add the endpoints from the -connect arg to the address manager.

--- a/src/Stratis.Bitcoin/Utilities/AsyncLoop.cs
+++ b/src/Stratis.Bitcoin/Utilities/AsyncLoop.cs
@@ -173,18 +173,10 @@ namespace Stratis.Bitcoin.Utilities
         /// </summary>
         public void Dispose()
         {
-            try
+            if (!this.RunningTask.IsCanceled)
             {
-                if (!this.RunningTask.IsCanceled)
-                {
-                    this.logger.LogInformation("Waiting for {0} to finish.", this.Name);
-                    this.RunningTask.Wait();
-                }
-            }
-            catch (Exception ex)
-            {
-                this.logger.LogInformation(ex.ToString());
-                throw;
+                this.logger.LogInformation("Waiting for {0} to finish.", this.Name);
+                this.RunningTask.Wait();
             }
         }
     }

--- a/src/Stratis.Bitcoin/Utilities/AsyncLoop.cs
+++ b/src/Stratis.Bitcoin/Utilities/AsyncLoop.cs
@@ -173,10 +173,18 @@ namespace Stratis.Bitcoin.Utilities
         /// </summary>
         public void Dispose()
         {
-            if (!this.RunningTask.IsCanceled)
+            try
             {
-                this.logger.LogInformation("Waiting for {0} to finish.", this.Name);
-                this.RunningTask.Wait();
+                if (!this.RunningTask.IsCanceled)
+                {
+                    this.logger.LogInformation("Waiting for {0} to finish.", this.Name);
+                    this.RunningTask.Wait();
+                }
+            }
+            catch (Exception ex)
+            {
+                this.logger.LogInformation(ex.ToString());
+                throw;
             }
         }
     }


### PR DESCRIPTION
I've noticed that integration tests that does NOT make a connection fails on the CI due to a `Wait` task cancelled exception when disposing the async loop in the peer connectors.

There is Task.Delay() in the async loop which I believe is causing a lock on the loop being disposed.

As we are already managing the repeat interval on the connector it seems wasteful to delay the process in the async loop. 

But then this got me thinking, is the burst connection mode really necessary? I don't think the gain of having the extra code in the system is that much as once we have a single connection, we set the interval to 1 second anyway.