### PR TITLE
Add retry logic

### DIFF
--- a/src/Stratis.Bitcoin.Features.Consensus/ProvenBlockHeaders/ProvenBlockHeaderRepository.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/ProvenBlockHeaders/ProvenBlockHeaderRepository.cs
@@ -150,24 +150,18 @@ namespace Stratis.Bitcoin.Features.Consensus.ProvenBlockHeaders
             {
                 this.logger.LogTrace("({0}.Count():{1})", nameof(headers), headers.Count());
 
-                RetryStrategy.Run(
-                    DBreezeRetryOptions.Default,
-                    () =>
-                    {
-                        using (DBreeze.Transactions.Transaction transaction = this.dbreeze.GetTransaction())
-                        {
-                            transaction.SynchronizeTables(BlockHashHeightTable, ProvenBlockHeaderTable);
+                using (DBreeze.Transactions.Transaction transaction = this.dbreeze.GetTransaction())
+                {
+                    transaction.SynchronizeTables(BlockHashHeightTable, ProvenBlockHeaderTable);
 
-                            this.InsertHeaders(transaction, headers);
+                    this.InsertHeaders(transaction, headers);
 
-                            this.SetTip(transaction, newTip);
+                    this.SetTip(transaction, newTip);
 
-                            transaction.Commit();
+                    transaction.Commit();
 
-                            this.TipHashHeight = newTip;
-                        }
-                    },
-                    this.logger);
+                    this.TipHashHeight = newTip;
+                }
             });
 
             return task;

--- a/src/Stratis.Bitcoin.Features.Consensus/ProvenBlockHeaders/ProvenBlockHeaderRepository.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/ProvenBlockHeaders/ProvenBlockHeaderRepository.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using DBreeze;
 using DBreeze.DataTypes;
-using DBreeze.Exceptions;
 using DBreeze.Utils;
 using Microsoft.Extensions.Logging;
 using NBitcoin;

