### PR TITLE
[Wallet] Fix sent transactions not confirming

### DIFF
--- a/src/Stratis.Bitcoin.Features.Wallet/WalletManager.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/WalletManager.cs
@@ -1149,7 +1149,7 @@ namespace Stratis.Bitcoin.Features.Wallet
             }
 
             // If the transaction is spent and confirmed, we remove the UTXO from the lookup dictionary.
-            if (spentTransaction.BlockHeight != null)
+            if (spentTransaction.SpendingDetails.BlockHeight != null)
             {
                 this.RemoveInputKeysLookupLock(spentTransaction);
             }


### PR DESCRIPTION
Rely on the spent transaction confirmation rather than on the receiving transaction confirmation to remove the output from the lookup table.

Related:
https://github.com/stratisproject/StratisBitcoinFullNode/issues/3107
https://github.com/stratisproject/StratisBitcoinFullNode/issues/3043