### PR TITLE
Duplicate log messages

### DIFF
--- a/src/Stratis.Bitcoin.Features.BlockStore/BlockStoreBehavior.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/BlockStoreBehavior.cs
@@ -124,8 +124,7 @@ namespace Stratis.Bitcoin.Features.BlockStore
             }
             catch (Exception ex)
             {
-                this.logger.LogError("Exception occurred: {0}", ex.ToString());
-                this.logger.LogTrace("(-)[EXCEPTION]");
+                this.logger.LogError("Exception occurred: {0}" + "\r\n" + "(-)[EXCEPTION]", ex.ToString());
                 throw;
             }
         }
@@ -216,8 +215,7 @@ namespace Stratis.Bitcoin.Features.BlockStore
             // If block store is lower than the fork point, or it is on different chain, we don't have anything to contribute to this peer at this point.
             if (blockStoreTip.FindAncestorOrSelf(forkPoint) == null)
             {
-                this.logger.LogDebug("Fork point of peer '{0}' was not found on the block store chain.", peer.RemoteSocketEndpoint);
-                this.logger.LogTrace("(-)[FORK_OUTSIDE_STORE]");
+                this.logger.LogDebug("Fork point of peer '{0}' was not found on the block store chain." + "\r\n" + "(-)[FORK_OUTSIDE_STORE]", peer.RemoteSocketEndpoint);
                 return;
             }
 

--- a/src/Stratis.Bitcoin.Features.ColdStaking/Controllers/ColdStakingController.cs
+++ b/src/Stratis.Bitcoin.Features.ColdStaking/Controllers/ColdStakingController.cs
@@ -70,8 +70,7 @@ namespace Stratis.Bitcoin.Features.ColdStaking.Controllers
             }
             catch (Exception e)
             {
-                this.logger.LogError("Exception occurred: {0}", e.ToString());
-                this.logger.LogTrace("(-)[ERROR]");
+                this.logger.LogError("Exception occurred: {0}" + "\r\n" + "(-)[ERROR]", e.ToString());
                 return ErrorHelpers.BuildErrorResponse(HttpStatusCode.BadRequest, e.Message, e.ToString());
             }
         }
@@ -111,8 +110,7 @@ namespace Stratis.Bitcoin.Features.ColdStaking.Controllers
             }
             catch (Exception e)
             {
-                this.logger.LogError("Exception occurred: {0}", e.ToString());
-                this.logger.LogTrace("(-)[ERROR]");
+                this.logger.LogError("Exception occurred: {0}" + "\r\n" + "(-)[ERROR]", e.ToString());
                 return ErrorHelpers.BuildErrorResponse(HttpStatusCode.BadRequest, e.Message, e.ToString());
             }
         }
@@ -155,8 +153,7 @@ namespace Stratis.Bitcoin.Features.ColdStaking.Controllers
             }
             catch (Exception e)
             {
-                this.logger.LogError("Exception occurred: {0}", e.ToString());
-                this.logger.LogTrace("(-)[ERROR]");
+                this.logger.LogError("Exception occurred: {0}"  + "\r\n" + "(-)[ERROR]", e.ToString());
                 return ErrorHelpers.BuildErrorResponse(HttpStatusCode.BadRequest, e.Message, e.ToString());
             }
         }
@@ -203,8 +200,7 @@ namespace Stratis.Bitcoin.Features.ColdStaking.Controllers
             }
             catch (Exception e)
             {
-                this.logger.LogError("Exception occurred: {0}", e.ToString());
-                this.logger.LogTrace("(-)[ERROR]");
+                this.logger.LogError("Exception occurred: {0}" + "\r\n" + "(-)[ERROR]", e.ToString());
                 return ErrorHelpers.BuildErrorResponse(HttpStatusCode.BadRequest, e.Message, e.ToString());
             }
         }
@@ -250,8 +246,7 @@ namespace Stratis.Bitcoin.Features.ColdStaking.Controllers
             }
             catch (Exception e)
             {
-                this.logger.LogError("Exception occurred: {0}", e.ToString());
-                this.logger.LogTrace("(-)[ERROR]");
+                this.logger.LogError("Exception occurred: {0}" + "\r\n" + "(-)[ERROR]", e.ToString());
                 return ErrorHelpers.BuildErrorResponse(HttpStatusCode.BadRequest, e.Message, e.ToString());
             }
         }

