### PR TITLE
[SC] Start test PoA mockchains from same time

### DIFF
--- a/src/Stratis.SmartContracts.Networks/SmartContractsPoARegTest.cs
+++ b/src/Stratis.SmartContracts.Networks/SmartContractsPoARegTest.cs
@@ -58,7 +58,7 @@ namespace Stratis.SmartContracts.Networks
                 maxBlockSigopsCost: 20_000,
                 maxStandardTxSigopsCost: 20_000 / 5,
                 federationPublicKeys: federationPubKeys,
-                targetSpacingSeconds: 3
+                targetSpacingSeconds: 4 // Low waiting time for PoA turn-taking, but goes into 16 so the intervals fall on the same time
             );
 
             var buriedDeployments = new BuriedDeploymentsArray

--- a/src/Stratis.SmartContracts.Tests.Common/MockChain/PoAMockChainFixture.cs
+++ b/src/Stratis.SmartContracts.Tests.Common/MockChain/PoAMockChainFixture.cs
@@ -12,8 +12,8 @@ namespace Stratis.SmartContracts.Tests.Common.MockChain
         {
             PoAMockChain mockChain = new PoAMockChain(2).Build();
             this.Chain = mockChain;
-            var node1 = this.Chain.Nodes[0];
-            var node2 = this.Chain.Nodes[1];
+            MockChainNode node1 = this.Chain.Nodes[0];
+            MockChainNode node2 = this.Chain.Nodes[1];
 
             // Get premine
             mockChain.MineBlocks(10);
@@ -21,11 +21,11 @@ namespace Stratis.SmartContracts.Tests.Common.MockChain
             // Send half to other from whoever received premine
             if ((long)node1.WalletSpendableBalance == node1.CoreNode.FullNode.Network.Consensus.PremineReward.Satoshi)
             {
-                PayHalfPremine(node1, node2);
+                this.PayHalfPremine(node1, node2);
             }
             else
             {
-                PayHalfPremine(node2, node1);
+                this.PayHalfPremine(node2, node1);
             }
         }
 

--- a/src/Stratis.SmartContracts.Tests.Common/MockChain/TargetSpacingDateTimeProvider.cs
+++ b/src/Stratis.SmartContracts.Tests.Common/MockChain/TargetSpacingDateTimeProvider.cs
@@ -13,7 +13,7 @@ namespace Stratis.SmartContracts.Tests.Common.MockChain
 
         public TargetSpacingDateTimeProvider(Network network)
         {
-            this.backing = DateTime.Now;
+            this.backing = DateTimeOffset.FromUnixTimeSeconds(network.GenesisTime + 1).UtcDateTime;
             this.spacing = (network.Consensus.Options as PoAConsensusOptions).TargetSpacingSeconds;
         }
 


### PR DESCRIPTION
Should make tests run 'deterministically' -> the time being fed to them will be consistent and so should avoid certain race conditions with poa turn-taking