### PR TITLE
Fix DBreeze transactional setups

### DIFF
--- a/src/Stratis.Bitcoin.Features.BlockStore.Tests/BlockRepositoryTest.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore.Tests/BlockRepositoryTest.cs
@@ -23,6 +23,7 @@ namespace Stratis.Bitcoin.Features.BlockStore.Tests
             using (var engine = new DBreezeEngine(dir))
             {
                 DBreeze.Transactions.Transaction transaction = engine.GetTransaction();
+                transaction.ValuesLazyLoadingIsOn = false;
 
                 Row<byte[], byte[]> blockRow = transaction.Select<byte[], byte[]>("Common", new byte[0]);
                 Row<byte[], bool> txIndexRow = transaction.Select<byte[], bool>("Common", new byte[1]);
@@ -53,6 +54,7 @@ namespace Stratis.Bitcoin.Features.BlockStore.Tests
             using (var engine = new DBreezeEngine(dir))
             {
                 DBreeze.Transactions.Transaction transaction = engine.GetTransaction();
+                transaction.ValuesLazyLoadingIsOn = false;
 
                 Row<byte[], byte[]> blockRow = transaction.Select<byte[], byte[]>("Common", new byte[0]);
                 Row<byte[], bool> txIndexRow = transaction.Select<byte[], bool>("Common", new byte[1]);
@@ -122,6 +124,7 @@ namespace Stratis.Bitcoin.Features.BlockStore.Tests
                 block.Transactions.Add(trans);
 
                 DBreeze.Transactions.Transaction transaction = engine.GetTransaction();
+                transaction.SynchronizeTables("Block", "Transaction", "Common");
                 transaction.Insert<byte[], byte[]>("Block", block.Header.GetHash().ToBytes(), block.ToBytes());
                 transaction.Insert<byte[], byte[]>("Transaction", trans.GetHash().ToBytes(), block.Header.GetHash().ToBytes());
                 transaction.Insert<byte[], byte[]>("Common", new byte[0], this.DBreezeSerializer.Serialize(new HashHeightPair(uint256.Zero, 1)));
@@ -190,6 +193,7 @@ namespace Stratis.Bitcoin.Features.BlockStore.Tests
             using (var engine = new DBreezeEngine(dir))
             {
                 DBreeze.Transactions.Transaction transaction = engine.GetTransaction();
+                transaction.SynchronizeTables("Transaction", "Common");
                 transaction.Insert<byte[], byte[]>("Transaction", new uint256(26).ToBytes(), new uint256(42).ToBytes());
                 transaction.Insert<byte[], byte[]>("Common", new byte[0], this.DBreezeSerializer.Serialize(new HashHeightPair(uint256.Zero, 1)));
                 transaction.Insert<byte[], bool>("Common", new byte[1], true);
@@ -247,6 +251,7 @@ namespace Stratis.Bitcoin.Features.BlockStore.Tests
             using (var engine = new DBreezeEngine(dir))
             {
                 DBreeze.Transactions.Transaction trans = engine.GetTransaction();
+                trans.ValuesLazyLoadingIsOn = false;
 
                 Row<byte[], byte[]> blockHashKeyRow = trans.Select<byte[], byte[]>("Common", new byte[0]);
                 Dictionary<byte[], byte[]> blockDict = trans.SelectDictionary<byte[], byte[]>("Block");
@@ -290,6 +295,7 @@ namespace Stratis.Bitcoin.Features.BlockStore.Tests
             using (var engine = new DBreezeEngine(dir))
             {
                 DBreeze.Transactions.Transaction trans = engine.GetTransaction();
+                trans.ValuesLazyLoadingIsOn = false;
 
                 Row<byte[], bool> txIndexRow = trans.Select<byte[], bool>("Common", new byte[1]);
                 Assert.False(txIndexRow.Value);
@@ -410,6 +416,7 @@ namespace Stratis.Bitcoin.Features.BlockStore.Tests
             using (var engine = new DBreezeEngine(dir))
             {
                 DBreeze.Transactions.Transaction transaction = engine.GetTransaction();
+                transaction.SynchronizeTables("Block", "Transaction", "Common");
                 transaction.Insert<byte[], byte[]>("Block", block.GetHash().ToBytes(), block.ToBytes());
                 transaction.Insert<byte[], byte[]>("Transaction", block.Transactions[0].GetHash().ToBytes(), block.GetHash().ToBytes());
                 transaction.Insert<byte[], bool>("Common", new byte[1], true);
@@ -427,6 +434,7 @@ namespace Stratis.Bitcoin.Features.BlockStore.Tests
             using (var engine = new DBreezeEngine(dir))
             {
                 DBreeze.Transactions.Transaction trans = engine.GetTransaction();
+                trans.SynchronizeTables("Common", "Block", "Transaction");
 
                 Row<byte[], byte[]> blockHashKeyRow = trans.Select<byte[], byte[]>("Common", new byte[0]);
                 Dictionary<byte[], byte[]> blockDict = trans.SelectDictionary<byte[], byte[]>("Block");
@@ -468,6 +476,8 @@ namespace Stratis.Bitcoin.Features.BlockStore.Tests
             using (var engine = new DBreezeEngine(dir))
             {
                 DBreeze.Transactions.Transaction dbreezeTransaction = engine.GetTransaction();
+                dbreezeTransaction.ValuesLazyLoadingIsOn = false;
+
                 Dictionary<byte[], byte[]> blockDict = dbreezeTransaction.SelectDictionary<byte[], byte[]>("Block");
                 Dictionary<byte[], byte[]> transDict = dbreezeTransaction.SelectDictionary<byte[], byte[]>("Transaction");
 
@@ -495,6 +505,7 @@ namespace Stratis.Bitcoin.Features.BlockStore.Tests
             using (var engine = new DBreezeEngine(dir))
             {
                 DBreeze.Transactions.Transaction dbreezeTransaction = engine.GetTransaction();
+                dbreezeTransaction.SynchronizeTables("Block", "Transaction");
                 dbreezeTransaction.Insert<byte[], byte[]>("Block", block.GetHash().ToBytes(), block.ToBytes());
                 dbreezeTransaction.Insert<byte[], byte[]>("Transaction", transaction.GetHash().ToBytes(), block.GetHash().ToBytes());
                 dbreezeTransaction.Commit();
@@ -514,6 +525,7 @@ namespace Stratis.Bitcoin.Features.BlockStore.Tests
             using (var engine = new DBreezeEngine(dir))
             {
                 DBreeze.Transactions.Transaction dbreezeTransaction = engine.GetTransaction();
+                dbreezeTransaction.ValuesLazyLoadingIsOn = false;
                 Dictionary<byte[], byte[]> blockDict = dbreezeTransaction.SelectDictionary<byte[], byte[]>("Block");
                 Dictionary<byte[], byte[]> transDict = dbreezeTransaction.SelectDictionary<byte[], byte[]>("Transaction");
 

--- a/src/Stratis.Bitcoin.Features.BlockStore/BlockRepository.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/BlockRepository.cs
@@ -320,7 +320,7 @@ namespace Stratis.Bitcoin.Features.BlockStore
                 // however we need to find how byte arrays are sorted in DBreeze.
                 using (DBreeze.Transactions.Transaction transaction = this.DBreeze.GetTransaction())
                 {
-                    transaction.SynchronizeTables(BlockTableName, TransactionTableName);
+                    transaction.SynchronizeTables(BlockTableName, TransactionTableName, CommonTableName);
                     this.OnInsertBlocks(transaction, blocks);
 
                     // Commit additions

--- a/src/Stratis.Bitcoin.Features.BlockStore/Pruning/PrunedBlockRepository.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/Pruning/PrunedBlockRepository.cs
@@ -138,7 +138,7 @@ namespace Stratis.Bitcoin.Features.BlockStore.Pruning
             {
                 using (DBreeze.Transactions.Transaction dbreezeTransaction = this.blockRepository.DBreeze.GetTransaction())
                 {
-                    dbreezeTransaction.SynchronizeTables(BlockRepository.BlockTableName, BlockRepository.TransactionTableName);
+                    dbreezeTransaction.SynchronizeTables(BlockRepository.BlockTableName, BlockRepository.TransactionTableName, BlockRepository.CommonTableName);
 
                     var tempBlocks = dbreezeTransaction.SelectDictionary<byte[], byte[]>(BlockRepository.BlockTableName);
 

--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/ProvenBlockHeaders/ProvenBlockHeaderRepositoryTests.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/ProvenBlockHeaders/ProvenBlockHeaderRepositoryTests.cs
@@ -61,7 +61,6 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.ProvenBlockHeaders
             using (var engine = new DBreezeEngine(folder))
             {
                 DBreeze.Transactions.Transaction txn = engine.GetTransaction();
-                txn.SynchronizeTables(ProvenBlockHeaderTable);
                 txn.ValuesLazyLoadingIsOn = false;
 
                 var headerOut = this.dBreezeSerializer.Deserialize<ProvenBlockHeader>(txn.Select<byte[], byte[]>(ProvenBlockHeaderTable, blockHashHeightPair.Height.ToBytes()).Value);
@@ -96,7 +95,6 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.ProvenBlockHeaders
             using (var engine = new DBreezeEngine(folder))
             {
                 DBreeze.Transactions.Transaction txn = engine.GetTransaction();
-                txn.SynchronizeTables(ProvenBlockHeaderTable);
                 txn.ValuesLazyLoadingIsOn = false;
 
                 var headersOut = txn.SelectDictionary<byte[], byte[]>(ProvenBlockHeaderTable);
@@ -141,6 +139,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.ProvenBlockHeaders
             using (var engine = new DBreezeEngine(folder))
             {
                 DBreeze.Transactions.Transaction txn = engine.GetTransaction();
+                txn.SynchronizeTables(ProvenBlockHeaderTable, BlockHashTable);
                 txn.Insert<byte[], byte[]>(ProvenBlockHeaderTable, 1.ToBytes(), this.dBreezeSerializer.Serialize(CreateNewProvenBlockHeaderMock()));
                 txn.Insert<byte[], byte[]>(BlockHashTable, new byte[0], this.DBreezeSerializer.Serialize(new HashHeightPair(new uint256(), 1)));
                 txn.Commit();

--- a/src/Stratis.Bitcoin.Features.Consensus/ProvenBlockHeaders/ProvenBlockHeaderRepository.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/ProvenBlockHeaders/ProvenBlockHeaderRepository.cs
@@ -121,8 +121,6 @@ namespace Stratis.Bitcoin.Features.Consensus.ProvenBlockHeaders
             {
                 using (DBreeze.Transactions.Transaction transaction = this.dbreeze.GetTransaction())
                 {
-                    transaction.SynchronizeTables(ProvenBlockHeaderTable);
-
                     transaction.ValuesLazyLoadingIsOn = false;
 
                     Row<byte[], byte[]> row = transaction.Select<byte[], byte[]>(ProvenBlockHeaderTable, blockHeight.ToBytes());

--- a/src/Stratis.Bitcoin.Tests/Utilities/DBreezeTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Utilities/DBreezeTest.cs
@@ -169,6 +169,7 @@ namespace Stratis.Bitcoin.Tests.Utilities
             {
                 using (DBreeze.Transactions.Transaction transaction = engine.GetTransaction())
                 {
+                    transaction.ValuesLazyLoadingIsOn = false;
                     var data2 = new uint256[data.Length];
                     int i = 0;
                     foreach (Row<int, byte[]> row in transaction.SelectForward<int, byte[]>("Table"))

--- a/src/Stratis.SmartContracts.Core/Receipts/PersistentReceiptRepository.cs
+++ b/src/Stratis.SmartContracts.Core/Receipts/PersistentReceiptRepository.cs
@@ -38,6 +38,8 @@ namespace Stratis.SmartContracts.Core.Receipts
         {
             using (DBreeze.Transactions.Transaction t = this.engine.GetTransaction())
             {
+                t.ValuesLazyLoadingIsOn = false;
+
                 byte[] result = t.Select<byte[], byte[]>(TableName, hash.ToBytes()).Value;
 
                 if (result == null)

--- a/src/Stratis.SmartContracts.Core/State/DBreezeByteStore.cs
+++ b/src/Stratis.SmartContracts.Core/State/DBreezeByteStore.cs
@@ -24,6 +24,7 @@ namespace Stratis.SmartContracts.Core.State
         {
             using (DBreeze.Transactions.Transaction t = this.engine.GetTransaction())
             {
+                t.ValuesLazyLoadingIsOn = false;
                 Row<byte[], byte[]> row = t.Select<byte[], byte[]>(this.table, key);
 
                 if (row.Exists)


### PR DESCRIPTION
This PR ensures that:

1) `SyncronizeTables` is used to list **ALL** tables that will be written to during a DBreeze transaction.

![image](https://user-images.githubusercontent.com/29645989/52934256-f7b78580-33a9-11e9-9116-1f91dc025e55.png)

![image](https://user-images.githubusercontent.com/29645989/52934425-83311680-33aa-11e9-8cc2-1b8296e1e878.png)

2) `transaction.ValuesLazyLoadingIsOn = false;` is used when reading from the DBreeze database.