--- a/src/Stratis.Bitcoin.Features.Consensus/Behaviors/ProvenHeadersConsensusManagerBehavior.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/Behaviors/ProvenHeadersConsensusManagerBehavior.cs
@@ -179,17 +179,15 @@ namespace Stratis.Bitcoin.Features.Consensus.Behaviors
                         // Proven header is not available yet for this header.
                         // This can happen in case headers were requested by the peer right after we advanced consensus tip
                         // So at this moment proven header is not created or not yet saved to headers store for the block connected.
-                        this.logger.LogDebug("No PH available for header '{0}'.", header);
-                        this.logger.LogTrace("(-)[NO_PH_AVAILABLE]");
-                        break;
+                        this.logger.LogDebug("No PH available for header '{0}'." + "\r\n" + "(-)[NO_PH_AVAILABLE]", header);
+						break;
                     }
                     else if (provenBlockHeader.GetHash() != header.HashBlock)
                     {
                         // Proven header is in the store, but with a wrong hash.
                         // This can happen in case of reorgs, when the store has not yet been updated.
                         // Without this check, we may send headers that aren't consecutive because are built from different branches, and the other peer may ban us.
-                        this.logger.LogDebug("Stored PH hash is wrong. Expected: {0}, Found: {1}", header.Header.GetHash(), provenBlockHeader.GetHash());
-                        this.logger.LogTrace("(-)[WRONG STORED PH]");
+                        this.logger.LogDebug("Stored PH hash is wrong. Expected: {0}, Found: {1}" + "\r\n" + "(-)[WRONG STORED PH]", header.Header.GetHash(), provenBlockHeader.GetHash());
                         break;
                     }
                 }
@@ -273,8 +271,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Behaviors
                 if (peer.IsWhitelisted())
                 {
                     // A gateway node can only sync using regular headers and from whitelisted peers
-                    this.logger.LogDebug("Node is a gateway, sync regular headers from whitelisted peer.");
-                    this.logger.LogTrace("(-)[PEER_WHITELISTED_BY_GATEWAY]");
+                    this.logger.LogDebug("Node is a gateway, sync regular headers from whitelisted peer." + "\r\n" + "(-)[PEER_WHITELISTED_BY_GATEWAY]");
                     return base.BuildGetHeadersPayload();
                 }
 

--- a/src/Stratis.Bitcoin.Features.Consensus/CoinviewPrefetcher.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/CoinviewPrefetcher.cs
@@ -87,8 +87,7 @@ namespace Stratis.Bitcoin.Features.Consensus
 
             if (!farFromTip)
             {
-                this.logger.LogDebug("Block selected for pre-fetching is too close to the tip! Skipping pre-fetching.");
-                this.logger.LogTrace("(-)[TOO_CLOSE_TO_PREFETCH]");
+                this.logger.LogDebug("Block selected for pre-fetching is too close to the tip! Skipping pre-fetching." + "\r\n" + "(-)[TOO_CLOSE_TO_PREFETCH]");
                 return;
             }
 

--- a/src/Stratis.Bitcoin.Features.Consensus/Rules/ProvenHeaderRules/ProvenHeaderCoinstakeRule.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/Rules/ProvenHeaderRules/ProvenHeaderCoinstakeRule.cs
@@ -361,8 +361,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Rules.ProvenHeaderRules
 
             if (rewindData == null)
             {
-                this.Logger.LogTrace("(-)[NO_REWIND_DATA_FOR_INDEX]");
-                this.Logger.LogError("Error - Rewind data should always be present");
+                this.Logger.LogError("(-)[NO_REWIND_DATA_FOR_INDEX]" + "\r\n" + "Error - Rewind data should always be present");
                 throw new ConsensusException("Rewind data should always be present");
             }
 

--- a/src/Stratis.Bitcoin.Features.MemoryPool/MempoolBehavior.cs
+++ b/src/Stratis.Bitcoin.Features.MemoryPool/MempoolBehavior.cs
@@ -215,8 +215,8 @@ namespace Stratis.Bitcoin.Features.MemoryPool
             Guard.NotNull(peer, nameof(peer));
             if (peer != this.AttachedPeer)
             {
-                this.logger.LogDebug("Attached peer '{0}' does not match the originating peer '{1}'.", this.AttachedPeer?.RemoteSocketEndpoint, peer.RemoteSocketEndpoint);
-                this.logger.LogTrace("(-)[PEER_MISMATCH]");
+                this.logger.LogDebug("Attached peer '{0}' does not match the originating peer '{1}'."
+									+ "\r\n" + "(-)[PEER_MISMATCH]", this.AttachedPeer?.RemoteSocketEndpoint, peer.RemoteSocketEndpoint);
                 return;
             }
 
