### PR TITLE
[RPC] Fix Json types for gettransaction response

### DIFF
--- a/src/Stratis.Bitcoin.Features.Wallet/Models/GetTransactionModel.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Models/GetTransactionModel.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Runtime.Serialization;
 using NBitcoin;
 using Newtonsoft.Json;
@@ -115,6 +114,12 @@ namespace Stratis.Bitcoin.Features.Wallet.Models
         /// </summary>
         [JsonProperty("fee", NullValueHandling = NullValueHandling.Ignore)]
         public decimal? Fee { get; set; }
+
+        /// <summary>
+        /// The index of the output being sent or received.
+        /// </summary>
+        [JsonProperty("vout", NullValueHandling = NullValueHandling.Ignore)]
+        public int? OutputIndex { get; set; }
     }
 
     [JsonConverter(typeof(StringEnumConverter))]

--- a/src/Stratis.Bitcoin.Features.Wallet/Models/GetTransactionModel.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Models/GetTransactionModel.cs
@@ -16,13 +16,13 @@ namespace Stratis.Bitcoin.Features.Wallet.Models
         /// Can be positive (received), negative (sent) or 0 (payment to yourself).
         /// </summary>
         [JsonProperty("amount")]
-        public Money Amount { get; set; }
+        public decimal Amount { get; set; }
 
         /// <summary>
         /// The amount of the fee. This is negative and only available for the 'send' category of transactions.
         /// </summary>
         [JsonProperty("fee", NullValueHandling = NullValueHandling.Ignore)]
-        public Money Fee { get; set; }
+        public decimal? Fee { get; set; }
 
         /// <summary>
         /// The number of confirmations.
@@ -53,8 +53,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Models
         /// The time in seconds since epoch (1 Jan 1970 GMT).
         /// </summary>
         [JsonProperty(PropertyName = "blocktime", NullValueHandling = NullValueHandling.Ignore)]
-        [JsonConverter(typeof(DateTimeOffsetConverter))]
-        public DateTimeOffset? BlockTime { get; set; }
+        public long? BlockTime { get; set; }
 
         /// <summary>
         /// The transaction id.
@@ -67,15 +66,13 @@ namespace Stratis.Bitcoin.Features.Wallet.Models
         /// The transaction time in seconds since epoch (1 Jan 1970 GMT).
         /// </summary>
         [JsonProperty("time")]
-        [JsonConverter(typeof(DateTimeOffsetConverter))]
-        public DateTimeOffset TransactionTime { get; set; }
+        public long TransactionTime { get; set; }
 
         /// <summary>
         /// The time received in seconds since epoch (1 Jan 1970 GMT).
         /// </summary>
-        [JsonProperty(PropertyName = "timereceived", NullValueHandling = NullValueHandling.Ignore)]
-        [JsonConverter(typeof(DateTimeOffsetConverter))]
-        public DateTimeOffset TimeReceived { get; set; }
+        [JsonProperty(PropertyName = "timereceived")]
+        public long TimeReceived { get; set; }
 
         /// <summary>
         /// Details of the transaction.
@@ -111,13 +108,13 @@ namespace Stratis.Bitcoin.Features.Wallet.Models
         /// Can be positive (received) or negative (sent).
         /// </summary>
         [JsonProperty("amount")]
-        public Money Amount { get; set; }
+        public decimal Amount { get; set; }
 
         /// <summary>
         /// The amount of the fee. This is negative and only available for the 'send' category of transactions.
         /// </summary>
         [JsonProperty("fee", NullValueHandling = NullValueHandling.Ignore)]
-        public Money Fee { get; set; }
+        public decimal? Fee { get; set; }
     }
 
     [JsonConverter(typeof(StringEnumConverter))]

--- a/src/Stratis.Bitcoin.Features.Wallet/Wallet.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Wallet.cs
@@ -1034,7 +1034,7 @@ namespace Stratis.Bitcoin.Features.Wallet
         /// <summary>
         /// The index of the output of the destination address.
         /// </summary>
-        [JsonProperty(PropertyName = "outputIndex")]
+        [JsonProperty(PropertyName = "outputIndex", NullValueHandling = NullValueHandling.Ignore)]
         public int? OutputIndex { get; set; }
 
         /// <summary>

--- a/src/Stratis.Bitcoin.Features.Wallet/Wallet.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Wallet.cs
@@ -1026,10 +1026,16 @@ namespace Stratis.Bitcoin.Features.Wallet
         public Script DestinationScriptPubKey { get; set; }
 
         /// <summary>
-        /// The Base58 representation of the destination  address.
+        /// The Base58 representation of the destination address.
         /// </summary>
         [JsonProperty(PropertyName = "destinationAddress")]
         public string DestinationAddress { get; set; }
+
+        /// <summary>
+        /// The index of the output of the destination address.
+        /// </summary>
+        [JsonProperty(PropertyName = "outputIndex")]
+        public int? OutputIndex { get; set; }
 
         /// <summary>
         /// The transaction amount.

--- a/src/Stratis.Bitcoin.Features.Wallet/WalletManager.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/WalletManager.cs
@@ -1126,7 +1126,8 @@ namespace Stratis.Bitcoin.Features.Wallet
                     {
                         DestinationScriptPubKey = paidToOutput.ScriptPubKey,
                         DestinationAddress = destinationAddress,
-                        Amount = paidToOutput.Value
+                        Amount = paidToOutput.Value,
+                        OutputIndex = transaction.Outputs.IndexOf(paidToOutput)
                     });
                 }
 

