### PR TITLE
Stop throwing exceptions in network classes.

### DIFF
--- a/src/Stratis.Bitcoin/P2P/Peer/NetworkPeer.cs
+++ b/src/Stratis.Bitcoin/P2P/Peer/NetworkPeer.cs
@@ -423,7 +423,6 @@ namespace Stratis.Bitcoin.P2P.Peer
                 await this.SetStateAsync(NetworkPeerState.Offline).ConfigureAwait(false);
 
                 this.logger.LogTrace("(-)[CANCELLED]");
-                throw;
             }
             catch (Exception ex)
             {
@@ -438,7 +437,6 @@ namespace Stratis.Bitcoin.P2P.Peer
                 await this.SetStateAsync(NetworkPeerState.Failed).ConfigureAwait(false);
 
                 this.logger.LogTrace("(-)[EXCEPTION]");
-                throw;
             }
         }
 
@@ -578,7 +576,6 @@ namespace Stratis.Bitcoin.P2P.Peer
                 this.selfEndpointTracker.Add(version.AddressReceiver);
 
                 this.logger.LogTrace("(-)[CONNECTED_TO_SELF]");
-                throw new OperationCanceledException();
             }
 
             using (CancellationTokenSource cancellationSource = CancellationTokenSource.CreateLinkedTokenSource(this.Connection.CancellationSource.Token, cancellation))
@@ -595,7 +592,6 @@ namespace Stratis.Bitcoin.P2P.Peer
                     this.Disconnect("Handshake timeout");
 
                     this.logger.LogTrace("(-)[HANDSHAKE_TIMEDOUT]");
-                    throw;
                 }
                 catch (Exception ex)
                 {
@@ -604,7 +600,6 @@ namespace Stratis.Bitcoin.P2P.Peer
                     this.Disconnect("Handshake exception", ex);
 
                     this.logger.LogTrace("(-)[HANDSHAKE_EXCEPTION]");
-                    throw;
                 }
             }
         }
@@ -664,7 +659,6 @@ namespace Stratis.Bitcoin.P2P.Peer
             catch (Exception ex)
             {
                 this.logger.LogError("Exception occurred while connecting to peer '{0}': {1}", this.PeerEndPoint, ex is SocketException ? ex.Message : ex.ToString());
-                throw;
             }
         }
 
@@ -676,7 +670,7 @@ namespace Stratis.Bitcoin.P2P.Peer
             if (!this.IsConnected)
             {
                 this.logger.LogTrace("(-)[NOT_CONNECTED]");
-                throw new OperationCanceledException("The peer has been disconnected");
+                this.logger.LogTrace("Peer {0} has been disconnected.", this.PeerEndPoint);
             }
 
             this.onSendingMessage?.Invoke(this.RemoteSocketEndpoint, payload);

--- a/src/Stratis.Bitcoin/P2P/Peer/NetworkPeerConnection.cs
+++ b/src/Stratis.Bitcoin/P2P/Peer/NetworkPeerConnection.cs
@@ -194,14 +194,12 @@ namespace Stratis.Bitcoin.P2P.Peer
             {
                 this.logger.LogTrace("Connecting to '{0}' cancelled.", endPoint);
                 this.logger.LogTrace("(-)[CANCELLED]");
-                throw;
             }
             catch (Exception e)
             {
                 if (e is AggregateException) e = e.InnerException;
                 this.logger.LogDebug("Error connecting to '{0}', exception message: {1}", endPoint, e.Message);
                 this.logger.LogTrace("(-)[UNHANDLED_EXCEPTION]");
-                throw e;
             }
         }
 
@@ -254,7 +252,6 @@ namespace Stratis.Bitcoin.P2P.Peer
             {
                 this.peer.Disconnect("Connection to the peer has been terminated");
                 this.logger.LogTrace("(-)[CANCELED_EXCEPTION]");
-                throw;
             }
             catch (Exception ex)
             {
@@ -285,7 +282,6 @@ namespace Stratis.Bitcoin.P2P.Peer
                 {
                     this.logger.LogTrace("Connection has been terminated.");
                     this.logger.LogTrace("(-)[NO_STREAM]");
-                    throw new OperationCanceledException();
                 }
 
                 try
@@ -299,13 +295,11 @@ namespace Stratis.Bitcoin.P2P.Peer
                         this.logger.LogTrace("Connection has been terminated.");
                         if (e is IOException) this.logger.LogTrace("(-)[IO_EXCEPTION]");
                         else this.logger.LogTrace("(-)[CANCELLED]");
-                        throw new OperationCanceledException();
                     }
                     else
                     {
                         this.logger.LogTrace("Exception occurred: {0}", e.ToString());
                         this.logger.LogTrace("(-)[UNHANDLED_EXCEPTION]");
-                        throw;
                     }
                 }
             }


### PR DESCRIPTION
_It is common place that nodes will sometimes not be able to connect to other nodes; this should not result in stack trace being saved to the *p2p.txt* log._

@Fazz: "The stack traces arise from rethrowing exceptions caused by from socket connection errors during P2P connection.  I can remove throw; at a few points in NetworkPeer, NetworkPeerConnection.  However - we should be careful as the intention of this bugfix is to reduce unnecessary logs, but at some points it looks like program flow is affected".

Preferred: @maciejzaleski @fassadlr 