@@ -369,8 +369,7 @@ namespace Stratis.Bitcoin.Features.MemoryPool
             // Stop processing the transaction early if we are in blocks only mode.
             if (this.isBlocksOnlyMode)
             {
-                this.logger.LogDebug("Transaction sent in violation of protocol from peer '{0}'.", peer.RemoteSocketEndpoint);
-                this.logger.LogTrace("(-)[BLOCKSONLY]");
+                this.logger.LogDebug("Transaction sent in violation of protocol from peer '{0}'." + "\r\n" + "(-)[BLOCKSONLY]", peer.RemoteSocketEndpoint);
                 return;
             }
 

--- a/src/Stratis.Bitcoin.Features.MemoryPool/MempoolOrphans.cs
+++ b/src/Stratis.Bitcoin.Features.MemoryPool/MempoolOrphans.cs
@@ -322,8 +322,7 @@ namespace Stratis.Bitcoin.Features.MemoryPool
 
             if (rejectedParents)
             {
-                this.logger.LogInformation("not keeping orphan with rejected parents {0}", tx.GetHash());
-                this.logger.LogTrace("(-)[REJECT_PARENTS_ORPH]:false");
+                this.logger.LogInformation("not keeping orphan with rejected parents {0}" + "\r\n" + "(-)[REJECT_PARENTS_ORPH]:false", tx.GetHash());
                 return false;
             }
 
@@ -435,8 +434,7 @@ namespace Stratis.Bitcoin.Features.MemoryPool
                 int sz = MempoolValidator.GetTransactionWeight(tx, this.Validator.ConsensusOptions);
                 if (sz >= this.chain.Network.Consensus.Options.MaxStandardTxWeight)
                 {
-                    this.logger.LogInformation("ignoring large orphan tx (size: {0}, hash: {1})", sz, hash);
-                    this.logger.LogTrace("(-)[LARGE_ORPH]:false");
+                    this.logger.LogInformation("ignoring large orphan tx (size: {0}, hash: {1})" + "\r\n" + "(-)[LARGE_ORPH]:false", sz, hash);
                     return false;
                 }
 

--- a/src/Stratis.Bitcoin.Features.Miner/PosPowBlockDefinition.cs
+++ b/src/Stratis.Bitcoin.Features.Miner/PosPowBlockDefinition.cs
@@ -85,8 +85,8 @@ namespace Stratis.Bitcoin.Features.Miner
             // When kernel is found txes with timestamp greater than header's timestamp are removed.
             if (entry.Transaction.Time > latestValidTime)
             {
-                this.logger.LogDebug("Transaction '{0}' has timestamp of {1} but latest valid tx time that can be mined is {2}.", entry.TransactionHash, entry.Transaction.Time, latestValidTime);
-                this.logger.LogTrace("(-)[TOO_EARLY_TO_MINE_TX]:false");
+                this.logger.LogDebug("Transaction '{0}' has timestamp of {1} but latest valid tx time that can be mined is {2}."
+									+ "\r\n" + "(-)[TOO_EARLY_TO_MINE_TX]:false", entry.TransactionHash, entry.Transaction.Time, latestValidTime);
                 return false;
             }
 

--- a/src/Stratis.Bitcoin.Features.Miner/Staking/PosMinting.cs
+++ b/src/Stratis.Bitcoin.Features.Miner/Staking/PosMinting.cs
@@ -318,8 +318,7 @@ namespace Stratis.Bitcoin.Features.Miner.Staking
                 }
                 catch (Exception ex)
                 {
-                    this.logger.LogError("Exception: {0}", ex);
-                    this.logger.LogTrace("(-)[UNHANDLED_EXCEPTION]");
+                    this.logger.LogError("Exception: {0}" + "\r\n" + "(-)[UNHANDLED_EXCEPTION]", ex);
                     throw;
                 }
             },