--- a/src/Stratis.Bitcoin.Features.Wallet/WalletRPCController.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/WalletRPCController.cs
@@ -289,6 +289,7 @@ namespace Stratis.Bitcoin.Features.Wallet
                         Category = GetTransactionDetailsCategoryModel.Send,
                         Amount = -paymentDetail.Amount.ToDecimal(MoneyUnit.BTC),
                         Fee = null, // TODO this still needs to be worked on.
+                        OutputIndex = paymentDetail.OutputIndex
                     });
                 }
             }
@@ -311,6 +312,7 @@ namespace Stratis.Bitcoin.Features.Wallet
                     Address = addresses.First(a => a.Transactions.Contains(trxInWallet)).Address,
                     Category = category,
                     Amount = trxInWallet.Amount.ToDecimal(MoneyUnit.BTC),
+                    OutputIndex = trxInWallet.Index
                 });
             }
 

--- a/src/Stratis.Bitcoin.Features.Wallet/WalletRPCController.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/WalletRPCController.cs
@@ -258,21 +258,21 @@ namespace Stratis.Bitcoin.Features.Wallet
                 hex = null; // TODO get from mempool
             }
 
-            long amountSent = sendTransactions.Select(s => s.SpendingDetails).SelectMany(sds => sds.Payments).GroupBy(p => p.DestinationAddress).Select(g => g.First()).Sum(p => p.Amount);
-            long totalAmount = receivedTransactions.Sum(t => t.Amount) - amountSent;
+            Money amountSent = sendTransactions.Select(s => s.SpendingDetails).SelectMany(sds => sds.Payments).GroupBy(p => p.DestinationAddress).Select(g => g.First()).Sum(p => p.Amount);
+            Money totalAmount = receivedTransactions.Sum(t => t.Amount) - amountSent;
 
             var model = new GetTransactionModel
             {
-                Amount = totalAmount,
-                //Fee = TODO this still needs to be worked on.
+                Amount = totalAmount.ToDecimal(MoneyUnit.BTC),
+                Fee = null,// TODO this still needs to be worked on.
                 Confirmations = blockHeight != null ? this.ConsensusManager.Tip.Height - blockHeight.Value + 1 : 0,
                 Isgenerated = isGenerated ? true : (bool?) null,
                 BlockHash = blockHash,
                 BlockIndex = block?.Transactions.FindIndex(t => t.GetHash() == trxid),
-                BlockTime = block?.Header.BlockTime,
+                BlockTime = block?.Header.BlockTime.ToUnixTimeSeconds(),
                 TransactionId = uint256.Parse(txid),
-                TransactionTime = transactionTime,
-                TimeReceived = transactionTime,
+                TransactionTime = transactionTime.ToUnixTimeSeconds(),
+                TimeReceived = transactionTime.ToUnixTimeSeconds(),
                 Details = new List<GetTransactionDetailsModel>(),
                 Hex = hex
             };
@@ -287,8 +287,8 @@ namespace Stratis.Bitcoin.Features.Wallet
                     {
                         Address = paymentDetail.DestinationAddress,
                         Category = GetTransactionDetailsCategoryModel.Send,
-                        Amount = -paymentDetail.Amount,
-                        Fee = Money.Zero // TODO this still needs to be worked on.
+                        Amount = -paymentDetail.Amount.ToDecimal(MoneyUnit.BTC),
+                        Fee = null, // TODO this still needs to be worked on.
                     });
                 }
             }
@@ -310,7 +310,7 @@ namespace Stratis.Bitcoin.Features.Wallet
                 {
                     Address = addresses.First(a => a.Transactions.Contains(trxInWallet)).Address,
                     Category = category,
-                    Amount = trxInWallet.Amount
+                    Amount = trxInWallet.Amount.ToDecimal(MoneyUnit.BTC),
                 });
             }
 

--- a/src/Stratis.Bitcoin.IntegrationTests/Wallet/WalletRPCControllerTest.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/Wallet/WalletRPCControllerTest.cs
@@ -99,21 +99,21 @@ namespace Stratis.Bitcoin.IntegrationTests.Wallet
 
                 // Assert.
                 GetTransactionModel result = walletTx.Result.ToObject<GetTransactionModel>();
-                result.Amount.Should().Be(new Money(400000000));
+                result.Amount.Should().Be((decimal)4.00000000);
                 result.Fee.Should().BeNull();
                 result.Confirmations.Should().Be(148);
                 result.Isgenerated.Should().BeTrue();
                 result.TransactionId.Should().Be(uint256.Parse(txId));
                 result.BlockHash.ToString().Should().Be("b1209de1c0347be83bb02a3bf9b70e33b06c82b91e68bc6392e6fb813cd5e4bd");
                 result.BlockIndex.Should().Be(0);
-                result.BlockTime.Should().Be(Utils.UnixTimeToDateTime(1547206662));
-                result.TimeReceived.Should().Be(Utils.UnixTimeToDateTime(1547206661));
-                result.TransactionTime.Should().Be(Utils.UnixTimeToDateTime(1547206661));
+                result.BlockTime.Should().Be(1547206662);
+                result.TimeReceived.Should().Be(1547206661);
+                result.TransactionTime.Should().Be(1547206661);
                 result.Details.Should().ContainSingle();
 
                 GetTransactionDetailsModel details = result.Details.Single();
                 details.Address.Should().Be("TXYdgqNVbHTfW5FsdxqSX6vejBByNEk2Yb");
