### PR TITLE
[RPC] Better error handling with sendmany

### DIFF
--- a/src/Stratis.Bitcoin.Features.Wallet/WalletRPCController.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/WalletRPCController.cs
@@ -447,6 +447,10 @@ namespace Stratis.Bitcoin.Features.Wallet
 
                 return transaction.GetHash();
             }
+            catch (SecurityException exception)
+            {
+                throw new RPCServerException(RPCErrorCode.RPC_WALLET_UNLOCK_NEEDED, exception.Message);
+            }
             catch (WalletException exception)
             {
                 throw new RPCServerException(RPCErrorCode.RPC_WALLET_ERROR, exception.Message);

--- a/src/Stratis.Bitcoin.IntegrationTests/RPC/RPCTestsMutable.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/RPC/RPCTestsMutable.cs
@@ -171,6 +171,28 @@ namespace Stratis.Bitcoin.IntegrationTests.RPC
         }
 
         [Fact]
+        public void TestRpcSendManyWithLockedWalletFails()
+        {
+            using (NodeBuilder builder = NodeBuilder.Create(this))
+            {
+                Network network = new BitcoinRegTest();
+                var node = builder.CreateStratisPowNode(new BitcoinRegTest()).WithReadyBlockchainData(ReadyBlockchain.BitcoinRegTest150Miner).Start();
+
+                RPCClient rpcClient = node.CreateRPCClient();
+
+                var addresses = new Dictionary<string, decimal>
+                {
+                    { new Key().GetBitcoinSecret(network).GetAddress().ToString(), 1.0m },
+                    { new Key().GetBitcoinSecret(network).GetAddress().ToString(), 2.0m }
+                };
+
+                var addressesJson = JsonConvert.SerializeObject(addresses);
+                Action action = () => rpcClient.SendCommand(RPCOperations.sendmany, string.Empty, addressesJson);
+                action.Should().Throw<RPCException>().Which.RPCCode.Should().Be(RPCErrorCode.RPC_WALLET_UNLOCK_NEEDED);
+            }
+        }
+
+        [Fact]
         public void TestRpcSendManyWithInvalidParametersFails()
         {
             using (NodeBuilder builder = NodeBuilder.Create(this))


### PR DESCRIPTION
Give a better error when wallet is locked and spend is attempted. Add test for this scenario.