--- a/src/Stratis.Bitcoin.Features.PoA/Voting/VotingDataEncoder.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/Voting/VotingDataEncoder.cs
@@ -46,8 +46,7 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
             }
             catch (Exception e)
             {
-                this.logger.LogDebug("Exception during deserialization: '{0}'.", e.ToString());
-                this.logger.LogTrace("(-)[DESERIALIZING_EXCEPTION]");
+                this.logger.LogDebug("Exception during deserialization: '{0}'." + "\r\n" + "(-)[DESERIALIZING_EXCEPTION]", e.ToString());
 
                 PoAConsensusErrors.VotingDataInvalidFormat.Throw();
                 return null;

--- a/src/Stratis.Bitcoin.Features.Wallet/WalletManager.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/WalletManager.cs
@@ -229,9 +229,7 @@ namespace Stratis.Bitcoin.Features.Wallet
             this.asyncLoop = this.asyncLoopFactory.Run("Wallet persist job", token =>
             {
                 this.SaveWallets();
-                this.logger.LogInformation("Wallets saved to file at {0}.", this.dateTimeProvider.GetUtcNow());
-
-                this.logger.LogTrace("(-)[IN_ASYNC_LOOP]");
+                this.logger.LogInformation("Wallets saved to file at {0}." + "\r\n" + "(-)[IN_ASYNC_LOOP]", this.dateTimeProvider.GetUtcNow());
                 return Task.CompletedTask;
             },
             this.nodeLifetime.ApplicationStopping,

--- a/src/Stratis.Bitcoin/Builder/FullNodeFeatureExecutor.cs
+++ b/src/Stratis.Bitcoin/Builder/FullNodeFeatureExecutor.cs
@@ -53,8 +53,7 @@ namespace Stratis.Bitcoin.Builder
             }
             catch
             {
-                this.logger.LogError("An error occurred starting the application.");
-                this.logger.LogTrace("(-)[INITIALIZE_EXCEPTION]");
+                this.logger.LogError("An error occurred starting the application." + "\r\n" + "(-)[INITIALIZE_EXCEPTION]");
                 throw;
             }
         }
@@ -68,8 +67,7 @@ namespace Stratis.Bitcoin.Builder
             }
             catch
             {
-                this.logger.LogError("An error occurred stopping the application.");
-                this.logger.LogTrace("(-)[DISPOSE_EXCEPTION]");
+                this.logger.LogError("An error occurred stopping the application." + "\r\n" + "(-)[DISPOSE_EXCEPTION]");
                 throw;
             }
         }

--- a/src/Stratis.Bitcoin/Consensus/ChainedHeaderTree.cs
+++ b/src/Stratis.Bitcoin/Consensus/ChainedHeaderTree.cs
@@ -316,8 +316,7 @@ namespace Stratis.Bitcoin.Consensus
             ChainedHeader peerTip;
             if (!this.chainedHeadersByHash.TryGetValue(peerTipHash, out peerTip))
             {
-                this.logger.LogError("Header '{0}' not found but it is claimed by {1} as its tip.", peerTipHash, networkPeerId);
-                this.logger.LogTrace("(-)[HEADER_NOT_FOUND]");
+                this.logger.LogError("Header '{0}' not found but it is claimed by {1} as its tip." + "\r\n" + "(-)[HEADER_NOT_FOUND]", peerTipHash, networkPeerId);
                 throw new ConsensusException("Header not found!");
             }
 
@@ -819,8 +818,8 @@ namespace Stratis.Bitcoin.Consensus
                 // Otherwise a new peer may connect and present headers on top of invalid chain and we wouldn't recognize it.
                 this.RemovePeerClaim(peerId, latestNewHeader);
 
-                this.logger.LogDebug("Chained header '{0}' does not match checkpoint '{1}'.", chainedHeader, checkpoint.Hash);
-                this.logger.LogTrace("(-)[INVALID_HEADER_NOT_MATCHING_CHECKPOINT]");
+                this.logger.LogDebug("Chained header '{0}' does not match checkpoint '{1}'." + "\r\n"
+                                    + "(-)[INVALID_HEADER_NOT_MATCHING_CHECKPOINT]", chainedHeader, checkpoint.Hash);
                 throw new CheckpointMismatchException();
             }
 