-                details.Amount.Should().Be(new Money(400000000));
+                details.Amount.Should().Be((decimal)4.00000000);
                 details.Fee.Should().BeNull();
                 details.Category.Should().Be(GetTransactionDetailsCategoryModel.Generate);
             }
@@ -144,20 +144,20 @@ namespace Stratis.Bitcoin.IntegrationTests.Wallet
 
                 // Assert.
                 GetTransactionModel result = walletTx.Result.ToObject<GetTransactionModel>();
-                result.Amount.Should().Be(new Money(400000000));
+                result.Amount.Should().Be((decimal)4.00000000);
                 result.Fee.Should().BeNull();
                 result.Confirmations.Should().Be(6);
                 result.Isgenerated.Should().BeTrue();
                 result.TransactionId.Should().Be(uint256.Parse(txId));
                 result.BlockHash.ToString().Should().Be("b8ab1d66febfde4c26d0b4755f7def50a63e06267cefc6d6836651fa8910babc");
                 result.BlockIndex.Should().Be(0);
-                result.BlockTime.Should().Be(block.Time);
-                result.TimeReceived.Should().BeOnOrBefore(block.Time);
+                result.BlockTime.Should().Be(block.Time.ToUnixTimeSeconds());
+                result.TimeReceived.Should().BeLessOrEqualTo(block.Time.ToUnixTimeSeconds());
                 result.Details.Should().ContainSingle();
 
                 GetTransactionDetailsModel details = result.Details.Single();
                 details.Address.Should().Be("TXYdgqNVbHTfW5FsdxqSX6vejBByNEk2Yb");
-                details.Amount.Should().Be(new Money(400000000));
+                details.Amount.Should().Be((decimal)4.00000000);
                 details.Fee.Should().BeNull();
                 details.Category.Should().Be(GetTransactionDetailsCategoryModel.Immature);
             }
@@ -242,38 +242,38 @@ namespace Stratis.Bitcoin.IntegrationTests.Wallet
 
                 // Assert.
                 GetTransactionModel resultSendingWallet = txSendingWallet.Result.ToObject<GetTransactionModel>();
-                resultSendingWallet.Amount.Should().Be(new Money(-100000000));
+                resultSendingWallet.Amount.Should().Be((decimal) -1.00000000);
                 //resultSendingWallet.Fee.Should().Be(new Money(100000000)); // TODO Uncomment when is available.
                 resultSendingWallet.Confirmations.Should().Be(0);
                 resultSendingWallet.TransactionId.Should().Be(txId);
                 resultSendingWallet.BlockHash.Should().BeNull();
                 resultSendingWallet.BlockIndex.Should().BeNull();
                 resultSendingWallet.BlockTime.Should().BeNull();
-                resultSendingWallet.TimeReceived.Should().BeAfter(DateTimeOffset.Now - TimeSpan.FromMinutes(1));
-                resultSendingWallet.TransactionTime.Should().Be(Utils.UnixTimeToDateTime(trx.Time));
+                resultSendingWallet.TimeReceived.Should().BeGreaterThan((DateTimeOffset.Now - TimeSpan.FromMinutes(1)).ToUnixTimeSeconds());
+                resultSendingWallet.TransactionTime.Should().Be(trx.Time);
                 resultSendingWallet.Details.Count.Should().Be(1);
 
                 GetTransactionDetailsModel detailsSendingWallet = resultSendingWallet.Details.Single();
                 detailsSendingWallet.Address.Should().Be(unusedaddresses.Single());
-                detailsSendingWallet.Amount.Should().Be(new Money(-100000000));
+                detailsSendingWallet.Amount.Should().Be((decimal)-1.00000000);
                 //detailsSendingWallet.Fee.Should().Be(new Money(100000000)); // TODO Uncomment when is available.
                 detailsSendingWallet.Category.Should().Be(GetTransactionDetailsCategoryModel.Send);
 
                 GetTransactionModel resultReceivingWallet = txReceivingWallet.Result.ToObject<GetTransactionModel>();
-                resultReceivingWallet.Amount.Should().Be(new Money(100000000));
+                resultReceivingWallet.Amount.Should().Be((decimal)1.00000000);
                 resultReceivingWallet.Fee.Should().BeNull();
                 resultReceivingWallet.Confirmations.Should().Be(0);
                 resultReceivingWallet.TransactionId.Should().Be(txId);
                 resultReceivingWallet.BlockHash.Should().BeNull();
                 resultReceivingWallet.BlockIndex.Should().BeNull();
                 resultReceivingWallet.BlockTime.Should().BeNull();
-                resultReceivingWallet.TimeReceived.Should().BeAfter(DateTimeOffset.Now - TimeSpan.FromMinutes(1));
-                resultReceivingWallet.TransactionTime.Should().BeAfter(DateTimeOffset.Now - TimeSpan.FromMinutes(1));
+                resultReceivingWallet.TimeReceived.Should().BeGreaterThan((DateTimeOffset.Now - TimeSpan.FromMinutes(1)).ToUnixTimeSeconds());
+                resultReceivingWallet.TransactionTime.Should().BeGreaterThan((DateTimeOffset.Now - TimeSpan.FromMinutes(1)).ToUnixTimeSeconds());
                 resultReceivingWallet.Details.Should().ContainSingle();
 
                 GetTransactionDetailsModel detailsReceivingWallet = resultReceivingWallet.Details.Single();
                 detailsReceivingWallet.Address.Should().Be(unusedaddresses.Single());
