### PR TITLE
[SC] Fix sporadically failing SC integration test

### DIFF
--- a/src/Stratis.SmartContracts.IntegrationTests/PoW/SmartContractWalletTests.cs
+++ b/src/Stratis.SmartContracts.IntegrationTests/PoW/SmartContractWalletTests.cs
@@ -62,7 +62,7 @@ namespace Stratis.SmartContracts.IntegrationTests.PoW
                 HdAddress address = scReceiver.GetUnusedAddress();
                 scSender.SendTransaction(address.ScriptPubKey, Money.COIN * 100);
                 scReceiver.WaitMempoolCount(1);
-                Assert.Equal(Money.COIN * 100, (long)scReceiver.WalletSpendableBalance); // Balance is added (unconfirmed)
+                TestHelper.WaitLoop(() => (long) scReceiver.WalletSpendableBalance == Money.COIN * 100, waitTimeSeconds:10); // Give the wallet a bit of time to process receiving the transaction
 
                 // Transaction is in chain in last block.
                 scReceiver.MineBlocks(1);


### PR DESCRIPTION
Fixes an issue where a race condition was happening between the notification reaching the wallet and our code making it to the Assert.