@@ -1118,8 +1117,7 @@ namespace Stratis.Bitcoin.Consensus
 
                 if (fork == null)
                 {
-                    this.logger.LogError("Header '{0}' is from a different network.", chainedHeader);
-                    this.logger.LogTrace("(-)[HEADER_IS_INVALID_NETWORK]");
+                    this.logger.LogError("Header '{0}' is from a different network." + "\r\n" + "(-)[HEADER_IS_INVALID_NETWORK]", chainedHeader);
                     throw new InvalidOperationException("Header is from a different network");
                 }
 

--- a/src/Stratis.Bitcoin/Consensus/ConsensusManager.cs
+++ b/src/Stratis.Bitcoin/Consensus/ConsensusManager.cs
@@ -336,8 +336,9 @@ namespace Stratis.Bitcoin.Consensus
                         this.chainedHeaderTree.PartialOrFullValidationFailed(chainedHeader);
                     }
 
-                    this.logger.LogError("Miner produced an invalid block, partial validation failed: {0}", validationContext.Error.Message);
-                    this.logger.LogTrace("(-)[PARTIAL_VALIDATION_FAILED]");
+                    this.logger.LogError("Miner produced an invalid block, partial validation failed: {0}"
+                                        + "\r\n" + "(-)[PARTIAL_VALIDATION_FAILED]", validationContext.Error.Message);
+
                     throw new ConsensusException(validationContext.Error.ToString());
                 }
             }
@@ -576,8 +577,7 @@ namespace Stratis.Bitcoin.Consensus
             if (fork == newTip)
             {
                 // The new header is behind the current tip this is a bug.
-                this.logger.LogCritical("New header '{0}' is behind the current tip '{1}'.", newTip, oldTip);
-                this.logger.LogTrace("(-)[INVALID_NEW_TIP]");
+                this.logger.LogCritical("New header '{0}' is behind the current tip '{1}'." + "\r\n" + "(-)[INVALID_NEW_TIP]", newTip, oldTip);
                 throw new ConsensusException("New tip must be ahead of old tip.");
             }
 
@@ -594,8 +594,7 @@ namespace Stratis.Bitcoin.Consensus
             // Sanity check. This should never happen.
             if (blocksToConnect == null)
             {
-                this.logger.LogCritical("Blocks to connect are missing!");
-                this.logger.LogTrace("(-)[NO_BLOCK_TO_CONNECT]");
+                this.logger.LogCritical("Blocks to connect are missing!" + "\r\n" + "(-)[NO_BLOCK_TO_CONNECT]");
                 throw new ConsensusException("Blocks to connect are missing!");
             }
 
@@ -781,8 +780,7 @@ namespace Stratis.Bitcoin.Consensus
 
             // We failed to jump back on the previous chain after a failed reorg.
             // And we failed to reconnect the old chain, database might be corrupted.
-            this.logger.LogError("A critical error has prevented reconnecting blocks, error = {0}", connectBlockResult.Error);
-            this.logger.LogTrace("(-)[FAILED_TO_RECONNECT]");
+            this.logger.LogError("A critical error has prevented reconnecting blocks, error = {0}" + "\r\n" + "(-)[FAILED_TO_RECONNECT]", connectBlockResult.Error);
             throw new ConsensusException("A critical error has prevented reconnecting blocks.");
         }
 
@@ -827,8 +825,9 @@ namespace Stratis.Bitcoin.Consensus
             if ((blockToConnect.ChainedHeader.BlockValidationState != ValidationState.PartiallyValidated) &&
                 (blockToConnect.ChainedHeader.BlockValidationState != ValidationState.FullyValidated))
             {
-                this.logger.LogError("Block '{0}' must be partially or fully validated but it is {1}.", blockToConnect, blockToConnect.ChainedHeader.BlockValidationState);
-                this.logger.LogTrace("(-)[BLOCK_INVALID_STATE]");
+                this.logger.LogError("Block '{0}' must be partially or fully validated but it is {1}."
+                                    + "\r\n" + "(-)[BLOCK_INVALID_STATE]", blockToConnect, blockToConnect.ChainedHeader.BlockValidationState);
+
                 throw new ConsensusException("Block must be partially or fully validated.");
             }
 
@@ -882,8 +881,7 @@ namespace Stratis.Bitcoin.Consensus
 
                 if (chainedHeaderBlock?.Block == null)
                 {
-                    this.logger.LogError("Block '{0}' wasn't loaded from store!", currentHeader);
-                    this.logger.LogTrace("(-):null");
+                    this.logger.LogError("Block '{0}' wasn't loaded from store!" + "\r\n" + "(-):null", currentHeader);	
                     return null;
                 }
 