-                detailsReceivingWallet.Amount.Should().Be(new Money(100000000));
+                detailsReceivingWallet.Amount.Should().Be((decimal)1.00000000);
                 detailsReceivingWallet.Fee.Should().BeNull();
                 detailsReceivingWallet.Category.Should().Be(GetTransactionDetailsCategoryModel.Receive);
             }
@@ -350,40 +350,40 @@ namespace Stratis.Bitcoin.IntegrationTests.Wallet
 
                 // Assert.
                 GetTransactionModel resultSendingWallet = txSendingWallet.Result.ToObject<GetTransactionModel>();
-                resultSendingWallet.Amount.Should().Be(new Money(-100000000));
+                resultSendingWallet.Amount.Should().Be((decimal)-1.00000000);
                 //resultSendingWallet.Fee.Should().Be(new Money(100000000)); // TODO Uncomment when is available.
                 resultSendingWallet.Confirmations.Should().Be(1);
                 resultSendingWallet.Isgenerated.Should().BeNull();
                 resultSendingWallet.TransactionId.Should().Be(txId);
                 resultSendingWallet.BlockHash.Should().Be(uint256.Parse(tip.Hash));
                 resultSendingWallet.BlockIndex.Should().Be(1);
-                resultSendingWallet.BlockTime.Should().Be(tip.Time);
-                resultSendingWallet.TimeReceived.Should().BeAfter(DateTimeOffset.Now - TimeSpan.FromMinutes(1));
-                resultSendingWallet.TransactionTime.Should().Be(Utils.UnixTimeToDateTime(trx.Time));
+                resultSendingWallet.BlockTime.Should().Be(tip.Time.ToUnixTimeSeconds());
+                resultSendingWallet.TimeReceived.Should().BeGreaterThan((DateTimeOffset.Now - TimeSpan.FromMinutes(1)).ToUnixTimeSeconds());
+                resultSendingWallet.TransactionTime.Should().Be(trx.Time);
                 resultSendingWallet.Details.Count.Should().Be(1);
 
                 GetTransactionDetailsModel detailsSendingWallet = resultSendingWallet.Details.Single();
                 detailsSendingWallet.Address.Should().Be(unusedaddresses.First());
-                detailsSendingWallet.Amount.Should().Be(new Money(-100000000));
+                detailsSendingWallet.Amount.Should().Be((decimal)-1.00000000);
                 //detailsSendingWallet.Fee.Should().Be(new Money(-100000000)); // TODO Uncomment when is available.
                 detailsSendingWallet.Category.Should().Be(GetTransactionDetailsCategoryModel.Send);
 
                 GetTransactionModel resultReceivingWallet = txReceivingWallet.Result.ToObject<GetTransactionModel>();
-                resultReceivingWallet.Amount.Should().Be(new Money(100000000));
+                resultReceivingWallet.Amount.Should().Be((decimal)1.00000000);
                 resultReceivingWallet.Fee.Should().BeNull();
                 resultReceivingWallet.Confirmations.Should().Be(1);
                 resultReceivingWallet.Isgenerated.Should().BeNull();
                 resultReceivingWallet.TransactionId.Should().Be(txId);
                 resultReceivingWallet.BlockHash.Should().Be(uint256.Parse(tip.Hash));
                 resultReceivingWallet.BlockIndex.Should().Be(1);
-                resultReceivingWallet.BlockTime.Should().Be(tip.Time);
-                resultReceivingWallet.TimeReceived.Should().BeAfter(DateTimeOffset.Now - TimeSpan.FromMinutes(1));
-                resultReceivingWallet.TransactionTime.Should().BeAfter(DateTimeOffset.Now - TimeSpan.FromMinutes(1));
+                resultReceivingWallet.BlockTime.Should().Be(tip.Time.ToUnixTimeSeconds());
+                resultReceivingWallet.TimeReceived.Should().BeGreaterThan((DateTimeOffset.Now - TimeSpan.FromMinutes(1)).ToUnixTimeSeconds());
+                resultReceivingWallet.TransactionTime.Should().BeGreaterThan((DateTimeOffset.Now - TimeSpan.FromMinutes(1)).ToUnixTimeSeconds());
                 resultReceivingWallet.Details.Should().ContainSingle();
 
                 GetTransactionDetailsModel detailsReceivingWallet = resultReceivingWallet.Details.Single();
                 detailsReceivingWallet.Address.Should().Be(unusedaddresses.Single());
-                detailsReceivingWallet.Amount.Should().Be(new Money(100000000));
+                detailsReceivingWallet.Amount.Should().Be((decimal)1.00000000);
                 detailsReceivingWallet.Fee.Should().BeNull();
                 detailsReceivingWallet.Category.Should().Be(GetTransactionDetailsCategoryModel.Receive);
             }
@@ -460,49 +460,49 @@ namespace Stratis.Bitcoin.IntegrationTests.Wallet
 
                 // Assert.
                 GetTransactionModel resultSendingWallet = txSendingWallet.Result.ToObject<GetTransactionModel>();
-                resultSendingWallet.Amount.Should().Be(new Money(-200000000));
+                resultSendingWallet.Amount.Should().Be((decimal)-2.00000000);
                 //resultSendingWallet.Fee.Should().Be(new Money(-100000000)); // TODO Uncomment when is available.
                 resultSendingWallet.Confirmations.Should().Be(1);
                 resultSendingWallet.Isgenerated.Should().BeNull();
                 resultSendingWallet.TransactionId.Should().Be(txId);
                 resultSendingWallet.BlockHash.Should().Be(uint256.Parse(tip.Hash));
                 resultSendingWallet.BlockIndex.Should().Be(1);
