### PR TITLE
Improve login peer disconnect message (2)

### DIFF
--- a/src/Stratis.Bitcoin/P2P/Peer/NetworkPeer.cs
+++ b/src/Stratis.Bitcoin/P2P/Peer/NetworkPeer.cs
@@ -590,7 +590,7 @@ namespace Stratis.Bitcoin.P2P.Peer
                 }
                 catch (OperationCanceledException ex)
                 {
-                    if (ex.CancellationToken == cancellationSource.Token)
+                    if (ex.CancellationToken != null)
                     {
                         this.logger.LogTrace("Remote peer hasn't responded within 10 seconds of the handshake completion, dropping connection.");
                         this.Disconnect("Handshake timeout");


### PR DESCRIPTION
Invalid message could have been reported in some cases. Testing null inequality is more robust.

I'm sorry I've made such a rookie mistake. :-| 

Fix #2998