### PR TITLE
[RPC] Fixes for RPC for NBitcoin integration

### DIFF
--- a/src/Stratis.Bitcoin.Features.RPC.Tests/Controller/FullNodeControllerTest.cs
+++ b/src/Stratis.Bitcoin.Features.RPC.Tests/Controller/FullNodeControllerTest.cs
@@ -637,7 +637,7 @@ namespace Stratis.Bitcoin.Features.RPC.Tests.Controller
             ValidatedAddress result = this.controller.ValidateAddress(address.ToString());
 
             bool isValid = result.IsValid;
-            Assert.True(isValid);
+            Assert.False(isValid);
         }
 
         private Transaction CreateTransaction()

--- a/src/Stratis.Bitcoin.Features.RPC/Controllers/FullNodeController.cs
+++ b/src/Stratis.Bitcoin.Features.RPC/Controllers/FullNodeController.cs
@@ -273,7 +273,8 @@ namespace Stratis.Bitcoin.Features.RPC.Controllers
             // P2WSH
             else if (BitcoinWitScriptAddress.IsValid(address, this.Network, out Exception _))
             {
-                res.IsValid = true;
+                // We don't support P2WSH addresses yet
+                res.IsValid = false;
             }
             // P2PKH
             else if (BitcoinPubKeyAddress.IsValid(address, this.Network))


### PR DESCRIPTION
Fix RPC batching when method doesn't exist. Also add a test that tests that scenario.
Fix RPC validateaddress to return invalid for P2WSH addresses (which we currently don't support)

Used by NBitcoin Altcoins.