-                resultSendingWallet.BlockTime.Should().Be(tip.Time);
-                resultSendingWallet.TimeReceived.Should().BeAfter(DateTimeOffset.Now - TimeSpan.FromMinutes(1));
-                resultSendingWallet.TransactionTime.Should().Be(Utils.UnixTimeToDateTime(trx.Time));
+                resultSendingWallet.BlockTime.Should().Be(tip.Time.ToUnixTimeSeconds());
+                resultSendingWallet.TimeReceived.Should().BeGreaterThan((DateTimeOffset.Now - TimeSpan.FromMinutes(1)).ToUnixTimeSeconds());
+                resultSendingWallet.TransactionTime.Should().Be(trx.Time);
                 resultSendingWallet.Details.Count.Should().Be(2);
 
                 GetTransactionDetailsModel detailsSendingWalletFirstRecipient = resultSendingWallet.Details.Single(d => d.Address == unusedaddresses.First());
-                detailsSendingWalletFirstRecipient.Amount.Should().Be(new Money(-100000000));
+                detailsSendingWalletFirstRecipient.Amount.Should().Be((decimal)-1.00000000);
                 //detailsSendingWalletFirstRecipient.Fee.Should().Be(new Money(-100000000)); // TODO Uncomment when is available.
 
                 GetTransactionDetailsModel detailsSendingWalletSecondRecipient = resultSendingWallet.Details.Single(d => d.Address == unusedaddresses.Last());
-                detailsSendingWalletSecondRecipient.Amount.Should().Be(new Money(-100000000));
+                detailsSendingWalletSecondRecipient.Amount.Should().Be((decimal)-1.00000000);
                 //detailsSendingWalletSecondRecipient.Fee.Should().Be(new Money(-100000000)); // TODO Uncomment when is available.
 
                 // Checking receiver.
                 GetTransactionModel resultReceivingWallet = txReceivingWallet.Result.ToObject<GetTransactionModel>();
-                resultReceivingWallet.Amount.Should().Be(new Money(200000000));
+                resultReceivingWallet.Amount.Should().Be((decimal)2.00000000);
                 resultReceivingWallet.Fee.Should().BeNull();
                 resultReceivingWallet.Confirmations.Should().Be(1);
                 resultReceivingWallet.Isgenerated.Should().BeNull();
                 resultReceivingWallet.TransactionId.Should().Be(txId);
                 resultReceivingWallet.BlockHash.Should().Be(uint256.Parse(tip.Hash));
                 resultReceivingWallet.BlockIndex.Should().Be(1);
-                resultReceivingWallet.BlockTime.Should().Be(tip.Time);
-                resultReceivingWallet.TimeReceived.Should().BeAfter(DateTimeOffset.Now - TimeSpan.FromMinutes(1));
-                resultReceivingWallet.TransactionTime.Should().BeAfter(DateTimeOffset.Now - TimeSpan.FromMinutes(1));
+                resultReceivingWallet.BlockTime.Should().Be(tip.Time.ToUnixTimeSeconds());
+                resultReceivingWallet.TimeReceived.Should().BeGreaterThan((DateTimeOffset.Now - TimeSpan.FromMinutes(1)).ToUnixTimeSeconds());
+                resultReceivingWallet.TransactionTime.Should().BeGreaterThan((DateTimeOffset.Now - TimeSpan.FromMinutes(1)).ToUnixTimeSeconds());
                 resultReceivingWallet.Details.Count.Should().Be(2);
 
                 GetTransactionDetailsModel firstDetailsReceivingWallet = resultReceivingWallet.Details.Single(d => d.Address == unusedaddresses.First());
                 firstDetailsReceivingWallet.Address.Should().Be(unusedaddresses.First());
-                firstDetailsReceivingWallet.Amount.Should().Be(new Money(100000000));
+                firstDetailsReceivingWallet.Amount.Should().Be((decimal)1.00000000);
                 firstDetailsReceivingWallet.Fee.Should().BeNull();
                 firstDetailsReceivingWallet.Category.Should().Be(GetTransactionDetailsCategoryModel.Receive);
 
                 GetTransactionDetailsModel secondDetailsReceivingWallet = resultReceivingWallet.Details.Single(d => d.Address == unusedaddresses.Last());
                 secondDetailsReceivingWallet.Address.Should().Be(unusedaddresses.Last());
-                secondDetailsReceivingWallet.Amount.Should().Be(new Money(100000000));
+                secondDetailsReceivingWallet.Amount.Should().Be((decimal)1.00000000);
                 secondDetailsReceivingWallet.Fee.Should().BeNull();
                 secondDetailsReceivingWallet.Category.Should().Be(GetTransactionDetailsCategoryModel.Receive);
             }
@@ -574,26 +574,26 @@ namespace Stratis.Bitcoin.IntegrationTests.Wallet
 
                 // Assert.
                 GetTransactionModel resultSendingWallet = txSendingWallet.Result.ToObject<GetTransactionModel>();