--- a/src/Stratis.Bitcoin.Features.Consensus/ProvenBlockHeaders/ProvenBlockHeaderRepository.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/ProvenBlockHeaders/ProvenBlockHeaderRepository.cs
@@ -150,8 +150,8 @@ namespace Stratis.Bitcoin.Features.Consensus.ProvenBlockHeaders
             {
                 this.logger.LogTrace("({0}.Count():{1})", nameof(headers), headers.Count());
 
-                RetryStrategy.Run<TableNotOperableException>(
-                    RetryOptions.Default,
+                RetryStrategy.Run(
+                    DBreezeRetryOptions.Default,
                     () =>
                     {
                         using (DBreeze.Transactions.Transaction transaction = this.dbreeze.GetTransaction())

--- a/src/Stratis.Bitcoin/Utilities/DBreezeRetryOptions.cs
+++ b/src/Stratis.Bitcoin/Utilities/DBreezeRetryOptions.cs
@@ -5,8 +5,8 @@ namespace Stratis.Bitcoin.Utilities
 {
     public class DBreezeRetryOptions : RetryOptions
     {
-        public DBreezeRetryOptions()
-            : base(1, TimeSpan.FromMilliseconds(100), typeof(TableNotOperableException))
+        public DBreezeRetryOptions(RetryStrategyType type = RetryStrategyType.Simple)
+            : base(1, TimeSpan.FromMilliseconds(100), type, typeof(TableNotOperableException))
         {
         }
 

--- a/src/Stratis.Bitcoin/Utilities/DBreezeRetryOptions.cs
+++ b/src/Stratis.Bitcoin/Utilities/DBreezeRetryOptions.cs
@@ -1,0 +1,15 @@
+using System;
+using DBreeze.Exceptions;
+
+namespace Stratis.Bitcoin.Utilities
+{
+    public class DBreezeRetryOptions : RetryOptions
+    {
+        public DBreezeRetryOptions()
+            : base(1, TimeSpan.FromMilliseconds(100), typeof(TableNotOperableException))
+        {
+        }
+
+        public static RetryOptions Default => new DBreezeRetryOptions();
+    }
+}

--- a/src/Stratis.Bitcoin/Utilities/RetryOptions.cs
+++ b/src/Stratis.Bitcoin/Utilities/RetryOptions.cs
@@ -1,0 +1,33 @@
+using System;
+
+namespace Stratis.Bitcoin.Utilities
+{
+    public class RetryOptions
+    {
+        public RetryOptions()
+        {
+            this.RetryCount = 1;
+            this.Delay = TimeSpan.FromMilliseconds(100);
+        }
+
+        public RetryOptions(short retryCount, TimeSpan delay)
+        {
+            if (retryCount < 1)
+                throw new ArgumentOutOfRangeException(nameof(retryCount), "Retry count cannot be less or equal to 0");
+
+            this.RetryCount = retryCount;
+            this.Delay = delay;
+        }
+
+        public static RetryOptions Default => new RetryOptions();
+
+        public short RetryCount { get; }
+
+        public TimeSpan Delay { get; }
+
+        public override string ToString()
+        {
+            return $"Retry count: {this.RetryCount}; Delay: {this.Delay}";
+        }
+    }
+}

--- a/src/Stratis.Bitcoin/Utilities/RetryOptions.cs
+++ b/src/Stratis.Bitcoin/Utilities/RetryOptions.cs
@@ -25,11 +25,6 @@ namespace Stratis.Bitcoin.Utilities
             if (retryCount < 1)
                 throw new ArgumentOutOfRangeException(nameof(retryCount), "Retry count cannot be less or equal to 0.");
 
-            if (exceptionTypeTypes.Length == 0)
-            {
-                this.ExceptionTypes = new[] { typeof(Exception) };
-            }
-
             this.RetryCount = retryCount;
             this.Delay = delay;
             this.ExceptionTypes = exceptionTypeTypes;

--- a/src/Stratis.Bitcoin/Utilities/RetryOptions.cs
+++ b/src/Stratis.Bitcoin/Utilities/RetryOptions.cs
@@ -9,7 +9,7 @@ namespace Stratis.Bitcoin.Utilities
         {
             this.RetryCount = 1;
             this.Delay = TimeSpan.FromMilliseconds(100);
-            this.ExceptionTypes = new[] { typeof(Exception) };
+            this.ExceptionTypes = Array.Empty<Type>();
         }
 
         public RetryOptions(short retryCount, TimeSpan delay, params Type[] exceptionTypeTypes)

--- a/src/Stratis.Bitcoin/Utilities/RetryOptions.cs
+++ b/src/Stratis.Bitcoin/Utilities/RetryOptions.cs
@@ -3,6 +3,12 @@ using System.Linq;
 
 namespace Stratis.Bitcoin.Utilities
 {
+    public enum RetryStrategyType
+    {
+        Simple = 1,
+        Backoff
+    }
+
     public class RetryOptions
     {
         public RetryOptions()
@@ -10,13 +16,14 @@ namespace Stratis.Bitcoin.Utilities
             this.RetryCount = 1;
             this.Delay = TimeSpan.FromMilliseconds(100);
             this.ExceptionTypes = Array.Empty<Type>();
+            this.Type = RetryStrategyType.Simple;
         }
 
-        public RetryOptions(short retryCount, TimeSpan delay, params Type[] exceptionTypeTypes)
+        public RetryOptions(short retryCount, TimeSpan delay, RetryStrategyType type = RetryStrategyType.Simple, params Type[] exceptionTypeTypes)
         {
             foreach (Type exceptionType in exceptionTypeTypes)
             {
-                if (!typeof(Exception).IsAssignableFrom(exceptionType)) 
+                if (!typeof(Exception).IsAssignableFrom(exceptionType))
                 {
                     throw new ArgumentException($"All exception types must be valid exceptions. {exceptionType} is not an Exception.");
                 }
@@ -28,10 +35,13 @@ namespace Stratis.Bitcoin.Utilities
             this.RetryCount = retryCount;
             this.Delay = delay;
             this.ExceptionTypes = exceptionTypeTypes;
+            this.Type = type;
         }
 
         public static RetryOptions Default => new RetryOptions();
 
+        public RetryStrategyType Type { get; }
+        
         public short RetryCount { get; }
 
         public Type[] ExceptionTypes { get; }

--- a/src/Stratis.Bitcoin/Utilities/RetryOptions.cs
+++ b/src/Stratis.Bitcoin/Utilities/RetryOptions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 
 namespace Stratis.Bitcoin.Utilities
 {
@@ -8,26 +9,43 @@ namespace Stratis.Bitcoin.Utilities
         {
             this.RetryCount = 1;
             this.Delay = TimeSpan.FromMilliseconds(100);
+            this.ExceptionTypes = new[] { typeof(Exception) };
         }
 
-        public RetryOptions(short retryCount, TimeSpan delay)
+        public RetryOptions(short retryCount, TimeSpan delay, params Type[] exceptionTypeTypes)
         {
+            foreach (Type exceptionType in exceptionTypeTypes)
+            {
+                if (!typeof(Exception).IsAssignableFrom(exceptionType)) 
+                {
+                    throw new ArgumentException($"All exception types must be valid exceptions. {exceptionType} is not an Exception.");
+                }
+            }
+
             if (retryCount < 1)
-                throw new ArgumentOutOfRangeException(nameof(retryCount), "Retry count cannot be less or equal to 0");
+                throw new ArgumentOutOfRangeException(nameof(retryCount), "Retry count cannot be less or equal to 0.");
+
+            if (exceptionTypeTypes.Length == 0)
+            {
+                this.ExceptionTypes = new[] { typeof(Exception) };
+            }
 
             this.RetryCount = retryCount;
             this.Delay = delay;
+            this.ExceptionTypes = exceptionTypeTypes;
         }
 
         public static RetryOptions Default => new RetryOptions();
 
         public short RetryCount { get; }
 
+        public Type[] ExceptionTypes { get; }
+
         public TimeSpan Delay { get; }
 
         public override string ToString()
         {
-            return $"Retry count: {this.RetryCount}; Delay: {this.Delay}";
+            return $"Retry count: {this.RetryCount}; Delay: {this.Delay}; Exceptions: {string.Join(", ", this.ExceptionTypes.Select(et => et.FullName))}";
         }
     }
 }

--- a/src/Stratis.Bitcoin/Utilities/RetryStrategy.cs
+++ b/src/Stratis.Bitcoin/Utilities/RetryStrategy.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+
+namespace Stratis.Bitcoin.Utilities
+{
+    public static class RetryStrategy
+    {
+        public static void Run<T>(RetryOptions retryOptions, Action actionToExecute, ILogger logger = null) where T : Exception
+        {
+            if (retryOptions == null || retryOptions.RetryCount == 0)
+            {
+                actionToExecute();
+                return;
+            }
+
+            for (int i = 0; i <= retryOptions.RetryCount; i++)
+            {
+                try
+                {
+                    actionToExecute();
+                    return;
+                }
+                catch (T ex)
+                {
+                    if (i >= retryOptions.RetryCount) throw;
+
+                    if (logger != null) logger.LogError("Failed to commit transaction. Retrying.", ex);
+                    Task.Delay(retryOptions.Delay).GetAwaiter().GetResult();
+                }
+            }
+        }
+
+        public static TReturn Run<T, TReturn>(RetryOptions retryOptions, Func<TReturn> actionToExecute, ILogger logger = null) where T : Exception
+        {
+            if (retryOptions == null || retryOptions.RetryCount == 0)
+            {
+                return actionToExecute();
+            }
+
+            for (int i = 0; i <= retryOptions.RetryCount; i++)
+            {
+                try
+                {
+                    TReturn result = actionToExecute();
+                    return result;
+                }
+                catch (T ex)
+                {
+                    if (i >= retryOptions.RetryCount) throw;
+
+                    if (logger != null) logger.LogError("Failed to commit transaction. Retrying.", ex);
+                    Task.Delay(retryOptions.Delay).GetAwaiter().GetResult();
+                }
+            }
+
+            throw default(T);
+        }
+    }
+}

--- a/src/Stratis.Bitcoin/Utilities/RetryStrategy.cs
+++ b/src/Stratis.Bitcoin/Utilities/RetryStrategy.cs
@@ -43,37 +43,5 @@ namespace Stratis.Bitcoin.Utilities
                 }
             }
         }
-
-        /// <summary>
-        /// Execute logic that should be retried if failure defined by <c>TException</c> occurs.
-        /// </summary>
-        /// <param name="retryOptions">Retry options, including number of retries and delay between them.</param>
-        /// <param name="actionToExecute">Logic to be executed.</param>
-        /// <param name="logger">Optional logger.</param>
-        public static TReturn Run<TReturn>(RetryOptions retryOptions, Func<TReturn> actionToExecute, ILogger logger = null)
-        {
-            if (retryOptions == null || retryOptions.RetryCount == 0)
-            {
-                return actionToExecute();
-            }
-
-            for (int i = 0; i <= retryOptions.RetryCount; i++)
-            {
-                try
-                {
-                    TReturn result = actionToExecute();
-                    return result;
-                }
-                catch (Exception ex)
-                {
-                    if (retryOptions.ExceptionTypes.All(et => et != ex.GetType()) || i >= retryOptions.RetryCount) throw;
-
-                    if (logger != null) logger.LogError("Failed to commit transaction. Retrying.", ex);
-                    Task.Delay(retryOptions.Delay).GetAwaiter().GetResult();
-                }
-            }
-
-            throw new InvalidOperationException("Retry strategy execution failed.");
-        }
     }
 }

--- a/src/Stratis.Bitcoin/Utilities/RetryStrategy.cs
+++ b/src/Stratis.Bitcoin/Utilities/RetryStrategy.cs
@@ -34,7 +34,12 @@ namespace Stratis.Bitcoin.Utilities
                     if (retryOptions.ExceptionTypes.All(et => et != ex.GetType()) || i >= retryOptions.RetryCount) throw;
 
                     if (logger != null) logger.LogError("Failed to commit transaction. Retrying.", ex);
-                    Task.Delay(retryOptions.Delay).GetAwaiter().GetResult();
+
+                    // Check strategy type and if it is a backoff type, use exponential delay. 
+                    TimeSpan delay = retryOptions.Type == RetryStrategyType.Simple
+                        ? retryOptions.Delay
+                        : TimeSpan.FromMilliseconds((int)(retryOptions.Delay.TotalMilliseconds * Math.Pow(2, i)));
+                    Task.Delay(delay).GetAwaiter().GetResult();
                 }
             }
         }


### PR DESCRIPTION
This is related to the issue when DBreeze transaction commit throws an I/O exception during disk write when multiple nodes are running on the same disk.

Another thing to consider is to upgrade DBreeze nuget package from 1.89 to 1.92 as few minor improvements were made.