### PR TITLE
Race condition coinview bug

### DIFF
--- a/src/Stratis.Bitcoin.Features.Consensus/CoinViews/CachedCoinView.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/CoinViews/CachedCoinView.cs
@@ -228,18 +228,15 @@ namespace Stratis.Bitcoin.Features.Consensus.CoinViews
 
                 this.performanceCounter.AddMissCount(miss.Count);
                 this.performanceCounter.AddHitCount(txIds.Length - miss.Count);
-            }
+            
+                FetchCoinsResponse fetchedCoins = null;
 
-            FetchCoinsResponse fetchedCoins = null;
+                if (missedTxIds.Count > 0 || this.blockHash == null)
+                {
+                    this.logger.LogTrace("{0} cache missed transaction needs to be loaded from underlying CoinView.", missedTxIds.Count);
+                    fetchedCoins = await this.Inner.FetchCoinsAsync(missedTxIds.ToArray(), cancellationToken).ConfigureAwait(false);
+                }
 
-            if (missedTxIds.Count > 0 || this.blockHash == null)
-            {
-                this.logger.LogTrace("{0} cache missed transaction needs to be loaded from underlying CoinView.", missedTxIds.Count);
-                fetchedCoins = await this.Inner.FetchCoinsAsync(missedTxIds.ToArray(), cancellationToken).ConfigureAwait(false);
-            }
-
-            using (await this.lockobj.LockAsync(cancellationToken).ConfigureAwait(false))
-            {
                 if (this.blockHash == null)
                 {
                     uint256 innerblockHash = fetchedCoins.BlockHash;

--- a/src/Stratis.Bitcoin/Utilities/UnspentOutputs.cs
+++ b/src/Stratis.Bitcoin/Utilities/UnspentOutputs.cs
@@ -190,8 +190,17 @@ namespace Stratis.Bitcoin.Utilities
             builder.AppendLine($"{nameof(this.Time)}={this.Time}");
             builder.AppendLine($"{nameof(this.Outputs)}.{nameof(this.Outputs.Length)}={this.Outputs.Length}");
 
-            foreach (TxOut output in this.Outputs)
-                builder.AppendLine(output == null ? "null" : output.ToString());
+            for (var i = 0; i < this.Outputs.Length; i++)
+            {
+                builder.AppendLine(this.Outputs[i] == null ? "null" : this.Outputs[i].ToString());
+
+                if (i > 4)
+                {
+                    // Only log out the first 5 outputs to avoid cluttering the logs.
+                    builder.AppendLine($"{this.Outputs.Length - 5} more outputs...");
+                    break;
+                }
+            }
 
             return builder.ToString();
         }

--- a/src/Stratis.Bitcoin/Utilities/UnspentOutputs.cs
+++ b/src/Stratis.Bitcoin/Utilities/UnspentOutputs.cs
@@ -190,16 +190,13 @@ namespace Stratis.Bitcoin.Utilities
             builder.AppendLine($"{nameof(this.Time)}={this.Time}");
             builder.AppendLine($"{nameof(this.Outputs)}.{nameof(this.Outputs.Length)}={this.Outputs.Length}");
 
-            for (var i = 0; i < this.Outputs.Length; i++)
-            {
-                builder.AppendLine(this.Outputs[i] == null ? "null" : this.Outputs[i].ToString());
+            foreach (TxOut output in this.Outputs.Take(5))
+                builder.AppendLine(output == null ? "null" : output.ToString());
 
-                if (i > 4)
-                {
-                    // Only log out the first 5 outputs to avoid cluttering the logs.
-                    builder.AppendLine($"{this.Outputs.Length - 5} more outputs...");
-                    break;
-                }
+            if (this.Outputs.Length > 5)
+            {
+                // Only log out the first 5 outputs to avoid cluttering the logs.
+                builder.AppendLine($"{this.Outputs.Length - 5} more outputs...");
             }
 
             return builder.ToString();


### PR DESCRIPTION
This is the scenario that likely caused  UTXOs to be out of sync in the cache

- [FetchCoinsAsync] Acquire the lock
- [FetchCoinsAsync] Fetch happens trx is not in cache
- [FetchCoinsAsync] Release the lock and try to fetch the trx from disk
- [RewindAsync ] The Lock is acquired by rewind we deleted the trx from disk and clear the cache
- [FetchCoinsAsync] Will wait for the lock to be released
- [RewindAsync] Release the lock
- [FetchCoinsAsync] Take the lock and add the rewinded trx to cache
- [FetchCoinsAsync] A block with that same reorged trx comes -> bip30 bug