-                resultSendingWallet.Amount.Should().Be(Money.Zero);
+                resultSendingWallet.Amount.Should().Be((decimal)0.00000000);
                 //resultSendingWallet.Fee.Should().Be(new Money(-100000000)); // TODO Uncomment when is available.
                 resultSendingWallet.Confirmations.Should().Be(1);
                 resultSendingWallet.Isgenerated.Should().BeNull();
                 resultSendingWallet.TransactionId.Should().Be(txId);
                 resultSendingWallet.BlockHash.Should().Be(uint256.Parse(tip.Hash));
                 resultSendingWallet.BlockIndex.Should().Be(1);
-                resultSendingWallet.BlockTime.Should().Be(tip.Time);
-                resultSendingWallet.TimeReceived.Should().BeAfter(DateTimeOffset.Now - TimeSpan.FromMinutes(1));
-                resultSendingWallet.TransactionTime.Should().Be(Utils.UnixTimeToDateTime(trx.Time));
+                resultSendingWallet.BlockTime.Should().Be(tip.Time.ToUnixTimeSeconds());
+                resultSendingWallet.TimeReceived.Should().BeGreaterThan((DateTimeOffset.Now - TimeSpan.FromMinutes(1)).ToUnixTimeSeconds());
+                resultSendingWallet.TransactionTime.Should().Be(trx.Time);
                 resultSendingWallet.Details.Count.Should().Be(2);
 
                 GetTransactionDetailsModel detailsReceivingWallet = resultSendingWallet.Details.Single(d => d.Category == GetTransactionDetailsCategoryModel.Receive);
                 detailsReceivingWallet.Address.Should().Be(unusedaddresses.Single());
-                detailsReceivingWallet.Amount.Should().Be(new Money(100000000));
+                detailsReceivingWallet.Amount.Should().Be((decimal)1.00000000);
                 detailsReceivingWallet.Fee.Should().BeNull();
 
                 GetTransactionDetailsModel secondDetailsReceivingWallet = resultSendingWallet.Details.Single(d => d.Category == GetTransactionDetailsCategoryModel.Send);
                 secondDetailsReceivingWallet.Address.Should().Be(unusedaddresses.Single());
-                secondDetailsReceivingWallet.Amount.Should().Be(new Money(-100000000));
+                secondDetailsReceivingWallet.Amount.Should().Be((decimal)-1.00000000);
                 //secondDetailsReceivingWallet.Fee.Should().Be(new Money(-100000000)); // TODO Uncomment when is available.
             }
         }
@@ -664,21 +664,21 @@ namespace Stratis.Bitcoin.IntegrationTests.Wallet
 
                 // Assert.
                 GetTransactionModel resultSendingWallet = txSendingWallet.Result.ToObject<GetTransactionModel>();
-                resultSendingWallet.Amount.Should().Be(new Money(-9800000200000000));
+                resultSendingWallet.Amount.Should().Be((decimal)-98000002.00000000);
                 //resultSendingWallet.Fee.Should().Be(new Money(-100000000)); // TODO Uncomment when is available.
                 resultSendingWallet.Confirmations.Should().Be(1);
                 resultSendingWallet.Isgenerated.Should().BeNull();
                 resultSendingWallet.TransactionId.Should().Be(txId);
                 resultSendingWallet.BlockHash.Should().Be(uint256.Parse(tip.Hash));
                 resultSendingWallet.BlockIndex.Should().Be(1);
-                resultSendingWallet.BlockTime.Should().Be(tip.Time);
-                resultSendingWallet.TimeReceived.Should().BeOnOrBefore(tip.Time);
-                resultSendingWallet.TransactionTime.Should().Be(Utils.UnixTimeToDateTime(trx.Time));
+                resultSendingWallet.BlockTime.Should().Be(tip.Time.ToUnixTimeSeconds());
+                resultSendingWallet.TimeReceived.Should().BeLessOrEqualTo(tip.Time.ToUnixTimeSeconds());
+                resultSendingWallet.TransactionTime.Should().Be(trx.Time);
                 resultSendingWallet.Details.Count.Should().Be(1);
 
                 GetTransactionDetailsModel detailsSendingWallet = resultSendingWallet.Details.Single();
                 detailsSendingWallet.Address.Should().Be(unusedaddresses.Single());
-                detailsSendingWallet.Amount.Should().Be(new Money(-9800000200000000));
+                detailsSendingWallet.Amount.Should().Be((decimal)-98000002.00000000);
                 detailsSendingWallet.Category.Should().Be(GetTransactionDetailsCategoryModel.Send);
             }
         }

--- a/src/Stratis.Bitcoin.IntegrationTests/Wallet/WalletRPCControllerTest.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/Wallet/WalletRPCControllerTest.cs
@@ -116,6 +116,7 @@ namespace Stratis.Bitcoin.IntegrationTests.Wallet
                 details.Amount.Should().Be((decimal)4.00000000);
                 details.Fee.Should().BeNull();
                 details.Category.Should().Be(GetTransactionDetailsCategoryModel.Generate);
+                details.OutputIndex.Should().Be(0);
             }
         }
 
@@ -160,6 +161,7 @@ namespace Stratis.Bitcoin.IntegrationTests.Wallet
                 details.Amount.Should().Be((decimal)4.00000000);
                 details.Fee.Should().BeNull();
                 details.Category.Should().Be(GetTransactionDetailsCategoryModel.Immature);
+                details.OutputIndex.Should().Be(0);
             }
         }
 
@@ -190,7 +192,7 @@ namespace Stratis.Bitcoin.IntegrationTests.Wallet
                         AccountName = "account 0",
                         FeeType = "low",
                         Password = "password",