@@ -1032,8 +1030,7 @@ namespace Stratis.Bitcoin.Consensus
                 else
                 {
                     // This means the puller has not filtered blocks correctly.
-                    this.logger.LogError("Unsolicited block '{0}'.", blockHash);
-                    this.logger.LogTrace("(-)[UNSOLICITED_BLOCK]");
+                    this.logger.LogError("Unsolicited block '{0}'." + "\r\n" + "(-)[UNSOLICITED_BLOCK]", blockHash);
                     throw new InvalidOperationException("Unsolicited block");
                 }
 
@@ -1071,8 +1068,7 @@ namespace Stratis.Bitcoin.Consensus
             if (reassignDownload)
             {
                 this.DownloadBlocks(new[] { chainedHeader });
-                this.logger.LogWarning("Downloading block for '{0}' failed, it will be enqueued again.", chainedHeader);
-                this.logger.LogTrace("(-)[BLOCK_DOWNLOAD_FAILED_REASSIGNED]");
+                this.logger.LogWarning("Downloading block for '{0}' failed, it will be enqueued again." + "\r\n" + "(-)[BLOCK_DOWNLOAD_FAILED_REASSIGNED]", chainedHeader);
                 return;
             }
 

--- a/src/Stratis.Bitcoin/Consensus/ConsensusManagerBehavior.cs
+++ b/src/Stratis.Bitcoin/Consensus/ConsensusManagerBehavior.cs
@@ -186,8 +186,8 @@ namespace Stratis.Bitcoin.Consensus
             // because that will slow down our own syncing process.
             if (this.initialBlockDownloadState.IsInitialBlockDownload() && !peer.IsWhitelisted())
             {
-                this.logger.LogDebug("GetHeaders message from {0} was ignored because node is in IBD.", peer.PeerEndPoint);
-                this.logger.LogTrace("(-)[IGNORE_ON_IBD]");
+                this.logger.LogDebug("GetHeaders message from {0} was ignored because node is in IBD."
+                                    + "\r\n" + "(-)[IGNORE_ON_IBD]", peer.PeerEndPoint);
                 return;
             }
 
@@ -289,8 +289,7 @@ namespace Stratis.Bitcoin.Consensus
 
             if (headers.Count == 0)
             {
-                this.logger.LogDebug("Headers payload with no headers was received. Assuming we're synced with the peer.");
-                this.logger.LogTrace("(-)[NO_HEADERS]");
+                this.logger.LogDebug("Headers payload with no headers was received. Assuming we're synced with the peer." + "\r\n" + "(-)[NO_HEADERS]");
                 return;
             }
 
@@ -298,8 +297,7 @@ namespace Stratis.Bitcoin.Consensus
             {
                 this.peerBanning.BanAndDisconnectPeer(peer.PeerEndPoint, validationError);
 
-                this.logger.LogDebug("Headers are invalid. Peer was banned.");
-                this.logger.LogTrace("(-)[VALIDATION_FAILED]");
+                this.logger.LogDebug("Headers are invalid. Peer was banned." + "\r\n" + "(-)[VALIDATION_FAILED]");
                 return;
             }
 
@@ -308,8 +306,7 @@ namespace Stratis.Bitcoin.Consensus
                 if (this.cachedHeaders.Count > CacheSyncHeadersThreshold) // TODO when proven headers are implemented combine this with size threshold of N mb.
                 {
                     // Ignore this message because cache is full.
-                    this.logger.LogDebug("Cache is full. Headers ignored.");
-                    this.logger.LogTrace("(-)[CACHE_IS_FULL]");
+                    this.logger.LogDebug("Cache is full. Headers ignored." + "\r\n" + "(-)[CACHE_IS_FULL]");
                     return;
                 }
 
@@ -324,8 +321,8 @@ namespace Stratis.Bitcoin.Consensus
                     {
                         this.cachedHeaders.AddRange(headers);
 
-                        this.logger.LogDebug("{0} headers were added to cache, new cache size is {1}.", headers.Count, this.cachedHeaders.Count);
-                        this.logger.LogTrace("(-)[HEADERS_ADDED_TO_CACHE]");
+                        this.logger.LogDebug("{0} headers were added to cache, new cache size is {1}."
+                                            + "\r\n" + "(-)[HEADERS_ADDED_TO_CACHE]", headers.Count, this.cachedHeaders.Count);
                         return;
                     }
 
