### PR TITLE
[SC] Up RuntimeObserver package

### DIFF
--- a/src/Stratis.SmartContracts.RuntimeObserver/Stratis.SmartContracts.RuntimeObserver.csproj
+++ b/src/Stratis.SmartContracts.RuntimeObserver/Stratis.SmartContracts.RuntimeObserver.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
-    <Version>0.0.1-beta</Version>
+    <Version>0.0.2-beta</Version>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
Has already been deployed to NuGet. 

Important because everything uses 'Gas' from this package now. Will get weird hidden issues if we don't have our packages requiring this version.