-                        ShuffleOutputs = true,
+                        ShuffleOutputs = false,
                         AllowUnconfirmed = true,
                         Recipients = unusedaddresses.Select(address => new RecipientModel
                         {
@@ -242,7 +244,7 @@ namespace Stratis.Bitcoin.IntegrationTests.Wallet
 
                 // Assert.
                 GetTransactionModel resultSendingWallet = txSendingWallet.Result.ToObject<GetTransactionModel>();
-                resultSendingWallet.Amount.Should().Be((decimal) -1.00000000);
+                resultSendingWallet.Amount.Should().Be((decimal)-1.00000000);
                 //resultSendingWallet.Fee.Should().Be(new Money(100000000)); // TODO Uncomment when is available.
                 resultSendingWallet.Confirmations.Should().Be(0);
                 resultSendingWallet.TransactionId.Should().Be(txId);
@@ -258,6 +260,7 @@ namespace Stratis.Bitcoin.IntegrationTests.Wallet
                 detailsSendingWallet.Amount.Should().Be((decimal)-1.00000000);
                 //detailsSendingWallet.Fee.Should().Be(new Money(100000000)); // TODO Uncomment when is available.
                 detailsSendingWallet.Category.Should().Be(GetTransactionDetailsCategoryModel.Send);
+                detailsSendingWallet.OutputIndex.Should().Be(1); // The output at index 0 is the change.
 
                 GetTransactionModel resultReceivingWallet = txReceivingWallet.Result.ToObject<GetTransactionModel>();
                 resultReceivingWallet.Amount.Should().Be((decimal)1.00000000);
@@ -276,6 +279,7 @@ namespace Stratis.Bitcoin.IntegrationTests.Wallet
                 detailsReceivingWallet.Amount.Should().Be((decimal)1.00000000);
                 detailsReceivingWallet.Fee.Should().BeNull();
                 detailsReceivingWallet.Category.Should().Be(GetTransactionDetailsCategoryModel.Receive);
+                detailsReceivingWallet.OutputIndex.Should().Be(1);
             }
         }
 
@@ -306,7 +310,7 @@ namespace Stratis.Bitcoin.IntegrationTests.Wallet
                         AccountName = "account 0",
                         FeeType = "low",
                         Password = "password",
-                        ShuffleOutputs = true,
+                        ShuffleOutputs = false,
                         AllowUnconfirmed = true,
                         Recipients = unusedaddresses.Select(address => new RecipientModel
                         {
@@ -367,6 +371,7 @@ namespace Stratis.Bitcoin.IntegrationTests.Wallet
                 detailsSendingWallet.Amount.Should().Be((decimal)-1.00000000);
                 //detailsSendingWallet.Fee.Should().Be(new Money(-100000000)); // TODO Uncomment when is available.
                 detailsSendingWallet.Category.Should().Be(GetTransactionDetailsCategoryModel.Send);
+                detailsSendingWallet.OutputIndex.Should().Be(1);
 
                 GetTransactionModel resultReceivingWallet = txReceivingWallet.Result.ToObject<GetTransactionModel>();
                 resultReceivingWallet.Amount.Should().Be((decimal)1.00000000);
@@ -386,6 +391,7 @@ namespace Stratis.Bitcoin.IntegrationTests.Wallet
                 detailsReceivingWallet.Amount.Should().Be((decimal)1.00000000);
                 detailsReceivingWallet.Fee.Should().BeNull();
                 detailsReceivingWallet.Category.Should().Be(GetTransactionDetailsCategoryModel.Receive);
+                detailsReceivingWallet.OutputIndex.Should().Be(1);
             }
         }
 
@@ -416,7 +422,7 @@ namespace Stratis.Bitcoin.IntegrationTests.Wallet
                         AccountName = "account 0",
                         FeeType = "low",
                         Password = "password",
-                        ShuffleOutputs = true,
+                        ShuffleOutputs = false,
                         AllowUnconfirmed = true,
                         Recipients = unusedaddresses.Select(address => new RecipientModel
                         {
@@ -473,12 +479,18 @@ namespace Stratis.Bitcoin.IntegrationTests.Wallet
                 resultSendingWallet.Details.Count.Should().Be(2);
 
                 GetTransactionDetailsModel detailsSendingWalletFirstRecipient = resultSendingWallet.Details.Single(d => d.Address == unusedaddresses.First());
+                detailsSendingWalletFirstRecipient.Address.Should().Be(unusedaddresses.First());
                 detailsSendingWalletFirstRecipient.Amount.Should().Be((decimal)-1.00000000);
                 //detailsSendingWalletFirstRecipient.Fee.Should().Be(new Money(-100000000)); // TODO Uncomment when is available.
+                detailsSendingWalletFirstRecipient.Category.Should().Be(GetTransactionDetailsCategoryModel.Send);
+                detailsSendingWalletFirstRecipient.OutputIndex.Should().Be(1); // Output at index 0 contains the change.
 
                 GetTransactionDetailsModel detailsSendingWalletSecondRecipient = resultSendingWallet.Details.Single(d => d.Address == unusedaddresses.Last());
+                detailsSendingWalletSecondRecipient.Address.Should().Be(unusedaddresses.Last());
                 detailsSendingWalletSecondRecipient.Amount.Should().Be((decimal)-1.00000000);
                 //detailsSendingWalletSecondRecipient.Fee.Should().Be(new Money(-100000000)); // TODO Uncomment when is available.
+                detailsSendingWalletSecondRecipient.Category.Should().Be(GetTransactionDetailsCategoryModel.Send);
+                detailsSendingWalletSecondRecipient.OutputIndex.Should().Be(2);
 
                 // Checking receiver.
                 GetTransactionModel resultReceivingWallet = txReceivingWallet.Result.ToObject<GetTransactionModel>();
@@ -499,12 +511,14 @@ namespace Stratis.Bitcoin.IntegrationTests.Wallet
                 firstDetailsReceivingWallet.Amount.Should().Be((decimal)1.00000000);
                 firstDetailsReceivingWallet.Fee.Should().BeNull();
                 firstDetailsReceivingWallet.Category.Should().Be(GetTransactionDetailsCategoryModel.Receive);
-
+                firstDetailsReceivingWallet.OutputIndex.Should().Be(1); // Output at index 0 contains the change.
+                
                 GetTransactionDetailsModel secondDetailsReceivingWallet = resultReceivingWallet.Details.Single(d => d.Address == unusedaddresses.Last());
                 secondDetailsReceivingWallet.Address.Should().Be(unusedaddresses.Last());
                 secondDetailsReceivingWallet.Amount.Should().Be((decimal)1.00000000);
                 secondDetailsReceivingWallet.Fee.Should().BeNull();
                 secondDetailsReceivingWallet.Category.Should().Be(GetTransactionDetailsCategoryModel.Receive);
+                secondDetailsReceivingWallet.OutputIndex.Should().Be(2);
             }
         }
 