@@ -348,8 +345,8 @@ namespace Stratis.Bitcoin.Consensus
                     this.cachedHeaders.Clear();
                     await this.ResyncAsync().ConfigureAwait(false);
 
-                    this.logger.LogDebug("Header {0} could not be connected to last cached header {1}, clear cache and resync.", headers[0].GetHash(), cachedHeader);
-                    this.logger.LogTrace("(-)[FAILED_TO_ATTACH_TO_CACHE]");
+                    this.logger.LogDebug("Header {0} could not be connected to last cached header {1}, clear cache and resync."
+                                        + "\r\n" + "(-)[FAILED_TO_ATTACH_TO_CACHE]", headers[0].GetHash(), cachedHeader);
                     return;
                 }
 
@@ -357,9 +354,7 @@ namespace Stratis.Bitcoin.Consensus
 
                 if (result == null)
                 {
-                    this.logger.LogDebug("Processing of {0} headers failed.", headers.Count);
-                    this.logger.LogTrace("(-)[PROCESSING_FAILED]");
-
+                    this.logger.LogDebug("Processing of {0} headers failed." + "\r\n" + "(-)[PROCESSING_FAILED]", headers.Count);
                     return;
                 }
 
@@ -441,8 +436,7 @@ namespace Stratis.Bitcoin.Consensus
 
             if (peer == null)
             {
-                this.logger.LogDebug("Peer detached!");
-                this.logger.LogTrace("(-)[PEER_DETACHED]:null");
+                this.logger.LogDebug("Peer detached!" + "\r\n" + "(-)[PEER_DETACHED]:null");
                 return null;
             }
 

--- a/src/Stratis.Bitcoin/P2P/Peer/NetworkPeer.cs
+++ b/src/Stratis.Bitcoin/P2P/Peer/NetworkPeer.cs
@@ -495,8 +495,9 @@ namespace Stratis.Bitcoin.P2P.Peer
             }
             catch
             {
-                this.logger.LogDebug("Exception occurred while processing a message from the peer. Connection has been closed and message won't be processed further.");
-                this.logger.LogTrace("(-)[EXCEPTION_PROCESSING]");
+                this.logger.LogDebug("Exception occurred while processing a message from the peer. "
+                                    + "Connection has been closed and message won't be processed further."
+                                    + "\r\n" + "(-)[EXCEPTION_PROCESSING]");
                 return;
             }
 
@@ -508,8 +509,8 @@ namespace Stratis.Bitcoin.P2P.Peer
             }
             catch (Exception e)
             {
-                this.logger.LogCritical("Exception occurred while calling message received callbacks: {0}", e.ToString());
-                this.logger.LogTrace("(-)[EXCEPTION_CALLBACKS]");
+                this.logger.LogCritical("Exception occurred while calling message received callbacks: {0}"
+                                        + "\r\n" + "(-)[EXCEPTION_CALLBACKS]", e.ToString());
                 throw;
             }
             finally

--- a/src/Stratis.Bitcoin/P2P/Peer/NetworkPeerConnection.cs
+++ b/src/Stratis.Bitcoin/P2P/Peer/NetworkPeerConnection.cs
@@ -199,8 +199,7 @@ namespace Stratis.Bitcoin.P2P.Peer
             catch (Exception e)
             {
                 if (e is AggregateException) e = e.InnerException;
-                this.logger.LogDebug("Error connecting to '{0}', exception message: {1}", endPoint, e.Message);
-                this.logger.LogTrace("(-)[UNHANDLED_EXCEPTION]");
+                this.logger.LogDebug("Error connecting to '{0}', exception message: {1}" + "\r\n" + "(-)[UNHANDLED_EXCEPTION]", endPoint, e.Message);
                 throw e;
             }
         }


### PR DESCRIPTION
https://stratisplatformuk.visualstudio.com/StratisBitcoinFullNode/_workitems/edit/3003

_...inefficient log messages where we log similar message on two different log levels.
Since the log messages logged on Error level are also included on Trace level there is no reason to log them twice._

@fazz: Fix replaces any two sequential log messages at different levels of granularity with one combined message output at the coarsest (lowest) level.

Preferred: @maciejzaleski