@@ -534,7 +548,7 @@ namespace Stratis.Bitcoin.IntegrationTests.Wallet
                         AccountName = "account 0",
                         FeeType = "low",
                         Password = "password",
-                        ShuffleOutputs = true,
+                        ShuffleOutputs = false,
                         AllowUnconfirmed = true,
                         Recipients = unusedaddresses.Select(address => new RecipientModel
                         {
@@ -590,11 +604,13 @@ namespace Stratis.Bitcoin.IntegrationTests.Wallet
                 detailsReceivingWallet.Address.Should().Be(unusedaddresses.Single());
                 detailsReceivingWallet.Amount.Should().Be((decimal)1.00000000);
                 detailsReceivingWallet.Fee.Should().BeNull();
+                detailsReceivingWallet.OutputIndex.Should().Be(1);
 
                 GetTransactionDetailsModel secondDetailsReceivingWallet = resultSendingWallet.Details.Single(d => d.Category == GetTransactionDetailsCategoryModel.Send);
                 secondDetailsReceivingWallet.Address.Should().Be(unusedaddresses.Single());
                 secondDetailsReceivingWallet.Amount.Should().Be((decimal)-1.00000000);
                 //secondDetailsReceivingWallet.Fee.Should().Be(new Money(-100000000)); // TODO Uncomment when is available.
+                secondDetailsReceivingWallet.OutputIndex.Should().Be(1);
             }
         }
 
@@ -624,7 +640,7 @@ namespace Stratis.Bitcoin.IntegrationTests.Wallet
                         AccountName = "account 0",
                         FeeType = "low",
                         Password = "password",
-                        ShuffleOutputs = true,
+                        ShuffleOutputs = false,
                         AllowUnconfirmed = true,
                         Recipients = unusedaddresses.Select(address => new RecipientModel
                         {
@@ -680,6 +696,7 @@ namespace Stratis.Bitcoin.IntegrationTests.Wallet
                 detailsSendingWallet.Address.Should().Be(unusedaddresses.Single());
                 detailsSendingWallet.Amount.Should().Be((decimal)-98000002.00000000);
                 detailsSendingWallet.Category.Should().Be(GetTransactionDetailsCategoryModel.Send);
+                detailsSendingWallet.OutputIndex.Should().Be(1);
             }
         }
     }


### PR DESCRIPTION
- fixed amount, fee and times types
- added vout to gettransaction response object
- added outputIndex to spend transactions

example response of a transaction sent to oneself (see example [here](https://bitcoin.org/en/developer-reference#gettransaction)):
```
{
	"amount": 0.0,
	"confirmations": 645,
	"blockhash": "c5cedbee6465116742c1326b9447e1b0bfdac3cc476597ddc45d1e543431a7f4",
	"blockindex": 2,
	"blocktime": 1550580960,
	"txid": "4487bcc967f04f607e428cb7bf0bf0fd4d17dddabf0be10fb6d863e92559c9d7",
	"time": 1550580944,
	"timereceived": 1550580944,
	"details": [{
		"address": "TLyPPCF4B7eePA1UkWf2hKGTGTtLuCA8Sr",
		"category": "send",
		"amount": -1.0,
		"vout": 0
	}, {
		"address": "TLyPPCF4B7eePA1UkWf2hKGTGTtLuCA8Sr",
		"category": "receive",
		"amount": 1.0,
		"vout": 0
	}],
	"hex": "01000000d0fc6b5c01cfe272f229ea319122d17624e4dea9e13f891e00f7c69f0e657aca58dd89269b01000000494830450221009d1975bf7a2d071d5c483210d932b8d164c458c8f862aec79502b9cbd19c892502206b38e8ac5509271af9320905c7a4ba2c769d7b7cc457a2bd77958eb8b0c4f1e801ffffffff0200e1f505000000001976a91478b20cbec3b5d8c1579797eaacc6c6bc85e33aa988acb9ebf6d2050200001976a9142ccdaa2b9482a0ab4c8f19f1d35be0ee2024db6388ac00000000"
}
```