### PR TITLE
[FS] Bring federated sidechains code in

### DIFF
--- a/src/Stratis.Bitcoin.FullNode.sln
+++ b/src/Stratis.Bitcoin.FullNode.sln
@@ -152,6 +152,12 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Stratis.SmartContracts.CLR.
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Stratis.SmartContracts.Core.Tests", "Stratis.SmartContracts.Core.Tests\Stratis.SmartContracts.Core.Tests.csproj", "{A1CF9560-A6A0-4270-9569-0D117AFA799C}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Stratis.Sidechains.Networks", "Stratis.Sidechains.Networks\Stratis.Sidechains.Networks.csproj", "{0CE08BBA-F636-460C-A1B7-7F2F971FA1B2}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Stratis.Features.FederatedPeg", "Stratis.Features.FederatedPeg\Stratis.Features.FederatedPeg.csproj", "{4890198B-5245-454D-9F82-4E8AAC179160}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Stratis.Features.FederatedPeg.Tests", "Stratis.Features.FederatedPeg.Tests\Stratis.Features.FederatedPeg.Tests.csproj", "{2065EF06-171F-42B9-AA17-ED5F301360AF}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -390,6 +396,18 @@ Global
 		{A1CF9560-A6A0-4270-9569-0D117AFA799C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A1CF9560-A6A0-4270-9569-0D117AFA799C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A1CF9560-A6A0-4270-9569-0D117AFA799C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0CE08BBA-F636-460C-A1B7-7F2F971FA1B2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0CE08BBA-F636-460C-A1B7-7F2F971FA1B2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0CE08BBA-F636-460C-A1B7-7F2F971FA1B2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0CE08BBA-F636-460C-A1B7-7F2F971FA1B2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4890198B-5245-454D-9F82-4E8AAC179160}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4890198B-5245-454D-9F82-4E8AAC179160}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4890198B-5245-454D-9F82-4E8AAC179160}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4890198B-5245-454D-9F82-4E8AAC179160}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2065EF06-171F-42B9-AA17-ED5F301360AF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2065EF06-171F-42B9-AA17-ED5F301360AF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2065EF06-171F-42B9-AA17-ED5F301360AF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2065EF06-171F-42B9-AA17-ED5F301360AF}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -445,6 +463,9 @@ Global
 		{8FEFF18B-3546-4237-8FD1-9F184BC7B4C7} = {1B9A916F-DDAC-4675-B424-EDEDC1A58231}
 		{E98CB412-9684-4061-8E76-B6CD12A3C32A} = {1B9A916F-DDAC-4675-B424-EDEDC1A58231}
 		{A1CF9560-A6A0-4270-9569-0D117AFA799C} = {1B9A916F-DDAC-4675-B424-EDEDC1A58231}
+		{0CE08BBA-F636-460C-A1B7-7F2F971FA1B2} = {1B9A916F-DDAC-4675-B424-EDEDC1A58231}
+		{4890198B-5245-454D-9F82-4E8AAC179160} = {15D29FFD-6142-4DC5-AFFD-10BA0CA55C45}
+		{2065EF06-171F-42B9-AA17-ED5F301360AF} = {EAE139C2-B19C-4905-9117-8A4068ABD3D2}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {6C780ABA-5872-4B83-AD3F-A5BD423AD907}

--- a/src/Stratis.Features.FederatedPeg.Tests/BlockObserverTests.cs
+++ b/src/Stratis.Features.FederatedPeg.Tests/BlockObserverTests.cs
@@ -1,0 +1,178 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using NBitcoin;
+using NSubstitute;
+using Stratis.Bitcoin;
+using Stratis.Bitcoin.Consensus;
+using Stratis.Bitcoin.Primitives;
+using Stratis.Bitcoin.Signals;
+using Stratis.Features.FederatedPeg.Interfaces;
+using Stratis.Features.FederatedPeg.Notifications;
+using Stratis.Features.FederatedPeg.RestClients;
+using Stratis.Features.FederatedPeg.SourceChain;
+using Stratis.Features.FederatedPeg.TargetChain;
+using Stratis.Features.FederatedPeg.Tests.Utils;
+using Xunit;
+
+namespace Stratis.Features.FederatedPeg.Tests
+{
+    public class BlockObserverTests
+    {
+        private readonly BlockObserver blockObserver;
+
+        private readonly IFederationWalletSyncManager federationWalletSyncManager;
+
+        private readonly IDepositExtractor depositExtractor;
+
+        private readonly IFederationGatewaySettings federationGatewaySettings;
+
+        private readonly IFullNode fullNode;
+
+        private readonly ConcurrentChain chain;
+
+        private readonly uint minimumDepositConfirmations;
+
+        private readonly IFederationGatewayClient federationGatewayClient;
+
+        private readonly IOpReturnDataReader opReturnDataReader;
+
+        private readonly ILoggerFactory loggerFactory;
+
+        private readonly IWithdrawalExtractor withdrawalExtractor;
+
+        private readonly IWithdrawalReceiver withdrawalReceiver;
+
+        private readonly ISignals signals;
+
+        private readonly IReadOnlyList<IWithdrawal> extractedWithdrawals;
+
+        private readonly IConsensusManager consensusManager;
+
+        public BlockObserverTests()
+        {
+            this.minimumDepositConfirmations = 10;
+
+            this.federationGatewaySettings = Substitute.For<IFederationGatewaySettings>();
+            this.federationGatewaySettings.MinimumDepositConfirmations.Returns(this.minimumDepositConfirmations);
+
+            this.federationWalletSyncManager = Substitute.For<IFederationWalletSyncManager>();
+            this.fullNode = Substitute.For<IFullNode>();
+            this.federationGatewayClient = Substitute.For<IFederationGatewayClient>();
+            this.chain = Substitute.ForPartsOf<ConcurrentChain>();
+            this.fullNode.NodeService<ConcurrentChain>().Returns(this.chain);
+            this.loggerFactory = Substitute.For<ILoggerFactory>();
+            this.opReturnDataReader = Substitute.For<IOpReturnDataReader>();
+            this.consensusManager = Substitute.For<IConsensusManager>();
+            this.withdrawalExtractor = Substitute.For<IWithdrawalExtractor>();
+            this.extractedWithdrawals = TestingValues.GetWithdrawals(2);
+            this.withdrawalExtractor.ExtractWithdrawalsFromBlock(null, 0).ReturnsForAnyArgs(this.extractedWithdrawals);
+  
+            this.withdrawalReceiver = Substitute.For<IWithdrawalReceiver>();
+
+            this.signals = Substitute.For<ISignals>();
+            this.signals.OnBlockConnected.Returns(Substitute.For<EventNotifier<ChainedHeaderBlock>>());
+
+            this.depositExtractor = new DepositExtractor(
+                this.loggerFactory,
+                this.federationGatewaySettings,
+                this.opReturnDataReader,
+                this.fullNode);
+
+            this.blockObserver = new BlockObserver(
+                this.federationWalletSyncManager,
+                this.depositExtractor,
+                this.withdrawalExtractor,
+                this.withdrawalReceiver,
+                this.federationGatewayClient,
+                this.signals);
+        }
+
+        [Retry(3)]
+        // This test requires retries because we are asserting result of a background thread that calls API.
+        // This will work in real life but in tests it produces a race condition and therefore requires retries.
+        public async Task BlockObserverShouldNotTryToExtractDepositsBeforeMinimumDepositConfirmationsAsync()
+        {
+            int confirmations = (int)this.minimumDepositConfirmations - 1;
+
+            var earlyBlock = new Block();
+            var earlyChainHeaderBlock = new ChainedHeaderBlock(earlyBlock, new ChainedHeader(new BlockHeader(), uint256.Zero, confirmations));
+
+            this.blockObserver.OnBlockReceived(earlyChainHeaderBlock);
+
+            this.federationWalletSyncManager.Received(1).ProcessBlock(earlyBlock);
+            this.withdrawalExtractor.ReceivedWithAnyArgs(1).ExtractWithdrawalsFromBlock(earlyBlock, 0);
+            this.withdrawalReceiver.Received(1).ReceiveWithdrawals(Arg.Is(this.extractedWithdrawals));
+
+            await Task.Delay(500).ConfigureAwait(false);
+
+            await this.federationGatewayClient.ReceivedWithAnyArgs(1).PushCurrentBlockTipAsync(null);
+        }
+
+        [Retry(3)]
+        // This test requires retries because we are asserting result of a background thread that calls API.
+        // This will work in real life but in tests it produces a race condition and therefore requires retries.
+        public void BlockObserverShouldTryToExtractDepositsAfterMinimumDepositConfirmations()
+        {
+            (ChainedHeaderBlock chainedHeaderBlock, Block block) blockBuilder = this.ChainHeaderBlockBuilder();
+
+            this.blockObserver.OnBlockReceived(blockBuilder.chainedHeaderBlock);
+
+            this.federationWalletSyncManager.Received(1).ProcessBlock(blockBuilder.block);
+
+            this.federationGatewayClient.ReceivedWithAnyArgs(1).PushCurrentBlockTipAsync(null);
+        }
+
+        [Retry(3)]
+        // This test requires retries because we are asserting result of a background thread that calls API.
+        // This will work in real life but in tests it produces a race condition and therefore requires retries.
+        public async Task BlockObserverShouldSendBlockTipAsync()
+        {
+            ChainedHeaderBlock chainedHeaderBlock = this.ChainHeaderBlockBuilder().chainedHeaderBlock;
+
+            this.blockObserver.OnBlockReceived(chainedHeaderBlock);
+
+            await Task.Delay(5000).ConfigureAwait(false);
+
+            await this.federationGatewayClient.ReceivedWithAnyArgs(1).PushCurrentBlockTipAsync(null);
+        }
+
+        [Fact]
+        public void BlockObserverShouldExtractWithdrawals()
+        {
+            ChainedHeaderBlock chainedHeaderBlock = this.ChainHeaderBlockBuilder().chainedHeaderBlock;
+
+            this.blockObserver.OnBlockReceived(chainedHeaderBlock);
+
+            this.withdrawalExtractor.ReceivedWithAnyArgs(1).ExtractWithdrawalsFromBlock(null, 0);
+        }
+
+        [Fact]
+        public void BlockObserverShouldSendExtractedWithdrawalsToWithdrawalReceiver()
+        {
+            ChainedHeaderBlock chainedHeaderBlock = this.ChainHeaderBlockBuilder().chainedHeaderBlock;
+
+            this.blockObserver.OnBlockReceived(chainedHeaderBlock);
+
+            this.withdrawalReceiver.ReceivedWithAnyArgs(1).ReceiveWithdrawals(Arg.Is(this.extractedWithdrawals));
+        }
+
+        private (ChainedHeaderBlock chainedHeaderBlock, Block block) ChainHeaderBlockBuilder()
+        {
+            int confirmations = (int)this.minimumDepositConfirmations;
+
+            var blockHeader = new BlockHeader();
+            var chainedHeader = new ChainedHeader(blockHeader, uint256.Zero, confirmations);
+            this.chain.GetBlock(0).Returns(chainedHeader);
+
+            var block = new Block();
+            var chainedHeaderBlock = new ChainedHeaderBlock(block, chainedHeader);
+
+            chainedHeaderBlock.ChainedHeader.Block = chainedHeaderBlock.Block;
+
+            this.consensusManager.GetBlockDataAsync(uint256.Zero).Returns(chainedHeaderBlock);
+
+            return (chainedHeaderBlock, block);
+        }
+    }
+}

--- a/src/Stratis.Features.FederatedPeg.Tests/BlockTipModelTests.cs
+++ b/src/Stratis.Features.FederatedPeg.Tests/BlockTipModelTests.cs
@@ -1,0 +1,35 @@
+﻿using FluentAssertions;
+using NBitcoin;
+using Newtonsoft.Json;
+using Stratis.Features.FederatedPeg.Models;
+using Stratis.Features.FederatedPeg.Tests.Utils;
+using Xunit;
+
+namespace Stratis.Features.FederatedPeg.Tests
+{
+    public class BlockTipModelTests
+    {
+        public static IBlockTip PrepareBlockTip()
+        {
+            uint256 blockHash = TestingValues.GetUint256();
+            int blockHeight = TestingValues.GetPositiveInt();
+            int matureConfirmation = TestingValues.GetPositiveInt();
+
+            var blockTip = new BlockTipModel(blockHash, blockHeight, matureConfirmation);
+            return blockTip;
+        }
+
+        [Fact]
+        public void ShouldSerialiseAsJson()
+        {
+            IBlockTip blockTip = PrepareBlockTip();
+            string asJson = blockTip.ToString();
+
+            var reconverted = JsonConvert.DeserializeObject<BlockTipModel>(asJson);
+
+            reconverted.Hash.Should().Be(blockTip.Hash);
+            reconverted.Height.Should().Be(blockTip.Height);
+            reconverted.MatureConfirmations.Should().Be(blockTip.MatureConfirmations);
+        }
+    }
+}

--- a/src/Stratis.Features.FederatedPeg.Tests/Chain_With_NetworkExtension_Shall.cs
+++ b/src/Stratis.Features.FederatedPeg.Tests/Chain_With_NetworkExtension_Shall.cs
@@ -1,0 +1,46 @@
+﻿using Xunit;
+
+namespace Stratis.Features.FederatedPeg.Tests
+{
+    [Collection("FederatedPegTests")]
+    public class Chain_With_NetworkExtension_Shall
+    {
+        [Fact]
+        public void correctly_identify_mainchain()
+        {
+            var stratisRegTest = new StratisRegTest();
+            Chain chain = stratisRegTest.ToChain();
+            chain.Should().Be(Chain.Mainchain);
+            chain.Should().NotBe(Chain.Sidechain);
+
+            var stratisTest = new StratisTest();
+            chain = stratisTest.ToChain();
+            chain.Should().Be(Chain.Mainchain);
+            chain.Should().NotBe(Chain.Sidechain);
+
+            var stratisMain = new StratisMain();
+            chain = stratisMain.ToChain();
+            chain.Should().Be(Chain.Mainchain);
+            chain.Should().NotBe(Chain.Sidechain);
+        }
+
+        [Fact]
+        public void correctly_identify_sidechain()
+        {	
+            Network apexRegTest = FederatedPegNetwork.NetworksSelector.Regtest();
+            Chain chain = apexRegTest.ToChain();
+            chain.Should().Be(Chain.Sidechain);
+            chain.Should().NotBe(Chain.Mainchain);
+
+            Network apexTest = FederatedPegNetwork.NetworksSelector.Testnet();
+            chain = apexTest.ToChain();
+            chain.Should().Be(Chain.Sidechain);
+            chain.Should().NotBe(Chain.Mainchain);
+
+            Network apexMain = FederatedPegNetwork.NetworksSelector.Mainnet();
+            chain = apexMain.ToChain();
+            chain.Should().Be(Chain.Sidechain);
+            chain.Should().NotBe(Chain.Mainchain);
+        }
+    }
+}

--- a/src/Stratis.Features.FederatedPeg.Tests/Chain_With_NetworkExtension_Shall.cs
+++ b/src/Stratis.Features.FederatedPeg.Tests/Chain_With_NetworkExtension_Shall.cs
@@ -1,4 +1,9 @@
-﻿using Xunit;
+﻿using FluentAssertions;
+using NBitcoin;
+using Stratis.Bitcoin.Networks;
+using Stratis.Features.FederatedPeg.NetworkHelpers;
+using Stratis.Sidechains.Networks;
+using Xunit;
 
 namespace Stratis.Features.FederatedPeg.Tests
 {

--- a/src/Stratis.Features.FederatedPeg.Tests/ControllersTests/FederationGatewayControllerTests.cs
+++ b/src/Stratis.Features.FederatedPeg.Tests/ControllersTests/FederationGatewayControllerTests.cs
@@ -1,0 +1,302 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using NBitcoin;
+using NBitcoin.Protocol;
+using NSubstitute;
+using Stratis.Bitcoin.Configuration;
+using Stratis.Bitcoin.Consensus;
+using Stratis.Bitcoin.Features.BlockStore;
+using Stratis.Bitcoin.Features.PoA;
+using Stratis.Bitcoin.Primitives;
+using Stratis.Bitcoin.Tests.Common;
+using Stratis.Bitcoin.Utilities;
+using Stratis.Bitcoin.Utilities.JsonErrors;
+using Stratis.Features.FederatedPeg.Controllers;
+using Stratis.Features.FederatedPeg.Interfaces;
+using Stratis.Features.FederatedPeg.Models;
+using Stratis.Features.FederatedPeg.SourceChain;
+using Stratis.Features.FederatedPeg.TargetChain;
+using Stratis.Features.FederatedPeg.Tests.Utils;
+using Stratis.Sidechains.Networks;
+using Xunit;
+
+namespace Stratis.Features.FederatedPeg.Tests.ControllersTests
+{
+    public class FederationGatewayControllerTests
+    {
+        private readonly Network network;
+
+        private readonly ILoggerFactory loggerFactory;
+
+        private readonly ILogger logger;
+
+        private readonly ILeaderProvider leaderProvider;
+
+        private readonly IDepositExtractor depositExtractor;
+
+        private readonly ILeaderReceiver leaderReceiver;
+
+        private readonly IConsensusManager consensusManager;
+
+        private readonly IFederationGatewaySettings federationGatewaySettings;
+
+        private readonly FederationManager federationManager;
+
+        private readonly IFederationWalletManager federationWalletManager;
+
+        private readonly IKeyValueRepository keyValueRepository;
+
+        public FederationGatewayControllerTests()
+        {
+            this.network = FederatedPegNetwork.NetworksSelector.Regtest();
+
+            this.loggerFactory = Substitute.For<ILoggerFactory>();
+            this.logger = Substitute.For<ILogger>();
+            this.loggerFactory.CreateLogger(null).ReturnsForAnyArgs(this.logger);
+            this.leaderProvider = Substitute.For<ILeaderProvider>();
+            this.depositExtractor = Substitute.For<IDepositExtractor>();
+            this.leaderReceiver = Substitute.For<ILeaderReceiver>();
+            this.consensusManager = Substitute.For<IConsensusManager>();
+            this.federationGatewaySettings = Substitute.For<IFederationGatewaySettings>();
+            this.federationWalletManager = Substitute.For<IFederationWalletManager>();
+            this.keyValueRepository = Substitute.For<IKeyValueRepository>();
+            this.federationManager = new FederationManager(NodeSettings.Default(this.network), this.network, this.loggerFactory, this.keyValueRepository);
+        }
+
+        private FederationGatewayController CreateController()
+        {
+            var controller = new FederationGatewayController(
+                this.loggerFactory,
+                this.network,
+                this.leaderProvider,
+                this.GetMaturedBlocksProvider(),
+                this.leaderReceiver,
+                this.federationGatewaySettings,
+                this.federationWalletManager,
+                this.federationManager);
+
+            return controller;
+        }
+
+        private MaturedBlocksProvider GetMaturedBlocksProvider()
+        {
+            var blockRepository = Substitute.For<IBlockRepository>();
+
+            blockRepository.GetBlocksAsync(Arg.Any<List<uint256>>()).ReturnsForAnyArgs((x) =>
+            {
+                var hashes = x.ArgAt<List<uint256>>(0);
+                var blocks = new List<Block>();
+
+                foreach (uint256 hash in hashes)
+                {
+                    blocks.Add(this.network.CreateBlock());
+                }
+
+                return blocks;
+            });
+
+            return new MaturedBlocksProvider(
+                this.loggerFactory,
+                this.depositExtractor,
+                this.consensusManager);
+        }
+
+        [Fact]
+        public async void GetMaturedBlockDeposits_Fails_When_Block_Not_In_Chain_Async()
+        {
+            FederationGatewayController controller = this.CreateController();
+
+            ChainedHeader tip = ChainedHeadersHelper.CreateConsecutiveHeaders(3, null, true)[2];
+
+            this.consensusManager.Tip.Returns(tip);
+
+            IActionResult result = await controller.GetMaturedBlockDepositsAsync(new MaturedBlockRequestModel(1, 1000)).ConfigureAwait(false);
+
+            result.Should().BeOfType<ErrorResult>();
+
+            var error = result as ErrorResult;
+            error.Should().NotBeNull();
+
+            var errorResponse = error.Value as ErrorResponse;
+            errorResponse.Should().NotBeNull();
+            errorResponse.Errors.Should().HaveCount(1);
+
+            errorResponse.Errors.Should().Contain(
+                e => e.Status == (int)HttpStatusCode.BadRequest);
+
+            errorResponse.Errors.Should().Contain(
+                e => e.Message.Contains("Unable to get deposits for block at height"));
+        }
+
+        [Fact]
+        public async void GetMaturedBlockDeposits_Fails_When_Block_Height_Greater_Than_Minimum_Deposit_Confirmations_Async()
+        {
+            ChainedHeader tip = ChainedHeadersHelper.CreateConsecutiveHeaders(5, null, true).Last();
+            this.consensusManager.Tip.Returns(tip);
+
+            FederationGatewayController controller = this.CreateController();
+
+            // Minimum deposit confirmations : 2
+            this.depositExtractor.MinimumDepositConfirmations.Returns((uint)2);
+
+            int maturedHeight = (int)(tip.Height - this.depositExtractor.MinimumDepositConfirmations);
+
+            // Back online at block height : 3
+            // 0 - 1 - 2 - 3
+            ChainedHeader earlierBlock = tip.GetAncestor(maturedHeight + 1);
+
+            // Mature height = 2 (Chain header height (4) - Minimum deposit confirmations (2))
+            IActionResult result = await controller.GetMaturedBlockDepositsAsync(new MaturedBlockRequestModel(earlierBlock.Height, 1000)).ConfigureAwait(false);
+
+            // Block height (3) > Mature height (2) - returns error message
+            result.Should().BeOfType<ErrorResult>();
+
+            var error = result as ErrorResult;
+            error.Should().NotBeNull();
+
+            var errorResponse = error.Value as ErrorResponse;
+            errorResponse.Should().NotBeNull();
+            errorResponse.Errors.Should().HaveCount(1);
+
+            errorResponse.Errors.Should().Contain(
+                e => e.Status == (int)HttpStatusCode.BadRequest);
+
+            errorResponse.Errors.Should().Contain(
+                e => e.Message.Contains($"Block height {earlierBlock.Height} submitted is not mature enough. Blocks less than a height of {maturedHeight} can be processed."));
+        }
+
+        [Fact]
+        public async void GetMaturedBlockDeposits_Gets_All_Matured_Block_Deposits_Async()
+        {
+            ChainedHeader tip = ChainedHeadersHelper.CreateConsecutiveHeaders(10, null, true).Last();
+            this.consensusManager.Tip.Returns(tip);
+
+            FederationGatewayController controller = this.CreateController();
+
+            ChainedHeader earlierBlock = tip.GetAncestor(2);
+
+            int minConfirmations = 2;
+            this.depositExtractor.MinimumDepositConfirmations.Returns((uint)minConfirmations);
+
+            int depositExtractorCallCount = 0;
+            this.depositExtractor.ExtractBlockDeposits(Arg.Any<ChainedHeaderBlock>()).Returns(new MaturedBlockDepositsModel(null, null));
+            this.depositExtractor.When(x => x.ExtractBlockDeposits(Arg.Any<ChainedHeaderBlock>())).Do(info =>
+            {
+                depositExtractorCallCount++;
+            });
+
+            IActionResult result = await controller.GetMaturedBlockDepositsAsync(new MaturedBlockRequestModel(earlierBlock.Height, 1000)).ConfigureAwait(false);
+
+            result.Should().BeOfType<JsonResult>();
+
+            // If the minConfirmations == 0 and this.chain.Height == earlierBlock.Height then expectedCallCount must be 1.
+            int expectedCallCount = (tip.Height - minConfirmations) - earlierBlock.Height + 1;
+
+            depositExtractorCallCount.Should().Be(expectedCallCount);
+        }
+
+        [Fact]
+        public void ReceiveCurrentBlockTip_Should_Call_LeaderProdvider_Update()
+        {
+            FederationGatewayController controller = this.CreateController();
+
+            var model = new BlockTipModel(TestingValues.GetUint256(), TestingValues.GetPositiveInt(), TestingValues.GetPositiveInt());
+
+            int leaderProviderCallCount = 0;
+            this.leaderProvider.When(x => x.Update(Arg.Any<BlockTipModel>())).Do(info =>
+            {
+                leaderProviderCallCount++;
+            });
+
+            IActionResult result = controller.PushCurrentBlockTip(model);
+
+            result.Should().BeOfType<OkResult>();
+            leaderProviderCallCount.Should().Be(1);
+        }
+
+        [Fact]
+        public void Call_Sidechain_Gateway_Get_Info()
+        {
+            string redeemScript = "2 02fad5f3c4fdf4c22e8be4cfda47882fff89aaa0a48c1ccad7fa80dc5fee9ccec3 02503f03243d41c141172465caca2f5cef7524f149e965483be7ce4e44107d7d35 03be943c3a31359cd8e67bedb7122a0898d2c204cf2d0119e923ded58c429ef97c 3 OP_CHECKMULTISIG";
+            string federationIps = "127.0.0.1:36201,127.0.0.1:36202,127.0.0.1:36203";
+            string multisigPubKey = "03be943c3a31359cd8e67bedb7122a0898d2c204cf2d0119e923ded58c429ef97c";
+            string[] args = new[] { "-sidechain", "-regtest", $"-federationips={federationIps}", $"-redeemscript={redeemScript}", $"-publickey={multisigPubKey}", "-mincoinmaturity=1", "-mindepositconfirmations=1" };
+            NodeSettings nodeSettings = new NodeSettings(FederatedPegNetwork.NetworksSelector.Regtest(), ProtocolVersion.ALT_PROTOCOL_VERSION, args: args);
+
+            this.federationWalletManager.IsFederationActive().Returns(true);
+
+            this.federationManager.Initialize();
+
+            FederationGatewaySettings settings = new FederationGatewaySettings(nodeSettings);
+
+            var controller = new FederationGatewayController(
+                this.loggerFactory,
+                this.network,
+                this.leaderProvider,
+                this.GetMaturedBlocksProvider(),
+                this.leaderReceiver,
+                settings,
+                this.federationWalletManager,
+                this.federationManager);
+
+            IActionResult result = controller.GetInfo();
+
+            result.Should().BeOfType<JsonResult>();
+            ((JsonResult)result).Value.Should().BeOfType<FederationGatewayInfoModel>();
+
+            FederationGatewayInfoModel model = ((JsonResult)result).Value as FederationGatewayInfoModel;
+            model.IsMainChain.Should().BeFalse();
+            model.FederationMiningPubKeys.Should().Equal(((PoAConsensusOptions)FederatedPegNetwork.NetworksSelector.Regtest().Consensus.Options).GenesisFederationPublicKeys.Select(keys => keys.ToString()));
+            model.MultiSigRedeemScript.Should().Be(redeemScript);
+            string.Join(",", model.FederationNodeIpEndPoints).Should().Be(federationIps);
+            model.IsActive.Should().BeTrue();
+            model.MinCoinMaturity.Should().Be(1);
+            model.MinimumDepositConfirmations.Should().Be(1);
+            model.MultisigPublicKey.Should().Be(multisigPubKey);
+        }
+
+        [Fact]
+        public void Call_Mainchain_Gateway_Get_Info()
+        {
+            string redeemScript = "2 02fad5f3c4fdf4c22e8be4cfda47882fff89aaa0a48c1ccad7fa80dc5fee9ccec3 02503f03243d41c141172465caca2f5cef7524f149e965483be7ce4e44107d7d35 03be943c3a31359cd8e67bedb7122a0898d2c204cf2d0119e923ded58c429ef97c 3 OP_CHECKMULTISIG";
+            string federationIps = "127.0.0.1:36201,127.0.0.1:36202,127.0.0.1:36203";
+            string multisigPubKey = "03be943c3a31359cd8e67bedb7122a0898d2c204cf2d0119e923ded58c429ef97c";
+            string[] args = new[] { "-mainchain", "-testnet", $"-federationips={federationIps}", $"-redeemscript={redeemScript}", $"-publickey={multisigPubKey}", "-mincoinmaturity=1", "-mindepositconfirmations=1" };
+            NodeSettings nodeSettings = new NodeSettings(FederatedPegNetwork.NetworksSelector.Regtest(), ProtocolVersion.ALT_PROTOCOL_VERSION, args: args);
+
+            this.federationWalletManager.IsFederationActive().Returns(true);
+
+            FederationGatewaySettings settings = new FederationGatewaySettings(nodeSettings);
+
+            var controller = new FederationGatewayController(
+                this.loggerFactory,
+                this.network,
+                this.leaderProvider,
+                this.GetMaturedBlocksProvider(),
+                this.leaderReceiver,
+                settings,
+                this.federationWalletManager,
+                this.federationManager);
+
+            IActionResult result = controller.GetInfo();
+
+            result.Should().BeOfType<JsonResult>();
+            ((JsonResult)result).Value.Should().BeOfType<FederationGatewayInfoModel>();
+
+            FederationGatewayInfoModel model = ((JsonResult)result).Value as FederationGatewayInfoModel;
+            model.IsMainChain.Should().BeTrue();
+            model.FederationMiningPubKeys.Should().BeNull();
+            model.MiningPublicKey.Should().BeNull();
+            model.MultiSigRedeemScript.Should().Be(redeemScript);
+            string.Join(",", model.FederationNodeIpEndPoints).Should().Be(federationIps);
+            model.IsActive.Should().BeTrue();
+            model.MinCoinMaturity.Should().Be(1);
+            model.MinimumDepositConfirmations.Should().Be(1);
+            model.MultisigPublicKey.Should().Be(multisigPubKey);
+        }
+    }
+}

--- a/src/Stratis.Features.FederatedPeg.Tests/ControllersTests/FederationWalletControllerTests.cs
+++ b/src/Stratis.Features.FederatedPeg.Tests/ControllersTests/FederationWalletControllerTests.cs
@@ -1,0 +1,150 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using NBitcoin;
+using NSubstitute;
+using Stratis.Bitcoin.Connection;
+using Stratis.Bitcoin.Features.Wallet;
+using Stratis.Bitcoin.Features.Wallet.Models;
+using Stratis.Bitcoin.Networks;
+using Stratis.Bitcoin.P2P.Peer;
+using Stratis.Bitcoin.Tests.Common;
+using Stratis.Bitcoin.Utilities;
+using Stratis.Features.FederatedPeg.Controllers;
+using Stratis.Features.FederatedPeg.Interfaces;
+using Stratis.Features.FederatedPeg.Models;
+using Stratis.Features.FederatedPeg.TargetChain;
+using Stratis.Features.FederatedPeg.Wallet;
+using Xunit;
+
+namespace Stratis.Features.FederatedPeg.Tests.ControllersTests
+{
+    public class FederationWalletControllerTests
+    {
+        private readonly ILoggerFactory loggerFactory;
+        private readonly IFederationWalletManager walletManager;
+        private readonly IFederationWalletSyncManager walletSyncManager;
+        private readonly IConnectionManager connectionManager;
+        private readonly Network network;
+        private readonly ConcurrentChain chain;
+        private readonly IDateTimeProvider dateTimeProvider;
+        private readonly IWithdrawalHistoryProvider withdrawalHistoryProvider;
+
+        private readonly FederationWalletController controller;
+        private readonly FederationWallet fedWallet;
+
+        public FederationWalletControllerTests()
+        {
+            this.loggerFactory = Substitute.For<ILoggerFactory>();
+            this.walletManager = Substitute.For<IFederationWalletManager>();
+            this.walletSyncManager = Substitute.For<IFederationWalletSyncManager>();
+            this.connectionManager = Substitute.For<IConnectionManager>();
+            this.network = new StratisTest();
+
+            this.chain = new ConcurrentChain(this.network);
+
+            ChainedHeader tip = ChainedHeadersHelper.CreateConsecutiveHeaders(100, ChainedHeadersHelper.CreateGenesisChainedHeader(this.network), true, null, this.network).Last();
+            this.chain.SetTip(tip);
+
+
+            this.dateTimeProvider = Substitute.For<IDateTimeProvider>();
+            this.withdrawalHistoryProvider = Substitute.For<IWithdrawalHistoryProvider>();
+
+            this.controller = new FederationWalletController(this.loggerFactory, this.walletManager, this.walletSyncManager,
+                this.connectionManager, this.network, this.chain, this.dateTimeProvider, this.withdrawalHistoryProvider);
+
+            this.fedWallet = new FederationWallet();
+            this.fedWallet.Network = this.network;
+            this.fedWallet.LastBlockSyncedHeight = 999;
+            this.fedWallet.CreationTime = DateTimeOffset.Now;
+
+            this.walletManager.GetWallet().Returns(this.fedWallet);
+        }
+
+        [Fact]
+        public void GetGeneralInfo()
+        {
+            this.connectionManager.ConnectedPeers.Returns(info => new NetworkPeerCollection());
+
+            IActionResult result = this.controller.GetGeneralInfo();
+            WalletGeneralInfoModel model = ActionResultToModel<WalletGeneralInfoModel>(result);
+
+            Assert.Equal(this.fedWallet.CreationTime, model.CreationTime);
+            Assert.Equal(this.fedWallet.LastBlockSyncedHeight, model.LastBlockSyncedHeight);
+            Assert.Equal(this.fedWallet.Network, model.Network);
+        }
+
+        [Fact]
+        public void GetBalance()
+        {
+            this.fedWallet.MultiSigAddress = new MultiSigAddress();
+
+            IActionResult result = this.controller.GetBalance();
+            WalletBalanceModel model = ActionResultToModel<WalletBalanceModel>(result);
+
+            Assert.Single(model.AccountsBalances);
+            Assert.Equal(CoinType.Stratis, model.AccountsBalances.First().CoinType);
+            Assert.Equal(0, model.AccountsBalances.First().AmountConfirmed.Satoshi);
+        }
+
+        [Fact]
+        public void GetHistory()
+        {
+            var withdrawals = new List<WithdrawalModel>() {new WithdrawalModel(), new WithdrawalModel()};
+
+            this.withdrawalHistoryProvider.GetHistory(0).ReturnsForAnyArgs(withdrawals);
+
+            IActionResult result = this.controller.GetHistory(5);
+            List<WithdrawalModel> model = ActionResultToModel<List<WithdrawalModel>>(result);
+
+            Assert.Equal(withdrawals.Count, model.Count);
+        }
+
+        [Fact]
+        public void Sync()
+        {
+            ChainedHeader header = this.chain.Tip;
+
+            bool called = false;
+            this.walletSyncManager.When(x => x.SyncFromHeight(header.Height)).Do(info => called = true);
+
+            this.controller.Sync(new HashModel() { Hash = header.HashBlock.ToString() });
+
+            Assert.True(called);
+        }
+
+        [Fact]
+        public void EnableFederation()
+        {
+            bool called = false;
+            this.walletManager.When(x => x.EnableFederation(null)).Do(info => called = true);
+
+            this.controller.EnableFederation(new EnableFederationRequest());
+
+            Assert.True(called);
+        }
+
+        [Fact]
+        public void RemoveTransactions()
+        {
+            var hashSet = new HashSet<(uint256, DateTimeOffset)>();
+            hashSet.Add((uint256.One, DateTimeOffset.MinValue));
+
+            this.walletManager.RemoveAllTransactions().Returns(info => hashSet);
+
+            IActionResult result = this.controller.RemoveTransactions(new RemoveFederationTransactionsModel());
+
+            IEnumerable<RemovedTransactionModel> model = ActionResultToModel<IEnumerable<RemovedTransactionModel>>(result);
+
+            Assert.Single(model);
+        }
+
+        private T ActionResultToModel<T>(IActionResult result) where T : class
+        {
+            T model = (result as JsonResult).Value as T;
+            return model;
+        }
+    }
+}

--- a/src/Stratis.Features.FederatedPeg.Tests/CrossChainTestBase.cs
+++ b/src/Stratis.Features.FederatedPeg.Tests/CrossChainTestBase.cs
@@ -1,0 +1,338 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Runtime.Serialization;
+using System.Threading;
+using Microsoft.Extensions.Logging;
+using NBitcoin;
+using NBitcoin.Networks;
+using NSubstitute;
+using Stratis.Bitcoin;
+using Stratis.Bitcoin.Configuration;
+using Stratis.Bitcoin.Connection;
+using Stratis.Bitcoin.Features.BlockStore;
+using Stratis.Bitcoin.Features.Wallet;
+using Stratis.Bitcoin.Features.Wallet.Interfaces;
+using Stratis.Bitcoin.Utilities;
+using Stratis.Features.FederatedPeg.Interfaces;
+using Stratis.Features.FederatedPeg.TargetChain;
+using Stratis.Features.FederatedPeg.Wallet;
+using Stratis.Sidechains.Networks;
+using Xunit;
+
+namespace Stratis.Features.FederatedPeg.Tests
+{
+    public class CrossChainTestBase
+    {
+        protected const string walletPassword = "password";
+        protected Network network;
+        protected ConcurrentChain chain;
+        protected ILoggerFactory loggerFactory;
+        protected ILogger logger;
+        protected IDateTimeProvider dateTimeProvider;
+        protected IOpReturnDataReader opReturnDataReader;
+        protected IWithdrawalExtractor withdrawalExtractor;
+        protected IBlockRepository blockRepository;
+        protected IFullNode fullNode;
+        protected IFederationWalletManager federationWalletManager;
+        protected IFederationWalletTransactionHandler federationWalletTransactionHandler;
+        protected IFederationGatewaySettings federationGatewaySettings;
+        protected IFederationWalletSyncManager federationWalletSyncManager;
+        protected DataFolder dataFolder;
+        protected IWalletFeePolicy walletFeePolicy;
+        protected IAsyncLoopFactory asyncLoopFactory;
+        protected INodeLifetime nodeLifetime;
+        protected IConnectionManager connectionManager;
+        protected DBreezeSerializer dBreezeSerializer;
+        protected Dictionary<uint256, Block> blockDict;
+        protected List<Transaction> fundingTransactions;
+        protected FederationWallet wallet;
+        protected ExtKey[] federationKeys;
+        protected ExtKey extendedKey;
+        protected Script redeemScript
+        {
+            get
+            {
+                return PayToMultiSigTemplate.Instance.GenerateScriptPubKey(2, this.federationKeys.Select(k => k.PrivateKey.PubKey).ToArray());
+            }
+        }
+
+        /// <summary>
+        /// Initializes the cross-chain transfer tests.
+        /// </summary>
+        /// <param name="network">The network to run the tests for.</param>
+        public CrossChainTestBase(Network network = null)
+        {
+            this.network = network ?? FederatedPegNetwork.NetworksSelector.Regtest();
+            NetworkRegistration.Register(this.network);
+
+            this.loggerFactory = Substitute.For<ILoggerFactory>();
+            this.logger = Substitute.For<ILogger>();
+            this.asyncLoopFactory = new AsyncLoopFactory(this.loggerFactory);
+            this.loggerFactory.CreateLogger(null).ReturnsForAnyArgs(this.logger);
+            this.dateTimeProvider = DateTimeProvider.Default;
+            this.opReturnDataReader = new OpReturnDataReader(this.loggerFactory, this.network);
+            this.blockRepository = Substitute.For<IBlockRepository>();
+            this.fullNode = Substitute.For<IFullNode>();
+            this.federationWalletManager = Substitute.For<IFederationWalletManager>();
+            this.federationWalletTransactionHandler = Substitute.For<IFederationWalletTransactionHandler>();
+            this.federationWalletSyncManager = Substitute.For<IFederationWalletSyncManager>();
+            this.walletFeePolicy = Substitute.For<IWalletFeePolicy>();
+            this.nodeLifetime = new NodeLifetime();
+            this.connectionManager = Substitute.For<IConnectionManager>();
+            this.dBreezeSerializer = new DBreezeSerializer(this.network);
+
+            this.wallet = null;
+            this.federationGatewaySettings = Substitute.For<IFederationGatewaySettings>();
+            this.chain = new ConcurrentChain(this.network);
+
+            this.federationGatewaySettings.MinCoinMaturity.Returns(1);
+            this.federationGatewaySettings.TransactionFee.Returns(new Money(0.01m, MoneyUnit.BTC));
+
+            // Generate the keys used by the federation members for our tests.
+            this.federationKeys = new[]
+            {
+                "ensure feel swift crucial bridge charge cloud tell hobby twenty people mandate",
+                "quiz sunset vote alley draw turkey hill scrap lumber game differ fiction",
+                "exchange rent bronze pole post hurry oppose drama eternal voice client state"
+            }.Select(m => HdOperations.GetExtendedKey(m)).ToArray();
+
+            SetExtendedKey(0);
+
+            this.fundingTransactions = new List<Transaction>();
+
+            this.blockDict = new Dictionary<uint256, Block>();
+            this.blockDict[this.network.GenesisHash] = this.network.GetGenesis();
+
+            this.blockRepository.GetBlocksAsync(Arg.Any<List<uint256>>()).ReturnsForAnyArgs((x) => {
+                var hashes = x.ArgAt<List<uint256>>(0);
+                var blocks = new List<Block>();
+                for (int i = 0; i < hashes.Count; i++)
+                {
+                    blocks.Add(this.blockDict.TryGetValue(hashes[i], out Block block) ? block : null);
+                }
+
+                return blocks;
+            });
+        }
+
+        /// <summary>
+        /// Chooses the key we use.
+        /// </summary>
+        /// <param name="keyNum">The key number.</param>
+        protected void SetExtendedKey(int keyNum)
+        {
+            this.extendedKey = this.federationKeys[keyNum];
+
+            this.federationGatewaySettings.IsMainChain.Returns(false);
+            this.federationGatewaySettings.MultiSigRedeemScript.Returns(this.redeemScript);
+            this.federationGatewaySettings.MultiSigAddress.Returns(this.redeemScript.Hash.GetAddress(this.network));
+            this.federationGatewaySettings.PublicKey.Returns(this.extendedKey.PrivateKey.PubKey.ToHex());
+            this.withdrawalExtractor = new WithdrawalExtractor(this.loggerFactory, this.federationGatewaySettings, this.opReturnDataReader, this.network);
+        }
+
+        protected Transaction AddFundingTransaction(Money[] amounts)
+        {
+            Transaction transaction = this.network.CreateTransaction();
+
+            foreach (Money amount in amounts)
+            {
+                transaction.Outputs.Add(new TxOut(amount, this.wallet.MultiSigAddress.ScriptPubKey));
+            }
+
+            transaction.AddInput(new TxIn(new OutPoint(0, 0), new Script(OpcodeType.OP_1)));
+
+            this.AppendBlock(transaction);
+            this.fundingTransactions.Add(transaction);
+
+            return transaction;
+        }
+
+        protected void AddFunding()
+        {
+            AddFundingTransaction(new Money[] { Money.COIN * 90, Money.COIN * 80 });
+            AddFundingTransaction(new Money[] { Money.COIN * 70 });
+        }
+
+        /// <summary>
+        /// Create the wallet manager and wallet transaction handler.
+        /// </summary>
+        /// <param name="dataFolder">The data folder.</param>
+        protected void Init(DataFolder dataFolder)
+        {
+            this.dataFolder = dataFolder;
+
+            // Create the wallet manager.
+            this.federationWalletManager = new FederationWalletManager(
+                this.loggerFactory,
+                this.network,
+                this.chain,
+                dataFolder,
+                this.walletFeePolicy,
+                this.asyncLoopFactory,
+                new NodeLifetime(),
+                this.dateTimeProvider,
+                this.federationGatewaySettings,
+                this.withdrawalExtractor);
+
+            // Starts and creates the wallet.
+            this.federationWalletManager.Start();
+            this.wallet = this.federationWalletManager.GetWallet();
+            this.federationWalletTransactionHandler = new FederationWalletTransactionHandler(this.loggerFactory, this.federationWalletManager, this.walletFeePolicy, this.network);
+
+            var storeSettings = (StoreSettings)FormatterServices.GetUninitializedObject(typeof(StoreSettings));
+
+            this.federationWalletSyncManager = new FederationWalletSyncManager(this.loggerFactory, this.federationWalletManager, this.chain, this.network,
+                this.blockRepository, storeSettings, Substitute.For<INodeLifetime>());
+
+            this.federationWalletSyncManager.Start();
+
+            // Set up the encrypted seed on the wallet.
+            string encryptedSeed = this.extendedKey.PrivateKey.GetEncryptedBitcoinSecret(walletPassword, this.network).ToWif();
+            this.wallet.EncryptedSeed = encryptedSeed;
+
+            this.federationWalletManager.Secret = new WalletSecret() { WalletPassword = walletPassword };
+
+            System.Reflection.FieldInfo prop = this.federationWalletManager.GetType().GetField("isFederationActive",
+                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+
+            prop.SetValue(this.federationWalletManager, true);
+        }
+
+        protected ICrossChainTransferStore CreateStore()
+        {
+            return new CrossChainTransferStore(this.network, this.dataFolder, this.chain, this.federationGatewaySettings, this.dateTimeProvider,
+                this.loggerFactory, this.withdrawalExtractor, this.fullNode, this.blockRepository, this.federationWalletManager, this.federationWalletTransactionHandler, this.dBreezeSerializer);
+        }
+
+        /// <summary>
+        /// Builds a chain with the requested number of blocks.
+        /// </summary>
+        /// <param name="blocks">The number of blocks.</param>
+        protected void AppendBlocks(int blocks)
+        {
+            for (int i = 0; i < blocks; i++)
+            {
+                this.AppendBlock();
+            }
+        }
+
+        /// <summary>
+        /// Create a block and add it to the dictionary used by the mock block repository.
+        /// </summary>
+        /// <param name="transactions">Additional transactions to add to the block.</param>
+        /// <returns>The last chained header.</returns>
+        protected ChainedHeader AppendBlock(params Transaction[] transactions)
+        {
+            Block block = this.network.CreateBlock();
+
+            // Create coinbase.
+            block.AddTransaction(this.network.CreateTransaction());
+
+            // Add additional transactions if any.
+            foreach (Transaction transaction in transactions)
+            {
+                block.AddTransaction(transaction);
+            }
+
+            block.UpdateMerkleRoot();
+            block.Header.HashPrevBlock = this.chain.Tip.HashBlock;
+            block.Header.Nonce = RandomUtils.GetUInt32();
+
+            return AppendBlock(block);
+        }
+
+        /// <summary>
+        /// Adds a previously created block to the dictionary used by the mock block repository.
+        /// </summary>
+        /// <param name="block">The block to add.</param>
+        /// <returns>The last chained header.</returns>
+        protected ChainedHeader AppendBlock(Block block)
+        {
+            if (!this.chain.TrySetTip(block.Header, out ChainedHeader last))
+                throw new InvalidOperationException("Previous not existing");
+
+            this.blockDict[block.GetHash()] = block;
+
+            this.federationWalletSyncManager.ProcessBlock(block);
+
+            return last;
+        }
+
+        /// <summary>
+        /// Waits for a function to return true.
+        /// </summary>
+        /// <param name="act">The function returning <c>true</c> or <c>false</c>.</param>
+        /// <param name="failureReason">The failure reason if any.</param>
+        /// <param name="retryDelayInMiliseconds">How often to retry in milliseconds.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        private static void WaitLoop(Func<bool> act, string failureReason = "Unknown Reason", int retryDelayInMiliseconds = 1000, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            cancellationToken = cancellationToken == default(CancellationToken)
+                ? new CancellationTokenSource(Debugger.IsAttached ? 15 * 60 * 1000 : 60 * 1000).Token
+                : cancellationToken;
+
+            while (!act())
+            {
+                try
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    Thread.Sleep(retryDelayInMiliseconds);
+                }
+                catch (OperationCanceledException e)
+                {
+                    Assert.False(true, $"{failureReason}{Environment.NewLine}{e.Message}");
+                }
+            }
+        }
+
+        /// <summary>
+        /// Creates a directory for a test, based on the name of the class containing the test and the name of the test.
+        /// </summary>
+        /// <param name="caller">The calling object, from which we derive the namespace in which the test is contained.</param>
+        /// <param name="callingMethod">The name of the test being executed. A directory with the same name will be created.</param>
+        /// <returns>The path of the directory that was created.</returns>
+        public static string CreateTestDir(object caller, [System.Runtime.CompilerServices.CallerMemberName] string callingMethod = "")
+        {
+            string directoryPath = GetTestDirectoryPath(caller, callingMethod);
+            return AssureEmptyDir(directoryPath);
+        }
+
+        /// <summary>
+        /// Gets the path of the directory that <see cref="CreateTestDir(object, string)"/> or <see cref="CreateDataFolder(object, string)"/> would create.
+        /// </summary>
+        /// <remarks>The path of the directory is of the form TestCase/{testClass}/{testName}.</remarks>
+        /// <param name="caller">The calling object, from which we derive the namespace in which the test is contained.</param>
+        /// <param name="callingMethod">The name of the test being executed. A directory with the same name will be created.</param>
+        /// <returns>The path of the directory.</returns>
+        public static string GetTestDirectoryPath(object caller, [System.Runtime.CompilerServices.CallerMemberName] string callingMethod = "")
+        {
+            return GetTestDirectoryPath(Path.Combine(caller.GetType().Name, callingMethod));
+        }
+
+        /// <summary>
+        /// Gets the path of the directory that <see cref="CreateTestDir(object, string)"/> would create.
+        /// </summary>
+        /// <remarks>The path of the directory is of the form TestCase/{testClass}/{testName}.</remarks>
+        /// <param name="testDirectory">The directory in which the test files are contained.</param>
+        /// <returns>The path of the directory.</returns>
+        public static string GetTestDirectoryPath(string testDirectory)
+        {
+            return Path.Combine("..", "..", "..", "..", "TestCase", testDirectory);
+        }
+
+        /// <summary>
+        /// Creates a new folder that will be empty.
+        /// </summary>
+        /// <param name="dir">The first part of the folder name.</param>
+        /// <returns>A folder name with the current time concatenated.</returns>
+        public static string AssureEmptyDir(string dir)
+        {
+            string uniqueDirName = $"{dir}-{DateTime.UtcNow:ddMMyyyyTHH.mm.ss.fff}";
+            Directory.CreateDirectory(uniqueDirName);
+            return uniqueDirName;
+        }
+    }
+}

--- a/src/Stratis.Features.FederatedPeg.Tests/CrossChainTransferStoreTests.cs
+++ b/src/Stratis.Features.FederatedPeg.Tests/CrossChainTransferStoreTests.cs
@@ -1,0 +1,541 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Threading;
+using NBitcoin;
+using Newtonsoft.Json;
+using NSubstitute;
+using Stratis.Bitcoin.Configuration;
+using Stratis.Bitcoin.Features.Wallet.Models;
+using Stratis.Bitcoin.Networks;
+using Stratis.Bitcoin.P2P.Peer;
+using Stratis.Features.FederatedPeg.Interfaces;
+using Stratis.Features.FederatedPeg.Models;
+using Stratis.Features.FederatedPeg.Payloads;
+using Stratis.Features.FederatedPeg.SourceChain;
+using Stratis.Features.FederatedPeg.TargetChain;
+using Stratis.Features.FederatedPeg.Wallet;
+using Xunit;
+
+namespace Stratis.Features.FederatedPeg.Tests
+{
+    public class CrossChainTransferStoreStratisTests : CrossChainTransferStoreTests
+    {
+        public CrossChainTransferStoreStratisTests() : base(new StratisRegTest())
+        {
+        }
+    }
+
+    public class CrossChainTransferStoreTests : CrossChainTestBase
+    {
+        public CrossChainTransferStoreTests(Network network = null) : base(network)
+        {
+        }
+
+        /// <summary>
+        /// Test that after synchronizing with the chain the store tip equals the chain tip.
+        /// </summary>
+        [Fact]
+        public void StartSynchronizesWithWallet()
+        {
+            var dataFolder = new DataFolder(CreateTestDir(this));
+
+            this.Init(dataFolder);
+            this.AppendBlocks(this.federationGatewaySettings.MinCoinMaturity);
+
+            using (ICrossChainTransferStore crossChainTransferStore = this.CreateStore())
+            {
+                crossChainTransferStore.Initialize();
+                crossChainTransferStore.Start();
+
+                Assert.Equal(this.wallet.LastBlockSyncedHash, crossChainTransferStore.TipHashAndHeight.HashBlock);
+                Assert.Equal(this.wallet.LastBlockSyncedHeight, crossChainTransferStore.TipHashAndHeight.Height);
+            }
+        }
+
+        /// <summary>
+        /// Test that after synchronizing with the chain the store tip equals the chain tip.
+        /// </summary>
+        [Fact]
+        public void StartSynchronizesWithWalletAndSurvivesRestart()
+        {
+            var dataFolder = new DataFolder(CreateTestDir(this));
+
+            this.Init(dataFolder);
+            this.AppendBlocks(this.federationGatewaySettings.MinCoinMaturity);
+
+            using (ICrossChainTransferStore crossChainTransferStore = this.CreateStore())
+            {
+                crossChainTransferStore.Initialize();
+                crossChainTransferStore.Start();
+
+                this.federationWalletManager.SaveWallet();
+
+                Assert.Equal(this.wallet.LastBlockSyncedHash, crossChainTransferStore.TipHashAndHeight.HashBlock);
+                Assert.Equal(this.wallet.LastBlockSyncedHeight, crossChainTransferStore.TipHashAndHeight.Height);
+            }
+
+            // Create a new instance of this test that loads from the persistence that we created in the step before.
+            var newTest = new CrossChainTransferStoreTests(this.network);
+
+            // Force a reorg by creating a new chain that only has genesis in common.
+            newTest.Init(dataFolder);
+            newTest.AppendBlocks(3);
+
+            using (ICrossChainTransferStore crossChainTransferStore2 = newTest.CreateStore())
+            {
+                // Test that synchronizing the store aligns it with the current chain tip after the fork.
+                crossChainTransferStore2.Initialize();
+                crossChainTransferStore2.Start();
+
+                Assert.Equal(newTest.wallet.LastBlockSyncedHash, crossChainTransferStore2.TipHashAndHeight.HashBlock);
+                Assert.Equal(newTest.wallet.LastBlockSyncedHeight, crossChainTransferStore2.TipHashAndHeight.Height);
+            }
+        }
+
+        /// <summary>
+        /// Recording deposits when the wallet UTXOs are sufficient succeeds with deterministic transactions.
+        /// </summary>
+        [Fact]
+        public void StoringDepositsWhenWalletBalanceSufficientSucceedsWithDeterministicTransactions()
+        {
+            var dataFolder = new DataFolder(CreateTestDir(this));
+
+            this.Init(dataFolder);
+            this.AddFunding();
+            this.AppendBlocks(this.federationGatewaySettings.MinCoinMaturity);
+
+            MultiSigAddress multiSigAddress = this.wallet.MultiSigAddress;
+
+            using (ICrossChainTransferStore crossChainTransferStore = this.CreateStore())
+            {
+                crossChainTransferStore.Initialize();
+                crossChainTransferStore.Start();
+
+                Assert.Equal(this.chain.Tip.HashBlock, crossChainTransferStore.TipHashAndHeight.HashBlock);
+                Assert.Equal(this.chain.Tip.Height, crossChainTransferStore.TipHashAndHeight.Height);
+
+                BitcoinAddress address1 = (new Key()).PubKey.Hash.GetAddress(this.network);
+                BitcoinAddress address2 = (new Key()).PubKey.Hash.GetAddress(this.network);
+
+                var deposit1 = new Deposit(0, new Money(160m, MoneyUnit.BTC), address1.ToString(), crossChainTransferStore.NextMatureDepositHeight, 1);
+                var deposit2 = new Deposit(1, new Money(60m, MoneyUnit.BTC), address2.ToString(), crossChainTransferStore.NextMatureDepositHeight, 1);
+
+                MaturedBlockDepositsModel[] blockDeposits = new[] { new MaturedBlockDepositsModel(
+                    new MaturedBlockInfoModel() {
+                        BlockHash = 1,
+                        BlockHeight = crossChainTransferStore.NextMatureDepositHeight },
+                    new[] { deposit1, deposit2 })
+                };
+
+                crossChainTransferStore.RecordLatestMatureDepositsAsync(blockDeposits).GetAwaiter().GetResult();
+
+                Transaction[] transactions = crossChainTransferStore.GetTransactionsByStatusAsync(CrossChainTransferStatus.Partial).GetAwaiter().GetResult().Values.ToArray();
+
+                Assert.Equal(2, transactions.Length);
+
+                // Transactions[0] inputs.
+                Assert.Equal(2, transactions[0].Inputs.Count);
+                Assert.Equal(this.fundingTransactions[0].GetHash(), transactions[0].Inputs[0].PrevOut.Hash);
+                Assert.Equal((uint)0, transactions[0].Inputs[0].PrevOut.N);
+                Assert.Equal(this.fundingTransactions[0].GetHash(), transactions[0].Inputs[1].PrevOut.Hash);
+                Assert.Equal((uint)1, transactions[0].Inputs[1].PrevOut.N);
+
+                // Transaction[0] outputs.
+                Assert.Equal(3, transactions[0].Outputs.Count);
+
+                // Transaction[0] output value - change.
+                Assert.Equal(new Money(9.99m, MoneyUnit.BTC), transactions[0].Outputs[0].Value);
+                Assert.Equal(multiSigAddress.ScriptPubKey, transactions[0].Outputs[0].ScriptPubKey);
+
+                // Transaction[0] output value - recipient 1.
+                Assert.Equal(new Money(160m, MoneyUnit.BTC), transactions[0].Outputs[1].Value);
+                Assert.Equal(address1.ScriptPubKey, transactions[0].Outputs[1].ScriptPubKey);
+
+                // Transaction[0] output value - op_return.
+                Assert.Equal(new Money(0m, MoneyUnit.BTC), transactions[0].Outputs[2].Value);
+                new OpReturnDataReader(this.loggerFactory, this.network).TryGetTransactionId(transactions[0], out string actualDepositId);
+                Assert.Equal(deposit1.Id.ToString(), actualDepositId);
+
+                // Transactions[1] inputs.
+                Assert.Single(transactions[1].Inputs);
+                Assert.Equal(this.fundingTransactions[1].GetHash(), transactions[1].Inputs[0].PrevOut.Hash);
+                Assert.Equal((uint)0, transactions[1].Inputs[0].PrevOut.N);
+
+                // Transaction[1] outputs.
+                Assert.Equal(3, transactions[1].Outputs.Count);
+
+                // Transaction[1] output value - change.
+                Assert.Equal(new Money(9.99m, MoneyUnit.BTC), transactions[1].Outputs[0].Value);
+                Assert.Equal(multiSigAddress.ScriptPubKey, transactions[1].Outputs[0].ScriptPubKey);
+
+                // Transaction[1] output value - recipient 2.
+                Assert.Equal(new Money(60m, MoneyUnit.BTC), transactions[1].Outputs[1].Value);
+                Assert.Equal(address2.ScriptPubKey, transactions[1].Outputs[1].ScriptPubKey);
+
+                // Transaction[1] output value - op_return.
+                Assert.Equal(new Money(0m, MoneyUnit.BTC), transactions[1].Outputs[2].Value);
+                new OpReturnDataReader(this.loggerFactory, this.network).TryGetTransactionId(transactions[1], out string actualDepositId2);
+                Assert.Equal(deposit2.Id.ToString(), actualDepositId2);
+
+                ICrossChainTransfer[] transfers = crossChainTransferStore.GetAsync(new uint256[] { 0, 1 }).GetAwaiter().GetResult().ToArray();
+
+                Assert.Equal(2, transfers.Length);
+                Assert.Equal(CrossChainTransferStatus.Partial, transfers[0].Status);
+                Assert.Equal(deposit1.Amount, new Money(transfers[0].DepositAmount));
+                Assert.Equal(address1.ScriptPubKey, transfers[0].DepositTargetAddress);
+                Assert.Equal(CrossChainTransferStatus.Partial, transfers[1].Status);
+                Assert.Equal(deposit2.Amount, new Money(transfers[1].DepositAmount));
+                Assert.Equal(address2.ScriptPubKey, transfers[1].DepositTargetAddress);
+            }
+        }
+
+        /// <summary>
+        /// Recording deposits when the wallet UTXOs are sufficient succeeds with deterministic transactions.
+        /// </summary>
+        [Fact]
+        public void StoringDepositsWhenWalletBalanceInSufficientSucceedsWithSuspendStatus()
+        {
+            var dataFolder = new DataFolder(CreateTestDir(this));
+
+            this.Init(dataFolder);
+            this.AddFunding();
+            this.AppendBlocks(this.federationGatewaySettings.MinCoinMaturity);
+
+            MultiSigAddress multiSigAddress = this.wallet.MultiSigAddress;
+
+            using (ICrossChainTransferStore crossChainTransferStore = this.CreateStore())
+            {
+                crossChainTransferStore.Initialize();
+                crossChainTransferStore.Start();
+
+                Assert.Equal(this.chain.Tip.HashBlock, crossChainTransferStore.TipHashAndHeight.HashBlock);
+                Assert.Equal(this.chain.Tip.Height, crossChainTransferStore.TipHashAndHeight.Height);
+
+                BitcoinAddress address1 = (new Key()).PubKey.Hash.GetAddress(this.network);
+                BitcoinAddress address2 = (new Key()).PubKey.Hash.GetAddress(this.network);
+
+                var deposit1 = new Deposit(0, new Money(160m, MoneyUnit.BTC), address1.ToString(), crossChainTransferStore.NextMatureDepositHeight, 1);
+                var deposit2 = new Deposit(1, new Money(100m, MoneyUnit.BTC), address2.ToString(), crossChainTransferStore.NextMatureDepositHeight, 1);
+
+                MaturedBlockDepositsModel[] blockDeposits = new[] { new MaturedBlockDepositsModel(
+                    new MaturedBlockInfoModel() {
+                        BlockHash = 1,
+                        BlockHeight = crossChainTransferStore.NextMatureDepositHeight },
+                    new[] { deposit1, deposit2 })
+                };
+
+                crossChainTransferStore.RecordLatestMatureDepositsAsync(blockDeposits).GetAwaiter().GetResult();
+
+                ICrossChainTransfer[] transfers = crossChainTransferStore.GetAsync(new uint256[] { 0, 1 }).GetAwaiter().GetResult().ToArray();
+
+                Transaction[] transactions = transfers.Select(t => t.PartialTransaction).ToArray();
+
+                Assert.Equal(2, transactions.Length);
+
+                // Transactions[0] inputs.
+                Assert.Equal(2, transactions[0].Inputs.Count);
+                Assert.Equal(this.fundingTransactions[0].GetHash(), transactions[0].Inputs[0].PrevOut.Hash);
+                Assert.Equal((uint)0, transactions[0].Inputs[0].PrevOut.N);
+                Assert.Equal(this.fundingTransactions[0].GetHash(), transactions[0].Inputs[1].PrevOut.Hash);
+                Assert.Equal((uint)1, transactions[0].Inputs[1].PrevOut.N);
+
+                // Transaction[0] outputs.
+                Assert.Equal(3, transactions[0].Outputs.Count);
+
+                // Transaction[0] output value - change.
+                Assert.Equal(new Money(9.99m, MoneyUnit.BTC), transactions[0].Outputs[0].Value);
+                Assert.Equal(multiSigAddress.ScriptPubKey, transactions[0].Outputs[0].ScriptPubKey);
+
+                // Transaction[0] output value - recipient 1.
+                Assert.Equal(new Money(160m, MoneyUnit.BTC), transactions[0].Outputs[1].Value);
+                Assert.Equal(address1.ScriptPubKey, transactions[0].Outputs[1].ScriptPubKey);
+
+                // Transaction[0] output value - op_return.
+                Assert.Equal(new Money(0m, MoneyUnit.BTC), transactions[0].Outputs[2].Value);
+                new OpReturnDataReader(this.loggerFactory, this.network).TryGetTransactionId(transactions[0], out string actualDepositId);
+                Assert.Equal(deposit1.Id.ToString(), actualDepositId);
+
+                Assert.Null(transactions[1]);
+
+                Assert.Equal(2, transfers.Length);
+                Assert.Equal(CrossChainTransferStatus.Partial, transfers[0].Status);
+                Assert.Equal(deposit1.Amount, new Money(transfers[0].DepositAmount));
+                Assert.Equal(address1.ScriptPubKey, transfers[0].DepositTargetAddress);
+                Assert.Equal(CrossChainTransferStatus.Suspended, transfers[1].Status);
+
+                // Add more funds and resubmit the deposits.
+                AddFundingTransaction(new Money[] { Money.COIN * 1000 });
+                crossChainTransferStore.RecordLatestMatureDepositsAsync(blockDeposits).GetAwaiter().GetResult();
+                transfers = crossChainTransferStore.GetAsync(new uint256[] { 0, 1 }).GetAwaiter().GetResult().ToArray();
+                transactions = transfers.Select(t => t.PartialTransaction).ToArray();
+
+                // Transactions[1] inputs.
+                Assert.Equal(2, transactions[1].Inputs.Count);
+                Assert.Equal(this.fundingTransactions[1].GetHash(), transactions[1].Inputs[0].PrevOut.Hash);
+                Assert.Equal((uint)0, transactions[1].Inputs[0].PrevOut.N);
+
+                // Transaction[1] outputs.
+                Assert.Equal(3, transactions[1].Outputs.Count);
+
+                // Transaction[1] output value - change.
+                Assert.Equal(new Money(969.99m, MoneyUnit.BTC), transactions[1].Outputs[0].Value);
+                Assert.Equal(multiSigAddress.ScriptPubKey, transactions[1].Outputs[0].ScriptPubKey);
+
+                // Transaction[1] output value - recipient 2.
+                Assert.Equal(new Money(100m, MoneyUnit.BTC), transactions[1].Outputs[1].Value);
+                Assert.Equal(address2.ScriptPubKey, transactions[1].Outputs[1].ScriptPubKey);
+
+                // Transaction[1] output value - op_return.
+                Assert.Equal(new Money(0m, MoneyUnit.BTC), transactions[1].Outputs[2].Value);
+                new OpReturnDataReader(this.loggerFactory, this.network).TryGetTransactionId(transactions[1], out string actualDepositId2);
+                Assert.Equal(deposit2.Id.ToString(), actualDepositId2);
+
+                Assert.Equal(2, transfers.Length);
+                Assert.Equal(CrossChainTransferStatus.Partial, transfers[1].Status);
+                Assert.Equal(deposit2.Amount, new Money(transfers[1].DepositAmount));
+                Assert.Equal(address2.ScriptPubKey, transfers[1].DepositTargetAddress);
+
+                (Money confirmed, Money unconfirmed) spendable = this.wallet.GetSpendableAmount();
+
+                Assert.Equal(new Money(979.98m, MoneyUnit.BTC), spendable.unconfirmed);
+            }
+        }
+
+        /// <summary>
+        /// Tests whether the store merges signatures as expected.
+        ///
+        /// TODO: The reason this fails is because the Stratis network in the referenced NuGet doesn't have a standardscript set. This will pass in the newest version.
+        /// </summary>
+        [Fact]
+        public void StoreMergesSignaturesAsExpected()
+        {
+            var dataFolder = new DataFolder(CreateTestDir(this));
+
+            this.Init(dataFolder);
+            this.AddFunding();
+            this.AppendBlocks(this.federationGatewaySettings.MinCoinMaturity);
+
+            using (ICrossChainTransferStore crossChainTransferStore = this.CreateStore())
+            {
+                crossChainTransferStore.Initialize();
+                crossChainTransferStore.Start();
+
+                Assert.Equal(this.chain.Tip.HashBlock, crossChainTransferStore.TipHashAndHeight.HashBlock);
+                Assert.Equal(this.chain.Tip.Height, crossChainTransferStore.TipHashAndHeight.Height);
+
+                BitcoinAddress address = (new Key()).PubKey.Hash.GetAddress(this.network);
+
+                var deposit = new Deposit(0, new Money(160m, MoneyUnit.BTC), address.ToString(), crossChainTransferStore.NextMatureDepositHeight, 1);
+
+                MaturedBlockDepositsModel[] blockDeposits = new[] { new MaturedBlockDepositsModel(
+                    new MaturedBlockInfoModel() {
+                        BlockHash = 1,
+                        BlockHeight = crossChainTransferStore.NextMatureDepositHeight },
+                    new[] { deposit })
+                };
+
+                crossChainTransferStore.RecordLatestMatureDepositsAsync(blockDeposits).GetAwaiter().GetResult();
+
+                ICrossChainTransfer crossChainTransfer = crossChainTransferStore.GetAsync(new[] { deposit.Id }).GetAwaiter().GetResult().SingleOrDefault();
+
+                Assert.NotNull(crossChainTransfer);
+
+                Transaction transaction = crossChainTransfer.PartialTransaction;
+
+                Assert.True(crossChainTransferStore.ValidateTransaction(transaction));
+
+                // Create a separate instance to generate another transaction.
+                Transaction transaction2;
+                var newTest = new CrossChainTransferStoreTests(this.network);
+                var dataFolder2 = new DataFolder(CreateTestDir(this));
+
+                newTest.federationKeys = this.federationKeys;
+                newTest.SetExtendedKey(1);
+                newTest.Init(dataFolder2);
+
+                // Clone chain
+                for (int i = 1; i <= this.chain.Height; i++)
+                {
+                    ChainedHeader header = this.chain.GetBlock(i);
+                    Block block = this.blockDict[header.HashBlock];
+                    newTest.AppendBlock(block);
+                }
+
+                using (ICrossChainTransferStore crossChainTransferStore2 = newTest.CreateStore())
+                {
+                    crossChainTransferStore2.Initialize();
+                    crossChainTransferStore2.Start();
+
+                    Assert.Equal(newTest.chain.Tip.HashBlock, crossChainTransferStore2.TipHashAndHeight.HashBlock);
+                    Assert.Equal(newTest.chain.Tip.Height, crossChainTransferStore2.TipHashAndHeight.Height);
+
+                    crossChainTransferStore2.RecordLatestMatureDepositsAsync(blockDeposits).GetAwaiter().GetResult();
+
+                    ICrossChainTransfer crossChainTransfer2 = crossChainTransferStore2.GetAsync(new[] { deposit.Id }).GetAwaiter().GetResult().SingleOrDefault();
+
+                    Assert.NotNull(crossChainTransfer2);
+
+                    transaction2 = crossChainTransfer2.PartialTransaction;
+
+                    Assert.True(crossChainTransferStore2.ValidateTransaction(transaction2));
+                }
+
+                // Merges the transaction signatures.
+                crossChainTransferStore.MergeTransactionSignaturesAsync(deposit.Id, new[] { transaction2 }).GetAwaiter().GetResult();
+
+                // Test the outcome.
+                crossChainTransfer = crossChainTransferStore.GetAsync(new[] { deposit.Id }).GetAwaiter().GetResult().SingleOrDefault();
+
+                Assert.NotNull(crossChainTransfer);
+                Assert.Equal(CrossChainTransferStatus.FullySigned, crossChainTransfer.Status);
+
+                // Should be returned as signed.
+                Transaction signedTransaction = crossChainTransferStore.GetTransactionsByStatusAsync(CrossChainTransferStatus.FullySigned).GetAwaiter().GetResult().Values.SingleOrDefault();
+
+                Assert.NotNull(signedTransaction);
+
+                // Check ths signature.
+                Assert.True(crossChainTransferStore.ValidateTransaction(signedTransaction, true));
+            }
+        }
+
+        /// <summary>
+        /// Check that partial transactions present in the store cause partial transaction requests made to peers.
+        /// </summary>
+        [Fact]
+        public void StoredPartialTransactionsTriggerSignatureRequest()
+        {
+            var dataFolder = new DataFolder(CreateTestDir(this));
+
+            this.Init(dataFolder);
+            this.AddFunding();
+            this.AppendBlocks(this.federationGatewaySettings.MinCoinMaturity);
+
+            MultiSigAddress multiSigAddress = this.wallet.MultiSigAddress;
+
+            using (ICrossChainTransferStore crossChainTransferStore = this.CreateStore())
+            {
+                crossChainTransferStore.Initialize();
+                crossChainTransferStore.Start();
+
+                Assert.Equal(this.chain.Tip.HashBlock, crossChainTransferStore.TipHashAndHeight.HashBlock);
+                Assert.Equal(this.chain.Tip.Height, crossChainTransferStore.TipHashAndHeight.Height);
+
+                BitcoinAddress address1 = (new Key()).PubKey.Hash.GetAddress(this.network);
+                BitcoinAddress address2 = (new Key()).PubKey.Hash.GetAddress(this.network);
+
+                var deposit1 = new Deposit(0, new Money(160m, MoneyUnit.BTC), address1.ToString(), crossChainTransferStore.NextMatureDepositHeight, 1);
+                var deposit2 = new Deposit(1, new Money(60m, MoneyUnit.BTC), address2.ToString(), crossChainTransferStore.NextMatureDepositHeight, 1);
+
+                MaturedBlockDepositsModel[] blockDeposits = new[] { new MaturedBlockDepositsModel(
+                    new MaturedBlockInfoModel() {
+                        BlockHash = 1,
+                        BlockHeight = crossChainTransferStore.NextMatureDepositHeight },
+                    new[] { deposit1, deposit2 })
+                };
+
+                crossChainTransferStore.RecordLatestMatureDepositsAsync(blockDeposits).GetAwaiter().GetResult();
+
+                Dictionary<uint256, Transaction> transactions = crossChainTransferStore.GetTransactionsByStatusAsync(
+                    CrossChainTransferStatus.Partial).GetAwaiter().GetResult();
+
+                var requester = new PartialTransactionRequester(this.loggerFactory, crossChainTransferStore, this.asyncLoopFactory,
+                    this.nodeLifetime, this.connectionManager, this.federationGatewaySettings);
+
+                var peerEndPoint = new System.Net.IPEndPoint(System.Net.IPAddress.Parse("1.2.3.4"), 5);
+                var peer = Substitute.For<INetworkPeer>();
+                peer.RemoteSocketAddress.Returns(peerEndPoint.Address);
+                peer.RemoteSocketPort.Returns(peerEndPoint.Port);
+                peer.PeerEndPoint.Returns(peerEndPoint);
+                peer.IsConnected.Returns(true);
+
+                var peers = new NetworkPeerCollection();
+                peers.Add(peer);
+
+                this.federationGatewaySettings.FederationNodeIpEndPoints.Returns(new[] { peerEndPoint });
+
+                this.connectionManager.ConnectedPeers.Returns(peers);
+
+                requester.Start();
+
+                Thread.Sleep(100);
+
+                peer.Received().SendMessageAsync(Arg.Is<RequestPartialTransactionPayload>(o =>
+                    o.DepositId == 0 && o.PartialTransaction.GetHash() == transactions[0].GetHash())).GetAwaiter().GetResult();
+
+                peer.DidNotReceive().SendMessageAsync(Arg.Is<RequestPartialTransactionPayload>(o =>
+                    o.DepositId == 1 && o.PartialTransaction.GetHash() == transactions[1].GetHash())).GetAwaiter().GetResult();
+            }
+        }
+
+        [Fact(Skip = "Requires main chain user to be running.")]
+        public void DoTest()
+        {
+            var transactionRequest = new BuildTransactionRequest()
+            {
+                FeeAmount = "0.01",
+                // Change this to the address that should receive the funds.
+                OpReturnData = "PLv2NAsyn22cNbk5veopWCkypaN6DBR27L",
+                AccountName = "account 0",
+                AllowUnconfirmed = true,
+                Recipients = new List<RecipientModel> { new RecipientModel {
+                    DestinationAddress = "2MyKFLbvhSouDYeAHhxsj9a5A4oV71j7SPR",
+                    Amount = "1.1" } },
+                Password = "test",
+                WalletName = "test"
+            };
+
+            WalletBuildTransactionModel model = Post<BuildTransactionRequest, WalletBuildTransactionModel>(
+                "http://127.0.0.1:38221/api/wallet/build-transaction", transactionRequest);
+
+            var transaction = new PosTransaction(model.Hex);
+
+            var reader = new OpReturnDataReader(this.loggerFactory, Networks.Stratis.Testnet());
+            var extractor = new DepositExtractor(this.loggerFactory, this.federationGatewaySettings, reader, this.fullNode);
+            IDeposit deposit = extractor.ExtractDepositFromTransaction(transaction, 2, 1);
+
+            Assert.NotNull(deposit);
+            Assert.Equal(transaction.GetHash(), deposit.Id);
+            Assert.Equal(transactionRequest.OpReturnData, deposit.TargetAddress);
+            Assert.Equal(Money.Parse(transactionRequest.Recipients[0].Amount), deposit.Amount);
+            Assert.Equal((uint256)1, deposit.BlockHash);
+            Assert.Equal(2, deposit.BlockNumber);
+
+            // Post the transaction
+            var sendRequest = new SendTransactionRequest()
+            {
+                Hex = model.Hex
+            };
+
+            WalletSendTransactionModel model2 = Post<SendTransactionRequest, WalletSendTransactionModel>(
+                "http://127.0.0.1:38221/api/wallet/send-transaction", sendRequest);
+
+        }
+
+        private Q Post<T,Q>(string url, T body)
+        {
+            // Request is sent to mainchain user.
+            var request = (HttpWebRequest)WebRequest.Create(url);
+            request.ContentType = "application/json";
+            request.Method = "POST";
+
+            var content = new JsonContent(body);
+
+            string strContent = content.ReadAsStringAsync().GetAwaiter().GetResult();
+
+            using (var streamWriter = new StreamWriter(request.GetRequestStream()))
+            {
+                streamWriter.Write(strContent);
+            }
+
+            var response = (HttpWebResponse)request.GetResponse();
+            using (var streamReader = new StreamReader(response.GetResponseStream()))
+            {
+                string result = streamReader.ReadToEnd();
+                return JsonConvert.DeserializeObject<Q>(result);
+            }
+        }
+    }
+}

--- a/src/Stratis.Features.FederatedPeg.Tests/CrossChainTransferStoreTests.cs
+++ b/src/Stratis.Features.FederatedPeg.Tests/CrossChainTransferStoreTests.cs
@@ -305,8 +305,6 @@ namespace Stratis.Features.FederatedPeg.Tests
 
         /// <summary>
         /// Tests whether the store merges signatures as expected.
-        ///
-        /// TODO: The reason this fails is because the Stratis network in the referenced NuGet doesn't have a standardscript set. This will pass in the newest version.
         /// </summary>
         [Fact]
         public void StoreMergesSignaturesAsExpected()

--- a/src/Stratis.Features.FederatedPeg.Tests/DepositExtractorTests.cs
+++ b/src/Stratis.Features.FederatedPeg.Tests/DepositExtractorTests.cs
@@ -1,0 +1,159 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using NBitcoin;
+using NSubstitute;
+using Stratis.Bitcoin;
+using Stratis.Features.FederatedPeg.Interfaces;
+using Stratis.Features.FederatedPeg.SourceChain;
+using Stratis.Features.FederatedPeg.Tests.Utils;
+using Stratis.Sidechains.Networks;
+using Xunit;
+
+namespace Stratis.Features.FederatedPeg.Tests
+{
+    public class DepositExtractorTests
+    {
+        private readonly IFederationGatewaySettings settings;
+
+        private readonly IOpReturnDataReader opReturnDataReader;
+
+        private readonly ILoggerFactory loggerFactory;
+
+        private readonly IFullNode fullNode;
+
+        private readonly DepositExtractor depositExtractor;
+
+        private readonly Network network;
+
+        private readonly MultisigAddressHelper addressHelper;
+
+        private readonly TestTransactionBuilder transactionBuilder;
+
+        private readonly ConcurrentChain chain;
+
+        public DepositExtractorTests()
+        {
+            this.network = FederatedPegNetwork.NetworksSelector.Regtest();
+
+            this.loggerFactory = Substitute.For<ILoggerFactory>();
+            this.settings = Substitute.For<IFederationGatewaySettings>();
+            this.opReturnDataReader = Substitute.For<IOpReturnDataReader>();
+            this.fullNode = Substitute.For<IFullNode>();
+            this.fullNode.NodeService<ConcurrentChain>().Returns(this.chain);
+
+            this.addressHelper = new MultisigAddressHelper(this.network);
+
+            this.settings.MultiSigRedeemScript.Returns(this.addressHelper.PayToMultiSig);
+            this.opReturnDataReader.TryGetTargetAddress(null, out string address).Returns(callInfo => { callInfo[1] = null; return false; });
+
+            this.transactionBuilder = new TestTransactionBuilder();
+
+            this.depositExtractor = new DepositExtractor(
+                this.loggerFactory,
+                this.settings,
+                this.opReturnDataReader,
+                this.fullNode);
+        }
+
+        [Fact]
+        public void ExtractDepositsFromBlock_Should_Only_Find_Deposits_To_Multisig()
+        {
+            Block block = this.network.Consensus.ConsensusFactory.CreateBlock();
+
+            BitcoinPubKeyAddress targetAddress = this.addressHelper.GetNewTargetChainPubKeyAddress();
+            byte[] opReturnBytes = Encoding.UTF8.GetBytes(targetAddress.ToString());
+            long depositAmount = Money.COIN * 3;
+            Transaction depositTransaction = this.transactionBuilder.BuildOpReturnTransaction(
+                this.addressHelper.SourceChainMultisigAddress, opReturnBytes, depositAmount);
+            block.AddTransaction(depositTransaction);
+
+            this.opReturnDataReader.TryGetTargetAddress(depositTransaction, out string address).Returns(callInfo => { callInfo[1] = targetAddress.ToString(); return true; });
+
+            Transaction nonDepositTransactionToMultisig = this.transactionBuilder.BuildTransaction(
+                this.addressHelper.SourceChainMultisigAddress);
+            block.AddTransaction(nonDepositTransactionToMultisig);
+
+            BitcoinPubKeyAddress otherAddress = this.addressHelper.GetNewSourceChainPubKeyAddress();
+            otherAddress.ToString().Should().NotBe(this.addressHelper.SourceChainMultisigAddress.ToString(),
+                "otherwise the next deposit should actually be extracted");
+            Transaction depositTransactionToOtherAddress =
+                this.transactionBuilder.BuildOpReturnTransaction(otherAddress, opReturnBytes);
+            block.AddTransaction(depositTransactionToOtherAddress);
+
+            Transaction nonDepositTransactionToOtherAddress = this.transactionBuilder.BuildTransaction(
+                otherAddress);
+            block.AddTransaction(nonDepositTransactionToOtherAddress);
+
+            int blockHeight = 230;
+            IReadOnlyList<IDeposit> extractedDeposits = this.depositExtractor.ExtractDepositsFromBlock(block, blockHeight);
+
+            extractedDeposits.Count.Should().Be(1);
+            IDeposit extractedTransaction = extractedDeposits[0];
+
+            extractedTransaction.Amount.Satoshi.Should().Be(depositAmount);
+            extractedTransaction.Id.Should().Be(depositTransaction.GetHash());
+            extractedTransaction.TargetAddress.Should().Be(targetAddress.ToString());
+            extractedTransaction.BlockNumber.Should().Be(blockHeight);
+            extractedTransaction.BlockHash.Should().Be(block.GetHash());
+        }
+
+        [Fact]
+        public void ExtractDepositsFromBlock_Should_Create_One_Deposit_Per_Transaction_To_Multisig()
+        {
+            Block block = this.network.Consensus.ConsensusFactory.CreateBlock();
+
+            BitcoinPubKeyAddress targetAddress = this.addressHelper.GetNewTargetChainPubKeyAddress();
+            byte[] opReturnBytes = Encoding.UTF8.GetBytes(targetAddress.ToString());
+            long depositAmount = Money.COIN * 3;
+            Transaction depositTransaction = this.transactionBuilder.BuildOpReturnTransaction(
+                this.addressHelper.SourceChainMultisigAddress, opReturnBytes, depositAmount);
+            block.AddTransaction(depositTransaction);
+
+            this.opReturnDataReader.TryGetTargetAddress(depositTransaction, out string unused1).Returns(callInfo => { callInfo[1] = targetAddress.ToString(); return true; });
+
+            //add another deposit to the same address
+            long secondDepositAmount = Money.COIN * 2;
+            Transaction secondDepositTransaction = this.transactionBuilder.BuildOpReturnTransaction(
+                this.addressHelper.SourceChainMultisigAddress, opReturnBytes, secondDepositAmount);
+            block.AddTransaction(secondDepositTransaction);
+            this.opReturnDataReader.TryGetTargetAddress(secondDepositTransaction, out string unused2).Returns(callInfo => { callInfo[1] = targetAddress.ToString(); return true; });
+
+            //add another deposit to a different address
+            string newTargetAddress = this.addressHelper.GetNewTargetChainPubKeyAddress().ToString();
+            byte[] newOpReturnBytes = Encoding.UTF8.GetBytes(newTargetAddress);
+            long thirdDepositAmount = Money.COIN * 34;
+            Transaction thirdDepositTransaction = this.transactionBuilder.BuildOpReturnTransaction(
+                this.addressHelper.SourceChainMultisigAddress, newOpReturnBytes, thirdDepositAmount);
+            block.AddTransaction(thirdDepositTransaction);
+
+            this.opReturnDataReader.TryGetTargetAddress(thirdDepositTransaction, out string unused3).Returns(callInfo => { callInfo[1] = newTargetAddress; return true; });
+
+            int blockHeight = 12345;
+            IReadOnlyList<IDeposit> extractedDeposits = this.depositExtractor.ExtractDepositsFromBlock(block, blockHeight);
+
+            extractedDeposits.Count.Should().Be(3);
+            extractedDeposits.Select(d => d.BlockNumber).Should().AllBeEquivalentTo(blockHeight);
+            extractedDeposits.Select(d => d.BlockHash).Should().AllBeEquivalentTo(block.GetHash());
+
+            IDeposit extractedTransaction = extractedDeposits[0];
+            extractedTransaction.Amount.Satoshi.Should().Be(depositAmount);
+            extractedTransaction.Id.Should().Be(depositTransaction.GetHash());
+            extractedTransaction.TargetAddress.Should()
+                .Be(targetAddress.ToString());
+
+            extractedTransaction = extractedDeposits[1];
+            extractedTransaction.Amount.Satoshi.Should().Be(secondDepositAmount);
+            extractedTransaction.Id.Should().Be(secondDepositTransaction.GetHash());
+            extractedTransaction.TargetAddress.Should()
+                .Be(targetAddress.ToString());
+
+            extractedTransaction = extractedDeposits[2];
+            extractedTransaction.Amount.Satoshi.Should().Be(thirdDepositAmount);
+            extractedTransaction.Id.Should().Be(thirdDepositTransaction.GetHash());
+            extractedTransaction.TargetAddress.Should().Be(newTargetAddress);
+        }
+    }
+}

--- a/src/Stratis.Features.FederatedPeg.Tests/LeaderProviderTests.cs
+++ b/src/Stratis.Features.FederatedPeg.Tests/LeaderProviderTests.cs
@@ -1,0 +1,62 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using NBitcoin;
+using NSubstitute;
+using Stratis.Features.FederatedPeg.Interfaces;
+using Stratis.Features.FederatedPeg.Models;
+using Xunit;
+
+namespace Stratis.Features.FederatedPeg.Tests
+{
+    public class LeaderProviderTests
+    {
+        private readonly IFederationGatewaySettings federationGatewaySettings;
+
+        private readonly LeaderProvider leaderProvider;
+
+        private List<string> leaderPubkeys;
+
+        public LeaderProviderTests()
+        {
+            this.federationGatewaySettings = Substitute.For<IFederationGatewaySettings>();
+            this.federationGatewaySettings.FederationPublicKeys.Returns(this.BuildLeaderPubKeys());
+            this.leaderProvider = new LeaderProvider(this.federationGatewaySettings);
+        }
+
+        [Fact]
+        public void UpdatingBlockHeightCarriesOutLeaderPubKeysRoundRobin()
+        {
+            var output = new PubKey[10];
+
+            for (int blockHeight = 0; blockHeight < 10; blockHeight++)
+            {
+                this.leaderProvider.Update(new BlockTipModel(new uint256(), blockHeight, 10));
+                output[blockHeight] = this.leaderProvider.CurrentLeaderKey;
+            }
+
+            this.leaderPubkeys = this.leaderPubkeys.OrderBy(k => k).ToList();
+
+            for (int i = 0; i < 5; i++)
+            {
+                output[i].ToString().Should().Contain(this.leaderPubkeys[i]);
+                output[i + 5].ToString().Should().Contain(this.leaderPubkeys[i]);
+            }
+        }
+
+        private PubKey[] BuildLeaderPubKeys()
+        {
+            // Unordered list.
+            this.leaderPubkeys = new List<string>()
+            {
+                "026ebcbf6bfe7ce1d957adbef8ab2b66c788656f35896a170257d6838bda70b95c",
+                "03c99f997ed71c7f92cf532175cea933f2f11bf08f1521d25eb3cc9b8729af8bf4",
+                "02e9d3cd0c2fa501957149ff9d21150f3901e6ece0e3fe3007f2372720c84e3ee1",
+                "02a97b7d0fad7ea10f456311dcd496ae9293952d4c5f2ebdfc32624195fde14687",
+                "034b191e3b3107b71d1373e840c5bf23098b55a355ca959b968993f5dec699fc38"
+            };
+
+            return this.leaderPubkeys.Select(s => new PubKey(s)).OrderBy(z => z.ToString()).ToArray();
+        }
+    }
+}

--- a/src/Stratis.Features.FederatedPeg.Tests/LeaderReceiverTests.cs
+++ b/src/Stratis.Features.FederatedPeg.Tests/LeaderReceiverTests.cs
@@ -1,0 +1,62 @@
+using System;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Stratis.Features.FederatedPeg.TargetChain;
+using Xunit;
+
+namespace Stratis.Features.FederatedPeg.Tests
+{
+    public class LeaderReceiverTests : IDisposable
+    {
+        private ILeaderReceiver leaderReceiver;
+        private IDisposable streamSubscription;
+        private readonly ILoggerFactory loggerFactory;
+        private readonly ILogger logger;
+        private readonly ILeaderProvider leaderProvider;
+
+        private const string PublicKey = "026ebcbf6bfe7ce1d957adbef8ab2b66c788656f35896a170257d6838bda70b95c";
+
+        public LeaderReceiverTests()
+        {
+            this.loggerFactory = Substitute.For<ILoggerFactory>();
+            this.logger = Substitute.For<ILogger>();
+            this.loggerFactory.CreateLogger(null).ReturnsForAnyArgs(this.logger);
+            this.leaderProvider = Substitute.For<ILeaderProvider>();
+        }
+
+        [Fact]
+        public void ReceiveLeaders_Should_Push_Items_Into_The_LeaderProvidersStream()
+        {
+            this.leaderReceiver = new LeaderReceiver(this.loggerFactory);
+
+            const int LeaderCount = 3;
+            int receivedLeaderCount = 0;
+
+            this.streamSubscription = this.leaderReceiver.LeaderProvidersStream.Subscribe(
+                _ => { receivedLeaderCount++; });
+
+            this.leaderProvider.CurrentLeaderKey.Returns(new NBitcoin.PubKey(PublicKey));
+
+            for (int i = 0; i < LeaderCount; i++)
+                this.leaderReceiver.PushLeader(this.leaderProvider);
+
+            receivedLeaderCount.Should().Be(LeaderCount);
+
+            string logMsg = $"Received federated leader: {PublicKey}.";
+
+            this.logger.Received(receivedLeaderCount).Log(LogLevel.Information,
+                Arg.Any<EventId>(),
+                Arg.Is<object>(o => o.ToString() == logMsg),
+                null,
+                Arg.Any<Func<object, Exception, string>>());
+        }
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            this.streamSubscription?.Dispose();
+            this.leaderReceiver?.Dispose();
+        }
+    }
+}

--- a/src/Stratis.Features.FederatedPeg.Tests/MaturedBlockDepositModelTests.cs
+++ b/src/Stratis.Features.FederatedPeg.Tests/MaturedBlockDepositModelTests.cs
@@ -1,4 +1,6 @@
-﻿using Newtonsoft.Json;
+﻿using FluentAssertions;
+using Newtonsoft.Json;
+using Stratis.Features.FederatedPeg.Models;
 using Stratis.Features.FederatedPeg.Tests.Utils;
 using Xunit;
 

--- a/src/Stratis.Features.FederatedPeg.Tests/MaturedBlockDepositModelTests.cs
+++ b/src/Stratis.Features.FederatedPeg.Tests/MaturedBlockDepositModelTests.cs
@@ -1,0 +1,23 @@
+﻿using Newtonsoft.Json;
+using Stratis.Features.FederatedPeg.Tests.Utils;
+using Xunit;
+
+namespace Stratis.Features.FederatedPeg.Tests
+{
+    
+    public class MaturedBlockDepositModelTests
+    {
+        [Fact]
+        public void ShouldSerialiseAsJson()
+        {
+            MaturedBlockDepositsModel maturedBlockDeposits = TestingValues.GetMaturedBlockDeposits(3);
+            string asJson = maturedBlockDeposits.ToString();
+
+            var reconverted = JsonConvert.DeserializeObject<MaturedBlockDepositsModel>(asJson);
+
+            reconverted.BlockInfo.BlockHash.Should().Be(maturedBlockDeposits.BlockInfo.BlockHash);
+            reconverted.BlockInfo.BlockHeight.Should().Be(maturedBlockDeposits.BlockInfo.BlockHeight);
+            reconverted.Deposits.Should().BeEquivalentTo(maturedBlockDeposits.Deposits);
+        }
+    }
+}

--- a/src/Stratis.Features.FederatedPeg.Tests/MaturedBlockRequestModelTests.cs
+++ b/src/Stratis.Features.FederatedPeg.Tests/MaturedBlockRequestModelTests.cs
@@ -1,0 +1,21 @@
+﻿using Newtonsoft.Json;
+using Stratis.Features.FederatedPeg.Tests.Utils;
+using Xunit;
+
+namespace Stratis.Features.FederatedPeg.Tests
+{
+    public class MaturedBlockRequestModelTests
+    {
+        [Fact]
+        public void ShouldSerialiseAsJson()
+        {
+            var maturedBlockDeposits = new MaturedBlockRequestModel(TestingValues.GetPositiveInt(), TestingValues.GetPositiveInt());
+            string asJson = maturedBlockDeposits.ToString();
+
+            MaturedBlockRequestModel reconverted = JsonConvert.DeserializeObject<MaturedBlockRequestModel>(asJson);
+
+            reconverted.BlockHeight.Should().Be(maturedBlockDeposits.BlockHeight);
+            reconverted.MaxBlocksToSend.Should().Be(maturedBlockDeposits.MaxBlocksToSend);
+        }
+    }
+}

--- a/src/Stratis.Features.FederatedPeg.Tests/MaturedBlockRequestModelTests.cs
+++ b/src/Stratis.Features.FederatedPeg.Tests/MaturedBlockRequestModelTests.cs
@@ -1,4 +1,6 @@
-﻿using Newtonsoft.Json;
+﻿using FluentAssertions;
+using Newtonsoft.Json;
+using Stratis.Features.FederatedPeg.Models;
 using Stratis.Features.FederatedPeg.Tests.Utils;
 using Xunit;
 

--- a/src/Stratis.Features.FederatedPeg.Tests/MaturedBlocksProviderTests.cs
+++ b/src/Stratis.Features.FederatedPeg.Tests/MaturedBlocksProviderTests.cs
@@ -1,0 +1,69 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Extensions.Logging;
+using NBitcoin;
+using NSubstitute;
+using NSubstitute.Core;
+using Stratis.Bitcoin.Consensus;
+using Stratis.Bitcoin.Primitives;
+using Stratis.Bitcoin.Tests.Common;
+using Stratis.Features.FederatedPeg.Interfaces;
+using Stratis.Features.FederatedPeg.Models;
+using Stratis.Features.FederatedPeg.SourceChain;
+using Xunit;
+
+namespace Stratis.Features.FederatedPeg.Tests
+{
+    public class MaturedBlocksProviderTests
+    {
+        private readonly IDepositExtractor depositExtractor;
+
+        private readonly ILoggerFactory loggerFactory;
+
+        private readonly ILogger logger;
+
+        private readonly IConsensusManager consensusManager;
+
+        public MaturedBlocksProviderTests()
+        {
+            this.loggerFactory = Substitute.For<ILoggerFactory>();
+            this.logger = Substitute.For<ILogger>();
+            this.loggerFactory.CreateLogger(null).ReturnsForAnyArgs(this.logger);
+            this.depositExtractor = Substitute.For<IDepositExtractor>();
+            this.consensusManager = Substitute.For<IConsensusManager>();
+        }
+
+        [Fact]
+        public void GetMaturedBlocksAsyncReturnsDeposits()
+        {
+            List<ChainedHeader> headers = ChainedHeadersHelper.CreateConsecutiveHeaders(10, null, true);
+
+            foreach (ChainedHeader chainedHeader in headers)
+                chainedHeader.Block = new Block(chainedHeader.Header);
+
+            List<ChainedHeaderBlock> blocks = new List<ChainedHeaderBlock>(headers.Count);
+            foreach (ChainedHeader chainedHeader in headers)
+                blocks.Add(new ChainedHeaderBlock(chainedHeader.Block, chainedHeader));
+
+            ChainedHeader tip = headers.Last();
+
+            this.consensusManager.GetBlockDataAsync(Arg.Any<uint256>()).Returns(delegate(CallInfo info)
+            {
+                uint256 hash = (uint256) info[0];
+                ChainedHeaderBlock block = blocks.Single(x => x.ChainedHeader.HashBlock == hash);
+                return block;
+            });
+
+            uint zero = 0;
+            this.depositExtractor.MinimumDepositConfirmations.Returns(info => zero);
+            this.depositExtractor.ExtractBlockDeposits(null).ReturnsForAnyArgs(new MaturedBlockDepositsModel(new MaturedBlockInfoModel(), new List<IDeposit>()));
+            this.consensusManager.Tip.Returns(tip);
+
+            var maturedBlocksProvider = new MaturedBlocksProvider(this.loggerFactory, this.depositExtractor, this.consensusManager);
+
+            List<MaturedBlockDepositsModel> deposits = maturedBlocksProvider.GetMaturedDepositsAsync(0, 10).GetAwaiter().GetResult();
+
+            Assert.Equal(10, deposits.Count);
+        }
+    }
+}

--- a/src/Stratis.Features.FederatedPeg.Tests/MaturedBlocksSyncManagerTests.cs
+++ b/src/Stratis.Features.FederatedPeg.Tests/MaturedBlocksSyncManagerTests.cs
@@ -1,0 +1,71 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Stratis.Features.FederatedPeg.Interfaces;
+using Stratis.Features.FederatedPeg.Models;
+using Stratis.Features.FederatedPeg.RestClients;
+using Stratis.Features.FederatedPeg.TargetChain;
+using Xunit;
+
+namespace Stratis.Features.FederatedPeg.Tests
+{
+    public class MaturedBlocksSyncManagerTests
+    {
+        private readonly TestOnlyMaturedBlocksSyncManager syncManager;
+
+        private readonly IFederationGatewayClient federationGatewayClient;
+        private readonly ICrossChainTransferStore crossChainTransferStore;
+
+        public MaturedBlocksSyncManagerTests()
+        {
+            ILoggerFactory loggerFactory = Substitute.For<ILoggerFactory>();
+            this.federationGatewayClient = Substitute.For<IFederationGatewayClient>();
+            this.crossChainTransferStore = Substitute.For<ICrossChainTransferStore>();
+
+            this.syncManager = new TestOnlyMaturedBlocksSyncManager(this.crossChainTransferStore, this.federationGatewayClient, loggerFactory);
+        }
+
+        [Fact]
+        public async Task BlocksAreRequestedIfThereIsSomethingToRequestAsync()
+        {
+            this.crossChainTransferStore.NextMatureDepositHeight.Returns(5);
+            this.crossChainTransferStore.RecordLatestMatureDepositsAsync(null).ReturnsForAnyArgs(true);
+
+            var models = new List<MaturedBlockDepositsModel>() { new MaturedBlockDepositsModel(new MaturedBlockInfoModel(), new List<IDeposit>())};
+            this.federationGatewayClient.GetMaturedBlockDepositsAsync(null).ReturnsForAnyArgs(Task.FromResult(models));
+
+            bool delayRequired = await this.syncManager.ExposedSyncBatchOfBlocksAsync();
+            // Delay shouldn't be required because not-empty list was provided.
+            Assert.False(delayRequired);
+
+            // Now provide empty list.
+            this.federationGatewayClient.GetMaturedBlockDepositsAsync(null).ReturnsForAnyArgs(Task.FromResult(new List<MaturedBlockDepositsModel>() {}));
+
+            bool delayRequired2 = await this.syncManager.ExposedSyncBatchOfBlocksAsync();
+            // Delay is required because empty list was provided.
+            Assert.True(delayRequired2);
+
+            // Now provide null.
+            this.federationGatewayClient.GetMaturedBlockDepositsAsync(null).ReturnsForAnyArgs(Task.FromResult(null as List<MaturedBlockDepositsModel>));
+
+            bool delayRequired3 = await this.syncManager.ExposedSyncBatchOfBlocksAsync();
+            // Delay is required because null list was provided.
+            Assert.True(delayRequired3);
+        }
+
+
+        private class TestOnlyMaturedBlocksSyncManager : MaturedBlocksSyncManager
+        {
+            public TestOnlyMaturedBlocksSyncManager(ICrossChainTransferStore store, IFederationGatewayClient federationGatewayClient, ILoggerFactory loggerFactory)
+                : base(store, federationGatewayClient, loggerFactory)
+            {
+            }
+
+            public Task<bool> ExposedSyncBatchOfBlocksAsync()
+            {
+                return this.SyncBatchOfBlocksAsync();
+            }
+        }
+    }
+}

--- a/src/Stratis.Features.FederatedPeg.Tests/OpReturnDataReaderTests.cs
+++ b/src/Stratis.Features.FederatedPeg.Tests/OpReturnDataReaderTests.cs
@@ -1,0 +1,173 @@
+﻿using System.Text;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using NBitcoin;
+using NSubstitute;
+using Stratis.Features.FederatedPeg.Tests.Utils;
+using Stratis.Sidechains.Networks;
+using Xunit;
+
+namespace Stratis.Features.FederatedPeg.Tests
+{
+    public class OpReturnDataReaderTests
+    {
+        private readonly ILoggerFactory loggerFactory;
+
+        private readonly Network network;
+
+        private readonly OpReturnDataReader opReturnDataReader;
+
+        private readonly AddressHelper addressHelper;
+
+        private readonly TestTransactionBuilder transactionBuilder;
+
+        public OpReturnDataReaderTests()
+        {
+            this.loggerFactory = Substitute.For<ILoggerFactory>();
+            this.network = FederatedPegNetwork.NetworksSelector.Regtest();
+            this.opReturnDataReader = new OpReturnDataReader(this.loggerFactory, this.network);
+
+            this.transactionBuilder = new TestTransactionBuilder();
+            this.addressHelper = new AddressHelper(this.network);
+        }
+
+        [Fact]
+        public void TryGetTargetAddressFromOpReturn_CanReadAddress()
+        {
+
+            BitcoinPubKeyAddress opReturnAddress = this.addressHelper.GetNewTargetChainPubKeyAddress();
+            byte[] opReturnBytes = Encoding.UTF8.GetBytes(opReturnAddress.ToString());
+            Transaction transaction = this.transactionBuilder.BuildOpReturnTransaction(this.addressHelper.GetNewSourceChainPubKeyAddress(), opReturnBytes);
+
+            this.opReturnDataReader.TryGetTargetAddress(transaction, out string addressFromOpReturn);
+
+            addressFromOpReturn.Should().Be(opReturnAddress.ToString());
+        }
+
+        [Fact]
+        public void TryGetTargetAddressFromOpReturn_Can_NOT_ReadAddress_FromOwnNetwork()
+        {
+            BitcoinPubKeyAddress opReturnAddress = this.addressHelper.GetNewSourceChainPubKeyAddress();
+            byte[] opReturnBytes = Encoding.UTF8.GetBytes(opReturnAddress.ToString());
+
+            Transaction transaction = this.transactionBuilder.BuildOpReturnTransaction(this.addressHelper.GetNewSourceChainPubKeyAddress(), opReturnBytes);
+
+            this.opReturnDataReader.TryGetTargetAddress(transaction, out string opReturnString);
+
+            opReturnString.Should().BeNull();
+        }
+
+        [Fact]
+        public void TryGetTargetAddressFromOpReturn_Can_NOT_Read_Transaction_with_two_valid_OpReturns_addresses()
+        {
+            BitcoinPubKeyAddress opReturnAddress1 = this.addressHelper.GetNewTargetChainPubKeyAddress();
+            byte[] opReturnBytes1 = Encoding.UTF8.GetBytes(opReturnAddress1.ToString());
+
+            Transaction transaction = this.transactionBuilder.BuildOpReturnTransaction(this.addressHelper.GetNewSourceChainPubKeyAddress(), opReturnBytes1);
+
+            BitcoinPubKeyAddress opReturnAddress2 = this.addressHelper.GetNewTargetChainPubKeyAddress();
+            opReturnAddress1.ToString().Should().NotBe(
+                opReturnAddress2.ToString(), "otherwise the transaction is not ambiguous");
+            byte[] opReturnBytes2 = Encoding.UTF8.GetBytes(opReturnAddress2.ToString());
+            transaction.AddOutput(Money.Zero, new Script(OpcodeType.OP_RETURN, Op.GetPushOp(opReturnBytes2)));
+
+            this.opReturnDataReader.TryGetTargetAddress(transaction, out string addressFromOpReturn);
+            addressFromOpReturn.Should().BeNull();
+        }
+
+        [Fact]
+        public void TryGetTargetAddressFromOpReturn_Can_Read_Transaction_with_many_OpReturns_but_only_a_valid_address_one()
+        {
+            BitcoinPubKeyAddress opReturnValidAddress = this.addressHelper.GetNewTargetChainPubKeyAddress();
+            byte[] opReturnValidAddressBytes = Encoding.UTF8.GetBytes(opReturnValidAddress.ToString());
+
+            Transaction transaction = this.transactionBuilder.BuildOpReturnTransaction(this.addressHelper.GetNewSourceChainPubKeyAddress(), opReturnValidAddressBytes);
+
+            //address 2 will be ignored as not valid for target chain
+            byte[] opReturnInvalidAddressBytes = Encoding.UTF8.GetBytes(this.addressHelper.GetNewSourceChainPubKeyAddress().ToString());
+            transaction.AddOutput(Money.Zero, new Script(OpcodeType.OP_RETURN, Op.GetPushOp(opReturnInvalidAddressBytes)));
+
+            //add another output with the same target address, this is not ambiguous
+            transaction.AddOutput(Money.Zero, new Script(OpcodeType.OP_RETURN, Op.GetPushOp(opReturnValidAddressBytes)));
+
+            //add other random message
+            byte[] randomMessageBytes = Encoding.UTF8.GetBytes("neither hash, nor address");
+            transaction.AddOutput(Money.Zero, new Script(OpcodeType.OP_RETURN, Op.GetPushOp(randomMessageBytes)));
+
+            this.opReturnDataReader.TryGetTargetAddress(transaction, out string addressFromOpReturn);
+            addressFromOpReturn.Should().Be(opReturnValidAddress.ToString());
+        }
+
+        [Fact]
+        public void TryGetTargetAddressFromOpReturn_Can_NOT_ReadRandomStrings()
+        {
+            byte[] opReturnBytes = Encoding.UTF8.GetBytes("neither hash, nor address");
+            Transaction transaction = this.transactionBuilder.BuildOpReturnTransaction(this.addressHelper.GetNewSourceChainPubKeyAddress(), opReturnBytes);
+
+            this.opReturnDataReader.TryGetTargetAddress(transaction, out string opReturnString);
+
+            opReturnString.Should().BeNull();
+        }
+
+        [Fact]
+        public void TryGetTransactionIdFromOpReturn_Can_NOT_Read_Random_Strings()
+        {
+            byte[] opReturnBytes = Encoding.UTF8.GetBytes("neither hash, nor address");
+            Transaction transaction = this.transactionBuilder.BuildOpReturnTransaction(this.addressHelper.GetNewSourceChainPubKeyAddress(), opReturnBytes);
+
+            this.opReturnDataReader.TryGetTransactionId(transaction, out string opReturnString);
+
+            opReturnString.Should().BeNull();
+        }
+
+        [Fact]
+        public void TryGetTransactionIdFromOpReturn_Can_NOT_Read_Two_Valid_uint256_OpReturns()
+        {
+            uint256 opReturnTransactionHash1 = this.transactionBuilder.BuildTransaction(this.addressHelper.GetNewSourceChainPubKeyAddress()).GetHash();
+            byte[] opReturnBytes1 = opReturnTransactionHash1.ToBytes();
+
+            uint256 opReturnTransactionHash2 = this.transactionBuilder.BuildTransaction(this.addressHelper.GetNewSourceChainPubKeyAddress()).GetHash();
+            byte[] opReturnBytes2 = opReturnTransactionHash2.ToBytes();
+
+            opReturnBytes2.Should().NotBeEquivalentTo(opReturnBytes1, "otherwise there is no ambiguity");
+
+            Transaction transaction = this.transactionBuilder.BuildOpReturnTransaction(this.addressHelper.GetNewSourceChainPubKeyAddress(), opReturnBytes1);
+            transaction.AddOutput(Money.Zero, new Script(OpcodeType.OP_RETURN, Op.GetPushOp(opReturnBytes2)));
+
+            this.opReturnDataReader.TryGetTransactionId(transaction, out string opReturnString);
+
+            opReturnString.Should().BeNull();
+        }
+
+        [Fact]
+        public void TryGetTransactionIdFromOpReturn_Can_Read_many_OpReturns_with_only_one_valid_uint256()
+        {
+            uint256 opReturnTransactionHash1 = this.transactionBuilder.BuildTransaction(this.addressHelper.GetNewSourceChainPubKeyAddress()).GetHash();
+            byte[] opReturnBytes1 = opReturnTransactionHash1.ToBytes();
+
+            byte[] opReturnBytes2 = Encoding.UTF8.GetBytes("neither hash, nor address");
+
+            Transaction transaction = this.transactionBuilder.BuildOpReturnTransaction(this.addressHelper.GetNewSourceChainPubKeyAddress(), opReturnBytes1);
+            transaction.AddOutput(Money.Zero, new Script(OpcodeType.OP_RETURN, Op.GetPushOp(opReturnBytes2)));
+
+            this.opReturnDataReader.TryGetTransactionId(transaction, out string opReturnString);
+
+            opReturnString.Should().NotBeNull();
+            opReturnString.Should().Be(new uint256(opReturnBytes1).ToString());
+        }
+
+        [Fact]
+        public void TryGetTransactionIdFromOpReturn_Can_Read_single_OpReturn_with_valid_uint256()
+        {
+            uint256 opReturnTransactionHash = this.transactionBuilder.BuildTransaction(this.addressHelper.GetNewSourceChainPubKeyAddress()).GetHash();
+            byte[] opReturnBytes = opReturnTransactionHash.ToBytes();
+
+            Transaction transaction = this.transactionBuilder.BuildOpReturnTransaction(this.addressHelper.GetNewSourceChainPubKeyAddress(), opReturnBytes);
+
+            this.opReturnDataReader.TryGetTransactionId(transaction, out string opReturnString);
+
+            opReturnString.Should().NotBeNull();
+            opReturnString.Should().Be(new uint256(opReturnBytes).ToString());
+        }
+    }
+}

--- a/src/Stratis.Features.FederatedPeg.Tests/RestClientsTests/FederationGatewayClientTests.cs
+++ b/src/Stratis.Features.FederatedPeg.Tests/RestClientsTests/FederationGatewayClientTests.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Stratis.Features.FederatedPeg.Interfaces;
+using Stratis.Features.FederatedPeg.Models;
+using Stratis.Features.FederatedPeg.RestClients;
+using Stratis.Features.FederatedPeg.Tests.Utils;
+using Xunit;
+
+namespace Stratis.Features.FederatedPeg.Tests.RestClientsTests
+{
+    // TODO log assertions in the tests? WYDT
+    public class FederationGatewayClientTests : IDisposable
+    {
+        private IHttpClientFactory httpClientFactory;
+
+        private HttpMessageHandler messageHandler;
+
+        private HttpClient httpClient;
+
+        private readonly ILoggerFactory loggerFactory;
+
+        private readonly ILogger logger;
+
+        public FederationGatewayClientTests()
+        {
+            this.loggerFactory = Substitute.For<ILoggerFactory>();
+            this.logger = Substitute.For<ILogger>();
+            this.loggerFactory.CreateLogger(null).ReturnsForAnyArgs(this.logger);
+        }
+
+        private FederationGatewayClient createClient(bool isFailingClient = false)
+        {
+            if (isFailingClient)
+                TestingHttpClient.PrepareFailingHttpClient(ref this.messageHandler, ref this.httpClient, ref this.httpClientFactory);
+            else
+                TestingHttpClient.PrepareWorkingHttpClient(ref this.messageHandler, ref this.httpClient, ref this.httpClientFactory);
+
+            IFederationGatewaySettings federationSettings = Substitute.For<IFederationGatewaySettings>();
+            FederationGatewayClient client = new FederationGatewayClient(this.loggerFactory, federationSettings, this.httpClientFactory);
+
+            return client;
+        }
+
+        [Fact]
+        public async Task SendBlockTip_Should_Be_Able_To_Send_IBlockTipAsync()
+        {
+            var blockTip = new BlockTipModel(TestingValues.GetUint256(), TestingValues.GetPositiveInt(), TestingValues.GetPositiveInt());
+
+            await this.createClient().PushCurrentBlockTipAsync(blockTip).ConfigureAwait(false);
+
+            this.logger.Received(0).Log<object>(LogLevel.Error, 0, Arg.Any<object>(), Arg.Any<Exception>(), Arg.Any<Func<object, Exception, string>>());
+        }
+
+        [Fact]
+        public async Task SendBlockTip_Should_Log_Error_When_Failing_To_Send_IBlockTipAsync()
+        {
+            var blockTip = new BlockTipModel(TestingValues.GetUint256(), TestingValues.GetPositiveInt(), TestingValues.GetPositiveInt());
+
+            HttpResponseMessage result = await this.createClient(true).PushCurrentBlockTipAsync(blockTip).ConfigureAwait(false);
+            Assert.False(result.IsSuccessStatusCode);
+        }
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            this.messageHandler?.Dispose();
+            this.httpClient?.Dispose();
+        }
+    }
+}

--- a/src/Stratis.Features.FederatedPeg.Tests/RestClientsTests/RestApiClientBaseTests.cs
+++ b/src/Stratis.Features.FederatedPeg.Tests/RestClientsTests/RestApiClientBaseTests.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Stratis.Features.FederatedPeg.Interfaces;
+using Stratis.Features.FederatedPeg.RestClients;
+using Xunit;
+
+namespace Stratis.Features.FederatedPeg.Tests.RestClientsTests
+{
+    public class RestApiClientBaseTests
+    {
+        private IHttpClientFactory httpClientFactory;
+
+        private readonly ILoggerFactory loggerFactory;
+
+        private readonly ILogger logger;
+
+        public RestApiClientBaseTests()
+        {
+            this.loggerFactory = Substitute.For<ILoggerFactory>();
+            this.logger = Substitute.For<ILogger>();
+            this.loggerFactory.CreateLogger(null).ReturnsForAnyArgs(this.logger);
+            this.httpClientFactory = new HttpClientFactory();
+        }
+
+        [Fact]
+        public async Task TestRetriesCountAsync()
+        {
+            IFederationGatewaySettings federationSettings = Substitute.For<IFederationGatewaySettings>();
+
+            var testClient = new TestRestApiClient(this.loggerFactory, federationSettings, this.httpClientFactory);
+
+            HttpResponseMessage result = await testClient.CallThatWillAlwaysFail().ConfigureAwait(false);
+
+            Assert.Equal(testClient.RetriesCount, RestApiClientBase.RetryCount);
+            Assert.Equal(result.StatusCode, HttpStatusCode.InternalServerError);
+        }
+    }
+
+    public class TestRestApiClient : RestApiClientBase
+    {
+        public int RetriesCount { get; private set; }
+
+        public TestRestApiClient(ILoggerFactory loggerFactory, IFederationGatewaySettings settings, IHttpClientFactory httpClientFactory)
+            : base(loggerFactory, settings, httpClientFactory)
+        {
+            this.RetriesCount = 0;
+        }
+
+        public Task<HttpResponseMessage> CallThatWillAlwaysFail()
+        {
+            return this.SendPostRequestAsync("stringModel", "nonExistentAPIMethod", CancellationToken.None);
+        }
+
+        protected override void OnRetry(Exception exception, TimeSpan delay)
+        {
+            this.RetriesCount++;
+            base.OnRetry(exception, delay);
+        }
+    }
+}

--- a/src/Stratis.Features.FederatedPeg.Tests/SignedMultisigTransactionBroadcasterTests.cs
+++ b/src/Stratis.Features.FederatedPeg.Tests/SignedMultisigTransactionBroadcasterTests.cs
@@ -1,0 +1,182 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reactive.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using NBitcoin;
+using NSubstitute;
+using Stratis.Bitcoin.Configuration;
+using Stratis.Bitcoin.Features.Consensus.CoinViews;
+using Stratis.Bitcoin.Features.MemoryPool;
+using Stratis.Bitcoin.Features.MemoryPool.Fee;
+using Stratis.Bitcoin.Features.Wallet.Interfaces;
+using Stratis.Bitcoin.Utilities;
+using Stratis.Features.FederatedPeg.Interfaces;
+using Stratis.Features.FederatedPeg.TargetChain;
+using Stratis.Sidechains.Networks;
+using Xunit;
+
+namespace Stratis.Features.FederatedPeg.Tests
+{
+    public class SignedMultisigTransactionBroadcasterTests : IDisposable
+    {
+        private readonly ILogger logger;
+        private readonly ILoggerFactory loggerFactory;
+        private readonly IDisposable leaderReceiverSubscription;
+        private readonly ICrossChainTransferStore store;
+        private readonly ILeaderReceiver leaderReceiver;
+        private readonly IFederationGatewaySettings federationGatewaySettings;
+        private readonly IBroadcasterManager broadcasterManager;
+        private ISignedMultisigTransactionBroadcaster signedMultisigTransactionBroadcaster;
+        private readonly ILeaderProvider leaderProvider;
+
+        private readonly MempoolManager mempoolManager;
+        private readonly IDateTimeProvider dateTimeProvider;
+        private readonly MempoolSettings mempoolSettings;
+        private readonly NodeSettings nodeSettings;
+        private readonly BlockPolicyEstimator blockPolicyEstimator;
+        private readonly TxMempool txMempool;
+        private readonly IMempoolValidator mempoolValidator;
+        private readonly IMempoolPersistence mempoolPersistence;
+        private readonly ICoinView coinView;
+
+        private const string PublicKey = "026ebcbf6bfe7ce1d957adbef8ab2b66c788656f35896a170257d6838bda70b95c";
+
+        public SignedMultisigTransactionBroadcasterTests()
+        {
+            this.loggerFactory = Substitute.For<ILoggerFactory>();
+            this.logger = Substitute.For<ILogger>();
+            this.leaderReceiver = Substitute.For<ILeaderReceiver>();
+            this.federationGatewaySettings = Substitute.For<IFederationGatewaySettings>();
+            this.loggerFactory.CreateLogger(null).ReturnsForAnyArgs(this.logger);
+            this.leaderReceiverSubscription = Substitute.For<IDisposable>();
+            this.store = Substitute.For<ICrossChainTransferStore>();
+            this.broadcasterManager = Substitute.For<IBroadcasterManager>();
+            this.leaderProvider = Substitute.For<ILeaderProvider>();
+
+            // Setup MempoolManager.
+            this.dateTimeProvider = Substitute.For<IDateTimeProvider>();
+            this.nodeSettings = new NodeSettings(networksSelector: FederatedPegNetwork.NetworksSelector, protocolVersion: NBitcoin.Protocol.ProtocolVersion.ALT_PROTOCOL_VERSION);
+
+            this.mempoolSettings = new MempoolSettings(this.nodeSettings)
+            {
+                MempoolExpiry = MempoolValidator.DefaultMempoolExpiry
+            };
+
+            this.blockPolicyEstimator = new BlockPolicyEstimator(
+                this.mempoolSettings,
+                this.loggerFactory,
+                this.nodeSettings);
+
+            this.txMempool = new TxMempool(
+                this.dateTimeProvider,
+                this.blockPolicyEstimator,
+                this.loggerFactory,
+                this.nodeSettings);
+
+            this.mempoolValidator = Substitute.For<IMempoolValidator>();
+            this.mempoolPersistence = Substitute.For<IMempoolPersistence>();
+            this.coinView = Substitute.For<ICoinView>();
+
+            this.mempoolManager = new MempoolManager(
+                new MempoolSchedulerLock(),
+                this.txMempool,
+                this.mempoolValidator,
+                this.dateTimeProvider,
+                this.mempoolSettings,
+                this.mempoolPersistence,
+                this.coinView,
+                this.loggerFactory,
+                this.nodeSettings.Network);
+        }
+
+        [Fact]
+        public async Task When_Not_The_CurrentLeader_Dont_Call_GetSignedTransactionsAsync()
+        {
+            this.federationGatewaySettings.PublicKey.Returns("dummykey");
+            this.leaderProvider.CurrentLeaderKey.Returns(new PubKey(PublicKey));
+
+            IObservable<ILeaderProvider> leaderStream = new[] { this.leaderProvider }.ToObservable();
+            this.leaderReceiver.LeaderProvidersStream.Returns(leaderStream);
+
+            this.signedMultisigTransactionBroadcaster = new SignedMultisigTransactionBroadcaster(
+                this.loggerFactory,
+                this.store,
+                this.leaderReceiver,
+                this.federationGatewaySettings,
+                this.mempoolManager,
+                this.broadcasterManager);
+
+            await this.signedMultisigTransactionBroadcaster.BroadcastTransactionsAsync(this.leaderProvider).ConfigureAwait(false);
+
+            this.store.DidNotReceive();
+        }
+
+        [Fact]
+        public async Task When_CurrentLeader_Call_GetSignedTransactionsAsync()
+        {
+            this.federationGatewaySettings.PublicKey.Returns(PublicKey);
+            this.leaderProvider.CurrentLeaderKey.Returns(new PubKey(PublicKey));
+
+            IObservable<ILeaderProvider> leaderStream = new[] { this.leaderProvider }.ToObservable();
+            this.leaderReceiver.LeaderProvidersStream.Returns(leaderStream);
+
+            var emptyTransactionPair = new Dictionary<uint256, Transaction>();
+
+            this.store.GetTransactionsByStatusAsync(CrossChainTransferStatus.FullySigned).Returns(emptyTransactionPair);
+
+            this.signedMultisigTransactionBroadcaster = new SignedMultisigTransactionBroadcaster(
+                this.loggerFactory,
+                this.store,
+                this.leaderReceiver,
+                this.federationGatewaySettings,
+                this.mempoolManager,
+                this.broadcasterManager);
+
+            await this.signedMultisigTransactionBroadcaster.BroadcastTransactionsAsync(this.leaderProvider).ConfigureAwait(false);
+
+            await this.store.Received().GetTransactionsByStatusAsync(CrossChainTransferStatus.FullySigned).ConfigureAwait(false);
+
+            this.logger.Received().Log(LogLevel.Trace,
+                Arg.Any<EventId>(),
+                Arg.Is<object>(o => o.ToString() == "Signed multisig transactions do not exist in the CrossChainTransfer store."),
+                null,
+                Arg.Any<Func<object, Exception, string>>());
+        }
+
+        [Fact]
+        public async Task When_CurrentLeader_BroadcastsTransactionAsync()
+        {
+            this.federationGatewaySettings.PublicKey.Returns(PublicKey);
+            this.leaderProvider.CurrentLeaderKey.Returns(new PubKey(PublicKey));
+
+            var transactionPair = new Dictionary<uint256, Transaction>
+            {
+                { new uint256(), new Transaction() }
+            };
+
+            this.store.GetTransactionsByStatusAsync(CrossChainTransferStatus.FullySigned).Returns(transactionPair);
+
+            IObservable<ILeaderProvider> leaderStream = new[] { this.leaderProvider }.ToObservable();
+            this.leaderReceiver.LeaderProvidersStream.Returns(leaderStream);
+
+            this.signedMultisigTransactionBroadcaster = new SignedMultisigTransactionBroadcaster(
+                this.loggerFactory,
+                this.store,
+                this.leaderReceiver,
+                this.federationGatewaySettings,
+                this.mempoolManager,
+                this.broadcasterManager);
+
+            await this.signedMultisigTransactionBroadcaster.BroadcastTransactionsAsync(this.leaderProvider).ConfigureAwait(false);
+            await this.store.Received().GetTransactionsByStatusAsync(CrossChainTransferStatus.FullySigned).ConfigureAwait(false);
+            await this.broadcasterManager.Received().BroadcastTransactionAsync(Arg.Any<Transaction>());
+        }
+
+        public void Dispose()
+        {
+            this.leaderReceiverSubscription?.Dispose();
+            this.leaderReceiver?.Dispose();
+        }
+    }
+}

--- a/src/Stratis.Features.FederatedPeg.Tests/Stratis.Features.FederatedPeg.Tests.csproj
+++ b/src/Stratis.Features.FederatedPeg.Tests/Stratis.Features.FederatedPeg.Tests.csproj
@@ -9,6 +9,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
+    <RuntimeFrameworkVersion>2.1.1</RuntimeFrameworkVersion>
     <DebugType>Full</DebugType>
     <IsPackable>false</IsPackable>
     <ApplicationIcon />

--- a/src/Stratis.Features.FederatedPeg.Tests/Stratis.Features.FederatedPeg.Tests.csproj
+++ b/src/Stratis.Features.FederatedPeg.Tests/Stratis.Features.FederatedPeg.Tests.csproj
@@ -1,0 +1,39 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup Label="Globals">
+    <SccProjectName>SAK</SccProjectName>
+    <SccProvider>SAK</SccProvider>
+    <SccAuxPath>SAK</SccAuxPath>
+    <SccLocalPath>SAK</SccLocalPath>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <DebugType>Full</DebugType>
+    <IsPackable>false</IsPackable>
+    <ApplicationIcon />
+    <OutputType>Library</OutputType>
+    <StartupObject />
+    <CodeAnalysisRuleSet>..\None.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="5.5.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="Moq" Version="4.10.1" />
+    <PackageReference Include="NSubstitute" Version="3.1.0" />
+    <PackageReference Include="Stratis.XUnitRetry" Version="1.0.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Stratis.Bitcoin.Tests.Common\Stratis.Bitcoin.Tests.Common.csproj" />
+    <ProjectReference Include="..\Stratis.Features.FederatedPeg\Stratis.Features.FederatedPeg.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Service Include="{508349b6-6b84-4df5-91f0-309beebad82d}" />
+  </ItemGroup>
+
+</Project>

--- a/src/Stratis.Features.FederatedPeg.Tests/SubstituteExtensions.cs
+++ b/src/Stratis.Features.FederatedPeg.Tests/SubstituteExtensions.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Linq;
+using System.Reflection;
+
+namespace Stratis.Features.FederatedPeg.Tests
+{
+    public static class SubstituteExtensions
+    {
+        public static object Protected(this object target, string name, params object[] args)
+        {
+            Type type = target.GetType();
+            MethodInfo method = type.GetMethods(BindingFlags.NonPublic | BindingFlags.Instance)
+                .Where(x => x.Name == name && x.IsVirtual).Single();
+            return method.Invoke(target, args);
+        }
+    }
+}

--- a/src/Stratis.Features.FederatedPeg.Tests/Utils/AddressHelper.cs
+++ b/src/Stratis.Features.FederatedPeg.Tests/Utils/AddressHelper.cs
@@ -1,0 +1,87 @@
+﻿using System.Linq;
+using NBitcoin;
+using Stratis.Features.FederatedPeg.NetworkHelpers;
+
+namespace Stratis.Features.FederatedPeg.Tests.Utils
+{
+    public class AddressHelper
+    {
+        public Network TargetChainNetwork { get; }
+
+        public Network SourceChainNetwork { get; }
+
+        public AddressHelper(Network targetChainNetwork)
+        {
+            this.TargetChainNetwork = targetChainNetwork;
+            this.SourceChainNetwork = this.TargetChainNetwork.ToCounterChainNetwork();
+        }
+
+        public BitcoinPubKeyAddress GetNewSourceChainPubKeyAddress()
+        {
+            var key = new Key();
+            BitcoinPubKeyAddress newAddress = this.TargetChainNetwork.CreateBitcoinSecret(key).GetAddress();
+            return newAddress;
+        }
+
+        public BitcoinPubKeyAddress GetNewTargetChainPubKeyAddress()
+        {
+            var key = new Key();
+            BitcoinPubKeyAddress newAddress = this.SourceChainNetwork.CreateBitcoinSecret(key).GetAddress();
+            return newAddress;
+        }
+
+        public Script GetNewTargetChainPaymentScript()
+        {
+            var key = new Key();
+            Script script = this.TargetChainNetwork.CreateBitcoinSecret(key).ScriptPubKey;
+            return script;
+        }
+
+        public Script GetNewSourceChainPaymentScript()
+        {
+            var key = new Key();
+            Script script = this.SourceChainNetwork.CreateBitcoinSecret(key).ScriptPubKey;
+            return script;
+        }
+    }
+
+    public class MultisigAddressHelper : AddressHelper
+    {
+        public const string Passphrase = "password";
+
+        public Key[] MultisigPrivateKeys { get;  }
+
+        public Mnemonic[] MultisigMnemonics { get; }
+
+        public Script PayToMultiSig { get;  }
+
+        public Script SourceChainPayToScriptHash { get;  }
+
+        public Script TargetChainPayToScriptHash { get;  }
+
+        public BitcoinAddress SourceChainMultisigAddress { get; }
+
+        public BitcoinAddress TargetChainMultisigAddress { get; }
+
+        public MultisigAddressHelper(Network targetChainNetwork, int quorum = 2, int sigCount = 3)
+            : base(targetChainNetwork)
+        {
+            this.MultisigMnemonics = Enumerable.Range(0, sigCount)
+                .Select(i => new Mnemonic(Wordlist.English, WordCount.Twelve))
+                .ToArray();
+
+            this.MultisigPrivateKeys = this.MultisigMnemonics
+                .Select(m => m.DeriveExtKey(Passphrase).PrivateKey)
+                .ToArray();
+
+            this.PayToMultiSig = PayToMultiSigTemplate.Instance.GenerateScriptPubKey(
+                quorum, this.MultisigPrivateKeys.Select(k => k.PubKey).ToArray());
+
+            this.SourceChainMultisigAddress = this.PayToMultiSig.Hash.GetAddress(this.SourceChainNetwork);
+            this.SourceChainPayToScriptHash = this.SourceChainMultisigAddress.ScriptPubKey;
+
+            this.TargetChainMultisigAddress = this.PayToMultiSig.Hash.GetAddress(this.TargetChainNetwork);
+            this.TargetChainPayToScriptHash = this.TargetChainMultisigAddress.ScriptPubKey;
+        }
+    }
+}

--- a/src/Stratis.Features.FederatedPeg.Tests/Utils/TestTransactionBuilder.cs
+++ b/src/Stratis.Features.FederatedPeg.Tests/Utils/TestTransactionBuilder.cs
@@ -1,0 +1,123 @@
+﻿using NBitcoin;
+
+namespace Stratis.Features.FederatedPeg.Tests.Utils
+{
+    public class TestTransactionBuilder
+    {
+        protected Coin RandomCoin(Money amount, Script scriptPubKey, bool p2sh)
+        {
+            OutPoint outpoint = RandomOutpoint();
+            return p2sh
+                       ? new ScriptCoin(outpoint, new TxOut(amount, scriptPubKey.Hash), scriptPubKey)
+                       : new Coin(outpoint, new TxOut(amount, scriptPubKey));
+        }
+
+        protected Coin RandomCoin(Money amount, Key receiver)
+        {
+            OutPoint outpoint = RandomOutpoint();
+            return new Coin(outpoint, new TxOut(amount, receiver));
+        }
+
+        private OutPoint RandomOutpoint()
+        {
+            return new OutPoint(TestingValues.GetUint256(), 0);
+        }
+
+        public Transaction BuildTransaction(IDestination receiverAddress, Money amount = null)
+        {
+            var transaction = new Transaction();
+            transaction.AddOutput(new TxOut(amount ?? TestingValues.GetMoney(), receiverAddress));
+            return transaction;
+        }
+
+        public Transaction BuildOpReturnTransaction(IDestination receiverAddress, byte[] opReturnBytes, Money amount = null)
+        {
+            Transaction transaction = this.BuildTransaction(receiverAddress, amount)
+                .AddOpReturn(opReturnBytes);
+            return transaction;
+        }
+
+        protected Transaction GetTransactionWithInputs(
+            Network network,
+            Key[] senderSecrets,
+            Script senderScript,
+            Script receiverScript,
+            byte[] opReturnBytes = null,
+            Money amount = null,
+            bool withChange = true)
+        {
+            var txBuilder = new TransactionBuilder(network);
+            amount = amount ?? TestingValues.GetMoney();
+            Money change = withChange ? TestingValues.GetMoney() : Money.Zero;
+            var multisigCoins = new ICoin[] { RandomCoin(amount + change, senderScript, true) };
+
+            txBuilder
+                .AddCoins(multisigCoins)
+                .Send(receiverScript, amount)
+                .SetChange(senderScript)
+                .BuildTransaction(false);
+
+            txBuilder.AddKeys(senderSecrets);
+
+            Transaction signed = txBuilder.BuildTransaction(true);
+
+            if (opReturnBytes != null) signed.AddOpReturn(opReturnBytes);
+
+            return signed;
+        }
+
+        public Transaction GetTransactionWithInputs(
+            Network network,
+            Key senderSecret,
+            Script receiverScript,
+            byte[] opReturnBytes = null,
+            Money amount = null,
+            bool withChange = true)
+        {
+            Key[] senderSecrets = new[] { senderSecret };
+            Script senderScript = senderSecret.ScriptPubKey;
+            return GetTransactionWithInputs(
+                network,
+                senderSecrets,
+                senderScript,
+                receiverScript,
+                opReturnBytes,
+                amount,
+                withChange);
+        }
+    }
+
+    public class TestMultisigTransactionBuilder : TestTransactionBuilder
+    {
+        private readonly MultisigAddressHelper multisigAddressHelper;
+
+        public Network Network { get; }
+
+        public TestMultisigTransactionBuilder(MultisigAddressHelper multisigAddressHelper)
+        {
+            this.multisigAddressHelper = multisigAddressHelper;
+            this.Network = multisigAddressHelper.TargetChainNetwork;
+        }
+
+        public Transaction GetWithdrawalOutOfMultisigTo(Script receiverScript, byte[] opReturnBytes, Money amount = null, bool withChange = true)
+        {
+            return this.GetTransactionWithInputs(
+                this.Network,
+                this.multisigAddressHelper.MultisigPrivateKeys,
+                this.multisigAddressHelper.PayToMultiSig,
+                receiverScript,
+                opReturnBytes,
+                amount,
+                withChange);
+        }
+    }
+
+    public static class TransactionExtensions
+    {
+        public static Transaction AddOpReturn(this Transaction transaction, byte[] opReturnContent)
+        {
+            transaction.AddOutput(new TxOut(Money.Zero, new Script(OpcodeType.OP_RETURN, Op.GetPushOp(opReturnContent))));
+            return transaction;
+        }
+    }
+}

--- a/src/Stratis.Features.FederatedPeg.Tests/Utils/TestingHttpClient.cs
+++ b/src/Stratis.Features.FederatedPeg.Tests/Utils/TestingHttpClient.cs
@@ -1,0 +1,38 @@
+﻿using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+
+namespace Stratis.Features.FederatedPeg.Tests.Utils
+{
+    public static class TestingHttpClient
+    {
+        public static void PrepareWorkingHttpClient(ref HttpMessageHandler httpMessageHandler, ref HttpClient httpClient, ref IHttpClientFactory httpClientFactory)
+        {
+            PrepareHttpClient(ref httpMessageHandler, ref httpClient, ref httpClientFactory);
+        }
+
+        public static void PrepareFailingHttpClient(ref HttpMessageHandler httpMessageHandler, ref HttpClient httpClient, ref IHttpClientFactory httpClientFactory)
+        {
+            PrepareHttpClient(ref httpMessageHandler, ref httpClient, ref httpClientFactory, true);
+        }
+
+        private static void PrepareHttpClient(ref HttpMessageHandler httpMessageHandler, ref HttpClient httpClient, ref IHttpClientFactory httpClientFactory, bool failingClient = false)
+        {
+            httpMessageHandler = Substitute.ForPartsOf<HttpMessageHandler>();
+
+            object sendCall = httpMessageHandler.Protected("SendAsync", Arg.Any<HttpRequestMessage>(), Arg.Any<CancellationToken>());
+
+            if (failingClient)
+                sendCall.ThrowsForAnyArgs(new HttpRequestException("failed"));
+            else
+                sendCall.Returns(Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)));
+
+            httpClient = new HttpClient(httpMessageHandler);
+            httpClientFactory = Substitute.For<IHttpClientFactory>();
+            httpClientFactory.CreateClient(Arg.Any<string>()).Returns(httpClient);
+        }
+    }
+}

--- a/src/Stratis.Features.FederatedPeg.Tests/Utils/TestingValues.cs
+++ b/src/Stratis.Features.FederatedPeg.Tests/Utils/TestingValues.cs
@@ -1,0 +1,89 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using NBitcoin;
+using Stratis.Bitcoin.Utilities;
+using Stratis.Features.FederatedPeg.Interfaces;
+using Stratis.Features.FederatedPeg.Models;
+using Stratis.Features.FederatedPeg.SourceChain;
+using Stratis.Features.FederatedPeg.TargetChain;
+
+namespace Stratis.Features.FederatedPeg.Tests.Utils
+{
+    public static class TestingValues
+    {
+        private static readonly Random Random = new Random(DateTime.Now.Millisecond);
+
+        public static uint256 GetUint256()
+        {
+            var buffer = new byte[256 / 8];
+            Random.NextBytes(buffer);
+            return new uint256(buffer);
+        }
+
+        public static int GetPositiveInt(int minValue = 0)
+        {
+            return Random.Next(minValue, int.MaxValue);
+        }
+
+        public static Money GetMoney(int minValue = 1, bool wholeCoins = false)
+        {
+            return wholeCoins ? new Money(GetPositiveInt(minValue)) : new Money(GetPositiveInt(minValue), MoneyUnit.BTC);
+        }
+
+        public static string GetString(int length = 30)
+        {
+            const string allowed = "abcdefghijklmnopqrstuvwxyz0123456789";
+            string result = new string(Enumerable.Repeat("_", length)
+                .Select(_ => allowed[Random.Next(0, allowed.Length)])
+                .ToArray());
+            return result;
+        }
+
+        public static HashHeightPair GetHashHeightPair(uint256 blockHash = null, int blockHeight = -1)
+        {
+            blockHash = blockHash ?? GetUint256();
+            if (blockHeight == -1) blockHeight = GetPositiveInt();
+            var hashHeightPair = new HashHeightPair(blockHash, blockHeight);
+            return hashHeightPair;
+        }
+
+        public static IDeposit GetDeposit(HashHeightPair hashHeightPair = null)
+        {
+            hashHeightPair = hashHeightPair ?? GetHashHeightPair();
+            uint256 depositId = GetUint256();
+            Money depositAmount = GetMoney();
+            string targetAddress = GetString();
+
+            return new Deposit(depositId, depositAmount, targetAddress, hashHeightPair.Height, hashHeightPair.Hash);
+        }
+
+        public static MaturedBlockDepositsModel GetMaturedBlockDeposits(int depositCount = 0, HashHeightPair fixedHashHeight = null)
+        {
+            HashHeightPair hashHeightPair = fixedHashHeight ?? GetHashHeightPair();
+            IEnumerable<IDeposit> deposits = Enumerable.Range(0, depositCount).Select(_ => GetDeposit(hashHeightPair));
+
+            var maturedBlockDeposits = new MaturedBlockDepositsModel(
+                new MaturedBlockInfoModel() { BlockHash = hashHeightPair.Hash, BlockHeight = hashHeightPair.Height },
+                deposits.ToList());
+            return maturedBlockDeposits;
+        }
+
+        public static IWithdrawal GetWithdrawal(HashHeightPair hashHeightPair = null)
+        {
+            hashHeightPair = hashHeightPair ?? GetHashHeightPair();
+            uint256 depositId = GetUint256();
+            uint256 id = GetUint256();
+            Money amount = GetMoney();
+            string targetAddress = GetString();
+
+            return new Withdrawal(depositId, id, amount, targetAddress, hashHeightPair.Height, hashHeightPair.Hash);
+        }
+
+
+        public static IReadOnlyList<IWithdrawal> GetWithdrawals(int count)
+        {
+            return Enumerable.Range(0, count).Select(_ => GetWithdrawal()).ToList().AsReadOnly();
+        }
+    }
+}

--- a/src/Stratis.Features.FederatedPeg.Tests/WithdrawalExtractorTests.cs
+++ b/src/Stratis.Features.FederatedPeg.Tests/WithdrawalExtractorTests.cs
@@ -1,0 +1,217 @@
+﻿using System.Linq;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using NBitcoin;
+using NSubstitute;
+using Stratis.Features.FederatedPeg.Interfaces;
+using Stratis.Features.FederatedPeg.TargetChain;
+using Stratis.Features.FederatedPeg.Tests.Utils;
+using Stratis.Sidechains.Networks;
+
+namespace Stratis.Features.FederatedPeg.Tests
+{
+    public class WithdrawalExtractorTests
+    {
+        private readonly IFederationGatewaySettings settings;
+
+        private readonly IOpReturnDataReader opReturnDataReader;
+
+        private readonly ILoggerFactory loggerFactory;
+
+        private IWithdrawalReceiver withdrawalReceiver;
+
+        private WithdrawalExtractor withdrawalExtractor;
+
+        private readonly Network network;
+
+        private readonly MultisigAddressHelper addressHelper;
+
+        private readonly TestMultisigTransactionBuilder transactionBuilder;
+
+        public WithdrawalExtractorTests()
+        {
+            this.network = FederatedPegNetwork.NetworksSelector.Regtest();
+
+            this.loggerFactory = Substitute.For<ILoggerFactory>();
+            this.settings = Substitute.For<IFederationGatewaySettings>();
+            this.opReturnDataReader = Substitute.For<IOpReturnDataReader>();
+            this.withdrawalReceiver = Substitute.For<IWithdrawalReceiver>();
+
+            this.addressHelper = new MultisigAddressHelper(this.network);
+
+            this.settings.MultiSigAddress.Returns(this.addressHelper.TargetChainMultisigAddress);
+            this.settings.MultiSigRedeemScript.Returns(this.addressHelper.PayToMultiSig);
+            this.settings.FederationPublicKeys.Returns(this.addressHelper.MultisigPrivateKeys.Select(k => k.PubKey).ToArray());
+
+            this.opReturnDataReader.TryGetTargetAddress(null, out string address).Returns(callInfo => { callInfo[1] = null; return false; });
+
+            this.transactionBuilder = new TestMultisigTransactionBuilder(this.addressHelper);
+
+            this.withdrawalExtractor = new WithdrawalExtractor(
+                this.loggerFactory, this.settings, this.opReturnDataReader, this.network);
+        }
+
+        // TODO: Will depend on decision made on backlog issue https://github.com/stratisproject/FederatedSidechains/issues/124
+        /*
+        [Fact]
+        public void ExtractWithdrawalsFromBlock_Should_Find_Withdrawals_From_Multisig()
+        {
+            var block = this.network.Consensus.ConsensusFactory.CreateBlock();
+
+            var (targetScript, opReturnDepositId, amount, validWithdrawalTransaction) = AddWithdrawalToBlock(block);
+
+            var blockHeight = 3456;
+
+            var withdrawals = this.withdrawalExtractor.ExtractWithdrawalsFromBlock(block, blockHeight);
+
+            withdrawals.Count.Should().Be(1);
+            this.VerifyWithdrawalData(
+                withdrawals[0],
+                amount,
+                block,
+                blockHeight,
+                validWithdrawalTransaction,
+                opReturnDepositId,
+                targetScript);
+        }
+
+        [Fact]
+        public void ExtractWithdrawalsFromBlock_Should_Handle_Transaction_with_no_inputs()
+        {
+            var block = this.network.Consensus.ConsensusFactory.CreateBlock();
+
+            var noInputRandomTransaction = this.transactionBuilder.BuildTransaction(this.addressHelper.GetNewTargetChainPubKeyAddress());
+            block.AddTransaction(noInputRandomTransaction);
+            var noInputTransactionToMultisig = this.transactionBuilder.BuildTransaction(this.addressHelper.TargetChainMultisigAddress);
+            block.AddTransaction(noInputTransactionToMultisig);
+
+            var (targetScript, opReturnDepositId, amount, validWithdrawalTransaction) = AddWithdrawalToBlock(block);
+
+            var blockHeight = 5972176;
+
+            var withdrawals = this.withdrawalExtractor.ExtractWithdrawalsFromBlock(block, blockHeight);
+
+            withdrawals.Count.Should().Be(1);
+            this.VerifyWithdrawalData(
+                withdrawals[0],
+                amount,
+                block,
+                blockHeight,
+                validWithdrawalTransaction,
+                opReturnDepositId,
+                targetScript);
+        }
+
+        [Fact]
+        public void ExtractWithdrawalsFromBlock_Should_Only_Find_Withdrawals_From_Multisig()
+        {
+            var block = this.network.Consensus.ConsensusFactory.CreateBlock();
+
+            var sender = new Key();
+            var transactionOutOfMultisigButNoOpReturn = this.transactionBuilder.GetWithdrawalOutOfMultisigTo(
+                this.addressHelper.GetNewTargetChainPaymentScript(),
+                null);
+            block.AddTransaction(transactionOutOfMultisigButNoOpReturn);
+
+            var transactionOutOfMultisigWithInvalidOpReturn =
+                this.transactionBuilder.GetWithdrawalOutOfMultisigTo(
+                    this.addressHelper.GetNewTargetChainPaymentScript(),
+                    Encoding.UTF8.GetBytes("not valid as uint256"));
+            block.AddTransaction(transactionOutOfMultisigWithInvalidOpReturn);
+
+            var standardTransactionInTargetChain = this.transactionBuilder.GetTransactionWithInputs(
+                this.network, sender, this.addressHelper.GetNewTargetChainPaymentScript());
+            block.AddTransaction(standardTransactionInTargetChain);
+
+            var validOpReturn = TestingValues.GetUint256();
+            var randomTransactionWithValidOpReturn = this.transactionBuilder.GetTransactionWithInputs(
+                this.network, sender, this.addressHelper.GetNewTargetChainPaymentScript(), validOpReturn.ToBytes());
+            block.AddTransaction(randomTransactionWithValidOpReturn);
+            this.opReturnDataReader.TryGetTransactionId(randomTransactionWithValidOpReturn)
+                .Returns(validOpReturn.ToString());
+
+            var (targetScript, opReturnDepositId, amount, validWithdrawalTransaction) = AddWithdrawalToBlock(block);
+
+            var blockHeight = 3456;
+            var withdrawals = this.withdrawalExtractor.ExtractWithdrawalsFromBlock(block, blockHeight);
+
+            withdrawals.Count.Should().Be(1);
+            this.VerifyWithdrawalData(
+                withdrawals[0],
+                amount,
+                block,
+                blockHeight,
+                validWithdrawalTransaction,
+                opReturnDepositId,
+                targetScript);
+        }
+
+        [Fact]
+        public void ExtractWithdrawalsFromBlock_Should_Find_Multiple_Withdrawals_From_Multisig()
+        {
+            var block = this.network.Consensus.ConsensusFactory.CreateBlock();
+
+            var (targetScript1, opReturnDepositId1, amount1, validWithdrawalTransaction1) = AddWithdrawalToBlock(block);
+            var (targetScript2, opReturnDepositId2, amount2, validWithdrawalTransaction2) = AddWithdrawalToBlock(block);
+
+            var blockHeight = 78931;
+            var withdrawals = this.withdrawalExtractor.ExtractWithdrawalsFromBlock(block, blockHeight);
+
+            withdrawals.Count.Should().Be(2);
+
+            this.VerifyWithdrawalData(
+                withdrawals[0],
+                amount1,
+                block,
+                blockHeight,
+                validWithdrawalTransaction1,
+                opReturnDepositId1,
+                targetScript1);
+
+            this.VerifyWithdrawalData(
+                withdrawals[1],
+                amount2,
+                block,
+                blockHeight,
+                validWithdrawalTransaction2,
+                opReturnDepositId2,
+                targetScript2);
+        }
+        */
+
+        private (Script targetScript, uint256 opReturnDepositId, long amount, Transaction validWithdrawalTransaction)
+            AddWithdrawalToBlock(Block block)
+        {
+            Script targetScript = this.addressHelper.GetNewTargetChainPaymentScript();
+            uint256 opReturnDepositId = TestingValues.GetUint256();
+            long amount = 22 * Money.COIN;
+            Transaction validWithdrawalTransaction = this.transactionBuilder.GetWithdrawalOutOfMultisigTo(
+                targetScript,
+                opReturnDepositId.ToBytes(),
+                amount,
+                true);
+
+            block.AddTransaction(validWithdrawalTransaction);
+            this.opReturnDataReader.TryGetTransactionId(validWithdrawalTransaction, out string txId).Returns(callInfo => { callInfo[1] = opReturnDepositId.ToString(); return true; });
+
+            return (targetScript, opReturnDepositId, amount, validWithdrawalTransaction);
+        }
+
+        private void VerifyWithdrawalData(
+            IWithdrawal withdrawals,
+            long amount,
+            Block block,
+            int blockHeight,
+            Transaction validWithdrawalTransaction,
+            uint256 opReturnDepositId,
+            Script targetScript)
+        {
+            withdrawals.Amount.Satoshi.Should().Be(amount);
+            withdrawals.BlockHash.Should().Be(block.Header.GetHash());
+            withdrawals.BlockNumber.Should().Be(blockHeight);
+            withdrawals.Id.Should().Be(validWithdrawalTransaction.GetHash());
+            withdrawals.DepositId.Should().Be(opReturnDepositId);
+            withdrawals.TargetAddress.Should().Be(targetScript.GetScriptAddress(this.network).ToString());
+        }
+    }
+}

--- a/src/Stratis.Features.FederatedPeg.Tests/WithdrawalReceiverTests.cs
+++ b/src/Stratis.Features.FederatedPeg.Tests/WithdrawalReceiverTests.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using FluentAssertions;
+using Stratis.Features.FederatedPeg.Interfaces;
+using Stratis.Features.FederatedPeg.TargetChain;
+using Stratis.Features.FederatedPeg.Tests.Utils;
+using Xunit;
+
+namespace Stratis.Features.FederatedPeg.Tests
+{
+    public class WithdrawalReceiverTests : IDisposable
+    {
+        private WithdrawalReceiver withdrawalReceiver;
+
+
+        private IDisposable streamSubscription;
+
+        [Fact]
+        public void ReceiveWithdrawals_Should_Push_An_Item_In_NewWithdrawalsOnTargetChainStream()
+        {
+            this.withdrawalReceiver = new WithdrawalReceiver();
+
+            int receivedWithdrawalListCount = 0;
+            this.streamSubscription = this.withdrawalReceiver.NewWithdrawalsOnTargetChainStream.Subscribe(
+                _ => { Interlocked.Increment(ref receivedWithdrawalListCount); });
+
+            IReadOnlyList<IWithdrawal> withdrawals = TestingValues.GetWithdrawals(3);
+
+            this.withdrawalReceiver.ReceiveWithdrawals(withdrawals);
+
+            receivedWithdrawalListCount.Should().Be(1);
+        }
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            this.streamSubscription?.Dispose();
+            this.withdrawalReceiver?.Dispose();
+        }
+    }
+}

--- a/src/Stratis.Features.FederatedPeg.Tests/WithdrawalTests.cs
+++ b/src/Stratis.Features.FederatedPeg.Tests/WithdrawalTests.cs
@@ -1,0 +1,25 @@
+﻿using Newtonsoft.Json;
+using Stratis.Features.FederatedPeg.Tests.Utils;
+using Xunit;
+
+namespace Stratis.Features.FederatedPeg.Tests
+{
+    public class WithdrawalTests
+    {
+        [Fact]
+        public void ShouldSerialiseAsJson()
+        {
+            IWithdrawal withdrawal = TestingValues.GetWithdrawal();
+
+            string asJson = withdrawal.ToString();
+            var reconverted = JsonConvert.DeserializeObject<Withdrawal>(asJson);
+
+            reconverted.BlockHash.Should().Be(withdrawal.BlockHash);
+            reconverted.Amount.Satoshi.Should().Be(withdrawal.Amount.Satoshi);
+            reconverted.BlockNumber.Should().Be(withdrawal.BlockNumber);
+            reconverted.Id.Should().Be(withdrawal.Id);
+            reconverted.DepositId.Should().Be(withdrawal.DepositId);
+            reconverted.TargetAddress.Should().Be(withdrawal.TargetAddress);
+        }
+    }
+}

--- a/src/Stratis.Features.FederatedPeg.Tests/WithdrawalTests.cs
+++ b/src/Stratis.Features.FederatedPeg.Tests/WithdrawalTests.cs
@@ -1,4 +1,7 @@
-﻿using Newtonsoft.Json;
+﻿using FluentAssertions;
+using Newtonsoft.Json;
+using Stratis.Features.FederatedPeg.Interfaces;
+using Stratis.Features.FederatedPeg.TargetChain;
 using Stratis.Features.FederatedPeg.Tests.Utils;
 using Xunit;
 

--- a/src/Stratis.Features.FederatedPeg/Controllers/FederationGatewayController.cs
+++ b/src/Stratis.Features.FederatedPeg/Controllers/FederationGatewayController.cs
@@ -1,0 +1,180 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.Extensions.Logging;
+using NBitcoin;
+using Stratis.Bitcoin.Features.PoA;
+using Stratis.Bitcoin.Utilities;
+using Stratis.Bitcoin.Utilities.JsonErrors;
+using Stratis.Features.FederatedPeg.Interfaces;
+using Stratis.Features.FederatedPeg.Models;
+using Stratis.Features.FederatedPeg.SourceChain;
+using Stratis.Features.FederatedPeg.TargetChain;
+
+namespace Stratis.Features.FederatedPeg.Controllers
+{
+    public static class FederationGatewayRouteEndPoint
+    {
+        // TODO do we have push mechanism for the block tip? Remove it. We only need pull mechanism. And I hope we don't have push and pull implemented at the same time
+        public const string PushCurrentBlockTip = "push_current_block_tip";
+
+        public const string GetMaturedBlockDeposits = "get_matured_block_deposits";
+        public const string GetInfo = "info";
+    }
+
+    /// <summary>
+    /// API used to communicate across to the counter chain.
+    /// </summary>
+    [Route("api/[controller]")]
+    public class FederationGatewayController : Controller
+    {
+        /// <summary>Instance logger.</summary>
+        private readonly ILogger logger;
+
+        private readonly Network network;
+
+        private readonly ILeaderProvider leaderProvider;
+
+        private readonly IMaturedBlocksProvider maturedBlocksProvider;
+
+        private readonly ILeaderReceiver leaderReceiver;
+
+        private readonly IFederationGatewaySettings federationGatewaySettings;
+
+        private readonly IFederationWalletManager federationWalletManager;
+
+        private readonly FederationManager federationManager;
+
+        public FederationGatewayController(
+            ILoggerFactory loggerFactory,
+            Network network,
+            ILeaderProvider leaderProvider,
+            IMaturedBlocksProvider maturedBlocksProvider,
+            ILeaderReceiver leaderReceiver,
+            IFederationGatewaySettings federationGatewaySettings,
+            IFederationWalletManager federationWalletManager,
+            FederationManager federationManager = null)
+        {
+            this.logger = loggerFactory.CreateLogger(this.GetType().FullName);
+            this.network = network;
+            this.leaderProvider = leaderProvider;
+            this.maturedBlocksProvider = maturedBlocksProvider;
+            this.leaderReceiver = leaderReceiver;
+            this.federationGatewaySettings = federationGatewaySettings;
+            this.federationWalletManager = federationWalletManager;
+            this.federationManager = federationManager;
+        }
+
+        /// <summary>Pushes the current block tip to be used for updating the federated leader in a round robin fashion.</summary>
+        /// <param name="blockTip"><see cref="BlockTipModel"/>Block tip Hash and Height received.</param>
+        /// <returns><see cref="IActionResult"/>OK on success.</returns>
+        [Route(FederationGatewayRouteEndPoint.PushCurrentBlockTip)]
+        [HttpPost]
+        public IActionResult PushCurrentBlockTip([FromBody] BlockTipModel blockTip)
+        {
+            Guard.NotNull(blockTip, nameof(blockTip));
+
+            if (!this.ModelState.IsValid)
+            {
+                return BuildErrorResponse(this.ModelState);
+            }
+
+            try
+            {
+                this.leaderProvider.Update(new BlockTipModel(blockTip.Hash, blockTip.Height, blockTip.MatureConfirmations));
+
+                this.leaderReceiver.PushLeader(this.leaderProvider);
+
+                return this.Ok();
+            }
+            catch (Exception e)
+            {
+                this.logger.LogError("Exception thrown calling /api/FederationGateway/{0}: {1}.", FederationGatewayRouteEndPoint.PushCurrentBlockTip, e.Message);
+                return ErrorHelpers.BuildErrorResponse(HttpStatusCode.BadRequest, $"Could not select the next federated leader: {e.Message}", e.ToString());
+            }
+        }
+
+        /// <summary>
+        /// Retrieves blocks deposits.
+        /// </summary>
+        /// <param name="blockRequest">Last known block height and the maximum number of blocks to send.</param>
+        /// <returns><see cref="IActionResult"/>OK on success.</returns>
+        [Route(FederationGatewayRouteEndPoint.GetMaturedBlockDeposits)]
+        [HttpPost]
+        public async Task<IActionResult> GetMaturedBlockDepositsAsync([FromBody] MaturedBlockRequestModel blockRequest)
+        {
+            Guard.NotNull(blockRequest, nameof(blockRequest));
+
+            if (!this.ModelState.IsValid)
+            {
+                IEnumerable<string> errors = this.ModelState.Values.SelectMany(e => e.Errors.Select(m => m.ErrorMessage));
+                return ErrorHelpers.BuildErrorResponse(HttpStatusCode.BadRequest, "Formatting error", string.Join(Environment.NewLine, errors));
+            }
+
+            try
+            {
+                List<MaturedBlockDepositsModel> deposits = await this.maturedBlocksProvider.GetMaturedDepositsAsync(
+                    blockRequest.BlockHeight, blockRequest.MaxBlocksToSend).ConfigureAwait(false);
+
+                return this.Json(deposits);
+            }
+            catch (Exception e)
+            {
+                this.logger.LogTrace("Exception thrown calling /api/FederationGateway/{0}: {1}.", FederationGatewayRouteEndPoint.GetMaturedBlockDeposits, e.Message);
+                return ErrorHelpers.BuildErrorResponse(HttpStatusCode.BadRequest, $"Could not re-sync matured block deposits: {e.Message}", e.ToString());
+            }
+        }
+
+        /// <summary>
+        /// Gets some info on the state of the federation.
+        /// </summary>
+        /// <returns>A <see cref="FederationGatewayInfoModel"/> with information about the federation.</returns>
+        [Route(FederationGatewayRouteEndPoint.GetInfo)]
+        [HttpGet]
+        public IActionResult GetInfo()
+        {
+            try
+            {
+                bool isMainchain = this.federationGatewaySettings.IsMainChain;
+
+                var model = new FederationGatewayInfoModel
+                {
+                    IsActive = this.federationWalletManager.IsFederationActive(),
+                    IsMainChain = isMainchain,
+                    FederationNodeIpEndPoints = this.federationGatewaySettings.FederationNodeIpEndPoints.Select(i => $"{i.Address}:{i.Port}"),
+                    MultisigPublicKey = this.federationGatewaySettings.PublicKey,
+                    FederationMultisigPubKeys = this.federationGatewaySettings.FederationPublicKeys.Select(k => k.ToString()),
+                    MiningPublicKey =  isMainchain ? null : this.federationManager.FederationMemberKey?.PubKey.ToString(),
+                    FederationMiningPubKeys =  isMainchain ? null : this.federationManager.GetFederationMembers().Select(k => k.ToString()),
+                    MultiSigAddress = this.federationGatewaySettings.MultiSigAddress,
+                    MultiSigRedeemScript = this.federationGatewaySettings.MultiSigRedeemScript.ToString(),
+                    MinCoinMaturity = this.federationGatewaySettings.MinCoinMaturity,
+                    MinimumDepositConfirmations = this.federationGatewaySettings.MinimumDepositConfirmations
+                };
+
+                return this.Json(model);
+            }
+            catch (Exception e)
+            {
+                this.logger.LogTrace("Exception thrown calling /api/FederationGateway/{0}: {1}.", FederationGatewayRouteEndPoint.GetInfo, e.Message);
+                return ErrorHelpers.BuildErrorResponse(HttpStatusCode.BadRequest, e.Message, e.ToString());
+            }
+        }
+
+        /// <summary>
+        /// Builds an <see cref="IActionResult"/> containing errors contained in the <see cref="ControllerBase.ModelState"/>.
+        /// </summary>
+        /// <returns>A result containing the errors.</returns>
+        private static IActionResult BuildErrorResponse(ModelStateDictionary modelState)
+        {
+            List<ModelError> errors = modelState.Values.SelectMany(e => e.Errors).ToList();
+            return ErrorHelpers.BuildErrorResponse(HttpStatusCode.BadRequest,
+                string.Join(Environment.NewLine, errors.Select(m => m.ErrorMessage)),
+                string.Join(Environment.NewLine, errors.Select(m => m.Exception?.Message)));
+        }
+    }
+}

--- a/src/Stratis.Features.FederatedPeg/Controllers/FederationWalletController.cs
+++ b/src/Stratis.Features.FederatedPeg/Controllers/FederationWalletController.cs
@@ -1,0 +1,282 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.Extensions.Logging;
+using NBitcoin;
+using Stratis.Bitcoin.Connection;
+using Stratis.Bitcoin.Features.Wallet;
+using Stratis.Bitcoin.Features.Wallet.Models;
+using Stratis.Bitcoin.Utilities;
+using Stratis.Bitcoin.Utilities.JsonErrors;
+using Stratis.Bitcoin.Utilities.ModelStateErrors;
+using Stratis.Features.FederatedPeg.Interfaces;
+using Stratis.Features.FederatedPeg.Models;
+using Stratis.Features.FederatedPeg.TargetChain;
+using Stratis.Features.FederatedPeg.Wallet;
+
+namespace Stratis.Features.FederatedPeg.Controllers
+{
+    public static class FederationWalletRouteEndPoint
+    {
+        public const string GeneralInfo = "general-info";
+        public const string Balance = "balance";
+        public const string History = "history";
+        public const string Sync = "sync";
+        public const string EnableFederation = "enable-federation";
+        public const string RemoveTransactions = "remove-transactions";
+    }
+
+    /// <summary>
+    /// Controller providing operations on a wallet.
+    /// </summary>
+    [Route("api/[controller]")]
+    public class FederationWalletController : Controller
+    {
+        private readonly IFederationWalletManager walletManager;
+
+        private readonly IFederationWalletSyncManager walletSyncManager;
+
+        private readonly CoinType coinType;
+
+        private readonly IConnectionManager connectionManager;
+
+        private readonly ConcurrentChain chain;
+
+        private readonly IWithdrawalHistoryProvider withdrawalHistoryProvider;
+
+        /// <summary>Instance logger.</summary>
+        private readonly ILogger logger;
+
+        public FederationWalletController(
+            ILoggerFactory loggerFactory,
+            IFederationWalletManager walletManager,
+            IFederationWalletSyncManager walletSyncManager,
+            IConnectionManager connectionManager,
+            Network network,
+            ConcurrentChain chain,
+            IDateTimeProvider dateTimeProvider,
+            IWithdrawalHistoryProvider withdrawalHistoryProvider)
+        {
+            this.walletManager = walletManager;
+            this.walletSyncManager = walletSyncManager;
+            this.connectionManager = connectionManager;
+            this.withdrawalHistoryProvider = withdrawalHistoryProvider;
+            this.coinType = (CoinType)network.Consensus.CoinType;
+            this.chain = chain;
+            this.logger = loggerFactory.CreateLogger(this.GetType().FullName);
+        }
+
+        [Route(FederationWalletRouteEndPoint.GeneralInfo)]
+        [HttpGet]
+        public IActionResult GetGeneralInfo()
+        {
+            try
+            {
+                FederationWallet wallet = this.walletManager.GetWallet();
+
+                if (wallet == null)
+                {
+                    return this.NotFound("No federation wallet found.");
+                }
+
+                var model = new WalletGeneralInfoModel
+                {
+                    Network = wallet.Network,
+                    CreationTime = wallet.CreationTime,
+                    LastBlockSyncedHeight = wallet.LastBlockSyncedHeight,
+                    ConnectedNodes = this.connectionManager.ConnectedPeers.Count(),
+                    ChainTip = this.chain.Tip.Height,
+                    IsChainSynced = this.chain.IsDownloaded(),
+                    IsDecrypted = true
+                };
+
+                return this.Json(model);
+            }
+            catch (Exception e)
+            {
+                this.logger.LogError("Exception occurred: {0}", e.ToString());
+                return ErrorHelpers.BuildErrorResponse(HttpStatusCode.BadRequest, e.Message, e.ToString());
+            }
+        }
+
+        [Route(FederationWalletRouteEndPoint.Balance)]
+        [HttpGet]
+        public IActionResult GetBalance()
+        {
+            try
+            {
+                FederationWallet wallet = this.walletManager.GetWallet();
+                if (wallet == null)
+                {
+                    return this.NotFound("No federation wallet found.");
+                }
+
+                (Money ConfirmedAmount, Money UnConfirmedAmount) result = wallet.GetSpendableAmount();
+
+                var balance = new AccountBalanceModel
+                {
+                    CoinType = this.coinType,
+                    AmountConfirmed = result.ConfirmedAmount,
+                    AmountUnconfirmed = result.UnConfirmedAmount,
+                };
+
+                var model = new WalletBalanceModel();
+                model.AccountsBalances.Add(balance);
+
+                return this.Json(model);
+            }
+            catch (Exception e)
+            {
+                this.logger.LogError("Exception occurred: {0}", e.ToString());
+                return ErrorHelpers.BuildErrorResponse(HttpStatusCode.BadRequest, e.Message, e.ToString());
+            }
+        }
+
+        [Route(FederationWalletRouteEndPoint.History)]
+        [HttpGet]
+        public IActionResult GetHistory([FromQuery] int maxEntriesToReturn)
+        {
+            try
+            {
+                FederationWallet wallet = this.walletManager.GetWallet();
+                if (wallet == null)
+                {
+                    return this.NotFound("No federation wallet found.");
+                }
+
+                List<WithdrawalModel> result = this.withdrawalHistoryProvider.GetHistory(maxEntriesToReturn);
+
+                return this.Json(result);
+            }
+            catch (Exception e)
+            {
+                this.logger.LogError("Exception occurred: {0}", e.ToString());
+                return ErrorHelpers.BuildErrorResponse(HttpStatusCode.BadRequest, e.Message, e.ToString());
+            }
+        }
+
+        /// <summary>
+        /// Starts sending block to the wallet for synchronisation.
+        /// This is for demo and testing use only.
+        /// </summary>
+        /// <param name="model">The hash of the block from which to start syncing.</param>
+        [HttpPost]
+        [Route(FederationWalletRouteEndPoint.Sync)]
+        public IActionResult Sync([FromBody] HashModel model)
+        {
+            if (!this.ModelState.IsValid)
+            {
+                return BuildErrorResponse(this.ModelState);
+            }
+
+            ChainedHeader block = this.chain.GetBlock(uint256.Parse(model.Hash));
+
+            if (block == null)
+            {
+                return ErrorHelpers.BuildErrorResponse(HttpStatusCode.BadRequest, $"Block with hash {model.Hash} was not found on the blockchain.", string.Empty);
+            }
+
+            this.walletSyncManager.SyncFromHeight(block.Height);
+            return this.Ok();
+        }
+
+        /// <summary>
+        /// Provide the federation wallet's credentials so that it can sign transactions.
+        /// </summary>
+        /// <param name="request">The password of the federation wallet.</param>
+        /// <returns>An <see cref="OkResult"/> object that produces a status code 200 HTTP response.</returns>
+        [Route(FederationWalletRouteEndPoint.EnableFederation)]
+        [HttpPost]
+        public IActionResult EnableFederation([FromBody]EnableFederationRequest request)
+        {
+            Guard.NotNull(request, nameof(request));
+
+            try
+            {
+                if (!this.ModelState.IsValid)
+                {
+                    IEnumerable<string> errors = this.ModelState.Values.SelectMany(e => e.Errors.Select(m => m.ErrorMessage));
+                    return ErrorHelpers.BuildErrorResponse(HttpStatusCode.BadRequest, "Formatting error", string.Join(Environment.NewLine, errors));
+                }
+
+                this.walletManager.EnableFederation(request.Password, request.Mnemonic, request.Passphrase);
+
+                return this.Ok();
+            }
+            catch (Exception e)
+            {
+                this.logger.LogError("Exception occurred: {0}", e.ToString());
+                return ErrorHelpers.BuildErrorResponse(HttpStatusCode.BadRequest, e.Message, e.ToString());
+            }
+        }
+
+        /// <summary>
+        /// Remove all transactions from the wallet.
+        /// </summary>
+        [Route(FederationWalletRouteEndPoint.RemoveTransactions)]
+        [HttpDelete]
+        public IActionResult RemoveTransactions([FromQuery]RemoveFederationTransactionsModel request)
+        {
+            Guard.NotNull(request, nameof(request));
+
+            // Checks the request is valid.
+            if (!this.ModelState.IsValid)
+            {
+                return ModelStateErrors.BuildErrorResponse(this.ModelState);
+            }
+
+            try
+            {
+                HashSet<(uint256 transactionId, DateTimeOffset creationTime)> result;
+
+                result = this.walletManager.RemoveAllTransactions();
+
+                // If the user chose to resync the wallet after removing transactions.
+                if (result.Any() && request.ReSync)
+                {
+                    // From the list of removed transactions, check which one is the oldest and retrieve the block right before that time.
+                    DateTimeOffset earliestDate = result.Min(r => r.creationTime);
+                    ChainedHeader chainedHeader = this.chain.GetBlock(this.chain.GetHeightAtTime(earliestDate.DateTime));
+
+                    // Update the wallet and save it to the file system.
+                    FederationWallet wallet = this.walletManager.GetWallet();
+                    wallet.LastBlockSyncedHeight = chainedHeader.Height;
+                    wallet.LastBlockSyncedHash = chainedHeader.HashBlock;
+                    this.walletManager.SaveWallet();
+
+                    // Start the syncing process from the block before the earliest transaction was seen.
+                    this.walletSyncManager.SyncFromHeight(chainedHeader.Height - 1);
+                }
+
+                IEnumerable<RemovedTransactionModel> model = result.Select(r => new RemovedTransactionModel
+                {
+                    TransactionId = r.transactionId,
+                    CreationTime = r.creationTime
+                });
+
+                return this.Json(model);
+            }
+            catch (Exception e)
+            {
+                this.logger.LogError("Exception occurred: {0}", e.ToString());
+                return ErrorHelpers.BuildErrorResponse(HttpStatusCode.BadRequest, e.Message, e.ToString());
+            }
+        }
+
+        /// <summary>
+        /// Builds an <see cref="IActionResult"/> containing errors contained in the <see cref="ControllerBase.ModelState"/>.
+        /// </summary>
+        /// <returns>A result containing the errors.</returns>
+        private static IActionResult BuildErrorResponse(ModelStateDictionary modelState)
+        {
+            List<ModelError> errors = modelState.Values.SelectMany(e => e.Errors).ToList();
+            return ErrorHelpers.BuildErrorResponse(
+                HttpStatusCode.BadRequest,
+                string.Join(Environment.NewLine, errors.Select(m => m.ErrorMessage)),
+                string.Join(Environment.NewLine, errors.Select(m => m.Exception?.Message)));
+        }
+    }
+}

--- a/src/Stratis.Features.FederatedPeg/FederatedPegBlockDefinition.cs
+++ b/src/Stratis.Features.FederatedPeg/FederatedPegBlockDefinition.cs
@@ -1,0 +1,54 @@
+﻿using Microsoft.Extensions.Logging;
+using NBitcoin;
+using Stratis.Bitcoin.Configuration;
+using Stratis.Bitcoin.Consensus;
+using Stratis.Bitcoin.Features.Consensus.CoinViews;
+using Stratis.Bitcoin.Features.MemoryPool;
+using Stratis.Bitcoin.Features.MemoryPool.Interfaces;
+using Stratis.Bitcoin.Features.SmartContracts;
+using Stratis.Bitcoin.Features.SmartContracts.PoA;
+using Stratis.Bitcoin.Mining;
+using Stratis.Bitcoin.Utilities;
+using Stratis.SmartContracts.Core;
+using Stratis.SmartContracts.Core.State;
+using Stratis.SmartContracts.Core.Util;
+
+namespace Stratis.Features.FederatedPeg
+{
+    public class FederatedPegBlockDefinition : SmartContractPoABlockDefinition
+    {
+        private readonly Script payToMultisigScript;
+
+        private readonly Script payToMemberScript;
+
+        /// <inheritdoc />
+        public FederatedPegBlockDefinition(
+            IBlockBufferGenerator blockBufferGenerator,
+            ICoinView coinView,
+            IConsensusManager consensusManager,
+            IDateTimeProvider dateTimeProvider,
+            IContractExecutorFactory executorFactory,
+            ILoggerFactory loggerFactory,
+            ITxMempool mempool,
+            MempoolSchedulerLock mempoolLock,
+            Network network,
+            ISenderRetriever senderRetriever,
+            IStateRepositoryRoot stateRoot,
+            NodeSettings nodeSettings)
+            : base(blockBufferGenerator, coinView, consensusManager, dateTimeProvider, executorFactory, loggerFactory, mempool, mempoolLock, network, senderRetriever, stateRoot, nodeSettings)
+        {
+            var federationGatewaySettings = new FederationGatewaySettings(nodeSettings);
+            this.payToMultisigScript = federationGatewaySettings.MultiSigAddress.ScriptPubKey;
+            this.payToMemberScript = PayToPubkeyTemplate.Instance.GenerateScriptPubKey(new PubKey(federationGatewaySettings.PublicKey));
+        }
+
+        public override BlockTemplate Build(ChainedHeader chainTip, Script scriptPubKey)
+        {
+            Script rewardScript = (chainTip.Height + 1) == this.Network.Consensus.PremineHeight 
+                                   ? this.payToMultisigScript 
+                                   : this.payToMemberScript;
+
+            return base.Build(chainTip, rewardScript);
+        }
+    }
+}

--- a/src/Stratis.Features.FederatedPeg/FederationGatewayFeature.cs
+++ b/src/Stratis.Features.FederatedPeg/FederationGatewayFeature.cs
@@ -1,0 +1,389 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using NBitcoin;
+using Stratis.Bitcoin;
+using Stratis.Bitcoin.Base;
+using Stratis.Bitcoin.Builder;
+using Stratis.Bitcoin.Builder.Feature;
+using Stratis.Bitcoin.Configuration.Logging;
+using Stratis.Bitcoin.Connection;
+using Stratis.Bitcoin.Consensus;
+using Stratis.Bitcoin.Features.Api;
+using Stratis.Bitcoin.Features.Consensus;
+using Stratis.Bitcoin.Features.Consensus.CoinViews;
+using Stratis.Bitcoin.Features.MemoryPool;
+using Stratis.Bitcoin.Features.Miner;
+using Stratis.Bitcoin.Features.Notifications;
+using Stratis.Bitcoin.Features.PoA;
+using Stratis.Bitcoin.Features.SmartContracts;
+using Stratis.Bitcoin.Features.SmartContracts.PoA;
+using Stratis.Bitcoin.Interfaces;
+using Stratis.Bitcoin.P2P.Peer;
+using Stratis.Bitcoin.P2P.Protocol.Payloads;
+using Stratis.Bitcoin.Signals;
+using Stratis.Bitcoin.Utilities;
+using Stratis.Features.FederatedPeg.Controllers;
+using Stratis.Features.FederatedPeg.Interfaces;
+using Stratis.Features.FederatedPeg.Models;
+using Stratis.Features.FederatedPeg.Notifications;
+using Stratis.Features.FederatedPeg.Payloads;
+using Stratis.Features.FederatedPeg.RestClients;
+using Stratis.Features.FederatedPeg.SourceChain;
+using Stratis.Features.FederatedPeg.TargetChain;
+using Stratis.Features.FederatedPeg.Wallet;
+
+[assembly: InternalsVisibleTo("Stratis.FederatedPeg.Features.FederationGateway.Tests")]
+[assembly: InternalsVisibleTo("Stratis.FederatedPeg.IntegrationTests")]
+
+//todo: this is pre-refactoring code
+//todo: ensure no duplicate or fake withdrawal or deposit transactions are possible (current work underway)
+
+namespace Stratis.Features.FederatedPeg
+{
+    internal class FederationGatewayFeature : FullNodeFeature
+    {
+        public const string FederationGatewayFeatureNamespace = "federationgateway";
+
+        private readonly Signals signals;
+
+        private readonly IDepositExtractor depositExtractor;
+
+        private readonly IWithdrawalExtractor withdrawalExtractor;
+
+        private readonly IWithdrawalReceiver withdrawalReceiver;
+
+        private IDisposable blockSubscriberDisposable;
+
+        private IDisposable transactionSubscriberDisposable;
+
+        private readonly IConnectionManager connectionManager;
+
+        private readonly IFederationGatewaySettings federationGatewaySettings;
+
+        private readonly IFullNode fullNode;
+
+        private readonly ILoggerFactory loggerFactory;
+
+        private readonly IFederationWalletManager federationWalletManager;
+
+        private readonly IFederationWalletSyncManager walletSyncManager;
+
+        private readonly ConcurrentChain chain;
+
+        private readonly Network network;
+
+        private readonly ICrossChainTransferStore crossChainTransferStore;
+
+        private readonly IPartialTransactionRequester partialTransactionRequester;
+
+        private readonly IFederationGatewayClient federationGatewayClient;
+
+        private readonly MempoolManager mempoolManager;
+
+        private readonly IMaturedBlocksSyncManager maturedBlocksSyncManager;
+
+        private readonly IWithdrawalHistoryProvider withdrawalHistoryProvider;
+
+        private readonly ILogger logger;
+
+        public FederationGatewayFeature(
+            ILoggerFactory loggerFactory,
+            Signals signals,
+            IDepositExtractor depositExtractor,
+            IWithdrawalExtractor withdrawalExtractor,
+            IWithdrawalReceiver withdrawalReceiver,
+            IConnectionManager connectionManager,
+            IFederationGatewaySettings federationGatewaySettings,
+            IFullNode fullNode,
+            IFederationWalletManager federationWalletManager,
+            IFederationWalletSyncManager walletSyncManager,
+            Network network,
+            ConcurrentChain chain,
+            INodeStats nodeStats,
+            ICrossChainTransferStore crossChainTransferStore,
+            IPartialTransactionRequester partialTransactionRequester,
+            IFederationGatewayClient federationGatewayClient,
+            MempoolManager mempoolManager,
+            IMaturedBlocksSyncManager maturedBlocksSyncManager,
+            IWithdrawalHistoryProvider withdrawalHistoryProvider)
+        {
+            this.loggerFactory = loggerFactory;
+            this.signals = signals;
+            this.depositExtractor = depositExtractor;
+            this.withdrawalExtractor = withdrawalExtractor;
+            this.withdrawalReceiver = withdrawalReceiver;
+            this.connectionManager = connectionManager;
+            this.federationGatewaySettings = federationGatewaySettings;
+            this.fullNode = fullNode;
+            this.chain = chain;
+            this.federationWalletManager = federationWalletManager;
+            this.walletSyncManager = walletSyncManager;
+            this.network = network;
+            this.crossChainTransferStore = crossChainTransferStore;
+            this.partialTransactionRequester = partialTransactionRequester;
+            this.federationGatewayClient = federationGatewayClient;
+            this.mempoolManager = mempoolManager;
+            this.maturedBlocksSyncManager = maturedBlocksSyncManager;
+            this.withdrawalHistoryProvider = withdrawalHistoryProvider;
+
+            this.logger = loggerFactory.CreateLogger(this.GetType().FullName);
+
+            // add our payload
+            var payloadProvider = (PayloadProvider)this.fullNode.Services.ServiceProvider.GetService(typeof(PayloadProvider));
+            payloadProvider.AddPayload(typeof(RequestPartialTransactionPayload));
+
+            nodeStats.RegisterStats(this.AddComponentStats, StatsType.Component);
+            nodeStats.RegisterStats(this.AddInlineStats, StatsType.Inline, 800);
+        }
+
+        public override Task InitializeAsync()
+        {
+            this.crossChainTransferStore.Initialize();
+
+            // maturedBlocksSyncManager should be initialized only after crossChainTransferStore.
+            this.maturedBlocksSyncManager.Initialize();
+
+            this.federationWalletManager.Start();
+            this.walletSyncManager.Start();
+            this.crossChainTransferStore.Start();
+            this.partialTransactionRequester.Start();
+
+            // Connect the node to the other federation members.
+            foreach (IPEndPoint federationMemberIp in this.federationGatewaySettings.FederationNodeIpEndPoints)
+                this.connectionManager.AddNodeAddress(federationMemberIp);
+
+            NetworkPeerConnectionParameters networkPeerConnectionParameters = this.connectionManager.Parameters;
+            networkPeerConnectionParameters.TemplateBehaviors.Add(new PartialTransactionsBehavior(this.loggerFactory, this.federationWalletManager,
+                this.network, this.federationGatewaySettings, this.crossChainTransferStore));
+
+            return Task.CompletedTask;
+        }
+
+        public override void Dispose()
+        {
+            this.blockSubscriberDisposable.Dispose();
+            this.transactionSubscriberDisposable.Dispose();
+
+            // Sync manager has to be disposed BEFORE cross chain transfer store.
+            this.maturedBlocksSyncManager.Dispose();
+
+            this.crossChainTransferStore.Dispose();
+        }
+
+        private void AddInlineStats(StringBuilder benchLogs)
+        {
+            if (this.federationWalletManager == null)
+                return;
+
+            int height = this.federationWalletManager.LastBlockHeight();
+            ChainedHeader block = this.chain.GetBlock(height);
+            uint256 hashBlock = block == null ? 0 : block.HashBlock;
+
+            FederationWallet federationWallet = this.federationWalletManager.GetWallet();
+            benchLogs.AppendLine("Fed. Wallet.Height: ".PadRight(LoggingConfiguration.ColumnLength + 1) +
+                                 (federationWallet != null ? height.ToString().PadRight(8) : "No Wallet".PadRight(8)) +
+                                 (federationWallet != null ? (" Fed. Wallet.Hash: ".PadRight(LoggingConfiguration.ColumnLength - 1) + hashBlock) : string.Empty));
+        }
+
+        private void AddComponentStats(StringBuilder benchLog)
+        {
+            try
+            {
+                string stats = this.CollectStats();
+                benchLog.Append(stats);
+            }
+            catch (Exception e)
+            {
+                this.logger.LogError(e.ToString());
+                throw;
+            }
+        }
+
+        private string CollectStats()
+        {
+            StringBuilder benchLog = new StringBuilder();
+            benchLog.AppendLine();
+            benchLog.AppendLine("====== Federation Wallet ======");
+
+            (Money ConfirmedAmount, Money UnConfirmedAmount) balances = this.federationWalletManager.GetWallet().GetSpendableAmount();
+            bool isFederationActive = this.federationWalletManager.IsFederationActive();
+            benchLog.AppendLine("Federation Wallet: ".PadRight(LoggingConfiguration.ColumnLength)
+                                + " Confirmed balance: " + balances.ConfirmedAmount.ToString().PadRight(LoggingConfiguration.ColumnLength)
+                                + " Unconfirmed balance: " + balances.UnConfirmedAmount.ToString().PadRight(LoggingConfiguration.ColumnLength)
+                                + " Federation Status: " + (isFederationActive ? "Active" : "Inactive"));
+            benchLog.AppendLine();
+
+            if (!isFederationActive)
+            {
+                var apiSettings = (ApiSettings)this.fullNode.Services.ServiceProvider.GetService(typeof(ApiSettings));
+
+                benchLog.AppendLine("".PadRight(59, '=') + " W A R N I N G " + "".PadRight(59, '='));
+                benchLog.AppendLine();
+                benchLog.AppendLine("This federation node is not enabled. You will not be able to store or participate in signing of transactions until you enable it.");
+                benchLog.AppendLine("If not done previously, please enable your federation node using " + $"{apiSettings.ApiUri}/api/FederationWallet/{FederationWalletRouteEndPoint.EnableFederation}.");
+                benchLog.AppendLine();
+                benchLog.AppendLine("".PadRight(133, '='));
+                benchLog.AppendLine();
+            }
+
+            // Display recent withdrawals (if any).
+            List<WithdrawalModel> withdrawals = this.withdrawalHistoryProvider.GetHistory(5);
+            if (withdrawals.Count > 0)
+            {
+                benchLog.AppendLine("--- Recent Withdrawals ---");
+                foreach (WithdrawalModel withdrawal in withdrawals)
+                    benchLog.AppendLine(withdrawal.ToString());
+                benchLog.AppendLine();
+            }
+
+            benchLog.AppendLine("====== NodeStore ======");
+            this.AddBenchmarkLine(benchLog, new (string, int)[] {
+                ("Height:", LoggingConfiguration.ColumnLength),
+                (this.crossChainTransferStore.TipHashAndHeight.Height.ToString(), LoggingConfiguration.ColumnLength),
+                ("Hash:",LoggingConfiguration.ColumnLength),
+                (this.crossChainTransferStore.TipHashAndHeight.HashBlock.ToString(), 0),
+                ("NextDepositHeight:", LoggingConfiguration.ColumnLength),
+                (this.crossChainTransferStore.NextMatureDepositHeight.ToString(), LoggingConfiguration.ColumnLength),
+                ("HasSuspended:",LoggingConfiguration.ColumnLength),
+                (this.crossChainTransferStore.HasSuspended().ToString(), 0)
+            },
+            4);
+
+            AddBenchmarkLine(benchLog,
+                this.crossChainTransferStore.GetCrossChainTransferStatusCounter().SelectMany(item => new (string, int)[]{
+                    (item.Key.ToString()+":", LoggingConfiguration.ColumnLength),
+                    (item.Value.ToString(), LoggingConfiguration.ColumnLength)
+                    }).ToArray(),
+                4);
+
+            benchLog.AppendLine();
+            return benchLog.ToString();
+        }
+
+        private void AddBenchmarkLine(StringBuilder benchLog, (string Value, int ValuePadding)[] items, int maxItemsPerLine = int.MaxValue)
+        {
+            if (items != null)
+            {
+                int itemsAdded = 0;
+                foreach (var item in items)
+                {
+                    if (itemsAdded++ >= maxItemsPerLine)
+                    {
+                        benchLog.AppendLine();
+                        itemsAdded = 1;
+                    }
+                    benchLog.Append(item.Value.PadRight(item.ValuePadding));
+                }
+                benchLog.AppendLine();
+            }
+        }
+    }
+
+    /// <summary>
+    /// A class providing extension methods for <see cref="IFullNodeBuilder"/>.
+    /// </summary>
+    public static class FullNodeBuilderSidechainRuntimeFeatureExtension
+    {
+        public static IFullNodeBuilder AddFederationGateway(this IFullNodeBuilder fullNodeBuilder)
+        {
+            LoggingConfiguration.RegisterFeatureNamespace<FederationGatewayFeature>(
+                FederationGatewayFeature.FederationGatewayFeatureNamespace);
+
+            fullNodeBuilder.ConfigureFeature(features =>
+            {
+                features.AddFeature<FederationGatewayFeature>().DependOn<BlockNotificationFeature>().FeatureServices(
+                    services =>
+                    {
+                        services.AddSingleton<IHttpClientFactory, HttpClientFactory>();
+                        services.AddSingleton<IMaturedBlocksProvider, MaturedBlocksProvider>();
+                        services.AddSingleton<IFederationGatewaySettings, FederationGatewaySettings>();
+                        services.AddSingleton<IOpReturnDataReader, OpReturnDataReader>();
+                        services.AddSingleton<IDepositExtractor, DepositExtractor>();
+                        services.AddSingleton<IWithdrawalExtractor, WithdrawalExtractor>();
+                        services.AddSingleton<IWithdrawalReceiver, WithdrawalReceiver>();
+                        services.AddSingleton<FederationGatewayController>();
+                        services.AddSingleton<IFederationWalletSyncManager, FederationWalletSyncManager>();
+                        services.AddSingleton<IFederationWalletTransactionHandler, FederationWalletTransactionHandler>();
+                        services.AddSingleton<IFederationWalletManager, FederationWalletManager>();
+                        services.AddSingleton<ILeaderProvider, LeaderProvider>();
+                        services.AddSingleton<FederationWalletController>();
+                        services.AddSingleton<ICrossChainTransferStore, CrossChainTransferStore>();
+                        services.AddSingleton<ILeaderReceiver, LeaderReceiver>();
+                        services.AddSingleton<ISignedMultisigTransactionBroadcaster, SignedMultisigTransactionBroadcaster>();
+                        services.AddSingleton<IPartialTransactionRequester, PartialTransactionRequester>();
+                        services.AddSingleton<IFederationGatewayClient, FederationGatewayClient>();
+                        services.AddSingleton<IMaturedBlocksSyncManager, MaturedBlocksSyncManager>();
+                        services.AddSingleton<IWithdrawalHistoryProvider, WithdrawalHistoryProvider>();
+
+                        // Set up events.
+                        services.AddSingleton<TransactionObserver>();
+                        services.AddSingleton<BlockObserver>();
+                    });
+            });
+            return fullNodeBuilder;
+        }
+
+        public static IFullNodeBuilder UseFederatedPegPoAMining(this IFullNodeBuilder fullNodeBuilder)
+        {
+            fullNodeBuilder.ConfigureFeature(features =>
+            {
+                features.AddFeature<PoAFeature>().DependOn<FederationGatewayFeature>().FeatureServices(services =>
+                    {
+                        services.AddSingleton<FederationManager>();
+                        services.AddSingleton<PoABlockHeaderValidator>();
+                        services.AddSingleton<IPoAMiner, PoAMiner>();
+                        services.AddSingleton<SlotsManager>();
+                        services.AddSingleton<BlockDefinition, FederatedPegBlockDefinition>();
+                        services.AddSingleton<IBlockBufferGenerator, BlockBufferGenerator>();
+                    });
+            });
+
+            // TODO: Consensus and Mining should be separated. Sidechain nodes don't need any of the Federation code but do need Consensus.
+            // In the dependency tree as it is currently however, consensus is dependent on PoAFeature (needs SlotManager) which is in turn dependent on
+            // FederationGatewayFeature. https://github.com/stratisproject/FederatedSidechains/issues/273
+
+            LoggingConfiguration.RegisterFeatureNamespace<ConsensusFeature>("consensus");
+            fullNodeBuilder.ConfigureFeature(features =>
+            {
+                features.AddFeature<ConsensusFeature>().FeatureServices(services =>
+                {
+                    services.AddSingleton<DBreezeCoinView>();
+                    services.AddSingleton<ICoinView, CachedCoinView>();
+                    services.AddSingleton<ConsensusController>();
+                    services.AddSingleton<IConsensusRuleEngine, SmartContractPoARuleEngine>();
+                    services.AddSingleton<IChainState, ChainState>();
+                    services.AddSingleton<ConsensusQuery>()
+                        .AddSingleton<INetworkDifficulty, ConsensusQuery>(provider => provider.GetService<ConsensusQuery>())
+                        .AddSingleton<IGetUnspentTransaction, ConsensusQuery>(provider => provider.GetService<ConsensusQuery>());
+                    new SmartContractPoARuleRegistration(fullNodeBuilder.Network).RegisterRules(fullNodeBuilder.Network.Consensus);
+                });
+            });
+
+            return fullNodeBuilder;
+        }
+    }
+
+    //todo: this should be removed when compatible with full node API, instead, we should use
+    //services.AddHttpClient from Microsoft.Extensions.Http
+    public class HttpClientFactory : IHttpClientFactory
+    {
+        /// <inheritdoc />
+        public HttpClient CreateClient(string name)
+        {
+            var httpClient = new HttpClient();
+            httpClient.DefaultRequestHeaders.Accept.Clear();
+            httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+            return httpClient;
+        }
+    }
+}
+

--- a/src/Stratis.Features.FederatedPeg/FederationGatewaySettings.cs
+++ b/src/Stratis.Features.FederatedPeg/FederationGatewaySettings.cs
@@ -1,0 +1,110 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using NBitcoin;
+using Stratis.Bitcoin.Configuration;
+using Stratis.Bitcoin.Utilities;
+using Stratis.Bitcoin.Utilities.Extensions;
+using Stratis.Features.FederatedPeg.Interfaces;
+
+namespace Stratis.Features.FederatedPeg
+{
+    /// <inheritdoc />
+    public sealed class FederationGatewaySettings : IFederationGatewaySettings
+    {
+        internal const string CounterChainApiPortParam = "counterchainapiport";
+
+        internal const string RedeemScriptParam = "redeemscript";
+
+        internal const string PublicKeyParam = "publickey";
+
+        internal const string FederationIpsParam = "federationips";
+
+        private const string MinCoinMaturityParam = "mincoinmaturity";
+
+        private const string MinimumDepositConfirmationsParam = "mindepositconfirmations";
+
+        private const string TransactionFeeParam = "transactionfee";
+
+        public FederationGatewaySettings(NodeSettings nodeSettings)
+        {
+            Guard.NotNull(nodeSettings, nameof(nodeSettings));
+
+            TextFileConfiguration configReader = nodeSettings.ConfigReader;
+
+            this.IsMainChain = configReader.GetOrDefault<bool>("mainchain", false);
+            if (!this.IsMainChain && !configReader.GetOrDefault("sidechain", false))
+                throw new ConfigurationException("Either -mainchain or -sidechain must be specified");
+
+            string redeemScriptRaw = configReader.GetOrDefault<string>(RedeemScriptParam, null);
+            Console.WriteLine(redeemScriptRaw);
+            if (redeemScriptRaw == null)
+                throw new ConfigurationException($"could not find {RedeemScriptParam} configuration parameter");
+            this.MultiSigRedeemScript = new Script(redeemScriptRaw);
+            this.MultiSigAddress = this.MultiSigRedeemScript.Hash.GetAddress(nodeSettings.Network);
+            PayToMultiSigTemplateParameters payToMultisigScriptParams = PayToMultiSigTemplate.Instance.ExtractScriptPubKeyParameters(this.MultiSigRedeemScript);
+            this.MultiSigM = payToMultisigScriptParams.SignatureCount;
+            this.MultiSigN = payToMultisigScriptParams.PubKeys.Length;
+            this.FederationPublicKeys = payToMultisigScriptParams.PubKeys;
+
+            this.PublicKey = configReader.GetOrDefault<string>(PublicKeyParam, null);
+            this.MinCoinMaturity = configReader.GetOrDefault<int>(MinCoinMaturityParam, (int)nodeSettings.Network.Consensus.MaxReorgLength + 1);
+            if (this.MinCoinMaturity <= 0)
+            {
+                throw new ConfigurationException("The minimum coin maturity can't be set to zero or less.");
+            }
+
+            this.TransactionFee = new Money(configReader.GetOrDefault<decimal>(TransactionFeeParam, 0.01m), MoneyUnit.BTC);
+
+            if (this.FederationPublicKeys.All(p => p != new PubKey(this.PublicKey)))
+            {
+                throw new ConfigurationException("Please make sure the public key passed as parameter was used to generate the multisig redeem script.");
+            }
+
+            this.CounterChainApiPort = configReader.GetOrDefault(CounterChainApiPortParam, 0);
+            this.FederationNodeIpEndPoints = configReader.GetOrDefault<string>(FederationIpsParam, null)?.Split(',')
+                .Select(a => a.ToIPEndPoint(nodeSettings.Network.DefaultPort)) ?? new List<IPEndPoint>();
+
+            //todo : remove that for prod code
+            this.MinimumDepositConfirmations = (uint)configReader.GetOrDefault<int>(MinimumDepositConfirmationsParam, (int)nodeSettings.Network.Consensus.MaxReorgLength + 1);
+            //this.MinimumDepositConfirmations = nodeSettings.Network.Consensus.MaxReorgLength + 1;
+        }
+
+        /// <inheritdoc/>
+        public bool IsMainChain { get; }
+
+        /// <inheritdoc/>
+        public IEnumerable<IPEndPoint> FederationNodeIpEndPoints { get; }
+
+        /// <inheritdoc/>
+        public string PublicKey { get; }
+
+        /// <inheritdoc/>
+        public PubKey[] FederationPublicKeys { get; }
+
+        /// <inheritdoc/>
+        public int CounterChainApiPort { get; }
+
+        /// <inheritdoc/>
+        public int MultiSigM { get; }
+
+        /// <inheritdoc/>
+        public int MultiSigN { get; }
+
+        /// <inheritdoc/>
+        public int MinCoinMaturity { get; }
+
+        /// <inheritdoc/>
+        public Money TransactionFee { get; }
+
+        /// <inheritdoc/>
+        public BitcoinAddress MultiSigAddress { get; }
+
+        /// <inheritdoc/>
+        public Script MultiSigRedeemScript { get; }
+
+        /// <inheritdoc />
+        public uint MinimumDepositConfirmations { get; }
+    }
+}

--- a/src/Stratis.Features.FederatedPeg/Interfaces/ICrossChainTransfer.cs
+++ b/src/Stratis.Features.FederatedPeg/Interfaces/ICrossChainTransfer.cs
@@ -1,0 +1,88 @@
+﻿using NBitcoin;
+
+namespace Stratis.Features.FederatedPeg.Interfaces
+{
+    /// <summary>
+    /// Cross-chain transfer statuses.
+    /// </summary>
+    public enum CrossChainTransferStatus
+    {
+        Suspended = 'U',
+        Partial = 'P',
+        FullySigned = 'F',
+        SeenInBlock = 'S'
+    }
+
+    public interface ICrossChainTransfer : IBitcoinSerializable
+    {
+        /// <summary>
+        /// The transaction id of the deposit transaction.
+        /// </summary>
+        uint256 DepositTransactionId { get; }
+
+        /// <summary>
+        /// The target address of the deposit transaction.
+        /// </summary>
+        Script DepositTargetAddress { get; }
+
+        /// <summary>
+        /// The amount (in satoshis) of the deposit transaction.
+        /// </summary>
+        long DepositAmount { get; }
+
+        /// <summary>
+        /// The chain A deposit height of the transaction. Is null if only seen in a block.
+        /// </summary>
+        int? DepositHeight { get; }
+
+        /// <summary>
+        /// The unsigned partial transaction containing a full set of available UTXO's.
+        /// </summary>
+        Transaction PartialTransaction { get; }
+
+        /// <summary>
+        /// The hash of the block where the transaction resides on our chain.
+        /// </summary>
+        uint256 BlockHash { get; }
+
+        /// <summary>
+        /// The height of the block where the transaction resides on our chain.
+        /// </summary>
+        int? BlockHeight { get; }
+
+        CrossChainTransferStatus Status { get; }
+
+        /// <summary>
+        /// Depending on the status some fields can't be null.
+        /// </summary>
+        /// <returns><c>false</c> if the object is invalid and <c>true</c> otherwise.</returns>
+        bool IsValid();
+
+        /// <summary>
+        /// Sets the status and verifies that the status is valid given the available fields.
+        /// </summary>
+        /// <param name="status">The new status.</param>
+        /// <param name="blockHash">The block hash of the partialTranction.</param>
+        /// <param name="blockHeight">The block height of the partialTransaction.</param>
+        void SetStatus(CrossChainTransferStatus status, uint256 blockHash = null, int? blockHeight = null);
+
+        /// <summary>
+        /// Combines signatures from partial transactions received from other federation members.
+        /// </summary>
+        /// <param name="builder">The transaction builder to use.</param>
+        /// <param name="partialTransactions">Partial transactions received from other federation members.</param>
+        void CombineSignatures(TransactionBuilder builder, Transaction[] partialTransactions);
+
+        /// <summary>
+        /// Sets the partial transaction.
+        /// </summary>
+        /// <param name="partialTransaction">Partial transaction.</param>
+        void SetPartialTransaction(Transaction partialTransaction);
+
+        /// <summary>
+        /// Gets the number of sigatures in the first input of the transaction.
+        /// </summary>
+        /// <returns>Number of signatures.</returns>
+        int GetSignatureCount(Network network);
+    }
+}

--- a/src/Stratis.Features.FederatedPeg/Interfaces/ICrossChainTransferStore.cs
+++ b/src/Stratis.Features.FederatedPeg/Interfaces/ICrossChainTransferStore.cs
@@ -1,0 +1,89 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using NBitcoin;
+using Stratis.Features.FederatedPeg.Models;
+
+namespace Stratis.Features.FederatedPeg.Interfaces
+{
+    /// <summary>Interface for interacting with the cross-chain transfer database.</summary>
+    public interface ICrossChainTransferStore : IDisposable
+    {
+        /// <summary>Initializes the cross-chain-transfer store.</summary>
+        void Initialize();
+
+        /// <summary>Starts the cross-chain-transfer store.</summary>
+        void Start();
+
+        /// <summary>
+        /// For optimization purposes the current tip is not saved after receiving an empty block.
+        /// This needs to be called to ensure the tip is persisted.
+        /// </summary>
+        Task SaveCurrentTipAsync();
+
+        /// <summary>
+        /// Records the mature deposits from <see cref="NextMatureDepositHeight"/> on the counter-chain.
+        /// The value of <see cref="NextMatureDepositHeight"/> is incremented at the end of this call.
+        /// </summary>
+        /// <param name="blockDeposits">The deposits in order of occurrence on the source chain.</param>
+        /// <returns><c>True</c> if there may be more blocks and <c>false</c> otherwise.</returns>
+        /// <remarks>
+        /// The transfers are set to <see cref="CrossChainTransfer.Status"/> of <see cref="CrossChainTransferStatus.Partial"/>
+        /// or <see cref="CrossChainTransferStatus.Rejected"/> depending on whether enough funds are available in the federation wallet.
+        /// New partial transactions are recorded in the wallet to ensure that future transactions will not
+        /// attempt to re-use UTXO's.
+        /// </remarks>
+        Task<bool> RecordLatestMatureDepositsAsync(IList<MaturedBlockDepositsModel> blockDeposits);
+
+        /// <summary>Returns transactions by status. Orders the results by UTXO selection order.</summary>
+        /// <param name="status">The status to get the transactions for.</param>
+        /// <param name="sort">Set to <c>true</c> to sort the transfers by their earliest inputs.</param>
+        /// <returns>An array of transactions.</returns>
+        Task<Dictionary<uint256, Transaction>> GetTransactionsByStatusAsync(CrossChainTransferStatus status, bool sort = false);
+
+        /// <summary>
+        /// Updates partial transactions in the store with signatures obtained from the passed transactions.
+        /// The <see cref="CrossChainTransferStatus.FullySigned"/> status is set on fully signed transactions.
+        /// </summary>
+        /// <param name="depositId">The deposit transaction to update.</param>
+        /// <param name="partialTransactions">Partial transactions received from other federation members.</param>
+        /// <remarks>
+        /// Changes to the transaction id caused by this operation will also be synchronised with the partial
+        /// transaction that has been recorded in the wallet.
+        /// </remarks>
+        /// <returns>The updated transaction.</returns>
+        Task<Transaction> MergeTransactionSignaturesAsync(uint256 depositId, Transaction[] partialTransactions);
+
+        /// <summary>
+        /// Get the cross-chain transfer information from the database, identified by the deposit transaction ids.
+        /// </summary>
+        /// <param name="depositIds">The deposit transaction ids.</param>
+        /// <returns>The cross-chain transfer information.</returns>
+        Task<ICrossChainTransfer[]> GetAsync(uint256[] depositIds);
+
+        /// <summary>Determines if the store contains suspended transactions.</summary>
+        /// <returns><c>True</c> if the store contains suspended transaction and <c>false</c> otherwise.</returns>
+        bool HasSuspended();
+
+        /// <summary>
+        /// Verifies that the transaction's input UTXO's have been reserved by the wallet.
+        /// Also checks that an earlier transaction for the same deposit id does not exist.
+        /// </summary>
+        /// <param name="transaction">The transaction to check.</param>
+        /// <param name="checkSignature">Indicates whether to check the signature.</param>
+        /// <returns><c>True</c> if all's well and <c>false</c> otherwise.</returns>
+        bool ValidateTransaction(Transaction transaction, bool checkSignature = false);
+
+        /// <summary>The tip of our chain when we last updated the store.</summary>
+        ChainedHeader TipHashAndHeight { get; }
+
+        /// <summary>The block height on the counter-chain for which the next list of deposits is expected.</summary>
+        int NextMatureDepositHeight { get; }
+
+        /// <summary>
+        /// Gets the counter of the cross chain transfer for each available status
+        /// </summary>
+        /// <returns>The counter of the cross chain transfer for each <see cref="CrossChainTransferStatus"/> status</returns>
+        Dictionary<CrossChainTransferStatus, int> GetCrossChainTransferStatusCounter();
+    }
+}

--- a/src/Stratis.Features.FederatedPeg/Interfaces/IDeposit.cs
+++ b/src/Stratis.Features.FederatedPeg/Interfaces/IDeposit.cs
@@ -1,0 +1,41 @@
+﻿using NBitcoin;
+using Newtonsoft.Json;
+using Stratis.Bitcoin.Utilities.JsonConverters;
+
+namespace Stratis.Features.FederatedPeg.Interfaces
+{
+    /// <summary>
+    /// Represents a deposit made to a sidechain mutlisig, with the aim of triggering
+    /// a cross chain transfer
+    /// </summary>
+    public interface IDeposit
+    {
+        /// <summary>
+        /// The Id (or hash) of the source transaction that originates the fund transfer.
+        /// </summary>
+        [JsonConverter(typeof(UInt256JsonConverter))]
+        uint256 Id { get; }
+
+        /// <summary>
+        /// The amount of the requested fund transfer.
+        /// </summary>
+        [JsonConverter(typeof(MoneyJsonConverter))]
+        Money Amount { get; }
+
+        /// <summary>
+        /// The target address, on the target chain, for the fund deposited on the multisig.
+        /// </summary>
+        string TargetAddress { get; }
+
+        /// <summary>
+        /// The block number where the source deposit has been persisted.
+        /// </summary>
+        int BlockNumber { get; }
+
+        /// <summary>
+        /// The hash of the block where the source deposit has been persisted.
+        /// </summary>
+        [JsonConverter(typeof(UInt256JsonConverter))]
+        uint256 BlockHash { get; }
+    }
+}

--- a/src/Stratis.Features.FederatedPeg/Interfaces/IDepositExtractor.cs
+++ b/src/Stratis.Features.FederatedPeg/Interfaces/IDepositExtractor.cs
@@ -1,0 +1,41 @@
+﻿using System.Collections.Generic;
+using NBitcoin;
+using Stratis.Bitcoin.Primitives;
+using Stratis.Features.FederatedPeg.Models;
+
+namespace Stratis.Features.FederatedPeg.Interfaces
+{
+    /// <summary>
+    /// This component is responsible for finding all deposits made to a given address
+    /// in a given block, find out if they should trigger a cross chain transfer, and if so
+    /// extracting the transfers' details.
+    /// </summary>
+    public interface IDepositExtractor
+    {
+        /// <summary>
+        /// Extracts deposits from the transactions in a block.
+        /// </summary>
+        /// <param name="block">The block containing the transactions.</param>
+        /// <param name="blockHeight">The height of the block containing the transactions.</param>
+        /// <returns>The extracted deposit (if any), otherwise returns an empty list.</returns>
+        IReadOnlyList<IDeposit> ExtractDepositsFromBlock(Block block, int blockHeight);
+
+        /// <summary>
+        /// Extracts a deposit from a transaction (if any).
+        /// </summary>
+        /// <param name="transaction">The transaction to extract deposits from.</param>
+        /// <param name="blockHeight">The block height of the block containing the transaction.</param>
+        /// <param name="blockHash">The block hash of the block containing the transaction.</param>
+        /// <returns>The extracted deposit (if any), otherwise <c>null</c>.</returns>
+        IDeposit ExtractDepositFromTransaction(Transaction transaction, int blockHeight, uint256 blockHash);
+
+        /// <summary>
+        /// Gets deposits from the newly matured block.
+        /// </summary>
+        /// <param name="newlyMaturedBlock">The newly matured block.</param>
+        /// <returns>The matured deposits.</returns>
+        MaturedBlockDepositsModel ExtractBlockDeposits(ChainedHeaderBlock newlyMaturedBlock);
+
+        uint MinimumDepositConfirmations { get; }
+    }
+}

--- a/src/Stratis.Features.FederatedPeg/Interfaces/IFederationGatewaySettings.cs
+++ b/src/Stratis.Features.FederatedPeg/Interfaces/IFederationGatewaySettings.cs
@@ -1,0 +1,72 @@
+﻿using System.Collections.Generic;
+using System.Net;
+using NBitcoin;
+
+namespace Stratis.Features.FederatedPeg.Interfaces
+{
+    /// <summary>
+    /// Configuration settings used to initialize a FederationGateway.
+    /// </summary>
+    public interface IFederationGatewaySettings
+    {
+        /// <summary>
+        /// Indicates whether this is the main chain. Set if the "-mainchain" switch was used.
+        /// </summary>
+        bool IsMainChain { get; }
+
+        /// <summary>
+        /// Ip Endpoints for the other nodes in the federation.
+        /// </summary>
+        IEnumerable<IPEndPoint> FederationNodeIpEndPoints { get; }
+
+        /// <summary>
+        /// Public keys of other federation members.
+        /// </summary>
+        PubKey[] FederationPublicKeys { get; }
+
+        /// <summary>
+        /// Public key of this federation member.
+        /// </summary>
+        string PublicKey { get; }
+
+        /// <summary>
+        /// The API port used to communicate with node on the counter chain.
+        /// </summary>
+        int CounterChainApiPort { get; }
+
+        /// <summary>
+        /// For the M of N multisig, this is the number of signers required to reach a quorum.
+        /// </summary>
+        int MultiSigM { get; }
+
+        /// <summary>
+        /// For the M of N multisig, this is the number of members in the federation.
+        /// </summary>
+        int MultiSigN { get; }
+
+        /// <summary>
+        /// The mimimum confirmations required for coins added to withdrawals.
+        /// </summary>
+        int MinCoinMaturity { get; }
+
+        /// <summary>
+        /// The transaction fee required for withdrawals.
+        /// </summary>
+        Money TransactionFee { get; }
+
+        /// <summary>
+        /// Address for the MultiSig script.
+        /// </summary>
+        BitcoinAddress MultiSigAddress { get; }
+
+        /// <summary>
+        /// Pay2Multisig redeem script.
+        /// </summary>
+        Script MultiSigRedeemScript { get; }
+
+        /// <summary>
+        /// The amount of blocks under which multisig deposit transactions need to be buried before the cross chains transfer actually trigger.
+        /// </summary>
+        uint MinimumDepositConfirmations { get; }
+    }
+}

--- a/src/Stratis.Features.FederatedPeg/Interfaces/IFederationWalletManager.cs
+++ b/src/Stratis.Features.FederatedPeg/Interfaces/IFederationWalletManager.cs
@@ -1,0 +1,153 @@
+﻿using System;
+using System.Collections.Generic;
+using NBitcoin;
+using Stratis.Features.FederatedPeg.Wallet;
+
+namespace Stratis.Features.FederatedPeg.Interfaces
+{
+    /// <summary>
+    /// Interface for a manager providing operations on wallets.
+    /// </summary>
+    public interface IFederationWalletManager
+    {
+        /// <summary>
+        /// Starts this wallet manager.
+        /// </summary>
+        void Start();
+
+        /// <summary>
+        /// Stops the wallet manager.
+        /// <para>Internally it waits for async loops to complete before saving the wallets to disk.</para>
+        /// </summary>
+        void Stop();
+
+        /// <summary>
+        /// The last processed block.
+        /// </summary>
+        uint256 WalletTipHash { get; set; }
+
+        /// <summary>
+        /// Lists all spendable transactions from all accounts in the wallet.
+        /// </summary>
+        /// <returns>A collection of spendable outputs</returns>
+        IEnumerable<Wallet.UnspentOutputReference> GetSpendableTransactionsInWallet(int confirmations = 0);
+
+        /// <summary>
+        /// Gets the last block height.
+        /// </summary>
+        /// <returns></returns>
+        int LastBlockHeight();
+
+        /// <summary>
+        /// Remove all the transactions in the wallet that are above this block height
+        /// </summary>
+        void RemoveBlocks(ChainedHeader fork);
+
+        /// <summary>
+        /// Processes a block received from the network.
+        /// </summary>
+        /// <param name="block">The block.</param>
+        /// <param name="chainedBlock">The blocks chain of headers.</param>
+        void ProcessBlock(Block block, ChainedHeader chainedBlock);
+
+        /// <summary>
+        /// Processes a transaction received from the network.
+        /// </summary>
+        /// <param name="transaction">The transaction.</param>
+        /// <param name="blockHeight">The height of the block this transaction came from. Null if it was not a transaction included in a block.</param>
+        /// <param name="block">The block in which this transaction was included.</param>
+        /// <param name="isPropagated">Transaction propagation state.</param>
+        /// <returns>A value indicating whether this transaction affects the wallet.</returns>
+        bool ProcessTransaction(Transaction transaction, int? blockHeight = null, Block block = null, bool isPropagated = true);
+
+        /// <summary>
+        /// Removes a transaction not yet broadcasted or included in a block.
+        /// </summary>
+        /// <param name="transaction">The transaction to remove.</param>
+        /// <returns>A value indicating whether this transaction affects the wallet.</returns>
+        bool RemoveTransaction(Transaction transaction);
+
+        /// <summary>
+        /// Verifies that the transaction's input UTXO's have been reserved by the wallet.
+        /// Also checks that an earlier transaction for the same deposit id does not exist.
+        /// </summary>
+        /// <param name="transaction">The transaction to check.</param>
+        /// <param name="checkSignature">Indicates whether to check the signature.</param>
+        /// <returns><c>True</c> if all's well and <c>false</c> otherwise.</returns>
+        bool ValidateTransaction(Transaction transaction, bool checkSignature = false);
+
+        /// <summary>
+        /// Saves the wallet into the file system.
+        /// </summary>
+        void SaveWallet();
+
+        /// <summary>
+        /// Gets some general information about a wallet.
+        /// </summary>
+        /// <returns></returns>
+        FederationWallet GetWallet();
+
+        /// <summary>
+        /// Updates the wallet with the height of the last block synced.
+        /// </summary>
+        /// <param name="wallet">The wallet to update.</param>
+        /// <param name="chainedBlock">The height of the last block synced.</param>
+        void UpdateLastBlockSyncedHeight(ChainedHeader chainedBlock);
+
+        /// <summary>
+        /// Gets whether there are any wallet files loaded or not.
+        /// </summary>
+        /// <returns>Whether any wallet files are loaded.</returns>
+        bool ContainsWallets { get; }
+
+        WalletSecret Secret { get; set; }
+
+        /// <summary>
+        /// Finds all withdrawal transactions with optional filtering by deposit id or transaction id.
+        /// </summary>
+        /// <param name="depositId">Filters by this deposit id if not <c>null</c>.</param>
+        /// <param name="transactionId">Filters by this transaction id if not <c>null</c>.</param>
+        /// <returns>The transaction data containing the withdrawal transaction.</returns>
+        List<(Transaction, TransactionData, IWithdrawal)> FindWithdrawalTransactions(uint256 depositId = null);
+
+        /// <summary>
+        /// Removes the transient transactions associated with the corresponding deposit ids.
+        /// </summary>
+        /// <param name="depositId">The deposit id identifying the transient transactions to remove. Set to <c>null</c> to remove all.</param>
+        bool RemoveTransientTransactions(uint256 depositId = null);
+
+        /// <summary>
+        /// Compares two outpoints to see which occurs earlier.
+        /// </summary>
+        /// <param name="outPoint1">The first outpoint to compare.</param>
+        /// <param name="outPoint2">The second outpoint to compare.</param>
+        /// <returns><c>-1</c> if the <paramref name="outPoint1"/> occurs first and <c>1</c> otherwise.</returns>
+        int CompareOutpoints(OutPoint outPoint1, OutPoint outPoint2);
+
+        /// <summary>
+        /// Determines if federation has been activated.
+        /// </summary>
+        /// <returns><c>True</c> if federation is active and <c>false</c> otherwise.</returns>
+        bool IsFederationActive();
+
+        /// <summary>
+        /// Enables federation.
+        /// </summary>
+        /// <param name="password">The federation wallet password.</param>
+        /// <param name="mnemonic">The user's mnemonic.</param>
+        /// <param name="passphrase">A passphrase used to derive the private key from the mnemonic.</param>
+        void EnableFederation(string password, string mnemonic = null, string passphrase = null);
+
+        /// <summary>
+        /// Removes all the transactions from the federation wallet.
+        /// </summary>
+        /// <returns>A list of objects made up of transaction IDs along with the time at which they were created.</returns>
+        HashSet<(uint256, DateTimeOffset)> RemoveAllTransactions();
+
+        /// <summary>
+        /// Enumerate withdrawals starting with the most recent.
+        /// </summary>
+        /// <returns>An enumeration of IWithdrawal objects.</returns>
+        IEnumerable<IWithdrawal> GetWithdrawals();
+    }
+}

--- a/src/Stratis.Features.FederatedPeg/Interfaces/IFederationWalletSyncManager.cs
+++ b/src/Stratis.Features.FederatedPeg/Interfaces/IFederationWalletSyncManager.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using NBitcoin;
+
+namespace Stratis.Features.FederatedPeg.Interfaces
+{
+    public interface IFederationWalletSyncManager
+    {
+        /// <summary>
+        /// Starts the walletSyncManager.
+        /// </summary>
+        void Start();
+
+        /// <summary>
+        /// Stops the walletSyncManager.
+        /// <para>
+        /// We need to call <see cref="Stop"/> explicitly to check that the internal async loop isn't still running
+        /// and subsequentlly dispose of it properly.
+        /// </para>
+        /// </summary>
+        void Stop();
+
+        /// <summary>
+        /// Processes a new block.
+        /// </summary>
+        /// <param name="block"></param>
+        void ProcessBlock(Block block);
+
+        /// <summary>
+        /// Processes a new transaction which is in a pending state (not included in a block).
+        /// </summary>
+        /// <param name="transaction"></param>
+        void ProcessTransaction(Transaction transaction);
+
+        /// <summary>
+        /// Synchronize the wallet starting from the date passed as a parameter.
+        /// </summary>
+        /// <param name="date">The date from which to start the sync process.</param>
+        /// <returns>The height of the block sync will start from.</returns>
+        void SyncFromDate(DateTime date);
+
+        /// <summary>
+        /// Synchronize the wallet starting from the height passed as a parameter.
+        /// </summary>
+        /// <param name="height">The height from which to start the sync process.</param>
+        /// <returns>The height of the block sync will start from.</returns>
+        void SyncFromHeight(int height);
+
+        /// <summary>
+        /// The current tip of the wallet.
+        /// </summary>
+        ChainedHeader WalletTip { get; }
+    }
+}

--- a/src/Stratis.Features.FederatedPeg/Interfaces/IWithdrawal.cs
+++ b/src/Stratis.Features.FederatedPeg/Interfaces/IWithdrawal.cs
@@ -1,0 +1,53 @@
+﻿using NBitcoin;
+using Newtonsoft.Json;
+using Stratis.Bitcoin.Utilities.JsonConverters;
+
+namespace Stratis.Features.FederatedPeg.Interfaces
+{
+    /// <summary>
+    /// Represents a withdrawals made from a sidechain mutlisig, with the aim of realising
+    /// a cross chain transfer.
+    /// </summary>
+    public interface IWithdrawal
+    {
+        /// <summary>
+        /// The Id (or hash) of the source transaction that originates the fund transfer.
+        /// </summary>
+        [JsonConverter(typeof(UInt256JsonConverter))]
+        uint256 DepositId { get; }
+
+        /// <summary>
+        /// The Id (or hash) of the source transaction that originated the fund
+        /// transfer causing this withdrawal.
+        /// </summary>
+        [JsonConverter(typeof(UInt256JsonConverter))]
+        uint256 Id { get; }
+
+        /// <summary>
+        /// The amount of fund transferred (in target currency).
+        /// </summary>
+        [JsonConverter(typeof(MoneyJsonConverter))]
+        Money Amount { get; }
+
+        /// <summary>
+        /// The target address, on the target chain, for the fund deposited on the multisig.
+        /// </summary>
+        string TargetAddress { get; }
+
+        /// <summary>
+        /// The block number where the target deposit has been persisted.
+        /// </summary>
+        int BlockNumber { get; }
+
+        /// <summary>
+        /// The hash of the block where the target deposit has been persisted.
+        /// </summary>
+        [JsonConverter(typeof(UInt256JsonConverter))]
+        uint256 BlockHash { get; }
+
+        /// <summary>
+        /// Abbreviated information about the withdrawal.
+        /// </summary>
+        string GetInfo();
+    }
+}

--- a/src/Stratis.Features.FederatedPeg/LeaderProvider.cs
+++ b/src/Stratis.Features.FederatedPeg/LeaderProvider.cs
@@ -1,0 +1,57 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using NBitcoin;
+using Stratis.Bitcoin.Utilities;
+using Stratis.Features.FederatedPeg.Interfaces;
+using Stratis.Features.FederatedPeg.Models;
+
+namespace Stratis.Features.FederatedPeg
+{
+    /// <summary>
+    /// This class determines which federated member to select as the next leader based on a change in block height.
+    /// </summary>
+    public interface ILeaderProvider
+    {
+        /// <summary>Public key of the current leader.</summary>
+        PubKey CurrentLeaderKey { get; }
+
+        void Update(BlockTipModel blockTipModel);
+    }
+
+    /// <summary>
+    /// This class determines which federated member to select as the next leader based on a change in block height.
+    /// <para>
+    /// Each federated member is selected in a round robin fashion.
+    /// </para>
+    /// <remarks>
+    /// On construction the provider will order the federated members' public keys - which live in <see cref="IFederationGatewaySettings"/> - before it determines the next leader.
+    /// </remarks>
+    /// </summary>
+    public class LeaderProvider : ILeaderProvider
+    {
+        /// <summary>
+        /// Ordered list of federated members' public keys.
+        /// </summary>
+        private readonly IReadOnlyList<string> orderedFederationPublicKeys;
+
+        public LeaderProvider(IFederationGatewaySettings federationGatewaySettings)
+        {
+            this.orderedFederationPublicKeys = federationGatewaySettings.FederationPublicKeys.
+                Select(k => k.ToString()).
+                OrderBy(j => j).
+                ToList().
+                AsReadOnly();
+
+            this.CurrentLeaderKey = new PubKey(this.orderedFederationPublicKeys.First());
+        }
+
+        public PubKey CurrentLeaderKey { get; private set; }
+
+        public void Update(BlockTipModel blockTipModel)
+        {
+            Guard.NotNull(blockTipModel, nameof(blockTipModel));
+
+            this.CurrentLeaderKey = new PubKey(this.orderedFederationPublicKeys[blockTipModel.Height % this.orderedFederationPublicKeys.Count]);
+        }
+    }
+}

--- a/src/Stratis.Features.FederatedPeg/Models/BlockTipModel.cs
+++ b/src/Stratis.Features.FederatedPeg/Models/BlockTipModel.cs
@@ -1,0 +1,39 @@
+﻿using System.ComponentModel.DataAnnotations;
+using NBitcoin;
+using Newtonsoft.Json;
+using Stratis.Bitcoin.Features.Wallet.Models;
+using Stratis.Bitcoin.Utilities.JsonConverters;
+
+namespace Stratis.Features.FederatedPeg.Models
+{
+    public interface IBlockTip
+    {
+        [JsonConverter(typeof(UInt256JsonConverter))]
+        uint256 Hash { get; }
+
+        int Height { get; }
+
+        int MatureConfirmations { get; }
+    }
+
+    /// <summary>Block tip Hash, Height and MatureConfirmation model.</summary>
+    public class BlockTipModel : RequestModel, IBlockTip
+    {
+        public BlockTipModel(uint256 hash, int height, int matureConfirmations)
+        {
+            this.Hash = hash;
+            this.Height = height;
+            this.MatureConfirmations = matureConfirmations;
+        }
+
+        [Required(ErrorMessage = "Block Hash is required")]
+        [JsonConverter(typeof(UInt256JsonConverter))]
+        public uint256 Hash { get; set; }
+
+        [Required(ErrorMessage = "Block Height is required")]
+        public int Height { get; set; }
+
+        [Required(ErrorMessage = "Mature Confirmations is required")]
+        public int MatureConfirmations { get; set; }
+    }
+}

--- a/src/Stratis.Features.FederatedPeg/Models/ConcreteTypeConverter.cs
+++ b/src/Stratis.Features.FederatedPeg/Models/ConcreteTypeConverter.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using Newtonsoft.Json;
+using TracerAttributes;
+
+namespace Stratis.Features.FederatedPeg.Models
+{
+    public class ConcreteConverter<T> : JsonConverter
+    {
+        public override bool CanConvert(Type objectType) => true;
+
+        [NoTrace]
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            return serializer.Deserialize<T>(reader);
+        }
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            serializer.Serialize(writer, value);
+        }
+    }
+}

--- a/src/Stratis.Features.FederatedPeg/Models/FederationGatewayInfoModel.cs
+++ b/src/Stratis.Features.FederatedPeg/Models/FederationGatewayInfoModel.cs
@@ -1,0 +1,42 @@
+﻿using System.Collections.Generic;
+using NBitcoin;
+using Newtonsoft.Json;
+
+namespace Stratis.Features.FederatedPeg.Models
+{
+    public class FederationGatewayInfoModel
+    {
+        [JsonProperty(PropertyName = "active")]
+        public bool IsActive { get; set; }
+
+        [JsonProperty(PropertyName = "mainchain")]
+        public bool IsMainChain { get; set; }
+
+        [JsonProperty(PropertyName = "endpoints")]
+        public IEnumerable<string> FederationNodeIpEndPoints { get; set; }
+
+        [JsonProperty(PropertyName = "multisigPubKey")]
+        public string MultisigPublicKey { get; set; }
+
+        [JsonProperty(PropertyName = "federationMultisigPubKeys")]
+        public IEnumerable<string> FederationMultisigPubKeys { get; set; }
+
+        [JsonProperty(PropertyName = "miningPubKey", NullValueHandling = NullValueHandling.Ignore)]
+        public string MiningPublicKey { get; set; }
+
+        [JsonProperty(PropertyName = "federationMiningPubKeys", NullValueHandling = NullValueHandling.Ignore)]
+        public IEnumerable<string> FederationMiningPubKeys { get; set; }
+
+        [JsonProperty(PropertyName = "multisigAddress")]
+        public BitcoinAddress MultiSigAddress { get; set; }
+
+        [JsonProperty(PropertyName = "multisigRedeemScript")]
+        public string MultiSigRedeemScript { get; set; }
+
+        [JsonProperty(PropertyName = "minDepositConfirmations")]
+        public uint MinimumDepositConfirmations { get; set; }
+
+        [JsonProperty(PropertyName = "minCoinMaturity")]
+        public int MinCoinMaturity { get; set; }
+    }
+}

--- a/src/Stratis.Features.FederatedPeg/Models/MaturedBlockDepositsModel.cs
+++ b/src/Stratis.Features.FederatedPeg/Models/MaturedBlockDepositsModel.cs
@@ -1,0 +1,31 @@
+﻿using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using Newtonsoft.Json;
+using Stratis.Bitcoin.Features.Wallet.Models;
+using Stratis.Features.FederatedPeg.Interfaces;
+using Stratis.Features.FederatedPeg.SourceChain;
+
+namespace Stratis.Features.FederatedPeg.Models
+{
+    /// <summary>
+    /// When a block matures, an instance of this class is created and passed on to the target chain.
+    /// If there are no deposits, we still need to send an empty list with corresponding block (height
+    /// and hash) so that the target node knows that block has been seen and dealt with.
+    /// </summary>
+    public class MaturedBlockDepositsModel : RequestModel
+    {
+        public MaturedBlockDepositsModel(MaturedBlockInfoModel maturedBlockInfo, IReadOnlyList<IDeposit> deposits)
+        {
+            this.BlockInfo = maturedBlockInfo;
+            this.Deposits = deposits;
+        }
+
+        [Required(ErrorMessage = "A list of deposits is required")]
+        [JsonConverter(typeof(ConcreteConverter<List<Deposit>>))]
+        public IReadOnlyList<IDeposit> Deposits { get; set; }
+
+        [Required(ErrorMessage = "A block is required")]
+        [JsonConverter(typeof(ConcreteConverter<MaturedBlockInfoModel>))]
+        public IMaturedBlockInfo BlockInfo { get; set; }
+    }
+}

--- a/src/Stratis.Features.FederatedPeg/Models/MaturedBlockModel.cs
+++ b/src/Stratis.Features.FederatedPeg/Models/MaturedBlockModel.cs
@@ -1,0 +1,33 @@
+﻿using System.ComponentModel.DataAnnotations;
+using NBitcoin;
+using Newtonsoft.Json;
+using Stratis.Bitcoin.Features.Wallet.Models;
+using Stratis.Bitcoin.Utilities.JsonConverters;
+
+namespace Stratis.Features.FederatedPeg.Models
+{
+    public interface IMaturedBlockInfo
+    {
+        uint256 BlockHash { get; }
+
+        int BlockHeight { get; }
+
+        uint BlockTime { get; }
+    }
+
+    /// <summary>
+    /// An instance of this class represents a particular block hash and associated height on the source chain.
+    /// </summary>
+    public class MaturedBlockInfoModel : RequestModel, IMaturedBlockInfo
+    {
+        [Required(ErrorMessage = "A block hash is required")]
+        [JsonConverter(typeof(UInt256JsonConverter))]
+        public uint256 BlockHash { get; set; }
+
+        [Required(ErrorMessage = "A block height is required")]
+        public int BlockHeight { get; set; }
+
+        [Required(ErrorMessage = "A block time is required")]
+        public uint BlockTime { get; set; }
+    }
+}

--- a/src/Stratis.Features.FederatedPeg/Models/MaturedBlockRequestModel.cs
+++ b/src/Stratis.Features.FederatedPeg/Models/MaturedBlockRequestModel.cs
@@ -1,0 +1,29 @@
+﻿using System.ComponentModel.DataAnnotations;
+using Stratis.Bitcoin.Features.Wallet.Models;
+
+namespace Stratis.Features.FederatedPeg.Models
+{
+    public interface IMaturedBlocksRequestModel
+    {
+        int MaxBlocksToSend { get; set; }
+        int BlockHeight { get; set; }
+    }
+
+    /// <summary>
+    /// This is used when requesting blocks from chain A.
+    /// </summary>
+    public class MaturedBlockRequestModel : RequestModel, IMaturedBlocksRequestModel
+    {
+        public MaturedBlockRequestModel(int blockHeight, int maxBlocksToSend)
+        {
+            this.BlockHeight = blockHeight;
+            this.MaxBlocksToSend = maxBlocksToSend;
+        }
+
+        [Required(ErrorMessage = "The maximum number of blocks to fetch is required")]
+        public int MaxBlocksToSend { get; set; }
+
+        [Required(ErrorMessage = "The block height is required")]
+        public int BlockHeight { get; set; }
+    }
+}

--- a/src/Stratis.Features.FederatedPeg/Models/RequestModels.cs
+++ b/src/Stratis.Features.FederatedPeg/Models/RequestModels.cs
@@ -1,0 +1,44 @@
+﻿using System.ComponentModel.DataAnnotations;
+using System.Net.Http;
+using System.Text;
+using Newtonsoft.Json;
+using Stratis.Bitcoin.Features.Wallet.Models;
+
+namespace Stratis.Features.FederatedPeg.Models
+{
+    /// <summary>
+    /// Helper class to interpret a string as json.
+    /// </summary>
+    public class JsonContent : StringContent
+    {
+        public JsonContent(object obj) :
+            base(JsonConvert.SerializeObject(obj), Encoding.UTF8, "application/json")
+        {
+
+        }
+    }
+
+    /// <summary>
+    /// Model for the "enablefederation" request.
+    /// </summary>
+    public class EnableFederationRequest : RequestModel
+    {
+        public string Mnemonic { get; set; }
+
+        [Required(ErrorMessage = "A password is required.")]
+        public string Password { get; set; }
+
+        public string Passphrase { get; set; }
+    }
+
+    /// <summary>
+    /// Model object to use as input to the Api request for removing transactions from a wallet.
+    /// </summary>
+    /// <seealso cref="RequestModel" />
+    public class RemoveFederationTransactionsModel : RequestModel
+    {
+        [Required(ErrorMessage = "The reSync flag is required.")]
+        [JsonProperty(PropertyName = "reSync")]
+        public bool ReSync { get; set; }
+    }
+}

--- a/src/Stratis.Features.FederatedPeg/Models/WithdrawalModel.cs
+++ b/src/Stratis.Features.FederatedPeg/Models/WithdrawalModel.cs
@@ -1,0 +1,19 @@
+﻿using Newtonsoft.Json;
+using Stratis.Features.FederatedPeg.Interfaces;
+using Stratis.Features.FederatedPeg.TargetChain;
+
+namespace Stratis.Features.FederatedPeg.Models
+{
+    public class WithdrawalModel
+    {
+        [JsonConverter(typeof(ConcreteConverter<Withdrawal>))]
+        public IWithdrawal withdrawal { get; set; }
+
+        public string TransferStatus { get; set; }
+
+        public override string ToString()
+        {
+            return this.withdrawal.GetInfo() + " Status=" + this.TransferStatus;
+        }
+    }
+}

--- a/src/Stratis.Features.FederatedPeg/NetworkHelpers/IPEndPointComparer.cs
+++ b/src/Stratis.Features.FederatedPeg/NetworkHelpers/IPEndPointComparer.cs
@@ -1,0 +1,21 @@
+﻿using System.Collections.Generic;
+using System.Net;
+
+namespace Stratis.Features.FederatedPeg.NetworkHelpers
+{
+    public class IPAddressComparer : IEqualityComparer<IPAddress>
+    {
+        public bool Equals(IPAddress x, IPAddress y)
+        {
+            if (x == null)
+                return y == null;
+
+            return x.MapToIPv6().Equals(y.MapToIPv6());
+        }
+
+        public int GetHashCode(IPAddress endPoint)
+        {
+            return endPoint.MapToIPv6().GetHashCode();
+        }
+    }
+}

--- a/src/Stratis.Features.FederatedPeg/NetworkHelpers/NetworkExtensions.cs
+++ b/src/Stratis.Features.FederatedPeg/NetworkHelpers/NetworkExtensions.cs
@@ -1,0 +1,41 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using NBitcoin;
+using Stratis.Bitcoin.Networks;
+using Stratis.Sidechains.Networks;
+
+namespace Stratis.Features.FederatedPeg.NetworkHelpers
+{
+    public enum Chain
+    {
+        Mainchain,
+        Sidechain
+    }
+
+    /// <summary>
+    /// Network helper extensions for identifying a sidechain or mainchain network.
+    /// </summary>
+    public static class NetworkExtensions
+    {
+        public static readonly List<string> MainChainNames = new List<Network> {
+            new StratisMain(), new StratisTest(), new StratisRegTest(),
+            new BitcoinMain(), new BitcoinTest(), new BitcoinRegTest()
+        }.Select(n => n.Name.ToLower()).ToList();
+
+        public static Chain ToChain(this Network network)
+        {
+            return MainChainNames.Contains(network.Name.ToLower()) ? Chain.Mainchain : Chain.Sidechain;
+        }
+
+        public static Network ToCounterChainNetwork(this Network network)
+        {
+            if (network.Name.ToLower() == MainChainNames[0]) return FederatedPegNetwork.NetworksSelector.Mainnet();
+            if (network.Name.ToLower() == MainChainNames[1]) return FederatedPegNetwork.NetworksSelector.Testnet();
+            if (network.Name.ToLower() == MainChainNames[2]) return FederatedPegNetwork.NetworksSelector.Regtest();
+            if (network.Name.ToLower() == FederatedPegNetwork.NetworksSelector.Mainnet().Name.ToLower()) return new StratisMain();
+            if (network.Name.ToLower() == FederatedPegNetwork.NetworksSelector.Testnet().Name.ToLower()) return new StratisTest();
+            if (network.Name.ToLower() == FederatedPegNetwork.NetworksSelector.Regtest().Name.ToLower()) return new StratisRegTest();
+            throw new System.ArgumentException("Unknown network.");
+        }
+    }
+}

--- a/src/Stratis.Features.FederatedPeg/Notifications/BlockObserver.cs
+++ b/src/Stratis.Features.FederatedPeg/Notifications/BlockObserver.cs
@@ -1,0 +1,111 @@
+﻿using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using NBitcoin;
+using Stratis.Bitcoin.Primitives;
+using Stratis.Bitcoin.Signals;
+using Stratis.Bitcoin.Utilities;
+using Stratis.Features.FederatedPeg.Interfaces;
+using Stratis.Features.FederatedPeg.Models;
+using Stratis.Features.FederatedPeg.RestClients;
+using Stratis.Features.FederatedPeg.TargetChain;
+
+namespace Stratis.Features.FederatedPeg.Notifications
+{
+    /// <summary>
+    /// Observer that passes notifications indicating the arrival of new <see cref="Block"/>s
+    /// onto the CrossChainTransactionMonitor.
+    /// </summary>
+    public class BlockObserver
+    {
+        // The monitor we pass the new blocks onto.
+        private readonly IFederationWalletSyncManager walletSyncManager;
+
+        private readonly IFederationGatewayClient federationGatewayClient;
+
+        private readonly IDepositExtractor depositExtractor;
+
+        private readonly IWithdrawalExtractor withdrawalExtractor;
+
+        private readonly IWithdrawalReceiver withdrawalReceiver;
+
+        private readonly ISignals signals;
+
+        private CancellationTokenSource cancellationSource;
+
+        private Task pushBlockTipTask;
+
+        /// <summary>
+        /// Initialize the block observer with the wallet manager and the cross chain monitor.
+        /// </summary>
+        /// <param name="walletSyncManager">The wallet sync manager to pass new incoming blocks to.</param>
+        /// <param name="depositExtractor">The component used to extract the deposits from the blocks appearing on chain.</param>
+        /// <param name="withdrawalExtractor">The component used to extract withdrawals from blocks.</param>
+        /// <param name="withdrawalReceiver">The component that receives the withdrawals extracted from blocks.</param>
+        /// <param name="federationGatewayClient">Client for federation gateway api.</param>
+        public BlockObserver(IFederationWalletSyncManager walletSyncManager,
+                             IDepositExtractor depositExtractor,
+                             IWithdrawalExtractor withdrawalExtractor,
+                             IWithdrawalReceiver withdrawalReceiver,
+                             IFederationGatewayClient federationGatewayClient,
+                             ISignals signals)
+        {
+            Guard.NotNull(walletSyncManager, nameof(walletSyncManager));
+            Guard.NotNull(federationGatewayClient, nameof(federationGatewayClient));
+            Guard.NotNull(depositExtractor, nameof(depositExtractor));
+            Guard.NotNull(withdrawalExtractor, nameof(withdrawalExtractor));
+            Guard.NotNull(withdrawalReceiver, nameof(withdrawalReceiver));
+
+            this.walletSyncManager = walletSyncManager;
+            this.federationGatewayClient = federationGatewayClient;
+            this.depositExtractor = depositExtractor;
+            this.withdrawalExtractor = withdrawalExtractor;
+            this.withdrawalReceiver = withdrawalReceiver;
+            this.signals = signals;
+
+            this.cancellationSource = null;
+            this.pushBlockTipTask = null;
+
+            this.signals.OnBlockConnected.Attach(this.OnBlockReceived);
+
+            // TODO: Dispose with Detach ??
+        }
+
+        /// <summary>
+        /// When a block is received it is passed to the monitor.
+        /// </summary>
+        /// <param name="chainedHeaderBlock">The new block.</param>
+        public void OnBlockReceived(ChainedHeaderBlock chainedHeaderBlock)
+        {
+            this.walletSyncManager.ProcessBlock(chainedHeaderBlock.Block);
+
+            // Cancel previous sending to avoid first sending new tip and then sending older tip.
+            if ((this.pushBlockTipTask != null) && !this.pushBlockTipTask.IsCompleted)
+            {
+                this.cancellationSource.Cancel();
+                this.pushBlockTipTask.GetAwaiter().GetResult();
+
+                this.pushBlockTipTask = null;
+                this.cancellationSource = null;
+            }
+
+            var blockTipModel = new BlockTipModel(chainedHeaderBlock.ChainedHeader.HashBlock,chainedHeaderBlock.ChainedHeader.Height, (int)this.depositExtractor.MinimumDepositConfirmations);
+
+            // There is no reason to wait for the message to be sent.
+            // Awaiting REST API call will only slow this callback.
+            // Callbacks never supposed to do any IO calls or web requests.
+            // Instead we start sending the message and if next block was connected faster than the message was sent we
+            // are canceling it and sending the next tip.
+            // Receiver of this message doesn't care if we are not providing tips for every block we connect,
+            // it just requires to know about out latest state.
+            this.cancellationSource = new CancellationTokenSource();
+            this.pushBlockTipTask = Task.Run(async () => await this.federationGatewayClient.PushCurrentBlockTipAsync(blockTipModel, this.cancellationSource.Token).ConfigureAwait(false));
+
+            IReadOnlyList<IWithdrawal> withdrawals = this.withdrawalExtractor.ExtractWithdrawalsFromBlock(
+                chainedHeaderBlock.Block,
+                chainedHeaderBlock.ChainedHeader.Height);
+
+            this.withdrawalReceiver.ReceiveWithdrawals(withdrawals);
+        }
+    }
+}

--- a/src/Stratis.Features.FederatedPeg/Notifications/TransactionObserver.cs
+++ b/src/Stratis.Features.FederatedPeg/Notifications/TransactionObserver.cs
@@ -1,0 +1,33 @@
+﻿using NBitcoin;
+using Stratis.Bitcoin.Signals;
+using Stratis.Features.FederatedPeg.Interfaces;
+
+namespace Stratis.Features.FederatedPeg.Notifications
+{
+    /// <summary>
+    /// Observer that receives notifications about the arrival of new <see cref="Transaction"/>s.
+    /// </summary>
+    public class TransactionObserver
+    {
+        private readonly IFederationWalletSyncManager walletSyncManager;
+        private readonly ISignals signals;
+
+        public TransactionObserver(IFederationWalletSyncManager walletSyncManager, ISignals signals)
+        {
+            this.walletSyncManager = walletSyncManager;
+            this.signals = signals;
+            this.signals.OnTransactionReceived.Attach(this.OnReceivingTransaction);
+
+            // TODO: Dispose with Detach ??
+        }
+
+        /// <summary>
+        /// Manages what happens when a new transaction is received.
+        /// </summary>
+        /// <param name="transaction">The new transaction</param>
+        private void OnReceivingTransaction(Transaction transaction)
+        {
+            this.walletSyncManager.ProcessTransaction(transaction);
+        }
+    }
+}

--- a/src/Stratis.Features.FederatedPeg/OpReturnDataReader.cs
+++ b/src/Stratis.Features.FederatedPeg/OpReturnDataReader.cs
@@ -1,0 +1,142 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Microsoft.Extensions.Logging;
+using NBitcoin;
+using Stratis.Features.FederatedPeg.NetworkHelpers;
+
+namespace Stratis.Features.FederatedPeg
+{
+    /// <summary>
+    /// OP_RETURN data can be a hash, an address or unknown.
+    /// This class interprets the data.
+    /// Addresses are contained in the source transactions on the monitor chain whereas
+    /// hashes are contained in the destination transaction on the counter chain and
+    /// are used to pair transactions together.
+    /// </summary>
+    public interface IOpReturnDataReader
+    {
+        /// <summary>
+        /// Tries to find a single OP_RETURN output that can be interpreted as an address.
+        /// </summary>
+        /// <param name="transaction">The transaction we are examining.</param>
+        /// <param name="address">The address as a string, or null if nothing is found, or if multiple addresses are found.</param>
+        /// <returns><c>true</c> if address was extracted; <c>false</c> otherwise.</returns>
+        bool TryGetTargetAddress(Transaction transaction, out string address);
+
+        /// <summary>
+        /// Tries to find a single OP_RETURN output that can be interpreted as a transaction id.
+        /// </summary>
+        /// <param name="transaction">The transaction we are examining.</param>
+        /// <param name="txId">The transaction id as a string, or null if nothing is found, or if multiple ids are found.</param>
+        /// <returns><c>true</c> if transaction id was extracted; <c>false</c> otherwise.</returns>
+        bool TryGetTransactionId(Transaction transaction, out string txId);
+    }
+
+    public class OpReturnDataReader : IOpReturnDataReader
+    {
+        private readonly ILogger logger;
+
+        private readonly Network network;
+
+        public OpReturnDataReader(ILoggerFactory loggerFactory, Network network)
+        {
+            this.logger = loggerFactory.CreateLogger(this.GetType().FullName);
+            this.network = network;
+        }
+
+        /// <inheritdoc />
+        public bool TryGetTargetAddress(Transaction transaction, out string address)
+        {
+            List<string> opReturnAddresses = SelectBytesContentFromOpReturn(transaction)
+                .Select(this.TryConvertValidOpReturnDataToAddress)
+                .Where(s => s != null)
+                .Distinct(StringComparer.InvariantCultureIgnoreCase).ToList();
+
+            this.logger.LogDebug("Address(es) found in OP_RETURN(s) of transaction {0}: [{1}]",
+                transaction.GetHash(), string.Join(",", opReturnAddresses));
+
+            if (opReturnAddresses.Count != 1)
+            {
+                address = null;
+                return false;
+            }
+
+            address = opReturnAddresses[0];
+            return true;
+        }
+
+        /// <inheritdoc />
+        public bool TryGetTransactionId(Transaction transaction, out string txId)
+        {
+            List<string> transactionId = SelectBytesContentFromOpReturn(transaction)
+                .Select(this.TryConvertValidOpReturnDataToHash)
+                .Where(s => s != null)
+                .Distinct(StringComparer.InvariantCultureIgnoreCase).ToList();
+
+            this.logger.LogDebug("Transaction Id(s) found in OP_RETURN(s) of transaction {0}: [{1}]",
+                transaction.GetHash(), string.Join(",", transactionId));
+
+            if (transactionId.Count != 1)
+            {
+                txId = null;
+                return false;
+            }
+
+            txId = transactionId[0];
+            return true;
+        }
+
+        private static IEnumerable<byte[]> SelectBytesContentFromOpReturn(Transaction transaction)
+        {
+            return transaction.Outputs
+                .Select(o => o.ScriptPubKey)
+                .Where(s => s.IsUnspendable)
+                .Select(s => s.ToBytes())
+                .Select(RemoveOpReturnOperator);
+        }
+
+        // Converts the raw bytes from the output into a BitcoinAddress.
+        // The address is parsed using the target network bytes and returns null if validation fails.
+        private string TryConvertValidOpReturnDataToAddress(byte[] data)
+        {
+            // Remove the RETURN operator and convert the remaining bytes to our candidate address.
+            string destination = Encoding.UTF8.GetString(data);
+
+            // Attempt to parse the string. Validates the base58 string.
+            try
+            {
+                var bitcoinAddress = this.network.ToCounterChainNetwork().Parse<BitcoinAddress>(destination);
+                this.logger.LogTrace($"ConvertValidOpReturnDataToAddress received {destination} and network.Parse received {bitcoinAddress}.");
+                return destination;
+            }
+            catch (Exception ex)
+            {
+                this.logger.LogTrace($"Address {destination} could not be converted to a valid address. Reason {ex.Message}.");
+                return null;
+            }
+        }
+
+        private string TryConvertValidOpReturnDataToHash(byte[] data)
+        {
+            // Attempt to parse the hash. Validates the uint256 string.
+            try
+            {
+                var hash256 = new uint256(data);
+                this.logger.LogTrace($"ConvertValidOpReturnDataToHash received {hash256}.");
+                return hash256.ToString();
+            }
+            catch (Exception ex)
+            {
+                this.logger.LogTrace($"Candidate hash {data} could not be converted to a valid uint256. Reason {ex.Message}.");
+                return null;
+            }
+        }
+
+        private static byte[] RemoveOpReturnOperator(byte[] rawBytes)
+        {
+            return rawBytes.Skip(2).ToArray();
+        }
+    }
+}

--- a/src/Stratis.Features.FederatedPeg/PartialTransactionsBehavior.cs
+++ b/src/Stratis.Features.FederatedPeg/PartialTransactionsBehavior.cs
@@ -1,0 +1,128 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using NBitcoin;
+using Stratis.Bitcoin.P2P.Peer;
+using Stratis.Bitcoin.P2P.Protocol;
+using Stratis.Bitcoin.P2P.Protocol.Behaviors;
+using Stratis.Bitcoin.Utilities;
+using Stratis.Features.FederatedPeg.Interfaces;
+using Stratis.Features.FederatedPeg.NetworkHelpers;
+using Stratis.Features.FederatedPeg.Payloads;
+
+namespace Stratis.Features.FederatedPeg
+{
+    public class PartialTransactionsBehavior : NetworkPeerBehavior
+    {
+        private readonly ILoggerFactory loggerFactory;
+
+        private readonly ILogger logger;
+
+        private readonly IFederationWalletManager federationWalletManager;
+
+        private readonly Network network;
+
+        private readonly IFederationGatewaySettings federationGatewaySettings;
+
+        private readonly IPAddressComparer ipAddressComparer;
+
+        private readonly ICrossChainTransferStore crossChainTransferStore;
+
+        public PartialTransactionsBehavior(
+            ILoggerFactory loggerFactory,
+            IFederationWalletManager federationWalletManager,
+            Network network,
+            IFederationGatewaySettings federationGatewaySettings,
+            ICrossChainTransferStore crossChainTransferStore)
+        {
+            Guard.NotNull(loggerFactory, nameof(loggerFactory));
+            Guard.NotNull(federationWalletManager, nameof(federationWalletManager));
+            Guard.NotNull(network, nameof(network));
+            Guard.NotNull(federationGatewaySettings, nameof(federationGatewaySettings));
+            Guard.NotNull(crossChainTransferStore, nameof(crossChainTransferStore));
+
+            this.logger = loggerFactory.CreateLogger(this.GetType().FullName);
+            this.loggerFactory = loggerFactory;
+            this.federationWalletManager = federationWalletManager;
+            this.network = network;
+            this.federationGatewaySettings = federationGatewaySettings;
+            this.crossChainTransferStore = crossChainTransferStore;
+            this.ipAddressComparer = new IPAddressComparer();
+        }
+
+        public override object Clone()
+        {
+            return new PartialTransactionsBehavior(this.loggerFactory, this.federationWalletManager, this.network,
+                this.federationGatewaySettings, this.crossChainTransferStore);
+        }
+
+        protected override void AttachCore()
+        {
+            if (this.federationGatewaySettings.FederationNodeIpEndPoints.Any(e => this.ipAddressComparer.Equals(e.Address, this.AttachedPeer.PeerEndPoint.Address)))
+                this.AttachedPeer.MessageReceived.Register(this.OnMessageReceivedAsync, true);
+        }
+
+        protected override void DetachCore()
+        {
+            if (this.federationGatewaySettings.FederationNodeIpEndPoints.Any(e => this.ipAddressComparer.Equals(e.Address, this.AttachedPeer.PeerEndPoint.Address)))
+                this.AttachedPeer.MessageReceived.Unregister(this.OnMessageReceivedAsync);
+        }
+
+        /// <summary>
+        /// Broadcast the partial transaction request to federation members.
+        /// </summary>
+        /// <param name="payload">The payload to broadcast.</param>
+        private async Task BroadcastAsync(RequestPartialTransactionPayload payload)
+        {
+            if (this.federationGatewaySettings.FederationNodeIpEndPoints.Any(e => this.ipAddressComparer.Equals(e.Address, this.AttachedPeer.PeerEndPoint.Address)))
+                await this.AttachedPeer.SendMessageAsync(payload).ConfigureAwait(false);
+        }
+
+        private Transaction GetTemplateTransaction(Transaction partialTransaction)
+        {
+            Transaction templateTransaction = this.network.CreateTransaction(partialTransaction.ToBytes(this.network.Consensus.ConsensusFactory));
+
+            foreach (TxIn input in templateTransaction.Inputs)
+                input.ScriptSig = new Script();
+
+            return templateTransaction;
+        }
+
+        private async Task OnMessageReceivedAsync(INetworkPeer peer, IncomingMessage message)
+        {
+            var payload = message.Message.Payload as RequestPartialTransactionPayload;
+
+            if (payload == null)
+                return;
+
+            // Get the template from the payload.
+            Transaction template = this.GetTemplateTransaction(payload.PartialTransaction);
+
+            ICrossChainTransfer[] transfer = await this.crossChainTransferStore.GetAsync(new[] { payload.DepositId });
+
+            if (transfer[0] == null)
+            {
+                this.logger.LogTrace("OnMessageReceivedAsync: Transaction {0} does not exist.", template);
+                return;
+            }
+
+            if (transfer[0].Status != CrossChainTransferStatus.Partial)
+            {
+                this.logger.LogTrace("OnMessageReceivedAsync: Transaction {0} is {1}.", template, transfer[0].Status);
+                return;
+            }
+
+            uint256 oldHash = transfer[0].PartialTransaction.GetHash();
+
+            Transaction signedTransaction = await this.crossChainTransferStore.MergeTransactionSignaturesAsync(payload.DepositId, new[] { payload.PartialTransaction }).ConfigureAwait(false);
+
+            if (oldHash != signedTransaction.GetHash())
+            {
+                this.logger.LogInformation("Signed transaction (deposit={1}) to produce {2} from {3}.", payload.DepositId, oldHash, signedTransaction.GetHash());
+
+                // Respond back to the peer that requested a signature.
+                await this.BroadcastAsync(payload.AddPartial(signedTransaction));
+            }
+        }
+    }
+}

--- a/src/Stratis.Features.FederatedPeg/Payloads/RequestPartialTransactionPayload.cs
+++ b/src/Stratis.Features.FederatedPeg/Payloads/RequestPartialTransactionPayload.cs
@@ -1,0 +1,44 @@
+﻿using NBitcoin;
+using Stratis.Bitcoin.P2P.Protocol.Payloads;
+
+namespace Stratis.Features.FederatedPeg.Payloads
+{
+    [Payload("partial")]
+    public class RequestPartialTransactionPayload : Payload
+    {
+        private Transaction transactionPartial;
+        private uint256 depositId;
+
+        public Transaction PartialTransaction => this.transactionPartial;
+
+        public uint256 DepositId => this.depositId;
+
+        /// <remarks>Needed for deserialization.</remarks>
+        public RequestPartialTransactionPayload()
+        {
+        }
+
+        public RequestPartialTransactionPayload(uint256 depositId)
+        {
+            this.depositId = depositId;
+        }
+
+        public RequestPartialTransactionPayload AddPartial(Transaction partialTransaction)
+        {
+            this.transactionPartial = partialTransaction;
+
+            return this;
+        }
+
+        public override void ReadWriteCore(BitcoinStream stream)
+        {
+            stream.ReadWrite(ref this.depositId);
+            stream.ReadWrite(ref this.transactionPartial);
+        }
+
+        public override string ToString()
+        {
+            return $"{nameof(this.Command)}:'{this.Command}',{nameof(this.DepositId)}:'{this.DepositId}'";
+        }
+    }
+}

--- a/src/Stratis.Features.FederatedPeg/RestClients/FederationGatewayClient.cs
+++ b/src/Stratis.Features.FederatedPeg/RestClients/FederationGatewayClient.cs
@@ -1,0 +1,42 @@
+﻿using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Stratis.Features.FederatedPeg.Controllers;
+using Stratis.Features.FederatedPeg.Interfaces;
+using Stratis.Features.FederatedPeg.Models;
+
+namespace Stratis.Features.FederatedPeg.RestClients
+{
+    /// <summary>Rest client for <see cref="FederationGatewayController"/>.</summary>
+    public interface IFederationGatewayClient
+    {
+        /// <summary><see cref="FederationGatewayController.PushCurrentBlockTip"/></summary>
+        Task<HttpResponseMessage> PushCurrentBlockTipAsync(BlockTipModel model, CancellationToken cancellation = default(CancellationToken));
+
+        /// <summary><see cref="FederationGatewayController.GetMaturedBlockDepositsAsync"/></summary>
+        Task<List<MaturedBlockDepositsModel>> GetMaturedBlockDepositsAsync(MaturedBlockRequestModel model, CancellationToken cancellation = default(CancellationToken));
+    }
+
+    /// <inheritdoc cref="IFederationGatewayClient"/>
+    public class FederationGatewayClient : RestApiClientBase, IFederationGatewayClient
+    {
+        public FederationGatewayClient(ILoggerFactory loggerFactory, IFederationGatewaySettings settings, IHttpClientFactory httpClientFactory)
+            : base(loggerFactory, settings, httpClientFactory)
+        {
+        }
+
+        /// <inheritdoc />
+        public Task<HttpResponseMessage> PushCurrentBlockTipAsync(BlockTipModel model, CancellationToken cancellation = default(CancellationToken))
+        {
+            return this.SendPostRequestAsync(model, FederationGatewayRouteEndPoint.PushCurrentBlockTip, cancellation);
+        }
+
+        /// <inheritdoc />
+        public Task<List<MaturedBlockDepositsModel>> GetMaturedBlockDepositsAsync(MaturedBlockRequestModel model, CancellationToken cancellation = default(CancellationToken))
+        {
+            return this.SendPostRequestAsync<MaturedBlockRequestModel, List<MaturedBlockDepositsModel>>(model, FederationGatewayRouteEndPoint.GetMaturedBlockDeposits, cancellation);
+        }
+    }
+}

--- a/src/Stratis.Features.FederatedPeg/RestClients/RestApiClientBase.cs
+++ b/src/Stratis.Features.FederatedPeg/RestClients/RestApiClientBase.cs
@@ -1,0 +1,126 @@
+﻿using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+using Polly;
+using Polly.Retry;
+using Stratis.Features.FederatedPeg.Interfaces;
+using Stratis.Features.FederatedPeg.Models;
+
+namespace Stratis.Features.FederatedPeg.RestClients
+{
+    /// <summary>Client for making API calls for methods provided by controllers.</summary>
+    public abstract class RestApiClientBase
+    {
+        private readonly IHttpClientFactory httpClientFactory;
+
+        private readonly ILogger logger;
+
+        /// <summary>URL of API endpoint.</summary>
+        private readonly string endpointUrl;
+
+        public const int RetryCount = 3;
+
+        /// <summary>Delay between retries.</summary>
+        private const int AttemptDelayMs = 1000;
+
+        public const int TimeoutMs = 60_000;
+
+        private readonly RetryPolicy policy;
+
+        public RestApiClientBase(ILoggerFactory loggerFactory, IFederationGatewaySettings settings, IHttpClientFactory httpClientFactory)
+        {
+            this.httpClientFactory = httpClientFactory;
+            this.logger = loggerFactory.CreateLogger(this.GetType().FullName);
+
+            this.endpointUrl = $"http://localhost:{settings.CounterChainApiPort}/api/FederationGateway";
+
+            this.policy = Policy.Handle<HttpRequestException>().WaitAndRetryAsync(retryCount: RetryCount, sleepDurationProvider:
+                attemptNumber =>
+                {
+                    // Intervals between new attempts are growing.
+                    int delayMs = AttemptDelayMs;
+
+                    if (attemptNumber > 1)
+                        delayMs *= attemptNumber;
+
+                    return TimeSpan.FromMilliseconds(delayMs);
+                }, onRetry: OnRetry);
+        }
+
+        protected async Task<HttpResponseMessage> SendPostRequestAsync<Model>(Model requestModel, string apiMethodName, CancellationToken cancellation) where Model : class
+        {
+            if (requestModel == null)
+                throw new ArgumentException($"{nameof(requestModel)} can't be null.");
+
+            var publicationUri = new Uri($"{this.endpointUrl}/{apiMethodName}");
+
+            HttpResponseMessage response = null;
+
+            using (HttpClient client = this.httpClientFactory.CreateClient())
+            {
+                client.Timeout = TimeSpan.FromMilliseconds(TimeoutMs);
+
+                var request = new JsonContent(requestModel);
+
+                try
+                {
+                    // Retry the following call according to the policy.
+                    await this.policy.ExecuteAsync(async token =>
+                    {
+                        this.logger.LogDebug("Sending request of type '{0}' to Uri '{1}'.",
+                            requestModel.GetType().FullName, publicationUri);
+
+                        response = await client.PostAsync(publicationUri, request, cancellation).ConfigureAwait(false);
+                        this.logger.LogDebug("Response received: {0}", response);
+
+                    }, cancellation);
+                }
+                catch (OperationCanceledException)
+                {
+                    this.logger.LogDebug("Operation canceled.");
+                    this.logger.LogTrace("(-)[CANCELLED]:null");
+                    return null;
+                }
+                catch (HttpRequestException ex)
+                {
+                    this.logger.LogError("The counter-chain daemon is not ready to receive API calls at this time ({0})", publicationUri);
+                    this.logger.LogError("Failed to send a message. Exception: '{0}'.", ex);
+                    return new HttpResponseMessage() { ReasonPhrase = ex.Message, StatusCode = HttpStatusCode.InternalServerError };
+                }
+            }
+
+            this.logger.LogTrace("(-)[SUCCESS]");
+            return response;
+        }
+
+        protected async Task<Response> SendPostRequestAsync<Model, Response>(Model requestModel, string apiMethodName, CancellationToken cancellation) where Response : class where Model : class
+        {
+            HttpResponseMessage response = await this.SendPostRequestAsync(requestModel, apiMethodName, cancellation).ConfigureAwait(false);
+
+            // Parse response.
+            if ((response != null) && response.IsSuccessStatusCode && (response.Content != null))
+            {
+                string successJson = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                if (successJson != null)
+                {
+                    Response responseModel = JsonConvert.DeserializeObject<Response>(successJson);
+
+                    this.logger.LogTrace("(-)[SUCCESS]");
+                    return responseModel;
+                }
+            }
+
+            this.logger.LogTrace("(-)[NO_CONTENT]:null");
+            return null;
+        }
+
+        protected virtual void OnRetry(Exception exception, TimeSpan delay)
+        {
+            this.logger.LogDebug("Exception while calling API method: {0}.", exception.ToString());
+        }
+    }
+}

--- a/src/Stratis.Features.FederatedPeg/SourceChain/Deposit.cs
+++ b/src/Stratis.Features.FederatedPeg/SourceChain/Deposit.cs
@@ -1,0 +1,39 @@
+﻿using NBitcoin;
+using Newtonsoft.Json;
+using Stratis.Features.FederatedPeg.Interfaces;
+
+namespace Stratis.Features.FederatedPeg.SourceChain
+{
+    public class Deposit : IDeposit
+    {
+        public Deposit(uint256 id, Money amount, string targetAddress, int blockNumber, uint256 blockHash)
+        {
+            this.Id = id;
+            this.Amount = amount;
+            this.TargetAddress = targetAddress;
+            this.BlockNumber = blockNumber;
+            this.BlockHash = blockHash;
+        }
+
+        /// <inheritdoc />
+        public uint256 Id { get; }
+
+        /// <inheritdoc />
+        public Money Amount { get; }
+
+        /// <inheritdoc />
+        public string TargetAddress { get; }
+
+        /// <inheritdoc />
+        public int BlockNumber { get; }
+
+        /// <inheritdoc />
+        public uint256 BlockHash { get; }
+
+        /// <inheritdoc />
+        public override string ToString()
+        {
+            return JsonConvert.SerializeObject(this, Formatting.Indented);
+        }
+    }
+}

--- a/src/Stratis.Features.FederatedPeg/SourceChain/DepositExtractor.cs
+++ b/src/Stratis.Features.FederatedPeg/SourceChain/DepositExtractor.cs
@@ -1,0 +1,94 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Extensions.Logging;
+using NBitcoin;
+using Stratis.Bitcoin;
+using Stratis.Bitcoin.Primitives;
+using Stratis.Features.FederatedPeg.Interfaces;
+using Stratis.Features.FederatedPeg.Models;
+
+namespace Stratis.Features.FederatedPeg.SourceChain
+{
+    public class DepositExtractor : IDepositExtractor
+    {
+        private readonly IOpReturnDataReader opReturnDataReader;
+
+        private readonly ILogger logger;
+
+        private readonly Script depositScript;
+
+        public uint MinimumDepositConfirmations { get; private set; }
+
+        public DepositExtractor(
+            ILoggerFactory loggerFactory,
+            IFederationGatewaySettings federationGatewaySettings,
+            IOpReturnDataReader opReturnDataReader,
+            IFullNode fullNode)
+        {
+            this.logger = loggerFactory.CreateLogger(this.GetType().FullName);
+            // Note: MultiSigRedeemScript.PaymentScript equals MultiSigAddress.ScriptPubKey
+            this.depositScript =
+                federationGatewaySettings?.MultiSigRedeemScript?.PaymentScript ??
+                federationGatewaySettings?.MultiSigAddress?.ScriptPubKey;
+            this.opReturnDataReader = opReturnDataReader;
+            this.MinimumDepositConfirmations = federationGatewaySettings.MinimumDepositConfirmations;
+        }
+
+        /// <inheritdoc />
+        public IReadOnlyList<IDeposit> ExtractDepositsFromBlock(Block block, int blockHeight)
+        {
+            var deposits = new List<IDeposit>();
+            uint256 blockHash = block.GetHash();
+
+            foreach (Transaction transaction in block.Transactions)
+            {
+                IDeposit deposit = this.ExtractDepositFromTransaction(transaction, blockHeight, blockHash);
+                if (deposit != null)
+                {
+                    deposits.Add(deposit);
+                }
+            }
+
+            return deposits.AsReadOnly();
+        }
+
+        /// <inheritdoc />
+        public IDeposit ExtractDepositFromTransaction(Transaction transaction, int blockHeight, uint256 blockHash)
+        {
+            List<TxOut> depositsToMultisig = transaction.Outputs.Where(output =>
+                output.ScriptPubKey == this.depositScript
+                && !output.IsDust(FeeRate.Zero)).ToList();
+
+            if (!depositsToMultisig.Any())
+                return null;
+
+            if (!this.opReturnDataReader.TryGetTargetAddress(transaction, out string targetAddress))
+                return null;
+
+            this.logger.LogInformation("Processing a received deposit transaction with address: {0}. Transaction hash: {1}.",
+                targetAddress, transaction.GetHash());
+
+            return new Deposit(transaction.GetHash(), depositsToMultisig.Sum(o => o.Value), targetAddress, blockHeight, blockHash);
+        }
+
+        public MaturedBlockDepositsModel ExtractBlockDeposits(ChainedHeaderBlock newlyMaturedBlock)
+        {
+            if (newlyMaturedBlock == null)
+                return null;
+
+            var maturedBlock = new MaturedBlockInfoModel()
+            {
+                BlockHash = newlyMaturedBlock.ChainedHeader.HashBlock,
+                BlockHeight = newlyMaturedBlock.ChainedHeader.Height,
+                BlockTime = newlyMaturedBlock.ChainedHeader.Header.Time
+            };
+
+            IReadOnlyList<IDeposit> deposits =
+                this.ExtractDepositsFromBlock(newlyMaturedBlock.Block, newlyMaturedBlock.ChainedHeader.Height);
+
+            var maturedBlockDeposits = new MaturedBlockDepositsModel(maturedBlock, deposits);
+
+            return maturedBlockDeposits;
+        }
+    }
+}

--- a/src/Stratis.Features.FederatedPeg/SourceChain/MaturedBlocksProvider.cs
+++ b/src/Stratis.Features.FederatedPeg/SourceChain/MaturedBlocksProvider.cs
@@ -1,0 +1,84 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using NBitcoin;
+using Stratis.Bitcoin.Consensus;
+using Stratis.Bitcoin.Primitives;
+using Stratis.Features.FederatedPeg.Interfaces;
+using Stratis.Features.FederatedPeg.Models;
+using Stratis.Features.FederatedPeg.RestClients;
+
+namespace Stratis.Features.FederatedPeg.SourceChain
+{
+    public interface IMaturedBlocksProvider
+    {
+        /// <summary>
+        /// Retrieves deposits for the indicated blocks from the block repository and throws an error if the blocks are not mature enough.
+        /// </summary>
+        /// <param name="blockHeight">The block height at which to start retrieving blocks.</param>
+        /// <param name="maxBlocks">The number of blocks to retrieve.</param>
+        /// <returns>A list of mature block deposits.</returns>
+        /// <exception cref="InvalidOperationException">Thrown if the blocks are not mature or not found.</exception>
+        Task<List<MaturedBlockDepositsModel>> GetMaturedDepositsAsync(int blockHeight, int maxBlocks);
+    }
+
+    public class MaturedBlocksProvider : IMaturedBlocksProvider
+    {
+        private readonly IDepositExtractor depositExtractor;
+
+        private readonly IConsensusManager consensusManager;
+
+        private readonly ILogger logger;
+
+        public MaturedBlocksProvider(ILoggerFactory loggerFactory, IDepositExtractor depositExtractor, IConsensusManager consensusManager)
+        {
+            this.depositExtractor = depositExtractor;
+            this.consensusManager = consensusManager;
+
+            this.logger = loggerFactory.CreateLogger(this.GetType().FullName);
+        }
+
+        /// <inheritdoc />
+        public async Task<List<MaturedBlockDepositsModel>> GetMaturedDepositsAsync(int blockHeight, int maxBlocks)
+        {
+            ChainedHeader consensusTip = this.consensusManager.Tip;
+
+            int matureTipHeight = (consensusTip.Height - (int)this.depositExtractor.MinimumDepositConfirmations);
+
+            if (blockHeight > matureTipHeight)
+            {
+                throw new InvalidOperationException($"Block height {blockHeight} submitted is not mature enough. Blocks less than a height of {matureTipHeight} can be processed.");
+            }
+
+            var maturedBlocks = new List<MaturedBlockDepositsModel>();
+
+            // Half of the timeout. We will also need time to convert it to json.
+            int maxTimeCollectionCanTakeMs = RestApiClientBase.TimeoutMs / 2;
+            var cancellation = new CancellationTokenSource(maxTimeCollectionCanTakeMs);
+
+            for (int i = blockHeight; (i <= matureTipHeight) && (i < blockHeight + maxBlocks); i++)
+            {
+                ChainedHeader currentHeader = consensusTip.GetAncestor(i);
+
+                ChainedHeaderBlock block = await this.consensusManager.GetBlockDataAsync(currentHeader.HashBlock).ConfigureAwait(false);
+
+                MaturedBlockDepositsModel maturedBlockDeposits = this.depositExtractor.ExtractBlockDeposits(block);
+
+                if (maturedBlockDeposits == null)
+                    throw new InvalidOperationException($"Unable to get deposits for block at height {currentHeader.Height}");
+
+                maturedBlocks.Add(maturedBlockDeposits);
+
+                if (cancellation.IsCancellationRequested && maturedBlocks.Count > 0)
+                {
+                    this.logger.LogDebug("Stop matured blocks collection because it's taking too long. Send what we've collected.");
+                    break;
+                }
+            }
+
+            return maturedBlocks;
+        }
+    }
+}

--- a/src/Stratis.Features.FederatedPeg/Stratis.Features.FederatedPeg.csproj
+++ b/src/Stratis.Features.FederatedPeg/Stratis.Features.FederatedPeg.csproj
@@ -1,0 +1,36 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup Label="Globals">
+    <SccProjectName>SAK</SccProjectName>
+    <SccProvider>SAK</SccProvider>
+    <SccAuxPath>SAK</SccAuxPath>
+    <SccLocalPath>SAK</SccLocalPath>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <DebugType>Full</DebugType>
+    <CodeAnalysisRuleSet>..\None.ruleset</CodeAnalysisRuleSet>
+    <AssemblyName>Stratis.Features.FederatedPeg</AssemblyName>
+    <RootNamespace>Stratis.Features.FederatedPeg</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.1.3" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="2.1.1" />
+    <PackageReference Include="Polly" Version="6.1.2" />
+    <PackageReference Include="Stratis.FodyNlogAdapter" Version="3.0.0.4-beta" />
+    <PackageReference Include="Tracer.Fody" Version="2.2.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Stratis.Bitcoin.Features.Api\Stratis.Bitcoin.Features.Api.csproj" />
+    <ProjectReference Include="..\Stratis.Bitcoin.Features.Notifications\Stratis.Bitcoin.Features.Notifications.csproj" />
+    <ProjectReference Include="..\Stratis.Bitcoin.Features.SmartContracts\Stratis.Bitcoin.Features.SmartContracts.csproj" />
+    <ProjectReference Include="..\Stratis.Sidechains.Networks\Stratis.Sidechains.Networks.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Stratis.Features.FederatedPeg/TargetChain/CrossChainTransfer.cs
+++ b/src/Stratis.Features.FederatedPeg/TargetChain/CrossChainTransfer.cs
@@ -1,0 +1,237 @@
+﻿using System.Linq;
+using NBitcoin;
+using Stratis.Bitcoin.Utilities;
+using Stratis.Features.FederatedPeg.Interfaces;
+
+namespace Stratis.Features.FederatedPeg.TargetChain
+{
+    /// <summary>
+    /// Tracks the status of the cross-chain transfer.
+    /// </summary>
+    public class CrossChainTransfer : ICrossChainTransfer
+    {
+        /// <inheritdoc />
+        public uint256 DepositTransactionId => this.depositTransactionId;
+        private uint256 depositTransactionId;
+
+        /// <inheritdoc />
+        public Script DepositTargetAddress => this.depositTargetAddress;
+        private Script depositTargetAddress;
+
+        /// <inheritdoc />
+        public long DepositAmount => this.depositAmount;
+        private long depositAmount;
+
+        /// <inheritdoc />
+        public int? DepositHeight => this.depositHeight;
+        private int? depositHeight;
+
+        /// <inheritdoc />
+        public Transaction PartialTransaction => this.partialTransaction;
+        private Transaction partialTransaction;
+
+        /// <inheritdoc />
+        public uint256 BlockHash => this.blockHash;
+        private uint256 blockHash;
+
+        /// <inheritdoc />
+        public int? BlockHeight => this.blockHeight;
+        private int? blockHeight;
+
+        /// <inheritdoc />
+        public CrossChainTransferStatus Status => this.status;
+        private CrossChainTransferStatus status;
+
+        /// <summary>
+        /// Parameter-less constructor for (de)serialization.
+        /// </summary>
+        public CrossChainTransfer()
+        {
+        }
+
+        /// <summary>
+        /// Constructs this object from passed parameters.
+        /// </summary>
+        /// <param name="status">The status of the cross chain transfer transaction.</param>
+        /// <param name="depositTransactionId">The transaction id of the deposit transaction.</param>
+        /// <param name="depositTargetAddress">The target address of the deposit transaction.</param>
+        /// <param name="depositAmount">The amount (in satoshis) of the deposit transaction.</param>
+        /// <param name="depositHeight">The chain A height at which the deposit was made (if known).</param>
+        /// <param name="partialTransaction">The unsigned partial transaction containing a full set of available UTXO's.</param>
+        /// <param name="blockHash">The hash of the block where the transaction resides.</param>
+        /// <param name="blockHeight">The height (in our chain) of the block where the transaction resides.</param>
+        public CrossChainTransfer(CrossChainTransferStatus status, uint256 depositTransactionId, Script depositTargetAddress, Money depositAmount,
+            int? depositHeight, Transaction partialTransaction, uint256 blockHash = null, int? blockHeight = null)
+        {
+            this.status = status;
+            this.depositTransactionId = depositTransactionId;
+            this.depositTargetAddress = depositTargetAddress;
+            this.depositAmount = depositAmount;
+            this.depositHeight = depositHeight;
+            this.partialTransaction = partialTransaction;
+            this.blockHash = blockHash;
+            this.blockHeight = blockHeight;
+
+            Guard.Assert(this.IsValid());
+        }
+
+        /// <summary>
+        /// (De)serializes this object.
+        /// </summary>
+        /// <param name="stream">Stream to use for (de)serialization.</param>
+        public void ReadWrite(BitcoinStream stream)
+        {
+            if (stream.Serializing)
+            {
+                Guard.Assert(this.IsValid());
+            }
+
+            byte status = (byte)this.status;
+            stream.ReadWrite(ref status);
+            this.status = (CrossChainTransferStatus)status;
+
+            stream.ReadWrite(ref this.depositTransactionId);
+            stream.ReadWrite(ref this.depositTargetAddress);
+            stream.ReadWrite(ref this.depositAmount);
+
+            int depositHeight = this.DepositHeight ?? -1;
+            stream.ReadWrite(ref depositHeight);
+            this.depositHeight = (depositHeight < 0) ? (int?)null : depositHeight;
+
+            stream.ReadWrite(ref this.partialTransaction);
+
+            if (!stream.Serializing && this.partialTransaction.Inputs.Count == 0 && this.partialTransaction.Outputs.Count == 0)
+                this.partialTransaction = null;
+
+            if (this.status == CrossChainTransferStatus.SeenInBlock)
+            {
+                uint256 blockHash = this.blockHash ?? 0;
+                stream.ReadWrite(ref blockHash);
+                this.blockHash = (blockHash == 0) ? null : blockHash;
+
+                int blockHeight = this.BlockHeight ?? -1;
+                stream.ReadWrite(ref blockHeight);
+                this.blockHeight = (blockHeight < 0) ? (int?)null : blockHeight;
+            }
+        }
+
+        /// <inheritdoc />
+        public bool IsValid()
+        {
+            if (this.depositTransactionId == null || this.depositTargetAddress == null || this.depositAmount == 0)
+                return false;
+
+            if (this.status == CrossChainTransferStatus.Suspended)
+                return true;
+
+            if (this.PartialTransaction == null)
+                return false;
+
+            if (this.status == CrossChainTransferStatus.SeenInBlock && (this.blockHash == null || this.blockHeight == null))
+            {
+                return false;
+            }
+
+             return true;
+        }
+
+        /// <inheritdoc />
+        public void SetStatus(CrossChainTransferStatus status, uint256 blockHash = null, int? blockHeight = null)
+        {
+            this.status = status;
+
+            if (this.status == CrossChainTransferStatus.SeenInBlock)
+            {
+                this.blockHash = blockHash;
+                this.blockHeight = blockHeight;
+            }
+
+            Guard.Assert(IsValid());
+        }
+
+        /// <summary>
+        /// Checks whether two transaction have identical inputs and outputs.
+        /// </summary>
+        /// <param name="partialTransaction1">First transaction.</param>
+        /// <param name="partialTransaction2">Second transaction.</param>
+        /// <returns><c>True</c> if identical and <c>false</c> otherwise.</returns>
+        public static bool TemplatesMatch(Network network, Transaction partialTransaction1, Transaction partialTransaction2)
+        {
+            if (network.Consensus.IsProofOfStake)
+            {
+                if (partialTransaction1.Time != partialTransaction2.Time)
+                {
+                    return false;
+                }
+            }
+
+            if ((partialTransaction1.Inputs.Count != partialTransaction2.Inputs.Count) ||
+                (partialTransaction1.Outputs.Count != partialTransaction2.Outputs.Count))
+            {
+                return false;
+            }
+
+            for (int i = 0; i < partialTransaction1.Inputs.Count; i++)
+            {
+                TxIn input1 = partialTransaction1.Inputs[i];
+                TxIn input2 = partialTransaction2.Inputs[i];
+
+                if ((input1.PrevOut.N != input2.PrevOut.N) || (input1.PrevOut.Hash != input2.PrevOut.Hash))
+                {
+                    return false;
+                }
+            }
+
+            for (int i = 0; i < partialTransaction1.Outputs.Count; i++)
+            {
+                TxOut output1 = partialTransaction1.Outputs[i];
+                TxOut output2 = partialTransaction2.Outputs[i];
+
+                if ((output1.Value != output2.Value) || (output1.ScriptPubKey != output2.ScriptPubKey))
+                    return false;
+            }
+
+            return true;
+        }
+
+        /// <inheritdoc />
+        public int GetSignatureCount(Network network)
+        {
+            Guard.NotNull(this.PartialTransaction, nameof(this.PartialTransaction));
+            Guard.Assert(this.PartialTransaction.Inputs.Any());
+
+            Script scriptSig = this.PartialTransaction.Inputs[0].ScriptSig;
+            if (scriptSig == null)
+                return 0;
+
+            // Remove the script from the end.
+            scriptSig = new Script(scriptSig.ToOps().SkipLast(1));
+
+            TransactionSignature[] result = PayToMultiSigTemplate.Instance.ExtractScriptSigParameters(network, scriptSig);
+
+            return result?.Count(s => s != null) ?? 0;
+        }
+
+        /// <inheritdoc />
+        public void CombineSignatures(TransactionBuilder builder, Transaction[] partialTransactions)
+        {
+            Guard.Assert(this.status == CrossChainTransferStatus.Partial);
+
+            Transaction[] validPartials = partialTransactions.Where(p => TemplatesMatch(builder.Network, p, this.partialTransaction) && p.GetHash() != this.PartialTransaction.GetHash()).ToArray();
+            if (validPartials.Any())
+            {
+                var allPartials = new Transaction[validPartials.Length + 1];
+                allPartials[0] = this.partialTransaction;
+                validPartials.CopyTo(allPartials, 1);
+
+                this.partialTransaction = builder.CombineSignatures(allPartials);
+            }
+        }
+
+        /// <inheritdoc />
+        public void SetPartialTransaction(Transaction partialTransaction)
+        {
+            this.partialTransaction = partialTransaction;
+        }
+    }
+}

--- a/src/Stratis.Features.FederatedPeg/TargetChain/CrossChainTransferStore.cs
+++ b/src/Stratis.Features.FederatedPeg/TargetChain/CrossChainTransferStore.cs
@@ -1,0 +1,1227 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using DBreeze;
+using DBreeze.DataTypes;
+using DBreeze.Utils;
+using Microsoft.Extensions.Logging;
+using NBitcoin;
+using Stratis.Bitcoin;
+using Stratis.Bitcoin.Configuration;
+using Stratis.Bitcoin.Features.BlockStore;
+using Stratis.Bitcoin.Utilities;
+using Stratis.Features.FederatedPeg.Interfaces;
+using Stratis.Features.FederatedPeg.Models;
+using Stratis.Features.FederatedPeg.Wallet;
+
+namespace Stratis.Features.FederatedPeg.TargetChain
+{
+    public class CrossChainTransferStore : ICrossChainTransferStore
+    {
+        /// <summary>This table contains the cross-chain transfer information.</summary>
+        private const string transferTableName = "Transfers";
+
+        /// <summary>This table keeps track of the chain tips so that we know exactly what data our transfer table contains.</summary>
+        private const string commonTableName = "Common";
+
+        // <summary>Block batch size for synchronization</summary>
+        private const int synchronizationBatchSize = 1000;
+
+        /// <summary>This contains deposits ids indexed by block hash of the corresponding transaction.</summary>
+        private readonly Dictionary<uint256, HashSet<uint256>> depositIdsByBlockHash = new Dictionary<uint256, HashSet<uint256>>();
+
+        /// <summary>This contains the block heights by block hashes for only the blocks of interest in our chain.</summary>
+        private readonly Dictionary<uint256, int> blockHeightsByBlockHash = new Dictionary<uint256, int>();
+
+        /// <summary>This table contains deposits ids by status.</summary>
+        private readonly Dictionary<CrossChainTransferStatus, HashSet<uint256>> depositsIdsByStatus = new Dictionary<CrossChainTransferStatus, HashSet<uint256>>();
+
+        /// <inheritdoc />
+        public int NextMatureDepositHeight { get; private set; }
+
+        /// <inheritdoc />
+        public ChainedHeader TipHashAndHeight { get; private set; }
+
+        /// <summary>The key of the repository tip in the common table.</summary>
+        private static readonly byte[] RepositoryTipKey = new byte[] { 0 };
+
+        /// <summary>The key of the counter-chain last mature block tip in the common table.</summary>
+        private static readonly byte[] NextMatureTipKey = new byte[] { 1 };
+
+        /// <summary>Instance logger.</summary>
+        private readonly ILogger logger;
+
+        /// <summary>Access to DBreeze database.</summary>
+        private readonly DBreezeEngine DBreeze;
+
+        private readonly DBreezeSerializer dBreezeSerializer;
+        private readonly Network network;
+        private readonly ConcurrentChain chain;
+        private readonly IWithdrawalExtractor withdrawalExtractor;
+        private readonly IBlockRepository blockRepository;
+        private readonly CancellationTokenSource cancellation;
+        private readonly IFederationWalletManager federationWalletManager;
+        private readonly IFederationWalletTransactionHandler federationWalletTransactionHandler;
+        private readonly IFederationGatewaySettings federationGatewaySettings;
+
+        /// <summary>Provider of time functions.</summary>
+        private readonly object lockObj;
+
+        public CrossChainTransferStore(Network network, DataFolder dataFolder, ConcurrentChain chain, IFederationGatewaySettings settings, IDateTimeProvider dateTimeProvider,
+            ILoggerFactory loggerFactory, IWithdrawalExtractor withdrawalExtractor, IFullNode fullNode, IBlockRepository blockRepository,
+            IFederationWalletManager federationWalletManager, IFederationWalletTransactionHandler federationWalletTransactionHandler, DBreezeSerializer dBreezeSerializer)
+        {
+            Guard.NotNull(network, nameof(network));
+            Guard.NotNull(dataFolder, nameof(dataFolder));
+            Guard.NotNull(chain, nameof(chain));
+            Guard.NotNull(settings, nameof(settings));
+            Guard.NotNull(dateTimeProvider, nameof(dateTimeProvider));
+            Guard.NotNull(loggerFactory, nameof(loggerFactory));
+            Guard.NotNull(withdrawalExtractor, nameof(withdrawalExtractor));
+            Guard.NotNull(fullNode, nameof(fullNode));
+            Guard.NotNull(blockRepository, nameof(blockRepository));
+            Guard.NotNull(federationWalletManager, nameof(federationWalletManager));
+            Guard.NotNull(federationWalletTransactionHandler, nameof(federationWalletTransactionHandler));
+
+            this.network = network;
+            this.chain = chain;
+            this.blockRepository = blockRepository;
+            this.federationWalletManager = federationWalletManager;
+            this.federationWalletTransactionHandler = federationWalletTransactionHandler;
+            this.federationGatewaySettings = settings;
+            this.withdrawalExtractor = withdrawalExtractor;
+            this.dBreezeSerializer = dBreezeSerializer;
+            this.lockObj = new object();
+            this.logger = loggerFactory.CreateLogger(this.GetType().FullName);
+            this.TipHashAndHeight = this.chain.GetBlock(0);
+            this.NextMatureDepositHeight = 1;
+            this.cancellation = new CancellationTokenSource();
+
+            // Future-proof store name.
+            string depositStoreName = "federatedTransfers" + settings.MultiSigAddress.ToString();
+            string folder = Path.Combine(dataFolder.RootPath, depositStoreName);
+            Directory.CreateDirectory(folder);
+            this.DBreeze = new DBreezeEngine(folder);
+
+            // Initialize tracking deposits by status.
+            foreach (object status in typeof(CrossChainTransferStatus).GetEnumValues())
+                this.depositsIdsByStatus[(CrossChainTransferStatus)status] = new HashSet<uint256>();
+        }
+
+        /// <summary>Performs any needed initialisation for the database.</summary>
+        public void Initialize()
+        {
+            lock (this.lockObj)
+            {
+                using (DBreeze.Transactions.Transaction dbreezeTransaction = this.DBreeze.GetTransaction())
+                {
+                    dbreezeTransaction.ValuesLazyLoadingIsOn = false;
+
+                    this.LoadTipHashAndHeight(dbreezeTransaction);
+                    this.LoadNextMatureHeight(dbreezeTransaction);
+
+                    // Initialize the lookups.
+                    foreach (Row<byte[], byte[]> transferRow in dbreezeTransaction.SelectForward<byte[], byte[]>(transferTableName))
+                    {
+                        var transfer = new CrossChainTransfer();
+                        transfer.FromBytes(transferRow.Value, this.network.Consensus.ConsensusFactory);
+                        this.depositsIdsByStatus[transfer.Status].Add(transfer.DepositTransactionId);
+
+                        if (transfer.BlockHash != null && transfer.BlockHeight != null)
+                        {
+                            if (!this.depositIdsByBlockHash.TryGetValue(transfer.BlockHash, out HashSet<uint256> deposits))
+                            {
+                                deposits = new HashSet<uint256>();
+                                this.depositIdsByBlockHash[transfer.BlockHash] = deposits;
+                            }
+
+                            deposits.Add(transfer.DepositTransactionId);
+
+                            this.blockHeightsByBlockHash[transfer.BlockHash] = (int)transfer.BlockHeight;
+                        }
+                    }
+                }
+            }
+        }
+
+        /// <summary>Starts the cross-chain-transfer store.</summary>
+        public void Start()
+        {
+            lock (this.lockObj)
+            {
+                // Remove all transient transactions from the wallet to be re-added according to the
+                // information carried in the store. This ensures that we will re-sync in the case
+                // where the store may have been deleted.
+                // Any partial transfers affected by these removals are expected to first become
+                // suspended due to the missing wallet transactions which will rewind the counter-
+                // chain tip to then reprocess them.
+                if (this.federationWalletManager.RemoveTransientTransactions())
+                    this.federationWalletManager.SaveWallet();
+
+                Guard.Assert(this.Synchronize());
+
+                // Any transactions seen in blocks must also be present in the wallet.
+                FederationWallet wallet = this.federationWalletManager.GetWallet();
+                ICrossChainTransfer[] transfers = this.GetTransfersByStatus(new[] { CrossChainTransferStatus.SeenInBlock }, true, false).ToArray();
+                foreach (ICrossChainTransfer transfer in transfers)
+                {
+                    (Transaction tran, TransactionData tranData, _) = this.federationWalletManager.FindWithdrawalTransactions(transfer.DepositTransactionId).FirstOrDefault();
+                    if (tran == null && wallet.LastBlockSyncedHeight >= transfer.BlockHeight)
+                    {
+                        this.federationWalletManager.ProcessTransaction(transfer.PartialTransaction);
+                        (tran, tranData, _) = this.federationWalletManager.FindWithdrawalTransactions(transfer.DepositTransactionId).FirstOrDefault();
+                        tranData.BlockHeight = transfer.BlockHeight;
+                        tranData.BlockHash = transfer.BlockHash;
+                    }
+                }
+            }
+        }
+
+        /// <inheritdoc />
+        public bool HasSuspended()
+        {
+            return this.depositsIdsByStatus[CrossChainTransferStatus.Suspended].Count != 0;
+        }
+
+        /// <summary>
+        /// The store will chase the wallet tip. This will ensure that we can rely on
+        /// information recorded in the wallet such as the list of unspent UTXO's.
+        /// </summary>
+        /// <returns>The height to which the wallet has been synced.</returns>
+        private HashHeightPair TipToChase()
+        {
+            FederationWallet wallet = this.federationWalletManager.GetWallet();
+
+            if (wallet?.LastBlockSyncedHeight == null)
+            {
+                this.logger.LogTrace("(-)[GENESIS]");
+                return new HashHeightPair(this.network.GenesisHash, 0);
+            }
+
+            return new HashHeightPair(wallet.LastBlockSyncedHash, (int)wallet.LastBlockSyncedHeight);
+        }
+
+        /// <summary>
+        /// Partial or fully signed transfers should have their source UTXO's recorded by an up-to-date wallet.
+        /// Sets transfers to <see cref="CrossChainTransferStatus.Suspended"/> if their UTXO's are not reserved
+        /// within the wallet.
+        /// </summary>
+        /// <param name="crossChainTransfers">The transfers to check. If not supplied then all partial and fully signed transfers are checked.</param>
+        /// <returns>Returns the list of transfers, possible with updated statuses.</returns>
+        private ICrossChainTransfer[] ValidateCrossChainTransfers(ICrossChainTransfer[] crossChainTransfers = null)
+        {
+            if (crossChainTransfers == null)
+            {
+                crossChainTransfers = Get(
+                    this.depositsIdsByStatus[CrossChainTransferStatus.Partial].Union(
+                        this.depositsIdsByStatus[CrossChainTransferStatus.FullySigned]).ToArray());
+            }
+
+            var tracker = new StatusChangeTracker();
+            int newChainATip = this.NextMatureDepositHeight;
+
+            foreach (ICrossChainTransfer partialTransfer in crossChainTransfers)
+            {
+                if (partialTransfer == null)
+                    continue;
+
+                if (partialTransfer.Status != CrossChainTransferStatus.Partial && partialTransfer.Status != CrossChainTransferStatus.FullySigned)
+                    continue;
+
+                List<(Transaction, TransactionData, IWithdrawal)> walletData = this.federationWalletManager.FindWithdrawalTransactions(partialTransfer.DepositTransactionId);
+                if (walletData.Count == 1 && this.ValidateTransaction(walletData[0].Item1))
+                {
+                    Transaction walletTran = walletData[0].Item1;
+                    if (walletTran.GetHash() == partialTransfer.PartialTransaction.GetHash())
+                        continue;
+
+                    if (CrossChainTransfer.TemplatesMatch(this.network, walletTran, partialTransfer.PartialTransaction))
+                    {
+                        partialTransfer.SetPartialTransaction(walletTran);
+
+                        if (walletData[0].Item2.BlockHeight != null)
+                            tracker.SetTransferStatus(partialTransfer, CrossChainTransferStatus.SeenInBlock, walletData[0].Item2.BlockHash, (int)walletData[0].Item2.BlockHeight);
+                        else if (this.ValidateTransaction(walletTran, true))
+                            tracker.SetTransferStatus(partialTransfer, CrossChainTransferStatus.FullySigned);
+                        else
+                            tracker.SetTransferStatus(partialTransfer, CrossChainTransferStatus.Partial);
+
+                        continue;
+                    }
+                }
+
+                // Remove any invalid withdrawal transactions.
+                foreach (IWithdrawal withdrawal in walletData.Select(d => d.Item3))
+                    this.federationWalletManager.RemoveTransientTransactions(withdrawal.DepositId);
+
+                // The chain may have been rewound so that this transaction or its UTXO's have been lost.
+                // Rewind our recorded chain A tip to ensure the transaction is re-built once UTXO's become available.
+                if (partialTransfer.DepositHeight < newChainATip)
+                    newChainATip = partialTransfer.DepositHeight ?? newChainATip;
+
+                tracker.SetTransferStatus(partialTransfer, CrossChainTransferStatus.Suspended);
+            }
+
+            if (tracker.Count == 0)
+            {
+                this.logger.LogTrace("(-)[NO_CHANGES_IN_TRACKER]");
+                return crossChainTransfers;
+            }
+
+            using (DBreeze.Transactions.Transaction dbreezeTransaction = this.DBreeze.GetTransaction())
+            {
+                dbreezeTransaction.SynchronizeTables(transferTableName, commonTableName);
+
+                int oldChainATip = this.NextMatureDepositHeight;
+
+                try
+                {
+                    foreach (KeyValuePair<ICrossChainTransfer, CrossChainTransferStatus?> kv in tracker)
+                    {
+                        this.PutTransfer(dbreezeTransaction, kv.Key);
+                    }
+
+                    this.SaveNextMatureHeight(dbreezeTransaction, newChainATip);
+                    dbreezeTransaction.Commit();
+                    this.UpdateLookups(tracker);
+
+                    // Remove any remnants of suspended transactions from the wallet.
+                    foreach (KeyValuePair<ICrossChainTransfer, CrossChainTransferStatus?> kv in tracker)
+                    {
+                        if (kv.Value == CrossChainTransferStatus.Suspended)
+                        {
+                            this.federationWalletManager.RemoveTransientTransactions(kv.Key.DepositTransactionId);
+                        }
+                    }
+
+                    // Remove transient transactions after the next mature deposit height.
+                    foreach ((Transaction, TransactionData, IWithdrawal) t in this.federationWalletManager.FindWithdrawalTransactions())
+                    {
+                        if (t.Item3.BlockNumber >= newChainATip)
+                        {
+                            this.federationWalletManager.RemoveTransientTransactions(t.Item3.DepositId);
+                        }
+                    }
+
+                    this.federationWalletManager.SaveWallet();
+
+                    return crossChainTransfers;
+                }
+                catch (Exception err)
+                {
+                    // Restore expected store state in case the calling code retries / continues using the store.
+                    this.NextMatureDepositHeight = oldChainATip;
+
+                    this.RollbackAndThrowTransactionError(dbreezeTransaction, err, "SANITY_ERROR");
+
+                    // Dummy return as the above method throws. Avoids compiler error.
+                    return null;
+                }
+            }
+        }
+
+        private Transaction BuildDeterministicTransaction(uint256 depositId, uint blockTime, Recipient recipient)
+        {
+            try
+            {
+                this.logger.LogInformation("BuildDeterministicTransaction depositId(opReturnData)={0} recipient.ScriptPubKey={1} recipient.Amount={2}", depositId, recipient.ScriptPubKey, recipient.Amount);
+
+                // Build the multisig transaction template.
+                uint256 opReturnData = depositId;
+                string walletPassword = this.federationWalletManager.Secret.WalletPassword;
+                bool sign = (walletPassword ?? "") != "";
+                var multiSigContext = new TransactionBuildContext(new[] { recipient }.ToList(), opReturnData: opReturnData.ToBytes())
+                {
+                    OrderCoinsDeterministic = true,
+                    TransactionFee = this.federationGatewaySettings.TransactionFee,
+                    MinConfirmations = this.federationGatewaySettings.MinCoinMaturity,
+                    Shuffle = false,
+                    IgnoreVerify = true,
+                    WalletPassword = walletPassword,
+                    Sign = sign,
+                };
+
+                Transaction transaction = this.federationWalletTransactionHandler.BuildTransaction(multiSigContext);
+
+                // Build the transaction.
+                if (this.network.Consensus.IsProofOfStake)
+                {
+                    transaction.Time = blockTime;
+
+                    if (sign)
+                    {
+                        transaction = multiSigContext.TransactionBuilder.SignTransaction(transaction);
+                    }
+                }
+
+                this.logger.LogInformation("transaction = {0}", transaction.ToString(this.network, RawFormat.BlockExplorer));
+
+                return transaction;
+            }
+            catch (Exception error)
+            {
+                this.logger.LogError("Could not create transaction for deposit {0}: {1}", depositId, error.Message);
+            }
+
+            this.logger.LogTrace("(-)[FAIL]");
+            return null;
+        }
+
+        /// <summary>Rolls back the database if an operation running in the context of a database transaction fails.</summary>
+        /// <param name="dbreezeTransaction">Database transaction to roll back.</param>
+        /// <param name="exception">Exception to report and re-raise.</param>
+        /// <param name="reason">Short reason/context code of failure.</param>
+        private void RollbackAndThrowTransactionError(DBreeze.Transactions.Transaction dbreezeTransaction, Exception exception, string reason = "FAILED_TRANSACTION")
+        {
+            this.logger.LogError("Error during database update: {0}, reason: {1}", exception.Message, reason);
+
+            dbreezeTransaction.Rollback();
+            throw exception;
+        }
+
+        /// <inheritdoc />
+        public Task SaveCurrentTipAsync()
+        {
+            return Task.Run(() =>
+            {
+                lock (this.lockObj)
+                {
+                    using (DBreeze.Transactions.Transaction dbreezeTransaction = this.DBreeze.GetTransaction())
+                    {
+                        dbreezeTransaction.SynchronizeTables(transferTableName, commonTableName);
+                        this.SaveNextMatureHeight(dbreezeTransaction, this.NextMatureDepositHeight);
+                        dbreezeTransaction.Commit();
+                    }
+                }
+            });
+        }
+
+        /// <inheritdoc />
+        public Task<bool> RecordLatestMatureDepositsAsync(IList<MaturedBlockDepositsModel> maturedBlockDeposits)
+        {
+            Guard.NotNull(maturedBlockDeposits, nameof(maturedBlockDeposits));
+            Guard.Assert(!maturedBlockDeposits.Any(m => m.Deposits.Any(d => d.BlockNumber != m.BlockInfo.BlockHeight || d.BlockHash != m.BlockInfo.BlockHash)));
+
+            return Task.Run(() =>
+            {
+                lock (this.lockObj)
+                {
+                    // Sanitize and sort the list.
+                    int originalDepositHeight = this.NextMatureDepositHeight;
+
+                    maturedBlockDeposits = maturedBlockDeposits
+                        .OrderBy(a => a.BlockInfo.BlockHeight)
+                        .SkipWhile(m => m.BlockInfo.BlockHeight < this.NextMatureDepositHeight).ToArray();
+
+                    if (maturedBlockDeposits.Count == 0 || maturedBlockDeposits.First().BlockInfo.BlockHeight != this.NextMatureDepositHeight)
+                    {
+                        this.logger.LogTrace("(-)[NO_VIABLE_BLOCKS]:true");
+                        return true;
+                    }
+
+                    if (maturedBlockDeposits.Last().BlockInfo.BlockHeight != this.NextMatureDepositHeight + maturedBlockDeposits.Count - 1)
+                    {
+                        this.logger.LogTrace("(-)[DUPLICATE_BLOCKS]:true");
+                        return true;
+                    }
+
+                    this.Synchronize();
+
+                    foreach (MaturedBlockDepositsModel maturedDeposit in maturedBlockDeposits)
+                    {
+                        if (maturedDeposit.BlockInfo.BlockHeight != this.NextMatureDepositHeight)
+                            continue;
+
+                        IReadOnlyList<IDeposit> deposits = maturedDeposit.Deposits;
+                        if (deposits.Count == 0)
+                        {
+                            this.NextMatureDepositHeight++;
+                            continue;
+                        }
+
+                        if (!this.federationWalletManager.IsFederationActive())
+                        {
+                            this.logger.LogError("The store can't persist mature deposits while the federation is inactive.");
+                            continue;
+                        }
+
+                        ICrossChainTransfer[] transfers = this.ValidateCrossChainTransfers(this.Get(deposits.Select(d => d.Id).ToArray()));
+                        var tracker = new StatusChangeTracker();
+                        bool walletUpdated = false;
+
+                        // Deposits are assumed to be in order of occurrence on the source chain.
+                        // If we fail to build a transaction the transfer and subsequent transfers
+                        // in the ordered list will be set to suspended.
+                        bool haveSuspendedTransfers = false;
+
+                        for (int i = 0; i < deposits.Count; i++)
+                        {
+                            // Only do work for non-existing or suspended transfers.
+                            if (transfers[i] != null && transfers[i].Status != CrossChainTransferStatus.Suspended)
+                            {
+                                continue;
+                            }
+
+                            IDeposit deposit = deposits[i];
+                            Transaction transaction = null;
+                            CrossChainTransferStatus status = CrossChainTransferStatus.Suspended;
+                            Script scriptPubKey = BitcoinAddress.Create(deposit.TargetAddress, this.network).ScriptPubKey;
+
+                            if (!haveSuspendedTransfers)
+                            {
+                                var recipient = new Recipient
+                                {
+                                    Amount = deposit.Amount,
+                                    ScriptPubKey = scriptPubKey
+                                };
+
+                                uint blockTime = maturedDeposit.BlockInfo.BlockTime;
+
+                                transaction = this.BuildDeterministicTransaction(deposit.Id, blockTime, recipient);
+
+                                if (transaction != null)
+                                {
+                                    // Reserve the UTXOs before building the next transaction.
+                                    walletUpdated |= this.federationWalletManager.ProcessTransaction(transaction, isPropagated: false);
+
+                                    status = CrossChainTransferStatus.Partial;
+                                }
+                                else
+                                {
+                                    haveSuspendedTransfers = true;
+                                }
+                            }
+
+                            if (transfers[i] == null || transaction == null)
+                            {
+                                transfers[i] = new CrossChainTransfer(status, deposit.Id, scriptPubKey, deposit.Amount, deposit.BlockNumber, transaction, null, null);
+                                tracker.SetTransferStatus(transfers[i]);
+                            }
+                            else
+                            {
+                                transfers[i].SetPartialTransaction(transaction);
+                                tracker.SetTransferStatus(transfers[i], CrossChainTransferStatus.Partial);
+                            }
+                        }
+
+                        using (DBreeze.Transactions.Transaction dbreezeTransaction = this.DBreeze.GetTransaction())
+                        {
+                            dbreezeTransaction.SynchronizeTables(transferTableName, commonTableName);
+
+                            int currentDepositHeight = this.NextMatureDepositHeight;
+
+                            try
+                            {
+                                if (walletUpdated)
+                                {
+                                    this.federationWalletManager.SaveWallet();
+                                }
+
+                                // Update new or modified transfers.
+                                foreach (KeyValuePair<ICrossChainTransfer, CrossChainTransferStatus?> kv in tracker)
+                                {
+                                    this.PutTransfer(dbreezeTransaction, kv.Key);
+                                }
+
+                                // Ensure we get called for a retry by NOT advancing the chain A tip if the block
+                                // contained any suspended transfers.
+                                if (!haveSuspendedTransfers)
+                                {
+                                    this.SaveNextMatureHeight(dbreezeTransaction, this.NextMatureDepositHeight + 1);
+                                }
+
+                                dbreezeTransaction.Commit();
+                                this.UpdateLookups(tracker);
+                            }
+                            catch (Exception err)
+                            {
+                                this.logger.LogError("An error occurred when processing deposits {0}", err);
+
+                                // Undo reserved UTXO's.
+                                if (walletUpdated)
+                                {
+                                    foreach (KeyValuePair<ICrossChainTransfer, CrossChainTransferStatus?> kv in tracker)
+                                    {
+                                        if (kv.Value == CrossChainTransferStatus.Partial)
+                                        {
+                                            this.federationWalletManager.RemoveTransientTransactions(kv.Key.DepositTransactionId);
+                                        }
+                                    }
+
+                                    this.federationWalletManager.SaveWallet();
+                                }
+
+                                // Restore expected store state in case the calling code retries / continues using the store.
+                                this.NextMatureDepositHeight = currentDepositHeight;
+                                this.RollbackAndThrowTransactionError(dbreezeTransaction, err, "DEPOSIT_ERROR");
+                            }
+                        }
+                    }
+
+                    // If progress was made we will check for more blocks.
+                    return this.NextMatureDepositHeight != originalDepositHeight;
+                }
+            });
+        }
+
+        /// <inheritdoc />
+        public Task<Transaction> MergeTransactionSignaturesAsync(uint256 depositId, Transaction[] partialTransactions)
+        {
+            Guard.NotNull(depositId, nameof(depositId));
+            Guard.NotNull(partialTransactions, nameof(partialTransactions));
+
+            return Task.Run(() =>
+            {
+                lock (this.lockObj)
+                {
+                    this.Synchronize();
+
+                    this.logger.LogInformation("ValidateCrossChainTransfers : {0}", depositId);
+                    ICrossChainTransfer transfer = this.ValidateCrossChainTransfers(this.Get(new[] { depositId })).FirstOrDefault();
+
+                    if (transfer == null)
+                    {
+                        this.logger.LogInformation("FAILED ValidateCrossChainTransfers : {0}", depositId);
+
+                        this.logger.LogTrace("(-)[MERGE_NOT_FOUND]:null");
+                        return null;
+                    }
+
+                    if (transfer.Status != CrossChainTransferStatus.Partial)
+                    {
+                        this.logger.LogTrace("(-)[MERGE_BAD_STATUS]");
+                        return transfer.PartialTransaction;
+                    }
+
+                    var builder = new TransactionBuilder(this.network);
+                    Transaction oldTransaction = transfer.PartialTransaction;
+
+                    transfer.CombineSignatures(builder, partialTransactions);
+
+                    if (transfer.PartialTransaction.GetHash() == oldTransaction.GetHash())
+                    {
+                        this.logger.LogInformation("FAILED to combineSignatures : {0}", transfer.DepositTransactionId);
+
+                        this.logger.LogTrace("(-)[MERGE_UNCHANGED]");
+                        return transfer.PartialTransaction;
+                    }
+
+                    using (DBreeze.Transactions.Transaction dbreezeTransaction = this.DBreeze.GetTransaction())
+                    {
+                        try
+                        {
+                            dbreezeTransaction.SynchronizeTables(transferTableName, commonTableName);
+
+                            this.federationWalletManager.ProcessTransaction(transfer.PartialTransaction);
+                            this.federationWalletManager.SaveWallet();
+
+                            if (this.ValidateTransaction(transfer.PartialTransaction, true))
+                            {
+                                this.logger.LogInformation("Deposit: {0} collected enough signatures and is FullySigned", transfer.DepositTransactionId);
+                                transfer.SetStatus(CrossChainTransferStatus.FullySigned);
+                            }
+
+                            this.PutTransfer(dbreezeTransaction, transfer);
+                            dbreezeTransaction.Commit();
+
+                            // Do this last to maintain DB integrity. We are assuming that this won't throw.
+                            this.logger.LogInformation("Deposit: {0} did not collected enough signatures and is Partial", transfer.DepositTransactionId);
+                            this.TransferStatusUpdated(transfer, CrossChainTransferStatus.Partial);
+                        }
+                        catch (Exception err)
+                        {
+                            this.logger.LogError("Error: {0} ", err);
+
+                            // Restore expected store state in case the calling code retries / continues using the store.
+                            transfer.SetPartialTransaction(oldTransaction);
+                            this.federationWalletManager.ProcessTransaction(oldTransaction);
+                            this.federationWalletManager.SaveWallet();
+                            this.RollbackAndThrowTransactionError(dbreezeTransaction, err, "MERGE_ERROR");
+                        }
+
+                        return transfer.PartialTransaction;
+                    }
+                }
+            });
+        }
+
+        /// <summary>
+        /// Uses the information contained in our chain's blocks to update the store.
+        /// Sets the <see cref="CrossChainTransferStatus.SeenInBlock"/> status for transfers
+        /// identified in the blocks.
+        /// </summary>
+        /// <param name="blocks">The blocks used to update the store. Must be sorted by ascending height leading up to the new tip.</param>
+        private void Put(List<Block> blocks)
+        {
+            if (blocks.Count == 0)
+                this.logger.LogTrace("(-)[NO_BLOCKS]:0");
+
+            Dictionary<uint256, ICrossChainTransfer> transferLookup;
+            Dictionary<uint256, IWithdrawal[]> allWithdrawals;
+
+            int blockHeight = this.TipHashAndHeight.Height + 1;
+            var allDepositIds = new HashSet<uint256>();
+
+            allWithdrawals = new Dictionary<uint256, IWithdrawal[]>();
+            foreach (Block block in blocks)
+            {
+                IReadOnlyList<IWithdrawal> blockWithdrawals = this.withdrawalExtractor.ExtractWithdrawalsFromBlock(block, blockHeight++);
+                allDepositIds.UnionWith(blockWithdrawals.Select(d => d.DepositId).ToArray());
+                allWithdrawals[block.GetHash()] = blockWithdrawals.ToArray();
+            }
+
+            // Nothing to do?
+            if (allDepositIds.Count == 0)
+            {
+                // Exiting here and saving the tip after the sync.
+                this.TipHashAndHeight = this.chain.GetBlock(blocks.Last().GetHash());
+
+                this.logger.LogTrace("(-)[NO_DEPOSIT_IDS]");
+                return;
+            }
+
+            // Create transfer lookup by deposit Id.
+            uint256[] uniqueDepositIds = allDepositIds.ToArray();
+            ICrossChainTransfer[] uniqueTransfers = this.Get(uniqueDepositIds);
+            transferLookup = new Dictionary<uint256, ICrossChainTransfer>();
+            for (int i = 0; i < uniqueDepositIds.Length; i++)
+                transferLookup[uniqueDepositIds[i]] = uniqueTransfers[i];
+
+
+            // Only create a transaction if there is important work to do.
+            using (DBreeze.Transactions.Transaction dbreezeTransaction = this.DBreeze.GetTransaction())
+            {
+                dbreezeTransaction.SynchronizeTables(transferTableName, commonTableName);
+
+                ChainedHeader prevTip = this.TipHashAndHeight;
+
+                try
+                {
+                    var tracker = new StatusChangeTracker();
+
+                    // Find transfer transactions in blocks
+                    foreach (Block block in blocks)
+                    {
+                        // First check the database to see if we already know about these deposits.
+                        IWithdrawal[] withdrawals = allWithdrawals[block.GetHash()].ToArray();
+                        ICrossChainTransfer[] crossChainTransfers = withdrawals.Select(d => transferLookup[d.DepositId]).ToArray();
+
+                        // Update the information about these deposits or record their status.
+                        for (int i = 0; i < crossChainTransfers.Length; i++)
+                        {
+                            IWithdrawal withdrawal = withdrawals[i];
+                            Transaction transaction = block.Transactions.Single(t => t.GetHash() == withdrawal.Id);
+
+                            // Ensure that the wallet is in step.
+                            this.federationWalletManager.ProcessTransaction(transaction, withdrawal.BlockNumber, block);
+
+                            if (crossChainTransfers[i] == null)
+                            {
+                                Script scriptPubKey = BitcoinAddress.Create(withdrawal.TargetAddress, this.network).ScriptPubKey;
+
+                                crossChainTransfers[i] = new CrossChainTransfer(CrossChainTransferStatus.SeenInBlock, withdrawal.DepositId,
+                                    scriptPubKey, withdrawal.Amount, null, transaction, withdrawal.BlockHash, withdrawal.BlockNumber);
+
+                                tracker.SetTransferStatus(crossChainTransfers[i]);
+                            }
+                            else
+                            {
+                                crossChainTransfers[i].SetPartialTransaction(transaction);
+
+                                tracker.SetTransferStatus(crossChainTransfers[i],
+                                    CrossChainTransferStatus.SeenInBlock, withdrawal.BlockHash, withdrawal.BlockNumber);
+                            }
+                        }
+                    }
+
+                    // Write transfers.
+                    this.PutTransfers(dbreezeTransaction, tracker.Keys.ToArray());
+
+                    // Commit additions
+                    ChainedHeader newTip = this.chain.GetBlock(blocks.Last().GetHash());
+                    this.SaveTipHashAndHeight(dbreezeTransaction, newTip);
+                    dbreezeTransaction.Commit();
+
+                    // Update the lookups last to ensure store integrity.
+                    this.UpdateLookups(tracker);
+                }
+                catch (Exception err)
+                {
+                    // Restore expected store state in case the calling code retries / continues using the store.
+                    this.TipHashAndHeight = prevTip;
+                    this.RollbackAndThrowTransactionError(dbreezeTransaction, err, "PUT_ERROR");
+                }
+            }
+        }
+
+        /// <summary>
+        /// Used to handle reorg (if required) and revert status from <see cref="CrossChainTransferStatus.SeenInBlock"/> to
+        /// <see cref="CrossChainTransferStatus.FullySigned"/>. Also returns a flag to indicate whether we are behind the current tip.
+        /// </summary>
+        /// <returns>Returns <c>true</c> if a rewind was performed and <c>false</c> otherwise.</returns>
+        private bool RewindIfRequired()
+        {
+            HashHeightPair tipToChase = this.TipToChase();
+
+            if (tipToChase.Hash == this.TipHashAndHeight.HashBlock)
+            {
+                // Indicate that we are synchronized.
+                this.logger.LogTrace("(-)[SYNCHRONIZED]:false");
+                return false;
+            }
+
+            // We are dependent on the wallet manager having dealt with any fork by now.
+            if (this.chain.GetBlock(tipToChase.Hash) == null)
+            {
+                ICollection<uint256> locators = this.federationWalletManager.GetWallet().BlockLocator;
+                var blockLocator = new BlockLocator { Blocks = locators.ToList() };
+                ChainedHeader fork = this.chain.FindFork(blockLocator);
+                this.federationWalletManager.RemoveBlocks(fork);
+                tipToChase = this.TipToChase();
+            }
+
+            // If the chain does not contain our tip.
+            if (this.TipHashAndHeight != null && (this.TipHashAndHeight.Height > tipToChase.Height ||
+                this.chain.GetBlock(this.TipHashAndHeight.HashBlock)?.Height != this.TipHashAndHeight.Height))
+            {
+                // We are ahead of the current chain or on the wrong chain.
+                ChainedHeader fork = this.chain.FindFork(this.TipHashAndHeight.GetLocator()) ?? this.chain.GetBlock(0);
+
+                // Must not exceed wallet height otherise transaction validations may fail.
+                while (fork.Height > tipToChase.Height)
+                    fork = fork.Previous;
+
+                using (DBreeze.Transactions.Transaction dbreezeTransaction = this.DBreeze.GetTransaction())
+                {
+                    dbreezeTransaction.SynchronizeTables(transferTableName, commonTableName);
+                    dbreezeTransaction.ValuesLazyLoadingIsOn = false;
+
+                    ChainedHeader prevTip = this.TipHashAndHeight;
+
+                    try
+                    {
+                        StatusChangeTracker tracker = this.OnDeleteBlocks(dbreezeTransaction, fork.Height);
+                        this.SaveTipHashAndHeight(dbreezeTransaction, fork);
+                        dbreezeTransaction.Commit();
+                        this.UndoLookups(tracker);
+                    }
+                    catch (Exception err)
+                    {
+                        // Restore expected store state in case the calling code retries / continues using the store.
+                        this.TipHashAndHeight = prevTip;
+                        this.RollbackAndThrowTransactionError(dbreezeTransaction, err, "REWIND_ERROR");
+                    }
+                }
+
+                this.ValidateCrossChainTransfers();
+                return true;
+            }
+
+            // Indicate that we are behind the current chain.
+            return false;
+        }
+
+        /// <summary>Attempts to synchronizes the store with the chain.</summary>
+        /// <returns>Returns <c>true</c> if the store is in sync or <c>false</c> otherwise.</returns>
+        private bool Synchronize()
+        {
+            lock (this.lockObj)
+            {
+                HashHeightPair tipToChase = this.TipToChase();
+                if (tipToChase.Hash == this.TipHashAndHeight.HashBlock)
+                {
+                    // Indicate that we are synchronized.
+                    this.logger.LogTrace("(-)[SYNCHRONIZED]:true");
+                    return true;
+                }
+
+                while (!this.cancellation.IsCancellationRequested)
+                {
+                    if (this.HasSuspended())
+                    {
+                        ICrossChainTransfer[] transfers = this.Get(this.depositsIdsByStatus[CrossChainTransferStatus.Suspended].ToArray());
+                        this.NextMatureDepositHeight = transfers.Min(t => t.DepositHeight) ?? this.NextMatureDepositHeight;
+                    }
+
+                    this.RewindIfRequired();
+
+                    if (this.SynchronizeBatch())
+                    {
+                        using (DBreeze.Transactions.Transaction dbreezeTransaction = this.DBreeze.GetTransaction())
+                        {
+                            dbreezeTransaction.SynchronizeTables(transferTableName, commonTableName);
+
+                            this.SaveTipHashAndHeight(dbreezeTransaction, this.TipHashAndHeight);
+
+                            dbreezeTransaction.Commit();
+                        }
+
+                        return true;
+                    }
+                }
+
+                return false;
+            }
+        }
+
+        /// <summary>Synchronize with a batch of blocks.</summary>
+        /// <returns>Returns <c>true</c> if we match the chain tip and <c>false</c> if we are behind the tip.</returns>
+        private bool SynchronizeBatch()
+        {
+            // Get a batch of blocks.
+            var blockHashes = new List<uint256>();
+            int batchSize = 0;
+            HashHeightPair tipToChase = this.TipToChase();
+
+            foreach (ChainedHeader header in this.chain.EnumerateToTip(this.TipHashAndHeight.HashBlock).Skip(1))
+            {
+                if (this.chain.GetBlock(header.HashBlock) == null)
+                    break;
+
+                if (header.Height > tipToChase.Height)
+                    break;
+
+                blockHashes.Add(header.HashBlock);
+
+                if (++batchSize >= synchronizationBatchSize)
+                    break;
+            }
+
+            List<Block> blocks = this.blockRepository.GetBlocksAsync(blockHashes).GetAwaiter().GetResult();
+            int availableBlocks = blocks.FindIndex(b => (b == null));
+            if (availableBlocks < 0)
+                availableBlocks = blocks.Count;
+
+            if (availableBlocks > 0)
+            {
+                Block lastBlock = blocks[availableBlocks - 1];
+                this.Put(blocks.GetRange(0, availableBlocks));
+                this.logger.LogInformation("Synchronized {0} blocks with cross-chain store to advance tip to block {1}", availableBlocks, this.TipHashAndHeight?.Height);
+            }
+
+            bool done = availableBlocks < synchronizationBatchSize;
+
+            return done;
+        }
+
+        /// <summary>Loads the tip and hash height.</summary>
+        /// <param name="dbreezeTransaction">The DBreeze transaction context to use.</param>
+        /// <returns>The hash and height pair.</returns>
+        private ChainedHeader LoadTipHashAndHeight(DBreeze.Transactions.Transaction dbreezeTransaction)
+        {
+            var blockLocator = new BlockLocator();
+            try
+            {
+                Row<byte[], byte[]> row = dbreezeTransaction.Select<byte[], byte[]>(commonTableName, RepositoryTipKey);
+                Guard.Assert(row.Exists);
+                blockLocator.FromBytes(row.Value);
+            }
+            catch (Exception)
+            {
+                blockLocator.Blocks = new List<uint256> { this.network.GenesisHash };
+            }
+
+            this.TipHashAndHeight = this.chain.GetBlock(blockLocator.Blocks[0]) ?? this.chain.FindFork(blockLocator);
+            return this.TipHashAndHeight;
+        }
+
+        /// <summary>Saves the tip and hash height.</summary>
+        /// <param name="dbreezeTransaction">The DBreeze transaction context to use.</param>
+        /// <param name="newTip">The new tip to persist.</param>
+        private void SaveTipHashAndHeight(DBreeze.Transactions.Transaction dbreezeTransaction, ChainedHeader newTip)
+        {
+            BlockLocator locator = this.chain.Tip.GetLocator();
+            this.TipHashAndHeight = newTip;
+            dbreezeTransaction.Insert<byte[], byte[]>(commonTableName, RepositoryTipKey, locator.ToBytes());
+        }
+
+        /// <summary>Loads the counter-chain next mature block height.</summary>
+        /// <param name="dbreezeTransaction">The DBreeze transaction context to use.</param>
+        /// <returns>The hash and height pair.</returns>
+        private int LoadNextMatureHeight(DBreeze.Transactions.Transaction dbreezeTransaction)
+        {
+            Row<byte[], int> row = dbreezeTransaction.Select<byte[], int>(commonTableName, NextMatureTipKey);
+            if (row.Exists)
+                this.NextMatureDepositHeight = row.Value;
+
+            return this.NextMatureDepositHeight;
+        }
+
+        /// <summary>Saves the counter-chain next mature block height.</summary>
+        /// <param name="dbreezeTransaction">The DBreeze transaction context to use.</param>
+        /// <param name="newTip">The next mature block height on the counter-chain.</param>
+        private void SaveNextMatureHeight(DBreeze.Transactions.Transaction dbreezeTransaction, int newTip)
+        {
+            this.NextMatureDepositHeight = newTip;
+            dbreezeTransaction.Insert<byte[], int>(commonTableName, NextMatureTipKey, this.NextMatureDepositHeight);
+        }
+
+        /// <inheritdoc />
+        public Task<ICrossChainTransfer[]> GetAsync(uint256[] depositIds)
+        {
+            return Task.Run(() =>
+            {
+                this.Synchronize();
+
+                ICrossChainTransfer[] res = this.ValidateCrossChainTransfers(this.Get(depositIds));
+                return res;
+            });
+        }
+
+        private ICrossChainTransfer[] Get(uint256[] depositId)
+        {
+            using (DBreeze.Transactions.Transaction dbreezeTransaction = this.DBreeze.GetTransaction())
+            {
+                dbreezeTransaction.ValuesLazyLoadingIsOn = false;
+
+                return this.Get(dbreezeTransaction, depositId);
+            }
+        }
+
+        private CrossChainTransfer[] Get(DBreeze.Transactions.Transaction transaction, uint256[] depositId)
+        {
+            Guard.NotNull(depositId, nameof(depositId));
+
+            // To boost performance we will access the deposits sorted by deposit id.
+            var depositDict = new Dictionary<uint256, int>();
+            for (int i = 0; i < depositId.Length; i++)
+                depositDict[depositId[i]] = i;
+
+            var byteListComparer = new ByteListComparer();
+            List<KeyValuePair<uint256, int>> depositList = depositDict.ToList();
+            depositList.Sort((pair1, pair2) => byteListComparer.Compare(pair1.Key.ToBytes(), pair2.Key.ToBytes()));
+
+            var res = new CrossChainTransfer[depositId.Length];
+
+            foreach (KeyValuePair<uint256, int> kv in depositList)
+            {
+                Row<byte[], byte[]> transferRow = transaction.Select<byte[], byte[]>(transferTableName, kv.Key.ToBytes());
+
+                if (transferRow.Exists)
+                {
+                    var crossChainTransfer = new CrossChainTransfer();
+                    crossChainTransfer.FromBytes(transferRow.Value, this.network.Consensus.ConsensusFactory);
+                    res[kv.Value] = crossChainTransfer;
+                }
+            }
+
+            return res;
+        }
+
+        private OutPoint EarliestOutput(Transaction transaction)
+        {
+            Comparer<OutPoint> comparer = Comparer<OutPoint>.Create((x, y) => this.federationWalletManager.CompareOutpoints(x, y));
+            return transaction.Inputs.Select(i => i.PrevOut).OrderByDescending(t => t, comparer).FirstOrDefault();
+        }
+
+        private ICrossChainTransfer[] GetTransfersByStatus(CrossChainTransferStatus[] statuses, bool sort = false, bool validate = true)
+        {
+            lock (this.lockObj)
+            {
+                this.Synchronize();
+
+                var depositIds = new HashSet<uint256>();
+                foreach (CrossChainTransferStatus status in statuses)
+                    depositIds.UnionWith(this.depositsIdsByStatus[status]);
+
+                uint256[] partialTransferHashes = depositIds.ToArray();
+                ICrossChainTransfer[] partialTransfers = this.Get(partialTransferHashes).Where(t => t != null).ToArray();
+
+                if (validate)
+                {
+                    this.ValidateCrossChainTransfers(partialTransfers);
+                    partialTransfers = partialTransfers.Where(t => statuses.Contains(t.Status)).ToArray();
+                }
+
+                if (!sort)
+                {
+                    return partialTransfers;
+                }
+
+                return partialTransfers.OrderBy(t => this.EarliestOutput(t.PartialTransaction), Comparer<OutPoint>.Create((x, y) =>
+                    this.federationWalletManager.CompareOutpoints(x, y))).ToArray();
+            }
+        }
+
+        /// <inheritdoc />
+        public Task<Dictionary<uint256, Transaction>> GetTransactionsByStatusAsync(CrossChainTransferStatus status, bool sort = false)
+        {
+            return Task.Run(() =>
+            {
+                ICrossChainTransfer[] res = this.GetTransfersByStatus(new[] { status }, sort);
+                return res.Where(t => t.PartialTransaction != null).ToDictionary(t => t.DepositTransactionId, t => t.PartialTransaction);
+            });
+        }
+
+        /// <summary>Persist the cross-chain transfer information into the database.</summary>
+        /// <param name="dbreezeTransaction">The DBreeze transaction context to use.</param>
+        /// <param name="crossChainTransfer">Cross-chain transfer information to be inserted.</param>
+        private void PutTransfer(DBreeze.Transactions.Transaction dbreezeTransaction, ICrossChainTransfer crossChainTransfer)
+        {
+            Guard.NotNull(crossChainTransfer, nameof(crossChainTransfer));
+
+            byte[] crossChainTransferBytes = this.dBreezeSerializer.Serialize(crossChainTransfer);
+
+            dbreezeTransaction.Insert<byte[], byte[]>(transferTableName, crossChainTransfer.DepositTransactionId.ToBytes(), crossChainTransferBytes);
+        }
+
+        /// <summary>Persist multiple cross-chain transfer information into the database.</summary>
+        /// <param name="dbreezeTransaction">The DBreeze transaction context to use.</param>
+        /// <param name="crossChainTransfers">Cross-chain transfers to be inserted.</param>
+        private void PutTransfers(DBreeze.Transactions.Transaction dbreezeTransaction, ICrossChainTransfer[] crossChainTransfers)
+        {
+            Guard.NotNull(crossChainTransfers, nameof(crossChainTransfers));
+
+            // Optimal ordering for DB consumption.
+            var byteListComparer = new ByteListComparer();
+            List<ICrossChainTransfer> orderedTransfers = crossChainTransfers.ToList();
+            orderedTransfers.Sort((pair1, pair2) => byteListComparer.Compare(pair1.DepositTransactionId.ToBytes(), pair2.DepositTransactionId.ToBytes()));
+
+            // Write each transfer in order.
+            foreach (ICrossChainTransfer transfer in orderedTransfers)
+            {
+                byte[] transferBytes = this.dBreezeSerializer.Serialize(transfer);
+                dbreezeTransaction.Insert<byte[], byte[]>(transferTableName, transfer.DepositTransactionId.ToBytes(), transferBytes);
+            }
+        }
+
+        /// <summary>Deletes the cross-chain transfer information from the database</summary>
+        /// <param name="dbreezeTransaction">The DBreeze transaction context to use.</param>
+        /// <param name="crossChainTransfer">Cross-chain transfer information to be deleted.</param>
+        private void DeleteTransfer(DBreeze.Transactions.Transaction dbreezeTransaction, ICrossChainTransfer crossChainTransfer)
+        {
+            Guard.NotNull(crossChainTransfer, nameof(crossChainTransfer));
+
+            dbreezeTransaction.RemoveKey<byte[]>(transferTableName, crossChainTransfer.DepositTransactionId.ToBytes());
+        }
+
+        /// <summary>
+        /// Forgets transfer information for the blocks being removed and returns information for updating the transient lookups.
+        /// </summary>
+        /// <param name="dbreezeTransaction">The DBreeze transaction context to use.</param>
+        /// <param name="lastBlockHeight">The last block to retain.</param>
+        /// <returns>A tracker with all the cross chain transfers that were affected.</returns>
+        private StatusChangeTracker OnDeleteBlocks(DBreeze.Transactions.Transaction dbreezeTransaction, int lastBlockHeight)
+        {
+            // Gather all the deposit ids that may have had transactions in the blocks being deleted.
+            var depositIds = new HashSet<uint256>();
+            uint256[] blocksToRemove = this.blockHeightsByBlockHash.Where(a => a.Value > lastBlockHeight).Select(a => a.Key).ToArray();
+
+            foreach (HashSet<uint256> deposits in blocksToRemove.Select(a => this.depositIdsByBlockHash[a]))
+            {
+                depositIds.UnionWith(deposits);
+            }
+
+            // Find the transfers related to these deposit ids in the database.
+            var tracker = new StatusChangeTracker();
+            CrossChainTransfer[] crossChainTransfers = this.Get(dbreezeTransaction, depositIds.ToArray());
+
+            foreach (CrossChainTransfer transfer in crossChainTransfers)
+            {
+                // Transfers that only exist in the DB due to having been seen in a block should be removed completely.
+                if (transfer.DepositHeight == null)
+                {
+                    // Trigger deletion from the status lookup.
+                    tracker.SetTransferStatus(transfer);
+
+                    // Delete the transfer completely.
+                    this.DeleteTransfer(dbreezeTransaction, transfer);
+                }
+                else
+                {
+                    // Transaction is no longer seen.
+                    tracker.SetTransferStatus(transfer, CrossChainTransferStatus.FullySigned);
+
+                    // Write the transfer status to the database.
+                    this.PutTransfer(dbreezeTransaction, transfer);
+                }
+            }
+
+            return tracker;
+        }
+
+        /// <summary>Updates the status lookup based on a transfer and its previous status.</summary>
+        /// <param name="transfer">The cross-chain transfer that was update.</param>
+        /// <param name="oldStatus">The old status.</param>
+        private void TransferStatusUpdated(ICrossChainTransfer transfer, CrossChainTransferStatus? oldStatus)
+        {
+            if (oldStatus != null)
+            {
+                this.depositsIdsByStatus[(CrossChainTransferStatus)oldStatus].Remove(transfer.DepositTransactionId);
+            }
+
+            this.depositsIdsByStatus[transfer.Status].Add(transfer.DepositTransactionId);
+        }
+
+        /// <summary>Update the transient lookups after changes have been committed to the store.</summary>
+        /// <param name="tracker">Information about how to update the lookups.</param>
+        private void UpdateLookups(StatusChangeTracker tracker)
+        {
+            foreach (uint256 hash in tracker.UniqueBlockHashes())
+            {
+                this.depositIdsByBlockHash[hash] = new HashSet<uint256>();
+            }
+
+            foreach (KeyValuePair<ICrossChainTransfer, CrossChainTransferStatus?> kv in tracker)
+            {
+                this.TransferStatusUpdated(kv.Key, kv.Value);
+
+                if (kv.Key.BlockHash != null && kv.Key.BlockHeight != null)
+                {
+                    if (!this.depositIdsByBlockHash[kv.Key.BlockHash].Contains(kv.Key.DepositTransactionId))
+                        this.depositIdsByBlockHash[kv.Key.BlockHash].Add(kv.Key.DepositTransactionId);
+                    this.blockHeightsByBlockHash[kv.Key.BlockHash] = (int)kv.Key.BlockHeight;
+                }
+            }
+        }
+
+        /// <summary>Undoes the transient lookups after block removals have been committed to the store.</summary>
+        /// <param name="tracker">Information about how to undo the lookups.</param>
+        private void UndoLookups(StatusChangeTracker tracker)
+        {
+            foreach (KeyValuePair<ICrossChainTransfer, CrossChainTransferStatus?> kv in tracker)
+            {
+                if (kv.Value == null)
+                {
+                    this.depositsIdsByStatus[kv.Key.Status].Remove(kv.Key.DepositTransactionId);
+                }
+
+                this.TransferStatusUpdated(kv.Key, kv.Value);
+            }
+
+            foreach (uint256 hash in tracker.UniqueBlockHashes())
+            {
+                this.depositIdsByBlockHash.Remove(hash);
+                this.blockHeightsByBlockHash.Remove(hash);
+            }
+        }
+
+        public bool ValidateTransaction(Transaction transaction, bool checkSignature = false)
+        {
+            return this.federationWalletManager.ValidateTransaction(transaction, checkSignature);
+        }
+
+        /// <inheritdoc />
+        public Dictionary<CrossChainTransferStatus, int> GetCrossChainTransferStatusCounter()
+        {
+            Dictionary<CrossChainTransferStatus, int> result = new Dictionary<CrossChainTransferStatus, int>();
+            foreach (CrossChainTransferStatus status in Enum.GetValues(typeof(CrossChainTransferStatus)).Cast<CrossChainTransferStatus>())
+            {
+                result[status] = this.depositsIdsByStatus.TryGet(status)?.Count ?? 0;
+            }
+
+            return result;
+        }
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            this.SaveCurrentTipAsync().GetAwaiter().GetResult();
+            this.cancellation.Cancel();
+            this.DBreeze.Dispose();
+        }
+    }
+}

--- a/src/Stratis.Features.FederatedPeg/TargetChain/LeaderReceiver.cs
+++ b/src/Stratis.Features.FederatedPeg/TargetChain/LeaderReceiver.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using Microsoft.Extensions.Logging;
+using Stratis.Bitcoin.Utilities;
+
+namespace Stratis.Features.FederatedPeg.TargetChain
+{
+    /// <summary>
+    /// This component is responsible for streaming a change in the federated leader that
+    /// other components can subscribe to.  Like <see cref="ISignedMultisigTransactionBroadcaster"/>.
+    /// </summary>
+    public interface ILeaderReceiver : IDisposable
+    {
+        /// <summary>
+        /// Notifies subscribed and future observers about the arrival of a change in federated leader.
+        /// </summary>
+        /// <param name="leaderProvider">
+        /// Provides the current federated leader.
+        /// </param>
+        void PushLeader(ILeaderProvider leaderProvider);
+
+        /// <summary>
+        /// Streams a change in federated leader.
+        /// </summary>
+        IObservable<ILeaderProvider> LeaderProvidersStream { get; }
+    }
+
+    /// <inheritdoc />
+    public class LeaderReceiver : ILeaderReceiver
+    {
+        private readonly ReplaySubject<ILeaderProvider> leaderProvidersStream;
+
+        private readonly ILogger logger;
+
+        public LeaderReceiver(ILoggerFactory loggerFactory)
+        {
+            Guard.NotNull(loggerFactory, nameof(loggerFactory));
+
+            this.logger = loggerFactory.CreateLogger(this.GetType().FullName);
+            this.leaderProvidersStream = new ReplaySubject<ILeaderProvider>(1);
+            this.LeaderProvidersStream = this.leaderProvidersStream.AsObservable();
+        }
+
+        /// <inheritdoc />
+        public IObservable<ILeaderProvider> LeaderProvidersStream { get; }
+
+        /// <inheritdoc />
+        public void PushLeader(ILeaderProvider leaderProvider)
+        {
+            this.logger.LogInformation("Received federated leader: {0}.", leaderProvider.CurrentLeaderKey);
+            this.leaderProvidersStream.OnNext(leaderProvider);
+        }
+
+        public void Dispose()
+        {
+            this.leaderProvidersStream?.Dispose();
+        }
+    }
+}

--- a/src/Stratis.Features.FederatedPeg/TargetChain/MaturedBlocksSyncManager.cs
+++ b/src/Stratis.Features.FederatedPeg/TargetChain/MaturedBlocksSyncManager.cs
@@ -1,0 +1,151 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Stratis.Features.FederatedPeg.Interfaces;
+using Stratis.Features.FederatedPeg.Models;
+using Stratis.Features.FederatedPeg.RestClients;
+
+namespace Stratis.Features.FederatedPeg.TargetChain
+{
+    /// <summary>
+    /// Handles block syncing between gateways on 2 chains. This node will request
+    /// blocks from another chain to look for cross chain deposit transactions.
+    /// </summary>
+    public interface IMaturedBlocksSyncManager : IDisposable
+    {
+        /// <summary>Starts requesting blocks from another chain.</summary>
+        void Initialize();
+    }
+
+    /// <inheritdoc cref="IMaturedBlocksSyncManager"/>
+    public class MaturedBlocksSyncManager : IMaturedBlocksSyncManager
+    {
+        private readonly ICrossChainTransferStore store;
+
+        private readonly IFederationGatewayClient federationGatewayClient;
+
+        private readonly ILogger logger;
+
+        private readonly CancellationTokenSource cancellation;
+
+        private Task blockRequestingTask;
+
+        /// <summary>The maximum amount of blocks to request at a time from alt chain.</summary>
+        private const int MaxBlocksToRequest = 100;
+
+        /// <summary>When we are fully synced we stop asking for more blocks for this amount of time.</summary>
+        private const int RefreshDelayMs = 10_000;
+
+        /// <summary>Delay between initialization and first request to other node.</summary>
+        /// <remarks>Needed to give other node some time to start before bombing it with requests.</remarks>
+        private const int InitializationDelayMs = 10_000;
+
+        public MaturedBlocksSyncManager(ICrossChainTransferStore store, IFederationGatewayClient federationGatewayClient, ILoggerFactory loggerFactory)
+        {
+            this.store = store;
+            this.federationGatewayClient = federationGatewayClient;
+
+            this.cancellation = new CancellationTokenSource();
+            this.logger = loggerFactory.CreateLogger(this.GetType().FullName);
+        }
+
+        /// <inheritdoc />
+        public void Initialize()
+        {
+            this.blockRequestingTask = RequestMaturedBlocksContinouslyAsync();
+        }
+
+        /// <summary>Continuously requests matured blocks from another chain.</summary>
+        private async Task RequestMaturedBlocksContinouslyAsync()
+        {
+            try
+            {
+                // Initialization delay.
+                // Give other node some time to start API service.
+                await Task.Delay(InitializationDelayMs, this.cancellation.Token).ConfigureAwait(false);
+
+                while (!this.cancellation.IsCancellationRequested)
+                {
+                    bool delayRequired = await this.SyncBatchOfBlocksAsync(this.cancellation.Token).ConfigureAwait(false);
+
+                    if (delayRequired)
+                    {
+                        // Since we are synced or had a problem syncing there is no need to ask for more blocks right away.
+                        // Therefore awaiting for a delay during which new block might be accepted on the alternative chain
+                        // or alt chain node might be started.
+                        await Task.Delay(RefreshDelayMs, this.cancellation.Token).ConfigureAwait(false);
+                    }
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                this.logger.LogTrace("(-)[CANCELLED]");
+            }
+        }
+
+        /// <summary>Asks for blocks from another gateway node and then processes them.</summary>
+        /// <returns><c>true</c> if delay between next time we should ask for blocks is required; <c>false</c> otherwise.</returns>
+        /// <exception cref="OperationCanceledException">Thrown when <paramref name="cancellationToken"/> is cancelled.</exception>
+        protected async Task<bool> SyncBatchOfBlocksAsync(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            int blocksToRequest = 1;
+
+            // TODO why are we asking for max of 1 block and if it's not suspended then 1000? investigate this logic in maturedBlocksProvider
+            if (!this.store.HasSuspended())
+                blocksToRequest = MaxBlocksToRequest;
+
+            // TODO investigate if we can ask for blocks that are reorgable. If so it's a problem and an attack vector.
+            // API method that provides blocks should't give us blocks that are not mature!
+            var model = new MaturedBlockRequestModel(this.store.NextMatureDepositHeight, blocksToRequest);
+
+            this.logger.LogDebug("Request model created: {0}:{1}, {2}:{3}.", nameof(model.BlockHeight), model.BlockHeight,
+                nameof(model.MaxBlocksToSend), model.MaxBlocksToSend);
+
+            // Ask for blocks.
+            IList<MaturedBlockDepositsModel> matureBlockDeposits = await this.federationGatewayClient.GetMaturedBlockDepositsAsync(model, cancellationToken).ConfigureAwait(false);
+
+            bool delayRequired = true;
+
+            if (matureBlockDeposits != null)
+            {
+                // Log what we've received.
+                foreach (MaturedBlockDepositsModel maturedBlockDeposit in matureBlockDeposits)
+                {
+                    foreach (IDeposit deposit in maturedBlockDeposit.Deposits)
+                    {
+                        this.logger.LogDebug("New deposit received BlockNumber={0}, TargetAddress='{1}', depositId='{2}', Amount='{3}'.",
+                            deposit.BlockNumber, deposit.TargetAddress, deposit.Id, deposit.Amount);
+                    }
+                }
+
+                if (matureBlockDeposits.Count > 0)
+                {
+                    bool success = await this.store.RecordLatestMatureDepositsAsync(matureBlockDeposits).ConfigureAwait(false);
+
+                    // If we received a portion of blocks we can ask for new portion without any delay.
+                    if (success)
+                        delayRequired = false;
+                }
+                else
+                {
+                    this.logger.LogDebug("Considering ourselves fully synced since no blocks were received");
+
+                    // If we've received nothing we assume we are at the tip and should flush.
+                    // Same mechanic as with syncing headers protocol.
+                    await this.store.SaveCurrentTipAsync().ConfigureAwait(false);
+                }
+            }
+
+            return delayRequired;
+        }
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            this.cancellation.Cancel();
+            this.blockRequestingTask?.GetAwaiter().GetResult();
+        }
+    }
+}

--- a/src/Stratis.Features.FederatedPeg/TargetChain/PartialTransactionRequester.cs
+++ b/src/Stratis.Features.FederatedPeg/TargetChain/PartialTransactionRequester.cs
@@ -1,0 +1,132 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using NBitcoin;
+using Stratis.Bitcoin.Connection;
+using Stratis.Bitcoin.P2P.Peer;
+using Stratis.Bitcoin.Utilities;
+using Stratis.Features.FederatedPeg.Interfaces;
+using Stratis.Features.FederatedPeg.NetworkHelpers;
+using Stratis.Features.FederatedPeg.Payloads;
+
+namespace Stratis.Features.FederatedPeg.TargetChain
+{
+    /// <summary>
+    /// Requests partial transactions from the peers and calls <see cref="ICrossChainTransferStore.MergeTransactionSignaturesAsync".
+    /// </summary>
+    public interface IPartialTransactionRequester
+    {
+        /// <summary>
+        /// Broadcast the partial transaction request to federation members.
+        /// </summary>
+        /// <param name="payload">The payload to broadcast.</param>
+        Task BroadcastAsync(RequestPartialTransactionPayload payload);
+
+        /// <summary>
+        /// Starts the broadcasting of partial transaction requests.
+        /// </summary>
+        void Start();
+
+        /// <summary>
+        /// Stops the broadcasting of partial transaction requests.
+        /// </summary>
+        void Stop();
+    }
+
+    /// <inheritdoc />
+    public class PartialTransactionRequester : IPartialTransactionRequester
+    {
+        private readonly ILoggerFactory loggerFactory;
+        private readonly ILogger logger;
+        private readonly ICrossChainTransferStore crossChainTransferStore;
+        private readonly IAsyncLoopFactory asyncLoopFactory;
+        private readonly INodeLifetime nodeLifetime;
+        private readonly IConnectionManager connectionManager;
+        private readonly IFederationGatewaySettings federationGatewaySettings;
+
+        private IAsyncLoop asyncLoop;
+
+        public PartialTransactionRequester(
+            ILoggerFactory loggerFactory,
+            ICrossChainTransferStore crossChainTransferStore,
+            IAsyncLoopFactory asyncLoopFactory,
+            INodeLifetime nodeLifetime,
+            IConnectionManager connectionManager,
+            IFederationGatewaySettings federationGatewaySettings)
+        {
+            Guard.NotNull(loggerFactory, nameof(loggerFactory));
+            Guard.NotNull(crossChainTransferStore, nameof(crossChainTransferStore));
+            Guard.NotNull(asyncLoopFactory, nameof(asyncLoopFactory));
+            Guard.NotNull(nodeLifetime, nameof(nodeLifetime));
+            Guard.NotNull(federationGatewaySettings, nameof(federationGatewaySettings));
+
+            this.loggerFactory = loggerFactory;
+            this.logger = loggerFactory.CreateLogger(this.GetType().FullName);
+            this.crossChainTransferStore = crossChainTransferStore;
+            this.asyncLoopFactory = asyncLoopFactory;
+            this.nodeLifetime = nodeLifetime;
+            this.connectionManager = connectionManager;
+            this.federationGatewaySettings = federationGatewaySettings;
+        }
+
+        /// <inheritdoc />
+        public async Task BroadcastAsync(RequestPartialTransactionPayload payload)
+        {
+            List<INetworkPeer> peers = this.connectionManager.ConnectedPeers.ToList();
+
+            var ipAddressComparer = new IPAddressComparer();
+
+            foreach (INetworkPeer peer in peers)
+            {
+                // Broadcast to peers.
+                if (!peer.IsConnected)
+                    continue;
+
+                if (this.federationGatewaySettings.FederationNodeIpEndPoints.Any(e => ipAddressComparer.Equals(e.Address, peer.PeerEndPoint.Address)))
+                {
+                    try
+                    {
+                        await peer.SendMessageAsync(payload).ConfigureAwait(false);
+                    }
+                    catch (OperationCanceledException)
+                    {
+                    }
+                }
+            }
+        }
+
+        /// <inheritdoc />
+        public void Start()
+        {
+            this.asyncLoop = this.asyncLoopFactory.Run(nameof(PartialTransactionRequester), token =>
+            {
+                // Broadcast the partial transaction with the earliest inputs.
+                KeyValuePair<uint256, Transaction> kv = this.crossChainTransferStore.GetTransactionsByStatusAsync(
+                    CrossChainTransferStatus.Partial, true).GetAwaiter().GetResult().FirstOrDefault();
+
+                if (kv.Key != null)
+                {
+                    BroadcastAsync(new RequestPartialTransactionPayload(kv.Key).AddPartial(kv.Value)).GetAwaiter().GetResult();
+                    this.logger.LogInformation("Partial template requested");
+                }
+
+                this.logger.LogTrace("(-)[PARTIAL_TEMPLATES_JOB]");
+                return Task.CompletedTask;
+            },
+            this.nodeLifetime.ApplicationStopping,
+            TimeSpans.TenSeconds);
+        }
+
+        /// <inheritdoc />
+        public void Stop()
+        {
+            if (this.asyncLoop != null)
+            {
+                this.asyncLoop.Dispose();
+                this.asyncLoop = null;
+            }
+        }
+    }
+}

--- a/src/Stratis.Features.FederatedPeg/TargetChain/SignedMultisigTransactionBroadcaster.cs
+++ b/src/Stratis.Features.FederatedPeg/TargetChain/SignedMultisigTransactionBroadcaster.cs
@@ -1,0 +1,96 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using NBitcoin;
+using Stratis.Bitcoin.Features.MemoryPool;
+using Stratis.Bitcoin.Features.Wallet.Interfaces;
+using Stratis.Bitcoin.Utilities;
+using Stratis.Features.FederatedPeg.Interfaces;
+
+namespace Stratis.Features.FederatedPeg.TargetChain
+{
+    /// <summary>
+    /// This component is responsible retrieving signed multisig transactions (from <see cref="ICrossChainTransferStore"/>)
+    /// and broadcasting them into the network.
+    /// </summary>
+    public interface ISignedMultisigTransactionBroadcaster
+    {
+        /// <summary>
+        /// Broadcast signed transactions that are not in the mempool.
+        /// </summary>
+        /// <param name="leaderProvider">
+        /// The current federated leader.
+        /// </param>
+        /// <remarks>
+        /// The current federated leader equal the <see cref="IFederationGatewaySettings.PublicKey"/> before it can broadcast the transactions.
+        /// </remarks>
+        Task BroadcastTransactionsAsync(ILeaderProvider leaderProvider);
+    }
+
+    public class SignedMultisigTransactionBroadcaster : ISignedMultisigTransactionBroadcaster, IDisposable
+    {
+        private readonly ILogger logger;
+        private readonly IDisposable leaderReceiverSubscription;
+        private readonly ICrossChainTransferStore store;
+        private readonly string publicKey;
+        private readonly MempoolManager mempoolManager;
+        private readonly IBroadcasterManager broadcasterManager;
+
+        public SignedMultisigTransactionBroadcaster(ILoggerFactory loggerFactory, ICrossChainTransferStore store, ILeaderReceiver leaderReceiver, IFederationGatewaySettings settings,
+            MempoolManager mempoolManager, IBroadcasterManager broadcasterManager)
+        {
+            Guard.NotNull(loggerFactory, nameof(loggerFactory));
+            Guard.NotNull(store, nameof(store));
+            Guard.NotNull(leaderReceiver, nameof(leaderReceiver));
+            Guard.NotNull(settings, nameof(settings));
+            Guard.NotNull(mempoolManager, nameof(mempoolManager));
+            Guard.NotNull(broadcasterManager, nameof(broadcasterManager));
+
+            this.logger = loggerFactory.CreateLogger(this.GetType().FullName);
+            this.store = store;
+            this.publicKey = settings.PublicKey;
+            this.mempoolManager = mempoolManager;
+            this.broadcasterManager = broadcasterManager;
+
+            this.leaderReceiverSubscription = leaderReceiver.LeaderProvidersStream.Subscribe(async m => await this.BroadcastTransactionsAsync(m).ConfigureAwait(false));
+            this.logger.LogDebug("Subscribed to {0}", nameof(leaderReceiver), nameof(leaderReceiver.LeaderProvidersStream));
+        }
+
+        /// <inheritdoc />
+        public async Task BroadcastTransactionsAsync(ILeaderProvider leaderProvider)
+        {
+            if (this.publicKey != leaderProvider.CurrentLeaderKey.ToString()) return;
+
+            Dictionary<uint256, Transaction> transactions = await this.store.GetTransactionsByStatusAsync(CrossChainTransferStatus.FullySigned).ConfigureAwait(false);
+
+            if (!transactions.Any())
+            {
+                this.logger.LogTrace("Signed multisig transactions do not exist in the CrossChainTransfer store.");
+                return;
+            }
+
+            foreach (KeyValuePair<uint256, Transaction> transaction in transactions)
+            {
+                TxMempoolInfo txInfo = await this.mempoolManager.InfoAsync(transaction.Value.GetHash()).ConfigureAwait(false);
+
+                if (txInfo != null)
+                {
+                    this.logger.LogTrace("Transaction ID '{0}' already in the mempool.", transaction.Key);
+                    continue;
+                }
+
+                this.logger.LogInformation("Broadcasting deposit-id={0} a signed multisig transaction {1} to the network.", transaction.Key, transaction.Value.GetHash());
+
+                await this.broadcasterManager.BroadcastTransactionAsync(transaction.Value).ConfigureAwait(false);
+            }
+        }
+
+        public void Dispose()
+        {
+            this.store?.Dispose();
+            this.leaderReceiverSubscription?.Dispose();
+        }
+    }
+}

--- a/src/Stratis.Features.FederatedPeg/TargetChain/StatusChangeTracker.cs
+++ b/src/Stratis.Features.FederatedPeg/TargetChain/StatusChangeTracker.cs
@@ -1,0 +1,45 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using NBitcoin;
+using Stratis.Features.FederatedPeg.Interfaces;
+
+namespace Stratis.Features.FederatedPeg.TargetChain
+{
+    public class StatusChangeTracker : Dictionary<ICrossChainTransfer, CrossChainTransferStatus?>
+    {
+        /// <summary>
+        /// Records changes to transfers for the purpose of synchronizing the transient lookups after the DB commit.
+        /// </summary>
+        /// <param name="transfer">The cross-chain transfer to update.</param>
+        /// <param name="status">The new status.</param>
+        /// <param name="blockHash">The block hash of the partialTranction.</param>
+        /// <param name="blockHeight">The block height of the partialTransaction.</param>
+        /// <remarks>
+        /// Within the store the earliest status is <see cref="CrossChainTransferStatus.Partial"/>. In this case <c>null</c>
+        /// is used to flag a new transfer - a transfer with no earlier status. <c>null</c> is not written to the DB.
+        /// </remarks>
+        public void SetTransferStatus(ICrossChainTransfer transfer, CrossChainTransferStatus? status = null, uint256 blockHash = null, int blockHeight = 0)
+        {
+            if (status != null)
+            {
+                // If setting the status then record the previous status.
+                this[transfer] = transfer.Status;
+                transfer.SetStatus((CrossChainTransferStatus)status, blockHash, blockHeight);
+            }
+            else
+            {
+                // If not setting the status then assume there is no previous status.
+                this[transfer] = null;
+            }
+        }
+
+        /// <summary>
+        /// Returns a list of unique block hashes for the transfers being tracked.
+        /// </summary>
+        /// <returns>A list of unique block hashes for the transfers being tracked.</returns>
+        public uint256[] UniqueBlockHashes()
+        {
+            return this.Keys.Where(k => k.BlockHash != null).Select(k => k.BlockHash).Distinct().ToArray();
+        }
+    }
+}

--- a/src/Stratis.Features.FederatedPeg/TargetChain/Withdrawal.cs
+++ b/src/Stratis.Features.FederatedPeg/TargetChain/Withdrawal.cs
@@ -1,0 +1,53 @@
+﻿using NBitcoin;
+using Newtonsoft.Json;
+using Stratis.Features.FederatedPeg.Interfaces;
+
+namespace Stratis.Features.FederatedPeg.TargetChain
+{
+    public class Withdrawal : IWithdrawal
+    {
+        public Withdrawal(uint256 depositId, uint256 id, Money amount, string targetAddress, int blockNumber, uint256 blockHash)
+        {
+            this.DepositId = depositId;
+            this.Id = id;
+            this.Amount = amount;
+            this.TargetAddress = targetAddress;
+            this.BlockNumber = blockNumber;
+            this.BlockHash = blockHash;
+        }
+
+        /// <inheritdoc />
+        public uint256 DepositId { get; }
+
+        /// <inheritdoc />
+        public uint256 Id { get; }
+
+        /// <inheritdoc />
+        public Money Amount { get; }
+
+        /// <inheritdoc />
+        public string TargetAddress { get; }
+
+        /// <inheritdoc />
+        public int BlockNumber { get; }
+
+        /// <inheritdoc />
+        public uint256 BlockHash { get; }
+
+        public override string ToString()
+        {
+            return JsonConvert.SerializeObject(this, Formatting.Indented);
+        }
+
+        public string GetInfo()
+        {
+            return string.Format("Tran#={0} Dep#={1} Amount={2,12} Addr={3} BlkNum={4,8} BlkHash={5}",
+                this.Id.ToString().Substring(0, 6),
+                this.DepositId.ToString().Substring(0, 6),
+                this.Amount.ToString(),
+                this.TargetAddress,
+                this.BlockNumber,
+                this.BlockHash?.ToString().Substring(0, 6));
+        }
+    }
+}

--- a/src/Stratis.Features.FederatedPeg/TargetChain/WithdrawalExtractor.cs
+++ b/src/Stratis.Features.FederatedPeg/TargetChain/WithdrawalExtractor.cs
@@ -1,0 +1,96 @@
+﻿using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using Microsoft.Extensions.Logging;
+using NBitcoin;
+using Stratis.Features.FederatedPeg.Interfaces;
+
+namespace Stratis.Features.FederatedPeg.TargetChain
+{
+    /// <summary>
+    /// This component is responsible for finding all deposits made from the federation's
+    /// multisig address to a target address, find out if they represent a cross chain transfer
+    /// and if so, extract the details into an <see cref="IWithdrawal"/>.
+    /// </summary>
+    public interface IWithdrawalExtractor
+    {
+        IReadOnlyList<IWithdrawal> ExtractWithdrawalsFromBlock(Block block, int blockHeight);
+
+        IWithdrawal ExtractWithdrawalFromTransaction(Transaction transaction, uint256 blockHash, int blockHeight);
+    }
+
+    public class WithdrawalExtractor : IWithdrawalExtractor
+    {
+        private readonly IOpReturnDataReader opReturnDataReader;
+
+        private readonly Network network;
+
+        private readonly ILogger logger;
+
+        private readonly BitcoinAddress multisigAddress;
+
+        public WithdrawalExtractor(
+            ILoggerFactory loggerFactory,
+            IFederationGatewaySettings federationGatewaySettings,
+            IOpReturnDataReader opReturnDataReader,
+            Network network)
+        {
+            this.logger = loggerFactory.CreateLogger(this.GetType().FullName);
+            this.multisigAddress = federationGatewaySettings.MultiSigAddress;
+            this.opReturnDataReader = opReturnDataReader;
+            this.network = network;
+        }
+
+        /// <inheritdoc />
+        public IReadOnlyList<IWithdrawal> ExtractWithdrawalsFromBlock(Block block, int blockHeight)
+        {
+            var withdrawals = new List<IWithdrawal>();
+            foreach (Transaction transaction in block.Transactions)
+            {
+                IWithdrawal withdrawal = this.ExtractWithdrawalFromTransaction(transaction, block.GetHash(), blockHeight);
+                if (withdrawal != null) withdrawals.Add(withdrawal);
+            }
+
+            ReadOnlyCollection<IWithdrawal> withdrawalsFromBlock = withdrawals.AsReadOnly();
+
+            return withdrawalsFromBlock;
+        }
+
+        public IWithdrawal ExtractWithdrawalFromTransaction(Transaction transaction, uint256 blockHash, int blockHeight)
+        {
+            if (transaction.Outputs.Count(this.IsTargetAddressCandidate) != 1) return null;
+            if (!this.IsOnlyFromMultisig(transaction)) return null;
+
+            if (!this.opReturnDataReader.TryGetTransactionId(transaction, out string depositId))
+                return null;
+
+            this.logger.LogDebug(
+                "Processing received transaction with source deposit id: {0}. Transaction hash: {1}.",
+                depositId,
+                transaction.GetHash());
+
+            TxOut targetAddressOutput = transaction.Outputs.Single(this.IsTargetAddressCandidate);
+            var withdrawal = new Withdrawal(
+                uint256.Parse(depositId),
+                transaction.GetHash(),
+                targetAddressOutput.Value,
+                targetAddressOutput.ScriptPubKey.GetDestinationAddress(this.network).ToString(),
+                blockHeight,
+                blockHash);
+
+            return withdrawal;
+        }
+
+        private bool IsTargetAddressCandidate(TxOut output)
+        {
+            return output.ScriptPubKey != this.multisigAddress.ScriptPubKey && !output.ScriptPubKey.IsUnspendable;
+        }
+
+        private bool IsOnlyFromMultisig(Transaction transaction)
+        {
+            if (!transaction.Inputs.Any()) return false;
+            return transaction.Inputs.All(
+                    i => i.ScriptSig?.GetSignerAddress(this.network) == this.multisigAddress);
+        }
+    }
+}

--- a/src/Stratis.Features.FederatedPeg/TargetChain/WithdrawalHistoryProvider.cs
+++ b/src/Stratis.Features.FederatedPeg/TargetChain/WithdrawalHistoryProvider.cs
@@ -1,0 +1,84 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using NBitcoin;
+using Stratis.Bitcoin.Features.MemoryPool;
+using Stratis.Features.FederatedPeg.Interfaces;
+using Stratis.Features.FederatedPeg.Models;
+
+namespace Stratis.Features.FederatedPeg.TargetChain
+{
+    public interface IWithdrawalHistoryProvider
+    {
+        List<WithdrawalModel> GetHistory(int maximumEntriesToReturn);
+    }
+
+    public class WithdrawalHistoryProvider : IWithdrawalHistoryProvider
+    {
+        private readonly Network network;
+        private readonly IFederationGatewaySettings federationGatewaySettings;
+        private readonly IFederationWalletManager federationWalletManager;
+        private readonly ICrossChainTransferStore crossChainTransferStore;
+        private readonly MempoolManager mempoolManager;
+
+        /// <summary>
+        /// The <see cref="WithdrawalHistoryProvider"/> constructor.
+        /// </summary>
+        /// <param name="network">Network we are running on.</param>
+        /// <param name="federationGatewaySettings">Federation settings providing access to number of signatures required.</param>
+        /// <param name="federationWalletManager">Wallet manager which provides access to the wallet.</param>
+        /// <param name="crossChainTransferStore">Store which provides access to the statuses.</param>
+        /// <param name="mempoolManager">Mempool which provides information about transactions in the mempool.</param>
+        public WithdrawalHistoryProvider(
+            Network network,
+            IFederationGatewaySettings federationGatewaySettings,
+            IFederationWalletManager federationWalletManager,
+            ICrossChainTransferStore crossChainTransferStore,
+            MempoolManager mempoolManager)
+        {
+            this.network = network;
+            this.federationGatewaySettings = federationGatewaySettings;
+            this.federationWalletManager = federationWalletManager;
+            this.crossChainTransferStore = crossChainTransferStore;
+            this.mempoolManager = mempoolManager;
+        }
+
+        /// <summary>
+        /// Get the history of withdrawals and statuses.
+        /// </summary>
+        /// <param name="maximumEntriesToReturn">The maximum number of entries to return.</param>
+        /// <returns>A <see cref="WithdrawalModel"/> object containing a history of withdrawals and statuses.</returns>
+        public List<WithdrawalModel> GetHistory(int maximumEntriesToReturn)
+        {
+            var result = new List<WithdrawalModel>();
+            IWithdrawal[] withdrawals = this.federationWalletManager.GetWithdrawals().Take(maximumEntriesToReturn).ToArray();
+
+            if (withdrawals.Length > 0)
+            {
+                ICrossChainTransfer[] transfers = this.crossChainTransferStore.GetAsync(withdrawals.Select(w => w.DepositId).ToArray()).GetAwaiter().GetResult().ToArray();
+
+                for (int i = 0; i < withdrawals.Length; i++)
+                {
+                    ICrossChainTransfer transfer = transfers[i];
+                    var model = new WithdrawalModel();
+                    model.withdrawal = withdrawals[i];
+                    string status = transfer?.Status.ToString();
+                    switch (transfer?.Status)
+                    {
+                        case CrossChainTransferStatus.FullySigned:
+                            if (this.mempoolManager.InfoAsync(model.withdrawal.Id).GetAwaiter().GetResult() != null)
+                                status += "+InMempool";
+                            break;
+                        case CrossChainTransferStatus.Partial:
+                            status += " (" + transfer.GetSignatureCount(this.network) + "/" + this.federationGatewaySettings.MultiSigM + ")";
+                            break;
+                    }
+
+                    model.TransferStatus = status;
+                    result.Add(model);
+                }
+            }
+
+            return result;
+        }
+    }
+}

--- a/src/Stratis.Features.FederatedPeg/TargetChain/WithdrawalReceiver.cs
+++ b/src/Stratis.Features.FederatedPeg/TargetChain/WithdrawalReceiver.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using Stratis.Features.FederatedPeg.Interfaces;
+
+namespace Stratis.Features.FederatedPeg.TargetChain
+{
+    public interface IWithdrawalReceiver
+    {
+        IObservable<IReadOnlyList<IWithdrawal>> NewWithdrawalsOnTargetChainStream { get; }
+
+
+        void ReceiveWithdrawals(IReadOnlyList<IWithdrawal> withdrawals);
+    }
+
+    public class WithdrawalReceiver : IWithdrawalReceiver, IDisposable
+    {
+        private readonly ReplaySubject<IReadOnlyList<IWithdrawal>> newWithdrawalsOnTargetChainStream;
+
+        public WithdrawalReceiver()
+        {
+            this.newWithdrawalsOnTargetChainStream = new ReplaySubject<IReadOnlyList<IWithdrawal>>(1);
+            this.NewWithdrawalsOnTargetChainStream = this.newWithdrawalsOnTargetChainStream.AsObservable();
+        }
+
+        /// <inheritdoc />
+        public IObservable<IReadOnlyList<IWithdrawal>> NewWithdrawalsOnTargetChainStream { get; }
+
+        /// <inheritdoc />
+        public void ReceiveWithdrawals(IReadOnlyList<IWithdrawal> withdrawals)
+        {
+            this.newWithdrawalsOnTargetChainStream.OnNext(withdrawals);
+        }
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            this.newWithdrawalsOnTargetChainStream?.Dispose();
+        }
+    }
+}

--- a/src/Stratis.Features.FederatedPeg/Wallet/FederationWallet.cs
+++ b/src/Stratis.Features.FederatedPeg/Wallet/FederationWallet.cs
@@ -1,0 +1,221 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using NBitcoin;
+using Newtonsoft.Json;
+using Stratis.Bitcoin.Features.Wallet;
+using Stratis.Bitcoin.Utilities.JsonConverters;
+
+namespace Stratis.Features.FederatedPeg.Wallet
+{
+    public class FederationWallet
+    {
+        /// <summary>
+        /// The seed for this wallet's multisig addresses, password encrypted.
+        /// </summary>
+        [JsonProperty(PropertyName = "encryptedSeed")]
+        public string EncryptedSeed { get; set; }
+
+        /// <summary>
+        /// Gets or sets the merkle path.
+        /// </summary>
+        [JsonProperty(PropertyName = "blockLocator", ItemConverterType = typeof(UInt256JsonConverter))]
+        public ICollection<uint256> BlockLocator { get; set; }
+
+        /// <summary>
+        /// The network this wallet contains addresses and transactions for.
+        /// </summary>
+        [JsonProperty(PropertyName = "network")]
+        [JsonConverter(typeof(NetworkConverter))]
+        public Network Network { get; set; }
+
+        /// <summary>
+        /// The time this wallet was created.
+        /// </summary>
+        [JsonProperty(PropertyName = "creationTime")]
+        [JsonConverter(typeof(DateTimeOffsetConverter))]
+        public DateTimeOffset CreationTime { get; set; }
+
+        /// <summary>
+        /// The height of the last block that was synced.
+        /// </summary>
+        [JsonProperty(PropertyName = "lastBlockSyncedHeight", NullValueHandling = NullValueHandling.Ignore)]
+        public int? LastBlockSyncedHeight { get; set; }
+
+        /// <summary>
+        /// The hash of the last block that was synced.
+        /// </summary>
+        [JsonProperty(PropertyName = "lastBlockSyncedHash", NullValueHandling = NullValueHandling.Ignore)]
+        [JsonConverter(typeof(UInt256JsonConverter))]
+        public uint256 LastBlockSyncedHash { get; set; }
+
+        /// <summary>
+        /// The type of coin, Bitcoin or Stratis.
+        /// </summary>
+        [JsonProperty(PropertyName = "coinType")]
+        public CoinType CoinType { get; set; }
+
+        /// <summary>
+        /// The multisig address, where this node is one of several signatories to transactions.
+        /// </summary>
+        [JsonProperty(PropertyName = "multiSigAddress")]
+        public MultiSigAddress MultiSigAddress { get; set; }
+
+        /// <summary>
+        /// Gets a collection of transactions with spendable outputs.
+        /// </summary>
+        /// <returns></returns>
+        public IEnumerable<TransactionData> GetSpendableTransactions()
+        {
+            return this.MultiSigAddress.Transactions.Where(t => t.IsSpendable());
+        }
+
+        /// <summary>
+        /// Lists all spendable transactions in the current wallet.
+        /// </summary>
+        /// <param name="currentChainHeight">The current height of the chain. Used for calculating the number of confirmations a transaction has.</param>
+        /// <param name="confirmations">The minimum number of confirmations required for transactions to be considered.</param>
+        /// <returns>A collection of spendable outputs that belong to the given account.</returns>
+        public IEnumerable<UnspentOutputReference> GetSpendableTransactions(int currentChainHeight, int confirmations = 0)
+        {
+            // A block that is at the tip has 1 confirmation.
+            // When calculating the confirmations the tip must be advanced by one.
+
+            int countFrom = currentChainHeight + 1;
+            foreach (TransactionData transactionData in this.GetSpendableTransactions())
+            {
+                int? confirmationCount = 0;
+                if (transactionData.BlockHeight != null)
+                    confirmationCount = countFrom >= transactionData.BlockHeight ? countFrom - transactionData.BlockHeight : 0;
+
+                if (confirmationCount >= confirmations)
+                {
+                    yield return new UnspentOutputReference
+                    {
+                        Transaction = transactionData,
+                    };
+                }
+            }
+        }
+
+        /// <summary>
+        /// Get the accounts total spendable value for both confirmed and unconfirmed UTXO.
+        /// </summary>
+        public (Money ConfirmedAmount, Money UnConfirmedAmount) GetSpendableAmount()
+        {
+            long confirmed = this.MultiSigAddress.Transactions.Sum(t => t.SpendableAmount(true));
+            long total = this.MultiSigAddress.Transactions.Sum(t => t.SpendableAmount(false));
+
+            return (confirmed, total - confirmed);
+        }
+
+        public Transaction SignPartialTransaction(Transaction partial, string password)
+        {
+            // Need to get the same ScriptCoins used by the other signatories.
+            // It is assumed that the funds are present in the MultiSigAddress
+            // transactions.
+
+            // Find the transaction(s) in the MultiSigAddress that have the
+            // referenced inputs among their outputs.
+
+            var fundingTransactions = new List<Transaction>();
+
+            foreach (TransactionData tx in this.MultiSigAddress.Transactions)
+            {
+                Transaction trx = tx.GetFullTransaction(this.Network);
+
+                foreach (IndexedTxOut output in trx.Outputs.AsIndexedOutputs())
+                {
+                    foreach (TxIn input in partial.Inputs)
+                    {
+                        if (input.PrevOut.Hash == tx.Id && input.PrevOut.N == output.N)
+                            fundingTransactions.Add(trx);
+                    }
+                }
+            }
+
+            // Then convert the outputs to Coins & make ScriptCoins out of them.
+
+            var scriptCoins = new List<ScriptCoin>();
+
+            foreach (Transaction tx in fundingTransactions)
+            {
+                foreach (Coin coin in tx.Outputs.AsCoins())
+                {
+                    // Only care about outputs for our particular multisig
+                    if (coin.ScriptPubKey == this.MultiSigAddress.ScriptPubKey)
+                    {
+                        scriptCoins.Add(coin.ToScriptCoin(this.MultiSigAddress.RedeemScript));
+                    }
+                }
+            }
+
+            // Need to construct a transaction using a transaction builder with
+            // the appropriate state
+
+            var builder = new TransactionBuilder(this.Network);
+
+            Transaction signed = builder
+                .AddCoins(scriptCoins)
+                .AddKeys(this.MultiSigAddress.GetPrivateKey(this.EncryptedSeed, password, this.Network))
+                .SignTransaction(partial);
+
+            return signed;
+        }
+
+        public Transaction CombinePartialTransactions(Transaction[] partials)
+        {
+            Transaction firstPartial = partials[0];
+
+            // Need to get the same ScriptCoins used by the other signatories.
+            // It is assumed that the funds are present in the MultiSigAddress
+            // transactions.
+
+            // Find the transaction(s) in the MultiSigAddress that have the
+            // referenced inputs among their outputs.
+
+            var fundingTransactions = new List<Transaction>();
+
+            foreach (TransactionData tx in this.MultiSigAddress.Transactions)
+            {
+                Transaction trx = tx.GetFullTransaction(this.Network);
+                foreach (IndexedTxOut output in trx.Outputs.AsIndexedOutputs())
+                {
+                    foreach (TxIn input in firstPartial.Inputs)
+                    {
+                        if (input.PrevOut.Hash == tx.Id && input.PrevOut.N == output.N)
+                            fundingTransactions.Add(trx);
+                    }
+                }
+            }
+
+            // Then convert the outputs to Coins & make ScriptCoins out of them.
+
+            var scriptCoins = new List<ScriptCoin>();
+
+            foreach (Transaction tx in fundingTransactions)
+            {
+                foreach (Coin coin in tx.Outputs.AsCoins())
+                {
+                    // Only care about outputs for our particular multisig
+                    if (coin.ScriptPubKey == this.MultiSigAddress.ScriptPubKey)
+                    {
+                        scriptCoins.Add(coin.ToScriptCoin(this.MultiSigAddress.RedeemScript));
+                    }
+                }
+            }
+
+            // Need to construct a transaction using a transaction builder with
+            // the appropriate state
+
+            var builder = new TransactionBuilder(this.Network);
+
+            Transaction combined =
+                builder
+                    .AddCoins(scriptCoins)
+                    .CombineSignatures(partials);
+
+            return combined;
+        }
+    }
+}

--- a/src/Stratis.Features.FederatedPeg/Wallet/FederationWalletManager.cs
+++ b/src/Stratis.Features.FederatedPeg/Wallet/FederationWalletManager.cs
@@ -1,0 +1,1020 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Security;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using NBitcoin;
+using NBitcoin.Policy;
+using Stratis.Bitcoin.Configuration;
+using Stratis.Bitcoin.Features.Wallet;
+using Stratis.Bitcoin.Features.Wallet.Broadcasting;
+using Stratis.Bitcoin.Features.Wallet.Interfaces;
+using Stratis.Bitcoin.Utilities;
+using Stratis.Features.FederatedPeg.Interfaces;
+using Stratis.Features.FederatedPeg.TargetChain;
+
+[assembly: InternalsVisibleTo("Stratis.Bitcoin.Features.FederationWallet.Tests")]
+
+namespace Stratis.Features.FederatedPeg.Wallet
+{
+    /// <summary>
+    /// A class that represents a flat view of the wallets history.
+    /// </summary>
+    public class FlatHistory
+    {
+        /// <summary>
+        /// The address associated with this UTXO
+        /// </summary>
+        public MultiSigAddress Address { get; set; }
+
+        /// <summary>
+        /// The transaction representing the UTXO.
+        /// </summary>
+        public TransactionData Transaction { get; set; }
+    }
+
+    /// <summary>
+    /// Credentials to the federation wallet.
+    /// </summary>
+    public class WalletSecret
+    {
+        /// <summary>The federation wallet's password, needed for getting the private key which is used for signing federation transactions.</summary>
+        public string WalletPassword { get; set; }
+    }
+
+    /// <summary>
+    /// A manager providing operations on wallets.
+    /// </summary>
+    public class FederationWalletManager : IFederationWalletManager
+    {
+        /// <summary>Timer for saving wallet files to the file system.</summary>
+        private const int WalletSavetimeIntervalInMinutes = 5;
+
+        /// <summary>
+        /// A lock object that protects access to the <see cref="FederationWallet"/>.
+        /// Any of the collections inside Wallet must be synchronized using this lock.
+        /// </summary>
+        private readonly object lockObject;
+
+        /// <summary>The async loop we need to wait upon before we can shut down this manager.</summary>
+        private IAsyncLoop asyncLoop;
+
+        /// <summary>Factory for creating background async loop tasks.</summary>
+        private readonly IAsyncLoopFactory asyncLoopFactory;
+
+        /// <summary>Gets the wallet.</summary>
+        public FederationWallet Wallet { get; set; }
+
+        /// <summary>The type of coin used in this manager.</summary>
+        private readonly CoinType coinType;
+
+        /// <summary>Specification of the network the node runs on - regtest/testnet/mainnet.</summary>
+        private readonly Network network;
+
+        /// <summary>The chain of headers.</summary>
+        private readonly ConcurrentChain chain;
+
+        /// <summary>Global application life cycle control - triggers when application shuts down.</summary>
+        private readonly INodeLifetime nodeLifetime;
+
+        /// <summary>The withdrawal extractor used to extract withdrawals from transactions.</summary>
+        private readonly IWithdrawalExtractor withdrawalExtractor;
+
+        /// <summary>Instance logger.</summary>
+        private readonly ILogger logger;
+
+        /// <summary>An object capable of storing <see cref="FederationWallet"/>s to the file system.</summary>
+        private readonly FileStorage<FederationWallet> fileStorage;
+
+        /// <summary>The broadcast manager.</summary>
+        private readonly IBroadcasterManager broadcasterManager;
+
+        /// <summary>Provider of time functions.</summary>
+        private readonly IDateTimeProvider dateTimeProvider;
+
+        /// <summary>Indicates whether the federation is active.</summary>
+        private bool isFederationActive;
+
+        public uint256 WalletTipHash { get; set; }
+
+        public bool ContainsWallets => throw new NotImplementedException();
+
+        /// <summary>
+        /// Credentials for the wallet. Initially unpopulated on node startup, has to be provided by the user.
+        /// </summary>
+        public WalletSecret Secret { get; set; }
+
+        /// <summary>
+        /// The name of the watch-only wallet as saved in the file system.
+        /// </summary>
+        private const string WalletFileName = "multisig_wallet.json";
+
+        // In order to allow faster look-ups of transactions affecting the wallets' addresses,
+        // we keep a couple of objects in memory:
+        // 1. the list of unspent outputs for checking whether inputs from a transaction are being spent by our wallet and
+        // 2. the list of addresses contained in our wallet for checking whether a transaction is being paid to the wallet.
+        private readonly Dictionary<OutPoint, TransactionData> outpointLookup;
+        //    internal Dictionary<Script, MultiSigAddress> multiSigKeysLookup;
+
+        // Gateway settings picked up from the node config.
+        private readonly IFederationGatewaySettings federationGatewaySettings;
+
+        public FederationWalletManager(
+            ILoggerFactory loggerFactory,
+            Network network,
+            ConcurrentChain chain,
+            DataFolder dataFolder,
+            IWalletFeePolicy walletFeePolicy,
+            IAsyncLoopFactory asyncLoopFactory,
+            INodeLifetime nodeLifetime,
+            IDateTimeProvider dateTimeProvider,
+            IFederationGatewaySettings federationGatewaySettings,
+            IWithdrawalExtractor withdrawalExtractor,
+            IBroadcasterManager broadcasterManager = null) // no need to know about transactions the node broadcasted
+        {
+            Guard.NotNull(loggerFactory, nameof(loggerFactory));
+            Guard.NotNull(network, nameof(network));
+            Guard.NotNull(chain, nameof(chain));
+            Guard.NotNull(dataFolder, nameof(dataFolder));
+            Guard.NotNull(walletFeePolicy, nameof(walletFeePolicy));
+            Guard.NotNull(asyncLoopFactory, nameof(asyncLoopFactory));
+            Guard.NotNull(nodeLifetime, nameof(nodeLifetime));
+            Guard.NotNull(federationGatewaySettings, nameof(federationGatewaySettings));
+            Guard.NotNull(withdrawalExtractor, nameof(withdrawalExtractor));
+
+            this.lockObject = new object();
+
+            this.logger = loggerFactory.CreateLogger(this.GetType().FullName);
+
+            this.network = network;
+            this.coinType = (CoinType)network.Consensus.CoinType;
+            this.chain = chain;
+            this.asyncLoopFactory = asyncLoopFactory;
+            this.nodeLifetime = nodeLifetime;
+            this.fileStorage = new FileStorage<FederationWallet>(dataFolder.WalletPath);
+            this.broadcasterManager = broadcasterManager;
+            this.dateTimeProvider = dateTimeProvider;
+            this.federationGatewaySettings = federationGatewaySettings;
+            this.withdrawalExtractor = withdrawalExtractor;
+            this.outpointLookup = new Dictionary<OutPoint, TransactionData>();
+            this.isFederationActive = false;
+
+            // register events
+            if (this.broadcasterManager != null)
+            {
+                this.broadcasterManager.TransactionStateChanged += this.BroadcasterManager_TransactionStateChanged;
+            }
+        }
+
+        private void BroadcasterManager_TransactionStateChanged(object sender, TransactionBroadcastEntry transactionEntry)
+        {
+            this.ProcessTransaction(transactionEntry.Transaction, null, null, transactionEntry.State == State.Propagated);
+        }
+
+        public void Start()
+        {
+            // Find the wallet and load it in memory.
+            if (this.fileStorage.Exists(WalletFileName))
+                this.Wallet = this.fileStorage.LoadByFileName(WalletFileName);
+            else
+            {
+                // Create the multisig wallet file if it doesn't exist
+                this.Wallet = GenerateWallet();
+                this.SaveWallet();
+            }
+
+            // Load data in memory for faster lookups.
+            this.LoadKeysLookupLock();
+
+            // find the last chain block received by the wallet manager.
+            this.WalletTipHash = this.LastReceivedBlockHash();
+
+            // save the wallets file every 5 minutes to help against crashes.
+            this.asyncLoop = this.asyncLoopFactory.Run("wallet persist job", token =>
+            {
+                this.SaveWallet();
+                this.logger.LogInformation("Wallets saved to file at {0}.", this.dateTimeProvider.GetUtcNow());
+
+                return Task.CompletedTask;
+            },
+            this.nodeLifetime.ApplicationStopping,
+            repeatEvery: TimeSpan.FromMinutes(WalletSavetimeIntervalInMinutes),
+            startAfter: TimeSpan.FromMinutes(WalletSavetimeIntervalInMinutes));
+        }
+
+        /// <inheritdoc />
+        public void Stop()
+        {
+            if (this.broadcasterManager != null)
+                this.broadcasterManager.TransactionStateChanged -= this.BroadcasterManager_TransactionStateChanged;
+
+            this.asyncLoop?.Dispose();
+            this.SaveWallet();
+        }
+
+        /// <inheritdoc />
+        public IEnumerable<FlatHistory> GetHistory()
+        {
+            FlatHistory[] items = null;
+            lock (this.lockObject)
+            {
+                // Get transactions contained in the wallet.
+                items = this.Wallet.MultiSigAddress.Transactions.Select(t => new FlatHistory { Address = this.Wallet.MultiSigAddress, Transaction = t }).ToArray();
+            }
+
+            return items;
+        }
+
+        /// <inheritdoc />
+        public int LastBlockHeight()
+        {
+            if (this.Wallet == null)
+            {
+                int height = this.chain.Tip.Height;
+                this.logger.LogTrace("(-)[NO_WALLET]:{0}", height);
+                return height;
+            }
+
+            int res = this.Wallet.LastBlockSyncedHeight ?? 0;
+            return res;
+        }
+
+        /// <summary>
+        /// Gets the hash of the last block received by the wallets.
+        /// </summary>
+        /// <returns>Hash of the last block received by the wallets.</returns>
+        public uint256 LastReceivedBlockHash()
+        {
+            if (this.Wallet == null)
+            {
+                uint256 hash = this.chain.Tip.HashBlock;
+                this.logger.LogTrace("(-)[NO_WALLET]:'{0}'", hash);
+                return hash;
+            }
+
+            uint256 lastBlockSyncedHash = this.Wallet.LastBlockSyncedHash;
+
+            if (lastBlockSyncedHash == null)
+            {
+                lastBlockSyncedHash = this.chain.Tip.HashBlock;
+            }
+
+            return lastBlockSyncedHash;
+        }
+
+        /// <inheritdoc />
+        public IEnumerable<UnspentOutputReference> GetSpendableTransactionsInWallet(int confirmations = 0)
+        {
+            if (this.Wallet == null)
+            {
+                return Enumerable.Empty<Wallet.UnspentOutputReference>();
+            }
+
+            UnspentOutputReference[] res;
+            lock (this.lockObject)
+            {
+                res = this.Wallet.GetSpendableTransactions(this.chain.Tip.Height, confirmations).ToArray();
+            }
+
+            return res;
+        }
+
+        /// <inheritdoc />
+        public void RemoveBlocks(ChainedHeader fork)
+        {
+            Guard.NotNull(fork, nameof(fork));
+
+            lock (this.lockObject)
+            {
+                // Remove all the UTXO that have been reorged.
+                IEnumerable<TransactionData> makeUnspendable = this.Wallet.MultiSigAddress.Transactions.Where(w => w.BlockHeight > fork.Height).ToList();
+                foreach (TransactionData transactionData in makeUnspendable)
+                    this.Wallet.MultiSigAddress.Transactions.Remove(transactionData);
+
+                // Bring back all the UTXO that are now spendable after the reorg.
+                IEnumerable<TransactionData> makeSpendable = this.Wallet.MultiSigAddress.Transactions.Where(w => (w.SpendingDetails != null) && (w.SpendingDetails.BlockHeight > fork.Height));
+                foreach (TransactionData transactionData in makeSpendable)
+                    transactionData.SpendingDetails = null;
+
+                this.UpdateLastBlockSyncedHeight(fork);
+            }
+        }
+
+
+        /// <inheritdoc />
+        public void ProcessBlock(Block block, ChainedHeader chainedHeader)
+        {
+            Guard.NotNull(block, nameof(block));
+            Guard.NotNull(chainedHeader, nameof(chainedHeader));
+
+            // If there is no wallet yet, update the wallet tip hash and do nothing else.
+            if (this.Wallet == null)
+            {
+                this.WalletTipHash = chainedHeader.HashBlock;
+                this.logger.LogTrace("(-)[NO_WALLET]");
+                return;
+            }
+
+            // Is this the next block.
+            if (chainedHeader.Header.HashPrevBlock != this.WalletTipHash)
+            {
+                this.logger.LogTrace("New block's previous hash '{0}' does not match current wallet's tip hash '{1}'.", chainedHeader.Header.HashPrevBlock, this.WalletTipHash);
+
+                // Are we still on the main chain.
+                ChainedHeader current = this.chain.GetBlock(this.WalletTipHash);
+                if (current == null)
+                {
+                    this.logger.LogTrace("(-)[REORG]");
+                    throw new WalletException("Reorg");
+                }
+
+                // The block coming in to the wallet should never be ahead of the wallet.
+                // If the block is behind, let it pass.
+                if (chainedHeader.Height > current.Height)
+                {
+                    this.logger.LogTrace("(-)[BLOCK_TOO_FAR]");
+                    throw new WalletException("block too far in the future has arrived to the wallet");
+                }
+            }
+
+            lock (this.lockObject)
+            {
+                bool walletUpdated = false;
+                foreach (Transaction transaction in block.Transactions.Where(t => !(t.IsCoinBase && t.TotalOut == Money.Zero)))
+                {
+                    bool trxFound = this.ProcessTransaction(transaction, chainedHeader.Height, block, true);
+                    if (trxFound)
+                    {
+                        walletUpdated = true;
+                    }
+                }
+
+                // Update the wallets with the last processed block height.
+                // It's important that updating the height happens after the block processing is complete,
+                // as if the node is stopped, on re-opening it will start updating from the previous height.
+                this.UpdateLastBlockSyncedHeight(chainedHeader);
+
+                if (walletUpdated)
+                {
+                    this.SaveWallet();
+                }
+            }
+        }
+
+        /// <inheritdoc />
+        public bool ProcessTransaction(Transaction transaction, int? blockHeight = null, Block block = null, bool isPropagated = true)
+        {
+            Guard.NotNull(transaction, nameof(transaction));
+            uint256 hash = transaction.GetHash();
+
+            if (this.Wallet == null)
+            {
+                this.logger.LogTrace("(-)");
+                return false;
+            }
+
+            bool foundReceivingTrx = false, foundSendingTrx = false;
+
+            lock (this.lockObject)
+            {
+                // Extract the withdrawal from the transaction (if any).
+                IWithdrawal withdrawal = this.withdrawalExtractor.ExtractWithdrawalFromTransaction(transaction, block?.GetHash(), blockHeight ?? 0);
+                if (withdrawal != null)
+                {
+                    // Exit if already present and included in a block.
+                    List<(Transaction, TransactionData, IWithdrawal)> walletData = FindWithdrawalTransactions(withdrawal.DepositId);
+                    if ((walletData.Count == 1) && (walletData[0].Item2.BlockHeight != null))
+                        return false;
+
+                    // Remove this to prevent duplicates if the transaction hash has changed.
+                    if (walletData.Count != 0)
+                        this.RemoveTransientTransactions(withdrawal.DepositId);
+                }
+
+                // Check the outputs.
+                foreach (TxOut utxo in transaction.Outputs)
+                {
+                    // Check if the outputs contain one of our addresses.
+                    if (this.Wallet.MultiSigAddress.ScriptPubKey == utxo.ScriptPubKey)
+                    {
+                        this.AddTransactionToWallet(transaction, utxo, blockHeight, block, isPropagated);
+                        foundReceivingTrx = true;
+                    }
+                }
+
+                // Check the inputs - include those that have a reference to a transaction containing one of our scripts and the same index.
+                foreach (TxIn input in transaction.Inputs)
+                {
+                    if (!this.outpointLookup.TryGetValue(input.PrevOut, out TransactionData tTx))
+                    {
+                        continue;
+                    }
+
+                    // Get the details of the outputs paid out.
+                    IEnumerable<TxOut> paidOutTo = transaction.Outputs.Where(o =>
+                    {
+                        // If script is empty ignore it.
+                        if (o.IsEmpty)
+                            return false;
+
+                        // Check if the destination script is one of the wallet's.
+                        // TODO fix this
+                        bool found = this.Wallet.MultiSigAddress.ScriptPubKey == o.ScriptPubKey;
+
+                        // Include the keys not included in our wallets (external payees).
+                        if (!found)
+                            return true;
+
+                        // Include the keys that are in the wallet but that are for receiving
+                        // addresses (which would mean the user paid itself).
+                        // We also exclude the keys involved in a staking transaction.
+                        //return !addr.IsChangeAddress() && !transaction.IsCoinStake;
+                        return true;
+                    });
+
+                    this.AddSpendingTransactionToWallet(transaction, paidOutTo, tTx.Id, tTx.Index, blockHeight, block);
+                    foundSendingTrx = true;
+                }
+            }
+
+            // Figure out what to do when this transaction is found to affect the wallet.
+            if (foundSendingTrx || foundReceivingTrx)
+            {
+                // Save the wallet when the transaction was not included in a block.
+                if (blockHeight == null)
+                {
+                    this.SaveWallet();
+                }
+            }
+
+            return foundSendingTrx || foundReceivingTrx;
+        }
+
+        /// <inheritdoc />
+        public bool RemoveTransaction(Transaction transaction)
+        {
+            Guard.NotNull(transaction, nameof(transaction));
+            uint256 hash = transaction.GetHash();
+
+            bool updatedWallet = false;
+
+            // Check the inputs - include those that have a reference to a transaction containing one of our scripts and the same index.
+            foreach (TxIn input in transaction.Inputs)
+            {
+                if (!this.outpointLookup.TryGetValue(input.PrevOut, out TransactionData tTx))
+                {
+                    continue;
+                }
+
+                // Get the transaction being spent and unspend it.
+                TransactionData spentTransaction = this.Wallet.MultiSigAddress.Transactions.SingleOrDefault(t => (t.Id == tTx.Id) && (t.Index == tTx.Index));
+                if (spentTransaction != null)
+                {
+                    spentTransaction.SpendingDetails = null;
+                    spentTransaction.MerkleProof = null;
+                    updatedWallet = true;
+                }
+            }
+
+            foreach (TxOut utxo in transaction.Outputs)
+            {
+                // Check if the outputs contain one of our addresses.
+                if (this.Wallet.MultiSigAddress.ScriptPubKey == utxo.ScriptPubKey)
+                {
+                    int index = transaction.Outputs.IndexOf(utxo);
+
+                    // Remove any UTXO's that were provided by this transaction from wallet.
+                    TransactionData foundTransaction = this.Wallet.MultiSigAddress.Transactions.FirstOrDefault(t => (t.Id == hash) && (t.Index == index));
+                    if (foundTransaction != null)
+                    {
+                        this.RemoveInputKeysLookupLock(foundTransaction);
+                        this.Wallet.MultiSigAddress.Transactions.Remove(foundTransaction);
+                        updatedWallet = true;
+                    }
+                }
+            }
+
+            return updatedWallet;
+        }
+
+        /// <inheritdoc />
+        public HashSet<(uint256, DateTimeOffset)> RemoveAllTransactions()
+        {
+            var removedTransactions = new HashSet<(uint256, DateTimeOffset)>();
+
+            lock (this.lockObject)
+            {
+                removedTransactions = this.Wallet.MultiSigAddress.Transactions.Select(t => (t.Id, t.CreationTime)).ToHashSet();
+                this.Wallet.MultiSigAddress.Transactions.Clear();
+            }
+
+            if (removedTransactions.Any())
+            {
+                this.SaveWallet();
+            }
+
+            return removedTransactions;
+        }
+
+        /// <summary>
+        /// Adds a transaction that credits the wallet with new coins.
+        /// This method is can be called many times for the same transaction (idempotent).
+        /// </summary>
+        /// <param name="transaction">The transaction from which details are added.</param>
+        /// <param name="utxo">The unspent output to add to the wallet.</param>
+        /// <param name="blockHeight">Height of the block.</param>
+        /// <param name="block">The block containing the transaction to add.</param>
+        /// <param name="isPropagated">Propagation state of the transaction.</param>
+        private void AddTransactionToWallet(Transaction transaction, TxOut utxo, int? blockHeight = null, Block block = null, bool isPropagated = true)
+        {
+            Guard.NotNull(transaction, nameof(transaction));
+            Guard.NotNull(utxo, nameof(utxo));
+
+            uint256 transactionHash = transaction.GetHash();
+
+            // Get the collection of transactions to add to.
+            Script script = utxo.ScriptPubKey;
+
+            // Check if a similar UTXO exists or not (same transaction ID and same index).
+            // New UTXOs are added, existing ones are updated.
+            int index = transaction.Outputs.IndexOf(utxo);
+            Money amount = utxo.Value;
+            TransactionData foundTransaction = this.Wallet.MultiSigAddress.Transactions.FirstOrDefault(t => (t.Id == transactionHash) && (t.Index == index));
+            if (foundTransaction == null)
+            {
+                this.logger.LogTrace("UTXO '{0}-{1}' not found, creating.", transactionHash, index);
+                TransactionData newTransaction = new TransactionData
+                {
+                    Amount = amount,
+                    BlockHeight = blockHeight,
+                    BlockHash = block?.GetHash(),
+                    Id = transactionHash,
+                    CreationTime = DateTimeOffset.FromUnixTimeSeconds(block?.Header.Time ?? transaction.Time),
+                    Index = index,
+                    ScriptPubKey = script,
+                    Hex = transaction.ToHex(),
+                    IsPropagated = isPropagated
+                };
+
+                // Add the Merkle proof to the (non-spending) transaction.
+                if (block != null)
+                {
+                    newTransaction.MerkleProof = new MerkleBlock(block, new[] { transactionHash }).PartialMerkleTree;
+                }
+
+                this.Wallet.MultiSigAddress.Transactions.Add(newTransaction);
+                this.AddInputKeysLookupLock(newTransaction);
+            }
+            else
+            {
+                this.logger.LogTrace("Transaction ID '{0}' found, updating.", transactionHash);
+
+                // Update the block height and block hash.
+                if ((foundTransaction.BlockHeight == null) && (blockHeight != null))
+                {
+                    foundTransaction.BlockHeight = blockHeight;
+                    foundTransaction.BlockHash = block?.GetHash();
+                }
+
+                // Update the block time.
+                if (block != null)
+                {
+                    foundTransaction.CreationTime = DateTimeOffset.FromUnixTimeSeconds(block.Header.Time);
+                }
+
+                // Add the Merkle proof now that the transaction is confirmed in a block.
+                if ((block != null) && (foundTransaction.MerkleProof == null))
+                {
+                    foundTransaction.MerkleProof = new MerkleBlock(block, new[] { transactionHash }).PartialMerkleTree;
+                }
+
+                if (isPropagated)
+                    foundTransaction.IsPropagated = true;
+            }
+
+            this.TransactionFoundInternal(script);
+        }
+
+        /// <summary>
+        /// Mark an output as spent, the credit of the output will not be used to calculate the balance.
+        /// The output will remain in the wallet for history (and reorg).
+        /// </summary>
+        /// <param name="transaction">The transaction from which details are added.</param>
+        /// <param name="paidToOutputs">A list of payments made out</param>
+        /// <param name="spendingTransactionId">The id of the transaction containing the output being spent, if this is a spending transaction.</param>
+        /// <param name="spendingTransactionIndex">The index of the output in the transaction being referenced, if this is a spending transaction.</param>
+        /// <param name="blockHeight">Height of the block.</param>
+        /// <param name="block">The block containing the transaction to add.</param>
+        private void AddSpendingTransactionToWallet(Transaction transaction, IEnumerable<TxOut> paidToOutputs,
+            uint256 spendingTransactionId, int? spendingTransactionIndex, int? blockHeight = null, Block block = null)
+        {
+            Guard.NotNull(transaction, nameof(transaction));
+            Guard.NotNull(paidToOutputs, nameof(paidToOutputs));
+
+            // Get the transaction being spent.
+            TransactionData spentTransaction = this.Wallet.MultiSigAddress.Transactions.SingleOrDefault(t => (t.Id == spendingTransactionId) && (t.Index == spendingTransactionIndex));
+            if (spentTransaction == null)
+            {
+                // Strange, why would it be null?
+                this.logger.LogTrace("(-)[TX_NULL]");
+                return;
+            }
+
+            // If the details of this spending transaction are seen for the first time.
+            if (spentTransaction.SpendingDetails == null)
+            {
+                this.logger.LogTrace("Spending UTXO '{0}-{1}' is new.", spendingTransactionId, spendingTransactionIndex);
+
+                List<PaymentDetails> payments = new List<PaymentDetails>();
+                foreach (TxOut paidToOutput in paidToOutputs)
+                {
+                    // Figure out how to retrieve the destination address.
+                    string destinationAddress = string.Empty;
+                    ScriptTemplate scriptTemplate = paidToOutput.ScriptPubKey.FindTemplate(this.network);
+                    switch (scriptTemplate.Type)
+                    {
+                        // Pay to PubKey can be found in outputs of staking transactions.
+                        case TxOutType.TX_PUBKEY:
+                            PubKey pubKey = PayToPubkeyTemplate.Instance.ExtractScriptPubKeyParameters(paidToOutput.ScriptPubKey);
+                            destinationAddress = pubKey.GetAddress(this.network).ToString();
+                            break;
+                        // Pay to PubKey hash is the regular, most common type of output.
+                        case TxOutType.TX_PUBKEYHASH:
+                            destinationAddress = paidToOutput.ScriptPubKey.GetDestinationAddress(this.network).ToString();
+                            break;
+                        case TxOutType.TX_NONSTANDARD:
+                        case TxOutType.TX_SCRIPTHASH:
+                            destinationAddress = paidToOutput.ScriptPubKey.GetDestinationAddress(this.network).ToString();
+                            break;
+                        case TxOutType.TX_MULTISIG:
+                        case TxOutType.TX_NULL_DATA:
+                        case TxOutType.TX_SEGWIT:
+                            break;
+                    }
+
+                    payments.Add(new PaymentDetails
+                    {
+                        DestinationScriptPubKey = paidToOutput.ScriptPubKey,
+                        DestinationAddress = destinationAddress,
+                        Amount = paidToOutput.Value
+                    });
+                }
+
+                SpendingDetails spendingDetails = new SpendingDetails
+                {
+                    TransactionId = transaction.GetHash(),
+                    Payments = payments,
+                    CreationTime = DateTimeOffset.FromUnixTimeSeconds(block?.Header.Time ?? transaction.Time),
+                    BlockHeight = blockHeight,
+                    Hex = transaction.ToHex(),
+                    IsCoinStake = transaction.IsCoinStake == false ? (bool?)null : true
+                };
+
+                spentTransaction.SpendingDetails = spendingDetails;
+                spentTransaction.MerkleProof = null;
+            }
+            else // If this spending transaction is being confirmed in a block.
+            {
+                this.logger.LogTrace("Spending transaction ID '{0}' is being confirmed, updating.", spendingTransactionId);
+
+                // Update the block height.
+                if (spentTransaction.SpendingDetails.BlockHeight == null && blockHeight != null)
+                {
+                    spentTransaction.SpendingDetails.BlockHeight = blockHeight;
+                }
+
+                // Update the block time to be that of the block in which the transaction is confirmed.
+                if (block != null)
+                {
+                    spentTransaction.SpendingDetails.CreationTime = DateTimeOffset.FromUnixTimeSeconds(block.Header.Time);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Loads the keys and transactions we're tracking in memory for faster lookups.
+        /// </summary>
+        public void LoadKeysLookupLock()
+        {
+            lock (this.lockObject)
+            {
+                foreach (TransactionData transaction in this.Wallet.MultiSigAddress.Transactions)
+                {
+                    this.outpointLookup[new OutPoint(transaction.Id, transaction.Index)] = transaction;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Add to the list of unspent outputs kept in memory for faster lookups.
+        /// </summary>
+        private void AddInputKeysLookupLock(TransactionData transactionData)
+        {
+            Guard.NotNull(transactionData, nameof(transactionData));
+
+            lock (this.lockObject)
+            {
+                this.outpointLookup[new OutPoint(transactionData.Id, transactionData.Index)] = transactionData;
+            }
+        }
+
+        /// <summary>
+        /// Remove from the list of unspent outputs kept in memory for faster lookups.
+        /// </summary>
+        private void RemoveInputKeysLookupLock(TransactionData transactionData)
+        {
+            Guard.NotNull(transactionData, nameof(transactionData));
+
+            lock (this.lockObject)
+            {
+                this.outpointLookup.Remove(new OutPoint(transactionData.Id, transactionData.Index));
+            }
+        }
+
+        public void TransactionFoundInternal(Script script)
+        {
+            // Persists the wallet file.
+            this.SaveWallet();
+        }
+
+        /// <inheritdoc />
+        public void SaveWallet()
+        {
+            if (this.Wallet != null)
+            {
+                lock (this.lockObject)
+                {
+                    this.fileStorage.SaveToFile(this.Wallet, WalletFileName);
+                }
+            }
+        }
+
+        /// <inheritdoc />
+        public bool RemoveTransientTransactions(uint256 depositId = null)
+        {
+            lock (this.lockObject)
+            {
+                // Remove transient transactions not seen in a block yet.
+                bool walletUpdated = false;
+
+                foreach ((Transaction transaction, TransactionData transactionData, _) in FindWithdrawalTransactions(depositId)
+                    .Where(w => w.Item2.BlockHash == null))
+                {
+                    Guard.Assert(transactionData.SpendingDetails == null);
+                    walletUpdated |= RemoveTransaction(transaction);
+                }
+
+                return walletUpdated;
+            }
+        }
+
+        /// <inheritdoc />
+        public IEnumerable<IWithdrawal> GetWithdrawals()
+        {
+            foreach (TransactionData transactionData in this.Wallet.MultiSigAddress.Transactions.OrderByDescending(t => t.CreationTime))
+            {
+                Transaction walletTrx = transactionData.GetFullTransaction(this.network);
+                IWithdrawal withdrawal = this.withdrawalExtractor.ExtractWithdrawalFromTransaction(walletTrx, transactionData.BlockHash, transactionData.BlockHeight ?? 0);
+                if (withdrawal == null)
+                    continue;
+
+                yield return withdrawal;
+            }
+        }
+
+        /// <inheritdoc />
+        public List<(Transaction, TransactionData, IWithdrawal)> FindWithdrawalTransactions(uint256 depositId = null)
+        {
+            lock (this.lockObject)
+            {
+                List<(Transaction, TransactionData, IWithdrawal)> withdrawals = new List<(Transaction, TransactionData, IWithdrawal)>();
+
+                foreach (TransactionData transactionData in this.Wallet.MultiSigAddress.Transactions)
+                {
+                    Transaction walletTran = transactionData.GetFullTransaction(this.network);
+                    IWithdrawal withdrawal = this.withdrawalExtractor.ExtractWithdrawalFromTransaction(walletTran, transactionData.BlockHash, transactionData.BlockHeight ?? 0);
+                    if (withdrawal == null)
+                        continue;
+
+                    if (depositId != null && withdrawal.DepositId != depositId)
+                        continue;
+
+                    withdrawals.Add((walletTran, transactionData, withdrawal));
+                }
+
+                return withdrawals;
+            }
+        }
+
+        /// <summary>
+        /// Checks if a transaction has valid UTXOs that are spent by it.
+        /// </summary>
+        /// <param name="transaction">The transaction to check.</param>
+        /// <param name="coins">Returns the coins found if this parameter supplies an empty coin list.</param>
+        /// <returns><c>True</c> if UTXO's are valid and <c>false</c> otherwise.</returns>
+        private bool TransactionHasValidUTXOs(Transaction transaction, List<Coin> coins = null)
+        {
+            lock (this.lockObject)
+            {
+                // All the input UTXO's should be present in spending details of the multi-sig address.
+                foreach (TxIn input in transaction.Inputs)
+                {
+                    foreach (TransactionData transactionData in this.Wallet.MultiSigAddress.Transactions
+                        .Where(t => t.SpendingDetails != null && t.Id == input.PrevOut.Hash && t.Index == input.PrevOut.N))
+                    {
+                        // Check that the previous outputs are only spent by this transaction.
+                        if (transactionData == null || transactionData.SpendingDetails.TransactionId != transaction.GetHash())
+                            return false;
+
+                        coins?.Add(new Coin(transactionData.Id, (uint)transactionData.Index, transactionData.Amount, transactionData.ScriptPubKey));
+                    }
+                }
+
+                return true;
+            }
+        }
+
+        /// <inheritdoc />
+        public int CompareOutpoints(OutPoint outPoint1, OutPoint outPoint2)
+        {
+            lock (this.lockObject)
+            {
+                TransactionData transactionData1 = this.outpointLookup[outPoint1];
+                TransactionData transactionData2 = this.outpointLookup[outPoint2];
+
+                return FederationWalletTransactionHandler.CompareTransactionData(transactionData1, transactionData2);
+            }
+        }
+
+        /// <inheritdoc />
+        public bool ValidateTransaction(Transaction transaction, bool checkSignature = false)
+        {
+            lock (this.lockObject)
+            {
+                // All the input UTXO's should be present in spending details of the multi-sig address.
+                List<Coin> coins = checkSignature ? new List<Coin>() : null;
+                // Verify that the transaction has valid UTXOs.
+                if (!this.TransactionHasValidUTXOs(transaction, coins))
+                    return false;
+
+                // Verify that there are no earlier unspent UTXOs.
+                Comparer<TransactionData> comparer = Comparer<TransactionData>.Create((x, y) => FederationWalletTransactionHandler.CompareTransactionData(x, y));
+                TransactionData earliestUnspent = this.Wallet.MultiSigAddress.Transactions.Where(t => t.SpendingDetails == null).OrderBy(t => t, comparer).FirstOrDefault();
+                if (earliestUnspent != null)
+                {
+                    TransactionData oldestInput = transaction.Inputs.Select(i => this.outpointLookup[i.PrevOut]).OrderByDescending(t => t, comparer).FirstOrDefault();
+                    if (oldestInput != null && FederationWalletTransactionHandler.CompareTransactionData(earliestUnspent, oldestInput) < 0)
+                        return false;
+                }
+
+                // Verify that all inputs are signed.
+                if (checkSignature)
+                {
+                    TransactionBuilder builder = new TransactionBuilder(this.Wallet.Network).AddCoins(coins);
+                    if (!builder.Verify(transaction, this.federationGatewaySettings.TransactionFee, out TransactionPolicyError[] errors))
+                    {
+                        foreach (TransactionPolicyError transactionPolicyError in errors)
+                        {
+                            this.logger.LogError("TransactionBuilder.Verify FAILED - {0}", transactionPolicyError.ToString());
+                        }
+
+                        return false;
+                    }
+                }
+
+                return true;
+            }
+        }
+
+        /// <inheritdoc />
+        public void UpdateLastBlockSyncedHeight(ChainedHeader chainedHeader)
+        {
+            Guard.NotNull(chainedHeader, nameof(chainedHeader));
+
+            lock (this.lockObject)
+            {
+                // The block locator will help when the wallet
+                // needs to rewind this will be used to find the fork.
+                this.Wallet.BlockLocator = chainedHeader.GetLocator().Blocks;
+
+                // Update the wallets with the last processed block height.
+                this.Wallet.LastBlockSyncedHeight = chainedHeader.Height;
+                this.Wallet.LastBlockSyncedHash = chainedHeader.HashBlock;
+            }
+
+            this.WalletTipHash = chainedHeader.HashBlock;
+        }
+
+        /// <summary>
+        /// Generates the wallet file.
+        /// </summary>
+        /// <returns>The wallet object that was saved into the file system.</returns>
+        /// <exception cref="WalletException">Thrown if wallet cannot be created.</exception>
+        public FederationWallet GenerateWallet()
+        {
+            this.logger.LogTrace("Generating the federation wallet file.");
+
+            // Check if any wallet file already exists, with case insensitive comparison.
+            if (this.fileStorage.Exists(WalletFileName))
+            {
+                this.logger.LogTrace("(-)[WALLET_ALREADY_EXISTS]");
+                throw new WalletException("A federation wallet already exists.");
+            }
+
+            FederationWallet wallet = new FederationWallet
+            {
+                CreationTime = this.dateTimeProvider.GetTimeOffset(),
+                Network = this.network,
+                CoinType = this.coinType,
+                LastBlockSyncedHeight = 0,
+                LastBlockSyncedHash = this.chain.Genesis.HashBlock,
+                MultiSigAddress = new MultiSigAddress
+                {
+                    Address = this.federationGatewaySettings.MultiSigAddress.ToString(),
+                    M = this.federationGatewaySettings.MultiSigM,
+                    ScriptPubKey = this.federationGatewaySettings.MultiSigAddress.ScriptPubKey,
+                    RedeemScript = this.federationGatewaySettings.MultiSigRedeemScript,
+                    Transactions = new List<TransactionData>()
+                }
+            };
+
+            this.logger.LogTrace("(-)");
+            return wallet;
+        }
+
+        /// <inheritdoc />
+        public void EnableFederation(string password, string mnemonic = null, string passphrase = null)
+        {
+            Guard.NotEmpty(password, nameof(password));
+
+            // Protect against de-activation if the federation is already active.
+            if (this.isFederationActive)
+            {
+                this.logger.LogWarning("(-):[FEDERATION_ALREADY_ACTIVE]");
+                return;
+            }
+
+            // Get the key and encrypted seed.
+            Key key = null;
+            string encryptedSeed = this.Wallet.EncryptedSeed;
+
+            if (!string.IsNullOrEmpty(mnemonic))
+            {
+                ExtKey extendedKey;
+                try
+                {
+                    extendedKey = HdOperations.GetExtendedKey(mnemonic, passphrase);
+                }
+                catch (NotSupportedException ex)
+                {
+                    this.logger.LogTrace("Exception occurred: {0}", ex.ToString());
+                    this.logger.LogTrace("(-)[EXCEPTION]");
+
+                    if (ex.Message == "Unknown")
+                        throw new WalletException("Please make sure you enter valid mnemonic words.");
+
+                    throw;
+                }
+
+                // Create a wallet file.
+                key = extendedKey.PrivateKey;
+                encryptedSeed = key.GetEncryptedBitcoinSecret(password, this.network).ToWif();
+            }
+
+            try
+            {
+                if (key == null)
+                    key = Key.Parse(encryptedSeed, password, this.Wallet.Network);
+
+                bool isValidKey = key.PubKey.ToHex() == this.federationGatewaySettings.PublicKey;
+                if (!isValidKey)
+                {
+                    this.logger.LogInformation("The wallet public key {0} does not match the federation member's public key {1}", key.PubKey.ToHex(), this.federationGatewaySettings.PublicKey);
+                    return;
+                }
+
+                this.Secret = new WalletSecret() { WalletPassword = password };
+                this.Wallet.EncryptedSeed = encryptedSeed;
+                this.SaveWallet();
+
+                this.isFederationActive = isValidKey;
+            }
+            catch (Exception ex)
+            {
+                throw new SecurityException(ex.Message);
+            }
+        }
+
+        public bool IsFederationActive()
+        {
+            return this.isFederationActive;
+        }
+
+        public FederationWallet GetWallet()
+        {
+            return this.Wallet;
+        }
+    }
+}

--- a/src/Stratis.Features.FederatedPeg/Wallet/FederationWalletSyncManager.cs
+++ b/src/Stratis.Features.FederatedPeg/Wallet/FederationWalletSyncManager.cs
@@ -1,0 +1,234 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using Microsoft.Extensions.Logging;
+using NBitcoin;
+using Stratis.Bitcoin.Features.BlockStore;
+using Stratis.Bitcoin.Features.Wallet;
+using Stratis.Bitcoin.Interfaces;
+using Stratis.Bitcoin.Utilities;
+using Stratis.Features.FederatedPeg.Interfaces;
+
+namespace Stratis.Features.FederatedPeg.Wallet
+{
+    public class FederationWalletSyncManager : IFederationWalletSyncManager
+    {
+        protected readonly IFederationWalletManager walletManager;
+
+        protected readonly ConcurrentChain chain;
+
+        protected readonly CoinType coinType;
+
+        private readonly ILogger logger;
+
+        private readonly IBlockStore blockStore;
+
+        private readonly StoreSettings storeSettings;
+
+        /// <summary>Global application life cycle control - triggers when application shuts down.</summary>
+        private readonly INodeLifetime nodeLifetime;
+
+        protected ChainedHeader walletTip;
+
+        public ChainedHeader WalletTip => this.walletTip;
+
+        public FederationWalletSyncManager(ILoggerFactory loggerFactory, IFederationWalletManager walletManager, ConcurrentChain chain,
+            Network network, IBlockStore blockStore, StoreSettings storeSettings, INodeLifetime nodeLifetime)
+        {
+            Guard.NotNull(loggerFactory, nameof(loggerFactory));
+            Guard.NotNull(walletManager, nameof(walletManager));
+            Guard.NotNull(chain, nameof(chain));
+            Guard.NotNull(network, nameof(network));
+            Guard.NotNull(blockStore, nameof(blockStore));
+            Guard.NotNull(storeSettings, nameof(storeSettings));
+            Guard.NotNull(nodeLifetime, nameof(nodeLifetime));
+
+            this.walletManager = walletManager;
+            this.chain = chain;
+            this.blockStore = blockStore;
+            this.coinType = (CoinType)network.Consensus.CoinType;
+            this.storeSettings = storeSettings;
+            this.nodeLifetime = nodeLifetime;
+            this.logger = loggerFactory.CreateLogger(this.GetType().FullName);
+        }
+
+        /// <inheritdoc />
+        public void Start()
+        {
+            // When a node is pruned it impossible to catch up
+            // if the wallet falls behind the block puller.
+            // To support pruning the wallet will need to be
+            // able to download blocks from peers to catch up.
+            if (this.storeSettings.PruningEnabled)
+                throw new WalletException("Wallet can not yet run on a pruned node");
+
+            this.logger.LogInformation("WalletSyncManager initialized. Wallet at block {0}.", this.walletManager.LastBlockHeight());
+
+            this.walletTip = this.chain.GetBlock(this.walletManager.WalletTipHash);
+            if (this.walletTip == null)
+            {
+                // The wallet tip was not found in the main chain.
+                // this can happen if the node crashes unexpectedly.
+                // To recover we need to find the first common fork
+                // with the best chain. As the wallet does not have a
+                // list of chain headers, we use a BlockLocator and persist
+                // that in the wallet. The block locator will help finding
+                // a common fork and bringing the wallet back to a good
+                // state (behind the best chain).
+                ICollection<uint256> locators = this.walletManager.GetWallet().BlockLocator;
+                var blockLocator = new BlockLocator { Blocks = locators.ToList() };
+                ChainedHeader fork = this.chain.FindFork(blockLocator);
+                this.walletManager.RemoveBlocks(fork);
+                this.walletManager.WalletTipHash = fork.HashBlock;
+                this.walletTip = fork;
+            }
+        }
+
+        /// <inheritdoc />
+        public void Stop()
+        {
+        }
+
+        /// <inheritdoc />
+        public virtual void ProcessBlock(Block block)
+        {
+            Guard.NotNull(block, nameof(block));
+
+            ChainedHeader newTip = this.chain.GetBlock(block.GetHash());
+            if (newTip == null)
+            {
+                this.logger.LogTrace("(-)[NEW_TIP_REORG]");
+                return;
+            }
+
+            // If the new block's previous hash is the same as the
+            // wallet hash then just pass the block to the manager.
+            if (block.Header.HashPrevBlock != this.walletTip.HashBlock)
+            {
+                // If previous block does not match there might have
+                // been a reorg, check if the wallet is still on the main chain.
+                ChainedHeader inBestChain = this.chain.GetBlock(this.walletTip.HashBlock);
+                if (inBestChain == null)
+                {
+                    // The current wallet hash was not found on the main chain.
+                    // A reorg happened so bring the wallet back top the last known fork.
+                    ChainedHeader fork = this.walletTip;
+
+                    // We walk back the chained block object to find the fork.
+                    while (this.chain.GetBlock(fork.HashBlock) == null)
+                        fork = fork.Previous;
+
+                    this.logger.LogInformation("Reorg detected, going back from '{0}' to '{1}'.", this.walletTip, fork);
+
+                    this.walletManager.RemoveBlocks(fork);
+                    this.walletTip = fork;
+
+                    this.logger.LogTrace("Wallet tip set to '{0}'.", this.walletTip);
+                }
+
+                // The new tip can be ahead or behind the wallet.
+                // If the new tip is ahead we try to bring the wallet up to the new tip.
+                // If the new tip is behind we just check the wallet and the tip are in the same chain.
+                if (newTip.Height > this.walletTip.Height)
+                {
+                    ChainedHeader findTip = newTip.FindAncestorOrSelf(this.walletTip);
+                    if (findTip == null)
+                    {
+                        this.logger.LogTrace("(-)[NEW_TIP_AHEAD_NOT_IN_WALLET]");
+                        return;
+                    }
+
+                    CancellationToken token = this.nodeLifetime.ApplicationStopping;
+                    this.logger.LogTrace("Wallet tip '{0}' is behind the new tip '{1}'.", this.walletTip, newTip);
+
+                    ChainedHeader next = this.walletTip;
+                    while (next != newTip)
+                    {
+                        // While the wallet is catching up the entire node will wait.
+                        // If a wallet is recovered to a date in the past. Consensus will stop till the wallet is up to date.
+
+                        // TODO: This code should be replaced with a different approach
+                        // Similar to BlockStore the wallet should be standalone and not depend on consensus.
+                        // The block should be put in a queue and pushed to the wallet in an async way.
+                        // If the wallet is behind it will just read blocks from store (or download in case of a pruned node).
+
+                        next = newTip.GetAncestor(next.Height + 1);
+                        Block nextblock = null;
+                        int index = 0;
+                        while (true)
+                        {
+                            if (token.IsCancellationRequested)
+                            {
+                                this.logger.LogTrace("(-)[CANCELLATION_REQUESTED]");
+                                return;
+                            }
+
+                            nextblock = this.blockStore.GetBlockAsync(next.HashBlock).GetAwaiter().GetResult();
+                            if (nextblock == null)
+                            {
+                                // The idea in this abandoning of the loop is to release consensus to push the block.
+                                // That will make the block available in the next push from consensus.
+                                index++;
+                                if (index > 10)
+                                {
+                                    this.logger.LogTrace("(-)[WALLET_CATCHUP_INDEX_MAX]");
+                                    return;
+                                }
+
+                                // Really ugly hack to let store catch up.
+                                // This will block the entire consensus pulling.
+                                this.logger.LogWarning("Wallet is behind the best chain and the next block is not found in store.");
+                                Thread.Sleep(100);
+                                continue;
+                            }
+
+                            break;
+                        }
+
+                        this.walletTip = next;
+                        this.walletManager.ProcessBlock(nextblock, next);
+                    }
+                }
+                else
+                {
+                    ChainedHeader findTip = this.walletTip.FindAncestorOrSelf(newTip);
+                    if (findTip == null)
+                    {
+                        this.logger.LogTrace("(-)[NEW_TIP_BEHIND_NOT_IN_WALLET]");
+                        return;
+                    }
+
+                    this.logger.LogTrace("Wallet tip '{0}' is ahead or equal to the new tip '{1}'.", this.walletTip, newTip);
+                }
+            }
+            else this.logger.LogTrace("New block follows the previously known block '{0}'.", this.walletTip);
+
+            this.walletTip = newTip;
+            this.walletManager.ProcessBlock(block, newTip);
+        }
+
+        /// <inheritdoc />
+        public virtual void ProcessTransaction(Transaction transaction)
+        {
+            Guard.NotNull(transaction, nameof(transaction));
+
+            this.walletManager.ProcessTransaction(transaction);
+        }
+
+        /// <inheritdoc />
+        public virtual void SyncFromDate(DateTime date)
+        {
+            int blockSyncStart = this.chain.GetHeightAtTime(date);
+            this.SyncFromHeight(blockSyncStart);
+        }
+
+        /// <inheritdoc />
+        public virtual void SyncFromHeight(int height)
+        {
+            ChainedHeader chainedBlock = this.chain.GetBlock(height);
+            this.walletTip = chainedBlock ?? throw new WalletException("Invalid block height");
+            this.walletManager.WalletTipHash = chainedBlock.HashBlock;
+        }
+    }
+}

--- a/src/Stratis.Features.FederatedPeg/Wallet/FederationWalletTransactionHandler.cs
+++ b/src/Stratis.Features.FederatedPeg/Wallet/FederationWalletTransactionHandler.cs
@@ -1,0 +1,495 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
+using NBitcoin;
+using NBitcoin.Policy;
+using Stratis.Bitcoin.Features.Wallet;
+using Stratis.Bitcoin.Features.Wallet.Interfaces;
+using Stratis.Bitcoin.Utilities;
+using Stratis.Bitcoin.Utilities.Extensions;
+using Stratis.Features.FederatedPeg.Interfaces;
+
+namespace Stratis.Features.FederatedPeg.Wallet
+{
+    public interface IFederationWalletTransactionHandler
+    {
+        /// <summary>
+        /// Builds a new transaction based on information from the <see cref="TransactionBuildContext"/>.
+        /// </summary>
+        /// <param name="context">The context that is used to build a new transaction.</param>
+        /// <returns>The new transaction.</returns>
+        Transaction BuildTransaction(Wallet.TransactionBuildContext context);
+    }
+
+    /// <summary>
+    /// A handler that has various functionalities related to transaction operations.
+    /// </summary>
+    /// <remarks>
+    /// This will uses the <see cref="IWalletFeePolicy"/> and the <see cref="TransactionBuilder"/>.
+    /// TODO: Move also the broadcast transaction to this class
+    /// TODO: Implement lockUnspents
+    /// TODO: Implement subtractFeeFromOutputs
+    /// </remarks>
+    public class FederationWalletTransactionHandler : IFederationWalletTransactionHandler
+    {
+        /// <summary>A threshold that if possible will limit the amount of UTXO sent to the <see cref="ICoinSelector"/>.</summary>
+        /// <remarks>
+        /// 500 is a safe number that if reached ensures the coin selector will not take too long to complete,
+        /// most regular wallets will never reach such a high number of UTXO.
+        /// </remarks>
+        private const int SendCountThresholdLimit = 500;
+
+        private readonly IFederationWalletManager walletManager;
+
+        private readonly IWalletFeePolicy walletFeePolicy;
+
+        private readonly ILogger logger;
+
+        private readonly Network network;
+
+        private readonly MemoryCache privateKeyCache;
+
+        public FederationWalletTransactionHandler(
+            ILoggerFactory loggerFactory,
+            IFederationWalletManager walletManager,
+            IWalletFeePolicy walletFeePolicy,
+            Network network)
+        {
+            Guard.NotNull(loggerFactory, nameof(loggerFactory));
+            Guard.NotNull(walletManager, nameof(walletManager));
+            Guard.NotNull(walletFeePolicy, nameof(walletFeePolicy));
+            Guard.NotNull(network, nameof(network));
+
+            this.walletManager = walletManager;
+            this.walletFeePolicy = walletFeePolicy;
+            this.network = network;
+            this.logger = loggerFactory.CreateLogger(this.GetType().FullName);
+            this.privateKeyCache = new MemoryCache(new MemoryCacheOptions() { ExpirationScanFrequency = new TimeSpan(0, 1, 0) });
+        }
+
+        /// <inheritdoc />
+        public Transaction BuildTransaction(TransactionBuildContext context)
+        {
+            this.InitializeTransactionBuilder(context);
+
+            if (context.Shuffle)
+            {
+                context.TransactionBuilder.Shuffle();
+            }
+
+            // build transaction
+            context.Transaction = context.TransactionBuilder.BuildTransaction(context.Sign);
+
+            // If this is a multisig transaction, then by definition we only (usually) possess one of the keys
+            // and can therefore not immediately construct a transaction that passes verification
+            if (!context.IgnoreVerify)
+            {
+                if (!context.TransactionBuilder.Verify(context.Transaction, out TransactionPolicyError[] errors))
+                {
+                    string errorsMessage = string.Join(" - ", errors.Select(s => s.ToString()));
+                    this.logger.LogError($"Build transaction failed: {errorsMessage}");
+                    throw new WalletException($"Could not build the transaction. Details: {errorsMessage}");
+                }
+            }
+
+            return context.Transaction;
+        }
+
+        /// <summary>
+        /// Initializes the context transaction builder from information in <see cref="TransactionBuildContext"/>.
+        /// </summary>
+        /// <param name="context">Transaction build context.</param>
+        private void InitializeTransactionBuilder(Wallet.TransactionBuildContext context)
+        {
+            Guard.NotNull(context, nameof(context));
+            Guard.NotNull(context.Recipients, nameof(context.Recipients));
+
+            context.TransactionBuilder = new TransactionBuilder(this.network);
+
+            this.AddRecipients(context);
+            this.AddOpReturnOutput(context);
+            this.AddCoins(context);
+            this.AddSecrets(context);
+            this.FindChangeAddress(context);
+            this.AddFee(context);
+        }
+
+        /// <summary>
+        /// Loads the private key for the multisig address.
+        /// </summary>
+        /// <param name="context">The context associated with the current transaction being built.</param>
+        private void AddSecrets(TransactionBuildContext context)
+        {
+            if (!context.Sign)
+                return;
+
+            FederationWallet wallet = this.walletManager.GetWallet();
+
+            // Get the encrypted private key.
+            string cacheKey = wallet.EncryptedSeed;
+
+            Key privateKey;
+
+            // Check if the private key is in the cache.
+            if (this.privateKeyCache.TryGetValue(cacheKey, out SecureString secretValue))
+            {
+                privateKey = wallet.Network.CreateBitcoinSecret(secretValue.FromSecureString()).PrivateKey;
+                this.privateKeyCache.Set(cacheKey, secretValue, new TimeSpan(0, 5, 0));
+            }
+            else
+            {
+                privateKey = Key.Parse(wallet.EncryptedSeed, context.WalletPassword, wallet.Network);
+                this.privateKeyCache.Set(cacheKey, privateKey.ToString(wallet.Network).ToSecureString(), new TimeSpan(0, 5, 0));
+            }
+
+            // Add the key used to sign the output.
+            context.TransactionBuilder.AddKeys(new[] { privateKey.GetBitcoinSecret(this.network) });
+        }
+
+        /// <summary>
+        /// Compares transaction data to determine the order of inclusion in the transaction.
+        /// </summary>
+        /// <param name="x">First transaction data.</param>
+        /// <param name="y">Second transaction data.</param>
+        /// <returns>Returns <c>0</c> if the outputs are the same and <c>-1<c> or <c>1</c> depending on whether the first or second output takes precedence.</returns>
+        public static int CompareTransactionData(TransactionData x, TransactionData y)
+        {
+            // The oldest UTXO (determined by block height) is selected first.
+            if ((x.BlockHeight ?? int.MaxValue) != (y.BlockHeight ?? int.MaxValue))
+            {
+                return ((x.BlockHeight ?? int.MaxValue) < (y.BlockHeight ?? int.MaxValue)) ? -1 : 1;
+            }
+
+            // If a block has more than one UTXO, then they are selected in order of transaction id.
+            if (x.Id != y.Id)
+            {
+                return (x.Id < y.Id) ? -1 : 1;
+            }
+
+            // If multiple UTXOs appear within a transaction then they are selected in ascending index order.
+            if (x.Index != y.Index)
+            {
+                return (x.Index < y.Index) ? -1 : 1;
+            }
+
+            return 0;
+        }
+
+        /// <summary>
+        /// Compares two unspent outputs to determine the order of inclusion in the transaction.
+        /// </summary>
+        /// <param name="x">First unspent output.</param>
+        /// <param name="y">Second unspent output.</param>
+        /// <returns>Returns <c>0</c> if the outputs are the same and <c>-1<c> or <c>1</c> depending on whether the first or second output takes precedence.</returns>
+        private int CompareUnspentOutputReferences(UnspentOutputReference x, UnspentOutputReference y)
+        {
+            return CompareTransactionData(x.Transaction, y.Transaction);
+        }
+
+        /// <summary>
+        /// Returns the unspent outputs in the preferred order of consumption.
+        /// </summary>
+        /// <param name="context">The context associated with the current transaction being built.</param>
+        /// <returns>The unspent outputs in the preferred order of consumption.</returns>
+        private IOrderedEnumerable<UnspentOutputReference> GetOrderedUnspentOutputs(TransactionBuildContext context)
+        {
+            return context.UnspentOutputs.OrderBy(a => a, Comparer<UnspentOutputReference>.Create((x, y) => this.CompareUnspentOutputReferences(x, y)));
+        }
+
+        /// <summary>
+        /// Find the next available change address.
+        /// </summary>
+        /// <param name="context">The context associated with the current transaction being built.</param>
+        private void FindChangeAddress(TransactionBuildContext context)
+        {
+            // Change address should be the multisig address.
+            context.ChangeAddress = this.walletManager.GetWallet().MultiSigAddress;
+            context.TransactionBuilder.SetChange(context.ChangeAddress.ScriptPubKey);
+        }
+
+        /// <summary>
+        /// Find all available outputs (UTXO's) that belong to the multisig address.
+        /// Then add them to the <see cref="TransactionBuildContext.UnspentOutputs"/> or <see cref="TransactionBuildContext.UnspentMultiSigOutputs"/>.
+        /// </summary>
+        /// <param name="context">The context associated with the current transaction being built.</param>
+        private void AddCoins(TransactionBuildContext context)
+        {
+            context.UnspentOutputs = this.walletManager.GetSpendableTransactionsInWallet(context.MinConfirmations).ToList();
+
+            if (context.UnspentOutputs.Count == 0)
+            {
+                throw new WalletException("No spendable transactions found.");
+            }
+
+            // Get total spendable balance in the account.
+            long balance = context.UnspentOutputs.Sum(t => t.Transaction.Amount);
+            long totalToSend = context.Recipients.Sum(s => s.Amount);
+            if (balance < totalToSend)
+                throw new WalletException("Not enough funds.");
+
+            if (context.SelectedInputs.Any())
+            {
+                // 'SelectedInputs' are inputs that must be included in the
+                // current transaction. At this point we check the given
+                // input is part of the UTXO set and filter out UTXOs that are not
+                // in the initial list if 'context.AllowOtherInputs' is false.
+
+                Dictionary<OutPoint, UnspentOutputReference> availableHashList = context.UnspentOutputs.ToDictionary(item => item.ToOutPoint(), item => item);
+
+                if (!context.SelectedInputs.All(input => availableHashList.ContainsKey(input)))
+                    throw new WalletException("Not all the selected inputs were found on the wallet.");
+
+                if (!context.AllowOtherInputs)
+                {
+                    foreach (KeyValuePair<OutPoint, UnspentOutputReference> unspentOutputsItem in availableHashList)
+                        if (!context.SelectedInputs.Contains(unspentOutputsItem.Key))
+                            context.UnspentOutputs.Remove(unspentOutputsItem.Value);
+                }
+            }
+
+            long sum = 0;
+            int index = 0;
+            var coins = new List<Coin>();
+
+            foreach (UnspentOutputReference item in context.OrderCoinsDeterministic ?
+                this.GetOrderedUnspentOutputs(context) : context.UnspentOutputs.OrderByDescending(a => a.Transaction.Amount))
+            {
+                coins.Add(ScriptCoin.Create(this.network, item.Transaction.Id, (uint)item.Transaction.Index, item.Transaction.Amount, item.Transaction.ScriptPubKey, this.walletManager.GetWallet().MultiSigAddress.RedeemScript));
+                sum += item.Transaction.Amount;
+                index++;
+
+                // Sufficient UTXOs are selected to cover the value of the outputs + fee.
+                if (sum >= (totalToSend + context.TransactionFee))
+                    break;
+
+            }
+
+            context.TransactionBuilder.AddCoins(coins);
+        }
+
+        /// <summary>
+        /// Add recipients to the <see cref="TransactionBuilder"/>.
+        /// </summary>
+        /// <param name="context">The context associated with the current transaction being built.</param>
+        /// <remarks>
+        /// Add outputs to the <see cref="TransactionBuilder"/> based on the <see cref="Recipient"/> list.
+        /// </remarks>
+        private void AddRecipients(TransactionBuildContext context)
+        {
+            if (context.Recipients.Any(a => a.Amount == Money.Zero))
+                throw new WalletException("No amount specified.");
+
+            if (context.Recipients.Any(a => a.SubtractFeeFromAmount))
+                throw new NotImplementedException("Substracting the fee from the recipient is not supported yet.");
+
+            foreach (Recipient recipient in context.Recipients)
+                context.TransactionBuilder.Send(recipient.ScriptPubKey, recipient.Amount);
+        }
+
+        /// <summary>
+        /// Use the <see cref="FeeRate"/> from the <see cref="walletFeePolicy"/>.
+        /// </summary>
+        /// <param name="context">The context associated with the current transaction being built.</param>
+        private void AddFee(TransactionBuildContext context)
+        {
+            Money fee;
+            Money minTrxFee = new Money(this.network.MinTxFee, MoneyUnit.Satoshi);
+
+            // If the fee hasn't been set manually, calculate it based on the fee type that was chosen.
+            if (context.TransactionFee == null)
+            {
+                FeeRate feeRate = context.OverrideFeeRate ?? this.walletFeePolicy.GetFeeRate(context.FeeType.ToConfirmations());
+                fee = context.TransactionBuilder.EstimateFees(feeRate);
+
+                // Make sure that the fee is at least the minimum transaction fee.
+                fee = Math.Max(fee, minTrxFee);
+            }
+            else
+            {
+                if (context.TransactionFee < minTrxFee)
+                {
+                    throw new WalletException($"Not enough fees. The minimum fee is {minTrxFee}.");
+                }
+
+                fee = context.TransactionFee;
+            }
+
+            context.TransactionBuilder.SendFees(fee);
+            context.TransactionFee = fee;
+        }
+
+        /// <summary>
+        /// Add extra unspendable output to the transaction if there is anything in OpReturnData.
+        /// </summary>
+        /// <param name="context">The context associated with the current transaction being built.</param>
+        private void AddOpReturnOutput(TransactionBuildContext context)
+        {
+            if (context.OpReturnData == null) return;
+
+            Script opReturnScript = TxNullDataTemplate.Instance.GenerateScriptPubKey(context.OpReturnData);
+            context.TransactionBuilder.Send(opReturnScript, Money.Zero);
+        }
+    }
+
+    public class TransactionBuildContext
+    {
+        /// <summary>
+        /// Initialize a new instance of a <see cref="TransactionBuildContext"/>
+        /// </summary>
+        /// <param name="recipients">The target recipients to send coins to.</param>
+        public TransactionBuildContext(List<Recipient> recipients) : this(recipients, string.Empty)
+        {
+        }
+
+        /// <summary>
+        /// Initialize a new instance of a <see cref="TransactionBuildContext"/>
+        /// </summary>
+        /// <param name="recipients">The target recipients to send coins to.</param>
+        /// <param name="walletPassword">The password that protects the member's seed.</param>
+        public TransactionBuildContext(List<Recipient> recipients, string walletPassword = "", byte[] opReturnData = null)
+        {
+            Guard.NotNull(recipients, nameof(recipients));
+
+            this.Recipients = recipients;
+            this.WalletPassword = walletPassword;
+            this.FeeType = FeeType.Medium;
+            this.MinConfirmations = 1;
+            this.SelectedInputs = new List<OutPoint>();
+            this.AllowOtherInputs = false;
+            this.Sign = !string.IsNullOrEmpty(walletPassword);
+            this.OpReturnData = opReturnData;
+            this.MultiSig = null;
+            this.IgnoreVerify = false;
+        }
+
+        /// <summary>
+        /// The recipients to send Bitcoin to.
+        /// </summary>
+        public List<Recipient> Recipients { get; set; }
+
+        /// <summary>
+        /// An indicator to estimate how much fee to spend on a transaction.
+        /// </summary>
+        /// <remarks>
+        /// The higher the fee the faster a transaction will get in to a block.
+        /// </remarks>
+        public FeeType FeeType { get; set; }
+
+        /// <summary>
+        /// The minimum number of confirmations an output must have to be included as an input.
+        /// </summary>
+        public int MinConfirmations { get; set; }
+
+        /// <summary>
+        /// Coins that are available to be spent.
+        /// </summary>
+        public List<Wallet.UnspentOutputReference> UnspentOutputs { get; set; }
+
+        public Network Network { get; set; }
+
+        /// <summary>
+        /// The builder used to build the current transaction.
+        /// </summary>
+        public TransactionBuilder TransactionBuilder { get; set; }
+
+        /// <summary>
+        /// The change address, where any remaining funds will be sent to.
+        /// </summary>
+        /// <remarks>
+        /// A Bitcoin has to spend the entire UTXO, if total value is greater then the send target
+        /// the rest of the coins go in to a change address that is under the senders control.
+        /// </remarks>
+        public MultiSigAddress ChangeAddress { get; set; }
+
+        /// <summary>
+        /// The total fee on the transaction.
+        /// </summary>
+        public Money TransactionFee { get; set; }
+
+        /// <summary>
+        /// The final transaction.
+        /// </summary>
+        public Transaction Transaction { get; set; }
+
+        /// <summary>
+        /// The password that protects the member's seed.
+        /// </summary>
+        /// <remarks>
+        /// TODO: replace this with System.Security.SecureString (https://github.com/dotnet/corefx/tree/master/src/System.Security.SecureString)
+        /// More info (https://github.com/dotnet/corefx/issues/1387)
+        /// </remarks>
+        public string WalletPassword { get; set; }
+
+        /// <summary>
+        /// The inputs that must be used when building the transaction.
+        /// </summary>
+        /// <remarks>
+        /// The inputs are required to be part of the wallet.
+        /// </remarks>
+        public List<OutPoint> SelectedInputs { get; set; }
+
+        /// <summary>
+        /// If false, allows unselected inputs, but requires all selected inputs be used
+        /// </summary>
+        public bool AllowOtherInputs { get; set; }
+
+        /// <summary>
+        /// If <c>true</c> coins will be ordered using (block height + transaction id + output index) ordering.
+        /// </summary>
+        public bool OrderCoinsDeterministic { get; set; }
+
+        /// <summary>
+        /// Specify whether to sign the transaction.
+        /// </summary>
+        public bool Sign { get; set; }
+
+        /// <summary>
+        /// Allows the context to specify a <see cref="FeeRate"/> when building a transaction.
+        /// </summary>
+        public FeeRate OverrideFeeRate { get; set; }
+
+        /// <summary>
+        /// Shuffles transaction inputs and outputs for increased privacy.
+        /// </summary>
+        public bool Shuffle { get; set; }
+
+        /// <summary>
+        /// Optional data to be added as an extra OP_RETURN transaction output with Money.Zero value.
+        /// </summary>
+        public byte[] OpReturnData { get; set; }
+
+        /// <summary>
+        /// If not null, indicates the multisig address details that funds can be sourced from.
+        /// </summary>
+        public MultiSigAddress MultiSig { get; set; }
+
+        /// <summary>
+        /// If true, do not perform verification on the built transaction (e.g. it is partially signed)
+        /// </summary>
+        public bool IgnoreVerify { get; set; }
+    }
+
+    /// <summary>
+    /// Represents recipients of a payment, used in <see cref="FederationWalletTransactionHandler.BuildTransaction"/>
+    /// </summary>
+    public class Recipient
+    {
+        /// <summary>
+        /// The destination script.
+        /// </summary>
+        public Script ScriptPubKey { get; set; }
+
+        /// <summary>
+        /// The amount that will be sent.
+        /// </summary>
+        public Money Amount { get; set; }
+
+        /// <summary>
+        /// An indicator if the fee is subtracted from the current recipient.
+        /// </summary>
+        public bool SubtractFeeFromAmount { get; set; }
+    }
+}

--- a/src/Stratis.Features.FederatedPeg/Wallet/MultiSigAddress.cs
+++ b/src/Stratis.Features.FederatedPeg/Wallet/MultiSigAddress.cs
@@ -1,0 +1,83 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using NBitcoin;
+using Newtonsoft.Json;
+using Stratis.Bitcoin.Utilities.JsonConverters;
+
+namespace Stratis.Features.FederatedPeg.Wallet
+{
+    /// <summary>
+    /// A multi-signature address; where only our private keys are derived from an HD seed.
+    /// </summary>
+    public class MultiSigAddress
+    {
+        public MultiSigAddress()
+        {
+            this.Transactions = new List<TransactionData>();
+        }
+
+        /// <summary>
+        /// The script pub key for this address. This is the P2SH version incorporating all the signatories.
+        /// This is the hashed version of the redeem script. In the context of a P2SH transaction this is
+        /// what is conventionally referred to as the scriptPubKey, even though it is only used for receiving
+        /// funds and cannot be used for spending them.
+        /// </summary>
+        [JsonProperty(PropertyName = "scriptPubKey")]
+        [JsonConverter(typeof(ScriptJsonConverter))]
+        public Script ScriptPubKey { get; set; }
+
+        /// <summary>
+        /// The number of signatories required for a multisig transaction to be signed.
+        /// </summary>
+        [JsonProperty(PropertyName = "m")]
+        public int M { get; set; }
+
+        /// <summary>
+        /// The pubkeys for this address, from all signatories.
+        /// </summary>
+        [JsonProperty(PropertyName = "pubkeys")]
+        public ICollection<Script> Pubkeys { get; set; }
+
+        /// <summary>
+        /// The redeemScript for this address. Needed for P2SH multisig as the full script is not present
+        /// in the previous transaction output(s). This is the full 'scriptPubKey' of the multisig address.
+        /// It is needed when the signatories wish to spend funds held in the multisig address.
+        /// </summary>
+        [JsonProperty(PropertyName = "redeemScript")]
+        [JsonConverter(typeof(ScriptJsonConverter))]
+        public Script RedeemScript{ get; set; }
+
+        /// <summary>
+        /// The Base58 representation of this address. The address is effectively derived from the
+        /// PaymentScript. It is possible to re-derive the scriptPubKey for receiving payments from the
+        /// address.
+        /// </summary>
+        [JsonProperty(PropertyName = "address")]
+        public string Address { get; set; }
+
+        /// <summary>
+        /// A list of transactions involving this multisig address.
+        /// </summary>
+        [JsonProperty(PropertyName = "transactions")]
+        public ICollection<TransactionData> Transactions { get; set; }
+        
+        public Key GetPrivateKey(string encryptedSeed, string password, Network network)
+        {
+            return Key.Parse(encryptedSeed, password, network);
+        }
+
+        /// <summary>
+        /// List all spendable transactions in a multisig address.
+        /// </summary>
+        /// <returns></returns>
+        public IEnumerable<TransactionData> UnspentTransactions()
+        {
+            if (this.Transactions == null)
+            {
+                return new List<TransactionData>();
+            }
+
+            return this.Transactions.Where(t => t.IsSpendable());
+        }
+    }
+}

--- a/src/Stratis.Features.FederatedPeg/Wallet/PaymentDetails.cs
+++ b/src/Stratis.Features.FederatedPeg/Wallet/PaymentDetails.cs
@@ -1,0 +1,32 @@
+﻿using NBitcoin;
+using Newtonsoft.Json;
+using Stratis.Bitcoin.Utilities.JsonConverters;
+
+namespace Stratis.Features.FederatedPeg.Wallet
+{
+    /// <summary>
+    /// An object representing a payment.
+    /// </summary>
+    public class PaymentDetails
+    {
+        /// <summary>
+        /// The script pub key of the destination address.
+        /// </summary>
+        [JsonProperty(PropertyName = "destinationScriptPubKey")]
+        [JsonConverter(typeof(ScriptJsonConverter))]
+        public Script DestinationScriptPubKey { get; set; }
+
+        /// <summary>
+        /// The Base58 representation of the destination  address.
+        /// </summary>
+        [JsonProperty(PropertyName = "destinationAddress")]
+        public string DestinationAddress { get; set; }
+
+        /// <summary>
+        /// The transaction amount.
+        /// </summary>
+        [JsonProperty(PropertyName = "amount")]
+        [JsonConverter(typeof(MoneyJsonConverter))]
+        public Money Amount { get; set; }
+    }
+}

--- a/src/Stratis.Features.FederatedPeg/Wallet/SpendingDetails.cs
+++ b/src/Stratis.Features.FederatedPeg/Wallet/SpendingDetails.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Collections.Generic;
+using NBitcoin;
+using Newtonsoft.Json;
+using Stratis.Bitcoin.Utilities.JsonConverters;
+
+namespace Stratis.Features.FederatedPeg.Wallet
+{
+    public class SpendingDetails
+    {
+        public SpendingDetails()
+        {
+            this.Payments = new List<PaymentDetails>();
+        }
+
+        /// <summary>
+        /// The id of the transaction in which the output referenced in this transaction is spent.
+        /// </summary>
+        [JsonProperty(PropertyName = "transactionId", NullValueHandling = NullValueHandling.Ignore)]
+        [JsonConverter(typeof(UInt256JsonConverter))]
+        public uint256 TransactionId { get; set; }
+
+        /// <summary>
+        /// A list of payments made out in this transaction.
+        /// </summary>
+        [JsonProperty(PropertyName = "payments", NullValueHandling = NullValueHandling.Ignore)]
+        public ICollection<PaymentDetails> Payments { get; set; }
+
+        /// <summary>
+        /// The height of the block including this transaction.
+        /// </summary>
+        [JsonProperty(PropertyName = "blockHeight", NullValueHandling = NullValueHandling.Ignore)]
+        public int? BlockHeight { get; set; }
+
+        /// <summary>
+        /// A value indicating whether this is a coin stake transaction or not.
+        /// </summary>
+        [JsonProperty(PropertyName = "isCoinStake", NullValueHandling = NullValueHandling.Ignore)]
+        public bool? IsCoinStake { get; set; }
+
+        /// <summary>
+        /// Gets or sets the creation time.
+        /// </summary>
+        [JsonProperty(PropertyName = "creationTime")]
+        [JsonConverter(typeof(DateTimeOffsetConverter))]
+        public DateTimeOffset CreationTime { get; set; }
+
+        /// <summary>
+        /// Hexadecimal representation of this spending transaction.
+        /// </summary>
+        [JsonProperty(PropertyName = "hex", NullValueHandling = NullValueHandling.Ignore)]
+        public string Hex { get; set; }
+
+        /// <summary>
+        /// Gets or sets the full transaction object.
+        /// </summary>
+        [JsonIgnore]
+        public Transaction Transaction => Transaction.Parse(this.Hex, RawFormat.BlockExplorer);
+
+        /// <summary>
+        /// Determines whether this transaction being spent is confirmed.
+        /// </summary>
+        public bool IsSpentConfirmed()
+        {
+            return this.BlockHeight != null;
+        }
+    }
+}

--- a/src/Stratis.Features.FederatedPeg/Wallet/TransactionData.cs
+++ b/src/Stratis.Features.FederatedPeg/Wallet/TransactionData.cs
@@ -1,0 +1,96 @@
+﻿using System;
+using NBitcoin;
+using Newtonsoft.Json;
+using Stratis.Bitcoin.Utilities.JsonConverters;
+
+namespace Stratis.Features.FederatedPeg.Wallet
+{
+    /// <summary>
+    /// An object containing transaction data.
+    /// </summary>
+    public class TransactionData
+    {
+        [JsonProperty(PropertyName = "id")]
+        [JsonConverter(typeof(UInt256JsonConverter))]
+        public uint256 Id { get; set; }
+
+        [JsonProperty(PropertyName = "amount")]
+        [JsonConverter(typeof(MoneyJsonConverter))]
+        public Money Amount { get; set; }
+
+        /// <summary>
+        /// The index of this scriptPubKey in the transaction it is contained.
+        /// </summary>
+        /// <remarks>
+        /// This is effectively the index of the output, the position of the output in the parent transaction.
+        /// </remarks>
+        [JsonProperty(PropertyName = "index", NullValueHandling = NullValueHandling.Ignore)]
+        public int Index { get; set; }
+
+        [JsonProperty(PropertyName = "blockHeight", NullValueHandling = NullValueHandling.Ignore)]
+        public int? BlockHeight { get; set; }
+
+        [JsonProperty(PropertyName = "blockHash", NullValueHandling = NullValueHandling.Ignore)]
+        [JsonConverter(typeof(UInt256JsonConverter))]
+        public uint256 BlockHash { get; set; }
+
+        [JsonProperty(PropertyName = "creationTime")]
+        [JsonConverter(typeof(DateTimeOffsetConverter))]
+        public DateTimeOffset CreationTime { get; set; }
+
+        [JsonProperty(PropertyName = "merkleProof", NullValueHandling = NullValueHandling.Ignore)]
+        [JsonConverter(typeof(BitcoinSerializableJsonConverter))]
+        public PartialMerkleTree MerkleProof { get; set; }
+
+        [JsonProperty(PropertyName = "scriptPubKey")]
+        [JsonConverter(typeof(ScriptJsonConverter))]
+        public Script ScriptPubKey { get; set; }
+
+        /// <summary>
+        /// Hexadecimal representation of this transaction.
+        /// </summary>
+        [JsonProperty(PropertyName = "hex", NullValueHandling = NullValueHandling.Ignore)]
+        public string Hex { get; set; }
+
+        /// <summary>
+        /// Propagation state of this transaction.
+        /// </summary>
+        /// <remarks>Assume it's <c>true</c> if the field is <c>null</c>.</remarks>
+        [JsonProperty(PropertyName = "isPropagated", NullValueHandling = NullValueHandling.Ignore)]
+        public bool? IsPropagated { get; set; }
+
+        [JsonProperty(PropertyName = "spendingDetails", NullValueHandling = NullValueHandling.Ignore)]
+        public SpendingDetails SpendingDetails { get; set; }
+
+        public bool IsConfirmed()
+        {
+            return this.BlockHeight != null;
+        }
+
+        public Transaction GetFullTransaction(Network network)
+        {
+            return network.CreateTransaction(this.Hex);
+        }
+
+        public bool IsSpendable()
+        {
+            // TODO: Coinbase maturity check?
+            return this.SpendingDetails == null;
+        }
+
+        public Money SpendableAmount(bool confirmedOnly)
+        {
+            // This method only returns a UTXO that has no spending output.
+            // If a spending output exists (even if its not confirmed) this will return as zero balance.
+            if (!this.IsSpendable()) return Money.Zero;
+            
+            if (confirmedOnly && !this.IsConfirmed())
+            {
+                return Money.Zero;
+            }
+
+            return this.Amount;
+
+        }
+    }
+}

--- a/src/Stratis.Features.FederatedPeg/Wallet/UnspentOutputReference.cs
+++ b/src/Stratis.Features.FederatedPeg/Wallet/UnspentOutputReference.cs
@@ -1,0 +1,24 @@
+﻿using NBitcoin;
+
+namespace Stratis.Features.FederatedPeg.Wallet
+{
+    /// <summary>
+    /// Represents an UTXO that keeps a reference to an address.
+    /// </summary>
+    public class UnspentOutputReference
+    {
+        /// <summary>
+        /// The transaction representing the UTXO.
+        /// </summary>
+        public TransactionData Transaction { get; set; }
+
+        /// <summary>
+        /// Convert the <see cref="TransactionData"/> to an <see cref="OutPoint"/>
+        /// </summary>
+        /// <returns>The corresponding <see cref="OutPoint"/>.</returns>
+        public OutPoint ToOutPoint()
+        {
+            return new OutPoint(this.Transaction.Id, (uint)this.Transaction.Index);
+        }
+    }
+}

--- a/src/Stratis.Sidechains.Networks/CirrusV2/CirrusMain.cs
+++ b/src/Stratis.Sidechains.Networks/CirrusV2/CirrusMain.cs
@@ -1,0 +1,158 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using NBitcoin;
+using NBitcoin.DataEncoders;
+using Stratis.Bitcoin.Features.PoA;
+using Stratis.Bitcoin.Features.SmartContracts;
+using Stratis.Bitcoin.Features.SmartContracts.PoA;
+using Stratis.SmartContracts.Networks.Policies;
+
+namespace Stratis.Sidechains.Networks.CirrusV2
+{
+    public class CirrusMain : PoANetwork, ISignedCodePubKeyHolder
+    {
+        /// <summary> The name of the root folder containing the different federated peg blockchains.</summary>
+        private const string NetworkRootFolderName = "cirrus";
+
+        /// <summary> The default name used for the federated peg configuration file. </summary>
+        private const string NetworkDefaultConfigFilename = "cirrus.conf";
+
+        public PubKey SigningContractPubKey { get; }
+
+        internal CirrusMain()
+        {
+            // TODO: Replace with real secret key.
+            this.SigningContractPubKey = new Mnemonic("lava frown leave wedding virtual ghost sibling able mammal liar wide wisdom").DeriveExtKey().PrivateKey.PubKey;
+
+            this.Name = nameof(CirrusMain);
+            this.CoinTicker = "CRS";
+            this.Magic = 0x522357A0; //
+            this.DefaultPort = 16179;
+            this.DefaultMaxOutboundConnections = 16;
+            this.DefaultMaxInboundConnections = 109;
+            this.RPCPort = 16175;
+            this.MaxTipAge = 2 * 60 * 60;
+            this.MinTxFee = 10000;
+            this.FallbackFee = 10000;
+            this.MinRelayTxFee = 10000;
+            this.RootFolderName = NetworkRootFolderName;
+            this.DefaultConfigFilename = NetworkDefaultConfigFilename;
+            this.MaxTimeOffsetSeconds = 25 * 60;
+
+            var consensusFactory = new SmartContractPoAConsensusFactory();
+
+            // Create the genesis block.
+            this.GenesisTime = 1545310504; // TODO: Update depending on when we launch.
+            this.GenesisNonce = 761900;
+            this.GenesisBits = new Target(new uint256("00000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"));
+            this.GenesisVersion = 1;
+            this.GenesisReward = Money.Zero;
+
+            string coinbaseText = "https://www.abc.net.au/news/science/2018-12-07/encryption-bill-australian-technology-industry-fuming-mad/10589962";
+            Block genesisBlock = CirrusNetwork.CreateGenesis(consensusFactory, this.GenesisTime, this.GenesisNonce, this.GenesisBits, this.GenesisVersion, this.GenesisReward, coinbaseText);
+
+            this.Genesis = genesisBlock;
+
+            // Configure federation public keys used to sign blocks.
+            // Keep in mind that order in which keys are added to this list is important
+            // and should be the same for all nodes operating on this network.
+            var federationPubKeys = new List<PubKey>
+            {
+                new PubKey("036317d97f911ce899fd0a360866d19f2dca5252c7960d4652d814ab155a8342de"),
+                new PubKey("02a08d72d47b3103261163c15aa2f6b0d007e1872ad9f5fddbfbd27bdb738156e9"),
+                new PubKey("03634c79d4e8e915cfb9f7bbef57bed32d715150836b7845b1a14c93670d816ab6"),
+                new PubKey("02062601ddfdb2208c1d074f1019fe6bc582ff9a0956a9cbe03f19af04b94f831b"),
+                new PubKey("03c36d4fd9a7f949df8ccd2b173e5cb8a5f77a8ad270d37b509314123b225afdfd"),
+                new PubKey("0254c4944820c49f8d595aa78bfce771453558dd159fd5eee8fac097fc3ac17c1b"),
+                new PubKey("03dad9bf0493560203ed6a1089749d140fa33d83aa15fcc8b22a108511389bdcef")
+            };
+
+            var consensusOptions = new PoAConsensusOptions(
+                maxBlockBaseSize: 1_000_000,
+                maxStandardVersion: 2,
+                maxStandardTxWeight: 100_000,
+                maxBlockSigopsCost: 20_000,
+                maxStandardTxSigopsCost: 20_000 / 5,
+                federationPublicKeys: federationPubKeys,
+                targetSpacingSeconds: 16,
+                votingEnabled: false
+            );
+
+            var buriedDeployments = new BuriedDeploymentsArray
+            {
+                [BuriedDeployments.BIP34] = 0,
+                [BuriedDeployments.BIP65] = 0,
+                [BuriedDeployments.BIP66] = 0
+            };
+
+            var bip9Deployments = new NoBIP9Deployments();
+
+            this.Consensus = new Consensus(
+                consensusFactory: consensusFactory,
+                consensusOptions: consensusOptions,
+                coinType: 401,
+                hashGenesisBlock: genesisBlock.GetHash(),
+                subsidyHalvingInterval: 210000,
+                majorityEnforceBlockUpgrade: 750,
+                majorityRejectBlockOutdated: 950,
+                majorityWindow: 1000,
+                buriedDeployments: buriedDeployments,
+                bip9Deployments: bip9Deployments,
+                bip34Hash: new uint256("0x000000000000024b89b42a942fe0d9fea3bb44ab7bd1b19115dd6a759c0808b8"),
+                ruleChangeActivationThreshold: 1916, // 95% of 2016
+                minerConfirmationWindow: 2016, // nPowTargetTimespan / nPowTargetSpacing
+                maxReorgLength: 0, // No max reorg limit on PoA networks.
+                defaultAssumeValid: null,
+                maxMoney: Money.Coins(100_000_000),
+                coinbaseMaturity: 1,
+                premineHeight: 2,
+                premineReward: Money.Coins(100_000_000),
+                proofOfWorkReward: Money.Coins(0),
+                powTargetTimespan: TimeSpan.FromDays(14), // two weeks
+                powTargetSpacing: TimeSpan.FromMinutes(1),
+                powAllowMinDifficultyBlocks: false,
+                powNoRetargeting: true,
+                powLimit: null,
+                minimumChainWork: null,
+                isProofOfStake: false,
+                lastPowBlock: 0,
+                proofOfStakeLimit: null,
+                proofOfStakeLimitV2: null,
+                proofOfStakeReward: Money.Zero
+            );
+
+            // Same as current smart contracts test networks to keep tests working
+            this.Base58Prefixes = new byte[12][];
+            this.Base58Prefixes[(int)Base58Type.PUBKEY_ADDRESS] = new byte[] { 28 }; // C
+            this.Base58Prefixes[(int)Base58Type.SCRIPT_ADDRESS] = new byte[] { 88 }; // c
+            this.Base58Prefixes[(int)Base58Type.SECRET_KEY] = new byte[] { (239) };
+            this.Base58Prefixes[(int)Base58Type.ENCRYPTED_SECRET_KEY_NO_EC] = new byte[] { 0x01, 0x42 };
+            this.Base58Prefixes[(int)Base58Type.ENCRYPTED_SECRET_KEY_EC] = new byte[] { 0x01, 0x43 };
+            this.Base58Prefixes[(int)Base58Type.EXT_PUBLIC_KEY] = new byte[] { (0x04), (0x35), (0x87), (0xCF) };
+            this.Base58Prefixes[(int)Base58Type.EXT_SECRET_KEY] = new byte[] { (0x04), (0x35), (0x83), (0x94) };
+            this.Base58Prefixes[(int)Base58Type.PASSPHRASE_CODE] = new byte[] { 0x2C, 0xE9, 0xB3, 0xE1, 0xFF, 0x39, 0xE2 };
+            this.Base58Prefixes[(int)Base58Type.CONFIRMATION_CODE] = new byte[] { 0x64, 0x3B, 0xF6, 0xA8, 0x9A };
+            this.Base58Prefixes[(int)Base58Type.STEALTH_ADDRESS] = new byte[] { 0x2b };
+            this.Base58Prefixes[(int)Base58Type.ASSET_ID] = new byte[] { 115 };
+            this.Base58Prefixes[(int)Base58Type.COLORED_ADDRESS] = new byte[] { 0x13 };
+
+            Bech32Encoder encoder = Encoders.Bech32("tb");
+            this.Bech32Encoders = new Bech32Encoder[2];
+            this.Bech32Encoders[(int)Bech32Type.WITNESS_PUBKEY_ADDRESS] = encoder;
+            this.Bech32Encoders[(int)Bech32Type.WITNESS_SCRIPT_ADDRESS] = encoder;
+
+            this.Checkpoints = new Dictionary<int, CheckpointInfo>();
+
+            this.DNSSeeds = new List<DNSSeedData>();
+
+            this.StandardScriptsRegistry = new SmartContractsStandardScriptsRegistry();
+
+            string[] seedNodes = { "40.112.89.58", "137.117.243.54", "51.140.255.152", "40.89.158.103", "40.89.158.153", "13.66.214.36", "23.101.147.254" };
+            this.SeedNodes = ConvertToNetworkAddresses(seedNodes, this.DefaultPort).ToList();
+
+            Assert(this.Consensus.HashGenesisBlock == uint256.Parse("0x000004b5e1be2efc806c0e779550e05fa11f4902063f87cc273959fadc5ca579"));
+            Assert(this.Genesis.Header.HashMerkleRoot == uint256.Parse("0x55168c43e5b997b99192af9819297efb43bedfdd698f29c6a2c22dfc671cc0fb"));
+        }
+    }
+}

--- a/src/Stratis.Sidechains.Networks/CirrusV2/CirrusNetwork.cs
+++ b/src/Stratis.Sidechains.Networks/CirrusV2/CirrusNetwork.cs
@@ -1,0 +1,50 @@
+﻿using NBitcoin;
+using NBitcoin.DataEncoders;
+using Stratis.Bitcoin.Features.SmartContracts.PoA;
+
+namespace Stratis.Sidechains.Networks.CirrusV2
+{
+    public static class CirrusNetwork
+    {
+        public static NetworksSelector NetworksSelector
+        {
+            get
+            {
+                return new NetworksSelector(() => new CirrusMain(), () => new CirrusTest(), () => new CirrusRegTest());
+            }
+        }
+
+        public static Block CreateGenesis(SmartContractPoAConsensusFactory consensusFactory, uint genesisTime, uint nonce, uint bits, int version, Money reward, string coinbaseText)
+        {
+            Transaction genesisTransaction = consensusFactory.CreateTransaction();
+            genesisTransaction.Time = genesisTime;
+            genesisTransaction.Version = 1;
+            genesisTransaction.AddInput(new TxIn()
+            {
+                ScriptSig = new Script(Op.GetPushOp(0), new Op()
+                {
+                    Code = (OpcodeType)0x1,
+                    PushData = new[] { (byte)42 }
+                }, Op.GetPushOp(Encoders.ASCII.DecodeData(coinbaseText)))
+            });
+
+            genesisTransaction.AddOutput(new TxOut()
+            {
+                Value = reward
+            });
+
+            Block genesis = consensusFactory.CreateBlock();
+            genesis.Header.BlockTime = Utils.UnixTimeToDateTime(genesisTime);
+            genesis.Header.Bits = bits;
+            genesis.Header.Nonce = nonce;
+            genesis.Header.Version = version;
+            genesis.Transactions.Add(genesisTransaction);
+            genesis.Header.HashPrevBlock = uint256.Zero;
+            genesis.UpdateMerkleRoot();
+
+            ((SmartContractPoABlockHeader)genesis.Header).HashStateRoot = new uint256("21B463E3B52F6201C0AD6C991BE0485B6EF8C092E64583FFA655CC1B171FE856");
+
+            return genesis;
+        }
+    }
+}

--- a/src/Stratis.Sidechains.Networks/CirrusV2/CirrusRegTest.cs
+++ b/src/Stratis.Sidechains.Networks/CirrusV2/CirrusRegTest.cs
@@ -1,0 +1,159 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using NBitcoin;
+using NBitcoin.DataEncoders;
+using NBitcoin.Protocol;
+using Stratis.Bitcoin.Features.PoA;
+using Stratis.Bitcoin.Features.SmartContracts;
+using Stratis.Bitcoin.Features.SmartContracts.PoA;
+using Stratis.SmartContracts.Networks.Policies;
+
+namespace Stratis.Sidechains.Networks.CirrusV2
+{
+    public class CirrusRegTest : PoANetwork, ISignedCodePubKeyHolder
+    {
+        public IList<Mnemonic> FederationMnemonics { get; }
+
+        /// <summary> The name of the root folder containing the different federated peg blockchains.</summary>
+        private const string NetworkRootFolderName = "cirrus";
+
+        /// <summary> The default name used for the federated peg configuration file. </summary>
+        private const string NetworkDefaultConfigFilename = "cirrus.conf";
+
+        // public IList<Mnemonic> FederationMnemonics { get; }
+        public IList<Key> FederationKeys { get; private set; }
+
+        public Key SigningContractPrivKey { get; }
+
+        public PubKey SigningContractPubKey { get; }
+
+        internal CirrusRegTest()
+        {
+            this.SigningContractPrivKey = new Mnemonic("lava frown leave wedding virtual ghost sibling able mammal liar wide wisdom").DeriveExtKey().PrivateKey;
+            this.SigningContractPubKey = this.SigningContractPrivKey.PubKey;
+
+            this.Name = nameof(CirrusRegTest);
+            this.CoinTicker = "TFPG";
+            this.Magic = 0x522357C;
+            this.DefaultPort = 26179;
+            this.DefaultMaxOutboundConnections = 16;
+            this.DefaultMaxInboundConnections = 109;
+            this.RPCPort = 26175;
+            this.MaxTipAge = 2 * 60 * 60;
+            this.MinTxFee = 10000;
+            this.FallbackFee = 10000;
+            this.MinRelayTxFee = 10000;
+            this.RootFolderName = NetworkRootFolderName;
+            this.DefaultConfigFilename = NetworkDefaultConfigFilename;
+            this.MaxTimeOffsetSeconds = 25 * 60;
+
+            var consensusFactory = new SmartContractPoAConsensusFactory();
+
+            // Create the genesis block.
+            this.GenesisTime = 1513622125;
+            this.GenesisNonce = 1560058197;
+            this.GenesisBits = 402691653;
+            this.GenesisVersion = 1;
+            this.GenesisReward = Money.Zero;
+
+            string coinbaseText = "https://news.bitcoin.com/markets-update-cryptocurrencies-shed-billions-in-bloody-sell-off/";
+            Block genesisBlock = CirrusNetwork.CreateGenesis(consensusFactory, this.GenesisTime, this.GenesisNonce, this.GenesisBits, this.GenesisVersion, this.GenesisReward, coinbaseText);
+
+            this.Genesis = genesisBlock;
+
+            this.FederationMnemonics = new[] {
+                   "ensure feel swift crucial bridge charge cloud tell hobby twenty people mandate",
+                   "quiz sunset vote alley draw turkey hill scrap lumber game differ fiction",
+                   "exchange rent bronze pole post hurry oppose drama eternal voice client state"
+               }.Select(m => new Mnemonic(m, Wordlist.English)).ToList();
+
+            this.FederationKeys = this.FederationMnemonics.Select(m => m.DeriveExtKey().PrivateKey).ToList();
+
+            List<PubKey> federationPubKeys = this.FederationKeys.Select(k => k.PubKey).ToList();
+
+            var consensusOptions = new PoAConsensusOptions(
+                maxBlockBaseSize: 1_000_000,
+                maxStandardVersion: 2,
+                maxStandardTxWeight: 100_000,
+                maxBlockSigopsCost: 20_000,
+                maxStandardTxSigopsCost: 20_000 / 5,
+                federationPublicKeys: federationPubKeys,
+                targetSpacingSeconds: 4, // For integration tests - avoid FastMining
+                votingEnabled: false
+            );
+
+            var buriedDeployments = new BuriedDeploymentsArray
+            {
+                [BuriedDeployments.BIP34] = 0,
+                [BuriedDeployments.BIP65] = 0,
+                [BuriedDeployments.BIP66] = 0
+            };
+
+            var bip9Deployments = new NoBIP9Deployments();
+
+            this.Consensus = new Consensus(
+                consensusFactory: consensusFactory,
+                consensusOptions: consensusOptions,
+                coinType: 400,
+                hashGenesisBlock: genesisBlock.GetHash(),
+                subsidyHalvingInterval: 210000,
+                majorityEnforceBlockUpgrade: 750,
+                majorityRejectBlockOutdated: 950,
+                majorityWindow: 1000,
+                buriedDeployments: buriedDeployments,
+                bip9Deployments: bip9Deployments,
+                bip34Hash: new uint256("0x000000000000024b89b42a942fe0d9fea3bb44ab7bd1b19115dd6a759c0808b8"),
+                ruleChangeActivationThreshold: 1916, // 95% of 2016
+                minerConfirmationWindow: 2016, // nPowTargetTimespan / nPowTargetSpacing
+                maxReorgLength: 0, // No max reorg limit on PoA networks.
+                defaultAssumeValid: null,
+                maxMoney: Money.Coins(20_000_000),
+                coinbaseMaturity: 1,
+                premineHeight: 2,
+                premineReward: Money.Coins(20_000_000),
+                proofOfWorkReward: Money.Coins(0),
+                powTargetTimespan: TimeSpan.FromDays(14), // two weeks
+                powTargetSpacing: TimeSpan.FromMinutes(1),
+                powAllowMinDifficultyBlocks: false,
+                powNoRetargeting: true,
+                powLimit: null,
+                minimumChainWork: null,
+                isProofOfStake: false,
+                lastPowBlock: 0,
+                proofOfStakeLimit: null,
+                proofOfStakeLimitV2: null,
+                proofOfStakeReward: Money.Zero
+            );
+
+            // Same as current smart contracts test networks to keep tests working
+            this.Base58Prefixes = new byte[12][];
+            this.Base58Prefixes[(int)Base58Type.PUBKEY_ADDRESS] = new byte[] { 55 }; // P
+            this.Base58Prefixes[(int)Base58Type.SCRIPT_ADDRESS] = new byte[] { 117 }; // p
+            this.Base58Prefixes[(int)Base58Type.SECRET_KEY] = new byte[] { (239) };
+            this.Base58Prefixes[(int)Base58Type.ENCRYPTED_SECRET_KEY_NO_EC] = new byte[] { 0x01, 0x42 };
+            this.Base58Prefixes[(int)Base58Type.ENCRYPTED_SECRET_KEY_EC] = new byte[] { 0x01, 0x43 };
+            this.Base58Prefixes[(int)Base58Type.EXT_PUBLIC_KEY] = new byte[] { (0x04), (0x35), (0x87), (0xCF) };
+            this.Base58Prefixes[(int)Base58Type.EXT_SECRET_KEY] = new byte[] { (0x04), (0x35), (0x83), (0x94) };
+            this.Base58Prefixes[(int)Base58Type.PASSPHRASE_CODE] = new byte[] { 0x2C, 0xE9, 0xB3, 0xE1, 0xFF, 0x39, 0xE2 };
+            this.Base58Prefixes[(int)Base58Type.CONFIRMATION_CODE] = new byte[] { 0x64, 0x3B, 0xF6, 0xA8, 0x9A };
+            this.Base58Prefixes[(int)Base58Type.STEALTH_ADDRESS] = new byte[] { 0x2b };
+            this.Base58Prefixes[(int)Base58Type.ASSET_ID] = new byte[] { 115 };
+            this.Base58Prefixes[(int)Base58Type.COLORED_ADDRESS] = new byte[] { 0x13 };
+
+            Bech32Encoder encoder = Encoders.Bech32("tb");
+            this.Bech32Encoders = new Bech32Encoder[2];
+            this.Bech32Encoders[(int)Bech32Type.WITNESS_PUBKEY_ADDRESS] = encoder;
+            this.Bech32Encoders[(int)Bech32Type.WITNESS_SCRIPT_ADDRESS] = encoder;
+
+            this.Checkpoints = new Dictionary<int, CheckpointInfo>();
+
+            this.DNSSeeds = new List<DNSSeedData>();
+            this.SeedNodes = new List<NetworkAddress>();
+
+            this.StandardScriptsRegistry = new SmartContractsStandardScriptsRegistry();
+
+            // TODO: Do we need Asserts for block hash
+        }
+    }
+}

--- a/src/Stratis.Sidechains.Networks/CirrusV2/CirrusTest.cs
+++ b/src/Stratis.Sidechains.Networks/CirrusV2/CirrusTest.cs
@@ -1,0 +1,154 @@
+﻿using System;
+using System.Collections.Generic;
+using NBitcoin;
+using NBitcoin.DataEncoders;
+using NBitcoin.Protocol;
+using Stratis.Bitcoin.Features.PoA;
+using Stratis.Bitcoin.Features.SmartContracts.PoA;
+using Stratis.Bitcoin.Features.SmartContracts;
+using Stratis.SmartContracts.Networks.Policies;
+
+namespace Stratis.Sidechains.Networks.CirrusV2
+{
+    public class CirrusTest : PoANetwork, ISignedCodePubKeyHolder
+    {
+        /// <summary> The name of the root folder containing the different federated peg blockchains.</summary>
+        private const string NetworkRootFolderName = "cirrus";
+
+        /// <summary> The default name used for the federated peg configuration file. </summary>
+        private const string NetworkDefaultConfigFilename = "cirrus.conf";
+
+        public PubKey SigningContractPubKey { get; }
+
+        internal CirrusTest()
+        {
+            // TODO: Replace with real secret key.
+            this.SigningContractPubKey = new Mnemonic("lava frown leave wedding virtual ghost sibling able mammal liar wide wisdom").DeriveExtKey().PrivateKey.PubKey;
+
+            this.Name = nameof(CirrusTest);
+            this.CoinTicker = "TCRS";
+            this.Magic = 0x522357B;
+            this.DefaultPort = 26179;
+            this.DefaultMaxOutboundConnections = 16;
+            this.DefaultMaxInboundConnections = 109;
+            this.RPCPort = 26175;
+            this.MaxTipAge = 2 * 60 * 60;
+            this.MinTxFee = 10000;
+            this.FallbackFee = 10000;
+            this.MinRelayTxFee = 10000;
+            this.RootFolderName = NetworkRootFolderName;
+            this.DefaultConfigFilename = NetworkDefaultConfigFilename;
+            this.MaxTimeOffsetSeconds = 25 * 60;
+
+            var consensusFactory = new SmartContractPoAConsensusFactory();
+
+            // Create the genesis block.
+            this.GenesisTime = 1544113232;
+            this.GenesisNonce = 56989;
+            this.GenesisBits = new Target(new uint256("0000ffff00000000000000000000000000000000000000000000000000000000"));
+            this.GenesisVersion = 1;
+            this.GenesisReward = Money.Zero;
+
+            string coinbaseText = "https://news.bitcoin.com/markets-update-cryptocurrencies-shed-billions-in-bloody-sell-off/";
+            Block genesisBlock = CirrusNetwork.CreateGenesis(consensusFactory, this.GenesisTime, this.GenesisNonce, this.GenesisBits, this.GenesisVersion, this.GenesisReward, coinbaseText);
+
+            this.Genesis = genesisBlock;
+
+            // Configure federation public keys used to sign blocks.
+            // Keep in mind that order in which keys are added to this list is important
+            // and should be the same for all nodes operating on this network.
+            var federationPubKeys = new List<PubKey>()
+            {
+                new PubKey("03e89abd3c9e791f4fb13ced638457c85beb4aff74d37b3fe031cd888f0f92989e"), // I
+                new PubKey("026b7b9092828f3bf9e73995bfa3547c3bcd3814f8101fac626b8349d9a6f0e534"), // J
+                new PubKey("02a8a565bf3c675aee4eb8585771c7517e358708faee4f9db2ed7502d7f9dae740"), // L
+                new PubKey("0248de019680c6f18e434547c8c9d48965b656b8e5e70c5a5564cfb1270db79a11"), // M
+                new PubKey("034bd1a94b0ae315f584ecd22b2ad8fa35056cc70862f33e3e08286f3bbe2207c4")  // P
+            };
+
+            var consensusOptions = new PoAConsensusOptions(
+                maxBlockBaseSize: 1_000_000,
+                maxStandardVersion: 2,
+                maxStandardTxWeight: 100_000,
+                maxBlockSigopsCost: 20_000,
+                maxStandardTxSigopsCost: 20_000 / 5,
+                federationPublicKeys: federationPubKeys,
+                targetSpacingSeconds: 16,
+                votingEnabled: false
+            );
+
+            var buriedDeployments = new BuriedDeploymentsArray
+            {
+                [BuriedDeployments.BIP34] = 0,
+                [BuriedDeployments.BIP65] = 0,
+                [BuriedDeployments.BIP66] = 0
+            };
+
+            var bip9Deployments = new NoBIP9Deployments();
+
+            this.Consensus = new Consensus(
+                consensusFactory: consensusFactory,
+                consensusOptions: consensusOptions,
+                coinType: 400,
+                hashGenesisBlock: genesisBlock.GetHash(),
+                subsidyHalvingInterval: 210000,
+                majorityEnforceBlockUpgrade: 750,
+                majorityRejectBlockOutdated: 950,
+                majorityWindow: 1000,
+                buriedDeployments: buriedDeployments,
+                bip9Deployments: bip9Deployments,
+                bip34Hash: new uint256("0x000000000000024b89b42a942fe0d9fea3bb44ab7bd1b19115dd6a759c0808b8"),
+                ruleChangeActivationThreshold: 1916, // 95% of 2016
+                minerConfirmationWindow: 2016, // nPowTargetTimespan / nPowTargetSpacing
+                maxReorgLength: 0, // No max reorg limit on PoA networks.
+                defaultAssumeValid: null,
+                maxMoney: Money.Coins(20_000_000),
+                coinbaseMaturity: 1,
+                premineHeight: 2,
+                premineReward: Money.Coins(20_000_000),
+                proofOfWorkReward: Money.Coins(0),
+                powTargetTimespan: TimeSpan.FromDays(14), // two weeks
+                powTargetSpacing: TimeSpan.FromMinutes(1),
+                powAllowMinDifficultyBlocks: false,
+                powNoRetargeting: true,
+                powLimit: null,
+                minimumChainWork: null,
+                isProofOfStake: false,
+                lastPowBlock: 0,
+                proofOfStakeLimit: null,
+                proofOfStakeLimitV2: null,
+                proofOfStakeReward: Money.Zero
+            );
+
+            // Same as current smart contracts test networks to keep tests working
+            this.Base58Prefixes = new byte[12][];
+            this.Base58Prefixes[(int)Base58Type.PUBKEY_ADDRESS] = new byte[] { 55 }; // P
+            this.Base58Prefixes[(int)Base58Type.SCRIPT_ADDRESS] = new byte[] { 117 }; // p
+            this.Base58Prefixes[(int)Base58Type.SECRET_KEY] = new byte[] { (239) };
+            this.Base58Prefixes[(int)Base58Type.ENCRYPTED_SECRET_KEY_NO_EC] = new byte[] { 0x01, 0x42 };
+            this.Base58Prefixes[(int)Base58Type.ENCRYPTED_SECRET_KEY_EC] = new byte[] { 0x01, 0x43 };
+            this.Base58Prefixes[(int)Base58Type.EXT_PUBLIC_KEY] = new byte[] { (0x04), (0x35), (0x87), (0xCF) };
+            this.Base58Prefixes[(int)Base58Type.EXT_SECRET_KEY] = new byte[] { (0x04), (0x35), (0x83), (0x94) };
+            this.Base58Prefixes[(int)Base58Type.PASSPHRASE_CODE] = new byte[] { 0x2C, 0xE9, 0xB3, 0xE1, 0xFF, 0x39, 0xE2 };
+            this.Base58Prefixes[(int)Base58Type.CONFIRMATION_CODE] = new byte[] { 0x64, 0x3B, 0xF6, 0xA8, 0x9A };
+            this.Base58Prefixes[(int)Base58Type.STEALTH_ADDRESS] = new byte[] { 0x2b };
+            this.Base58Prefixes[(int)Base58Type.ASSET_ID] = new byte[] { 115 };
+            this.Base58Prefixes[(int)Base58Type.COLORED_ADDRESS] = new byte[] { 0x13 };
+
+            Bech32Encoder encoder = Encoders.Bech32("tb");
+            this.Bech32Encoders = new Bech32Encoder[2];
+            this.Bech32Encoders[(int)Bech32Type.WITNESS_PUBKEY_ADDRESS] = encoder;
+            this.Bech32Encoders[(int)Bech32Type.WITNESS_SCRIPT_ADDRESS] = encoder;
+
+            this.Checkpoints = new Dictionary<int, CheckpointInfo>();
+
+            this.DNSSeeds = new List<DNSSeedData>();
+            this.SeedNodes = new List<NetworkAddress>();
+
+            this.StandardScriptsRegistry = new SmartContractsStandardScriptsRegistry();
+
+            Assert(this.Consensus.HashGenesisBlock == uint256.Parse("0x00008460b940e3e9c7415a07a54cb569a9f69adf790961f11de0c42aa6470708"));
+            Assert(this.Genesis.Header.HashMerkleRoot == uint256.Parse("0xb68311ebfee717754de683570de6e792a2149776381ed49df9cdf3383e59749d"));
+        }
+    }
+}

--- a/src/Stratis.Sidechains.Networks/FederatedPegMain.cs
+++ b/src/Stratis.Sidechains.Networks/FederatedPegMain.cs
@@ -1,0 +1,156 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using NBitcoin;
+using NBitcoin.DataEncoders;
+using NBitcoin.Protocol;
+using Stratis.Bitcoin.Features.PoA;
+using Stratis.Bitcoin.Features.SmartContracts.PoA;
+using Stratis.SmartContracts.Networks.Policies;
+
+namespace Stratis.Sidechains.Networks
+{
+    /// <summary>
+    /// Right now, ripped nearly straight from <see cref="PoANetwork"/>.
+    /// </summary>
+    public class FederatedPegMain : PoANetwork
+    {
+        /// <summary> The name of the root folder containing the different federated peg blockchains.</summary>
+        private const string NetworkRootFolderName = "cirrus";
+
+        /// <summary> The default name used for the federated peg configuration file. </summary>
+        private const string NetworkDefaultConfigFilename = "cirrus.conf";
+
+        internal FederatedPegMain()
+        {
+            this.Name = "CirrusMain";
+            this.CoinTicker = "CRS";
+            this.Magic = 0x522357A0;
+            this.DefaultPort = 16179;
+            this.DefaultMaxOutboundConnections = 16;
+            this.DefaultMaxInboundConnections = 109;
+            this.RPCPort = 16175;
+            this.MaxTipAge = 2 * 60 * 60;
+            this.MinTxFee = 10000;
+            this.FallbackFee = 10000;
+            this.MinRelayTxFee = 10000;
+            this.RootFolderName = NetworkRootFolderName;
+            this.DefaultConfigFilename = NetworkDefaultConfigFilename;
+            this.MaxTimeOffsetSeconds = 25 * 60;
+
+            var consensusFactory = new SmartContractPoAConsensusFactory();
+
+            // Create the genesis block.
+            this.GenesisTime = 1545310504;
+            this.GenesisNonce = 761900;
+            this.GenesisBits = new Target(new uint256("00000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"));
+            this.GenesisVersion = 1;
+            this.GenesisReward = Money.Zero;
+
+            string coinbaseText = "https://www.abc.net.au/news/science/2018-12-07/encryption-bill-australian-technology-industry-fuming-mad/10589962";
+            Block genesisBlock = FederatedPegNetwork.CreateGenesis(consensusFactory, this.GenesisTime, this.GenesisNonce, this.GenesisBits, this.GenesisVersion, this.GenesisReward, coinbaseText);
+
+            this.Genesis = genesisBlock;
+
+            // Configure federation public keys used to sign blocks.
+            // Keep in mind that order in which keys are added to this list is important
+            // and should be the same for all nodes operating on this network.
+            var federationPubKeys = new List<PubKey>
+            {
+                new PubKey("036317d97f911ce899fd0a360866d19f2dca5252c7960d4652d814ab155a8342de"),
+                new PubKey("02a08d72d47b3103261163c15aa2f6b0d007e1872ad9f5fddbfbd27bdb738156e9"),
+                new PubKey("03634c79d4e8e915cfb9f7bbef57bed32d715150836b7845b1a14c93670d816ab6"),
+                new PubKey("02062601ddfdb2208c1d074f1019fe6bc582ff9a0956a9cbe03f19af04b94f831b"),
+                new PubKey("03c36d4fd9a7f949df8ccd2b173e5cb8a5f77a8ad270d37b509314123b225afdfd"),
+                new PubKey("0254c4944820c49f8d595aa78bfce771453558dd159fd5eee8fac097fc3ac17c1b"),
+                new PubKey("03dad9bf0493560203ed6a1089749d140fa33d83aa15fcc8b22a108511389bdcef")
+            };
+
+            var consensusOptions = new PoAConsensusOptions(
+                maxBlockBaseSize: 1_000_000,
+                maxStandardVersion: 2,
+                maxStandardTxWeight: 100_000,
+                maxBlockSigopsCost: 20_000,
+                maxStandardTxSigopsCost: 20_000 / 5,
+                federationPublicKeys: federationPubKeys,
+                targetSpacingSeconds: 16,
+                votingEnabled: false
+            );
+
+            var buriedDeployments = new BuriedDeploymentsArray
+            {
+                [BuriedDeployments.BIP34] = 0,
+                [BuriedDeployments.BIP65] = 0,
+                [BuriedDeployments.BIP66] = 0
+            };
+
+            var bip9Deployments = new NoBIP9Deployments();
+
+            this.Consensus = new Consensus(
+                consensusFactory: consensusFactory,
+                consensusOptions: consensusOptions,
+                coinType: 401,
+                hashGenesisBlock: genesisBlock.GetHash(),
+                subsidyHalvingInterval: 210000,
+                majorityEnforceBlockUpgrade: 750,
+                majorityRejectBlockOutdated: 950,
+                majorityWindow: 1000,
+                buriedDeployments: buriedDeployments,
+                bip9Deployments: bip9Deployments,
+                bip34Hash: new uint256("0x000000000000024b89b42a942fe0d9fea3bb44ab7bd1b19115dd6a759c0808b8"),
+                ruleChangeActivationThreshold: 1916, // 95% of 2016
+                minerConfirmationWindow: 2016, // nPowTargetTimespan / nPowTargetSpacing
+                maxReorgLength: 0, // No max reorg limit on PoA networks.
+                defaultAssumeValid: null,
+                maxMoney: Money.Coins(100_000_000),
+                coinbaseMaturity: 1,
+                premineHeight: 2,
+                premineReward: Money.Coins(100_000_000),
+                proofOfWorkReward: Money.Coins(0),
+                powTargetTimespan: TimeSpan.FromDays(14), // two weeks
+                powTargetSpacing: TimeSpan.FromMinutes(1),
+                powAllowMinDifficultyBlocks: false,
+                powNoRetargeting: true,
+                powLimit: null,
+                minimumChainWork: null,
+                isProofOfStake: false,
+                lastPowBlock: 0,
+                proofOfStakeLimit: null,
+                proofOfStakeLimitV2: null,
+                proofOfStakeReward: Money.Zero
+            );
+
+            // Same as current smart contracts test networks to keep tests working
+            this.Base58Prefixes = new byte[12][];
+            this.Base58Prefixes[(int)Base58Type.PUBKEY_ADDRESS] = new byte[] { 28 }; // C
+            this.Base58Prefixes[(int)Base58Type.SCRIPT_ADDRESS] = new byte[] { 88 }; // c
+            this.Base58Prefixes[(int)Base58Type.SECRET_KEY] = new byte[] { (239) };
+            this.Base58Prefixes[(int)Base58Type.ENCRYPTED_SECRET_KEY_NO_EC] = new byte[] { 0x01, 0x42 };
+            this.Base58Prefixes[(int)Base58Type.ENCRYPTED_SECRET_KEY_EC] = new byte[] { 0x01, 0x43 };
+            this.Base58Prefixes[(int)Base58Type.EXT_PUBLIC_KEY] = new byte[] { (0x04), (0x35), (0x87), (0xCF) };
+            this.Base58Prefixes[(int)Base58Type.EXT_SECRET_KEY] = new byte[] { (0x04), (0x35), (0x83), (0x94) };
+            this.Base58Prefixes[(int)Base58Type.PASSPHRASE_CODE] = new byte[] { 0x2C, 0xE9, 0xB3, 0xE1, 0xFF, 0x39, 0xE2 };
+            this.Base58Prefixes[(int)Base58Type.CONFIRMATION_CODE] = new byte[] { 0x64, 0x3B, 0xF6, 0xA8, 0x9A };
+            this.Base58Prefixes[(int)Base58Type.STEALTH_ADDRESS] = new byte[] { 0x2b };
+            this.Base58Prefixes[(int)Base58Type.ASSET_ID] = new byte[] { 115 };
+            this.Base58Prefixes[(int)Base58Type.COLORED_ADDRESS] = new byte[] { 0x13 };
+
+            Bech32Encoder encoder = Encoders.Bech32("tb");
+            this.Bech32Encoders = new Bech32Encoder[2];
+            this.Bech32Encoders[(int)Bech32Type.WITNESS_PUBKEY_ADDRESS] = encoder;
+            this.Bech32Encoders[(int)Bech32Type.WITNESS_SCRIPT_ADDRESS] = encoder;
+
+            this.Checkpoints = new Dictionary<int, CheckpointInfo>();
+
+            this.DNSSeeds = new List<DNSSeedData>();
+
+            this.StandardScriptsRegistry = new SmartContractsStandardScriptsRegistry();
+
+            string[] seedNodes = { "40.112.89.58", "137.117.243.54", "51.140.255.152", "40.89.158.103", "40.89.158.153", "13.66.214.36", "23.101.147.254" };
+            this.SeedNodes = ConvertToNetworkAddresses(seedNodes, this.DefaultPort).ToList();
+
+            Assert(this.Consensus.HashGenesisBlock == uint256.Parse("0x000004b5e1be2efc806c0e779550e05fa11f4902063f87cc273959fadc5ca579"));
+            Assert(this.Genesis.Header.HashMerkleRoot == uint256.Parse("0x55168c43e5b997b99192af9819297efb43bedfdd698f29c6a2c22dfc671cc0fb"));
+        }
+    }
+}

--- a/src/Stratis.Sidechains.Networks/FederatedPegNetwork.cs
+++ b/src/Stratis.Sidechains.Networks/FederatedPegNetwork.cs
@@ -1,0 +1,50 @@
+﻿using NBitcoin;
+using NBitcoin.DataEncoders;
+using Stratis.Bitcoin.Features.SmartContracts.PoA;
+
+namespace Stratis.Sidechains.Networks
+{
+    public static class FederatedPegNetwork
+    {
+        public static NetworksSelector NetworksSelector
+        {
+            get
+            {
+                return new NetworksSelector(() => new FederatedPegMain(), () => new FederatedPegTest(), () => new FederatedPegRegTest());
+            }
+        }
+
+        public static Block CreateGenesis(SmartContractPoAConsensusFactory consensusFactory, uint genesisTime, uint nonce, uint bits, int version, Money reward, string coinbaseText)
+        {
+            Transaction genesisTransaction = consensusFactory.CreateTransaction();
+            genesisTransaction.Time = genesisTime;
+            genesisTransaction.Version = 1;
+            genesisTransaction.AddInput(new TxIn()
+            {
+                ScriptSig = new Script(Op.GetPushOp(0), new Op()
+                {
+                    Code = (OpcodeType)0x1,
+                    PushData = new[] { (byte)42 }
+                }, Op.GetPushOp(Encoders.ASCII.DecodeData(coinbaseText)))
+            });
+
+            genesisTransaction.AddOutput(new TxOut()
+            {
+                Value = reward
+            });
+
+            Block genesis = consensusFactory.CreateBlock();
+            genesis.Header.BlockTime = Utils.UnixTimeToDateTime(genesisTime);
+            genesis.Header.Bits = bits;
+            genesis.Header.Nonce = nonce;
+            genesis.Header.Version = version;
+            genesis.Transactions.Add(genesisTransaction);
+            genesis.Header.HashPrevBlock = uint256.Zero;
+            genesis.UpdateMerkleRoot();
+
+            ((SmartContractPoABlockHeader)genesis.Header).HashStateRoot = new uint256("21B463E3B52F6201C0AD6C991BE0485B6EF8C092E64583FFA655CC1B171FE856");
+
+            return genesis;
+        }
+    }
+}

--- a/src/Stratis.Sidechains.Networks/FederatedPegRegTest.cs
+++ b/src/Stratis.Sidechains.Networks/FederatedPegRegTest.cs
@@ -1,0 +1,154 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using NBitcoin;
+using NBitcoin.DataEncoders;
+using NBitcoin.Protocol;
+using Stratis.Bitcoin.Features.PoA;
+using Stratis.Bitcoin.Features.SmartContracts.PoA;
+using Stratis.SmartContracts.Networks.Policies;
+
+namespace Stratis.Sidechains.Networks
+{
+    /// <summary>
+    /// Right now, ripped nearly straight from <see cref="PoANetwork"/>.
+    /// </summary>
+    public class FederatedPegRegTest : PoANetwork
+    {
+        public IList<Mnemonic> FederationMnemonics { get; }
+
+        /// <summary> The name of the root folder containing the different federated peg blockchains.</summary>
+        private const string NetworkRootFolderName = "fedpeg";
+
+        /// <summary> The default name used for the federated peg configuration file. </summary>
+        private const string NetworkDefaultConfigFilename = "fedpeg.conf";
+
+        // public IList<Mnemonic> FederationMnemonics { get; }
+        public IList<Key> FederationKeys { get; private set; }
+
+        internal FederatedPegRegTest()
+        {
+            this.Name = "FederatedPegRegTest";
+            this.CoinTicker = "TFPG";
+            this.Magic = 0x522357C;
+            this.DefaultPort = 26179;
+            this.DefaultMaxOutboundConnections = 16;
+            this.DefaultMaxInboundConnections = 109;
+            this.RPCPort = 26175;
+            this.MaxTipAge = 2 * 60 * 60;
+            this.MinTxFee = 10000;
+            this.FallbackFee = 10000;
+            this.MinRelayTxFee = 10000;
+            this.RootFolderName = NetworkRootFolderName;
+            this.DefaultConfigFilename = NetworkDefaultConfigFilename;
+            this.MaxTimeOffsetSeconds = 25 * 60;
+
+            var consensusFactory = new SmartContractPoAConsensusFactory();
+
+            // Create the genesis block.
+            this.GenesisTime = 1513622125;
+            this.GenesisNonce = 1560058197;
+            this.GenesisBits = 402691653;
+            this.GenesisVersion = 1;
+            this.GenesisReward = Money.Zero;
+
+            string coinbaseText = "https://news.bitcoin.com/markets-update-cryptocurrencies-shed-billions-in-bloody-sell-off/";
+            Block genesisBlock = FederatedPegNetwork.CreateGenesis(consensusFactory, this.GenesisTime, this.GenesisNonce, this.GenesisBits, this.GenesisVersion, this.GenesisReward, coinbaseText);
+
+            this.Genesis = genesisBlock;
+
+            this.FederationMnemonics = new[] {
+                   "ensure feel swift crucial bridge charge cloud tell hobby twenty people mandate",
+                   "quiz sunset vote alley draw turkey hill scrap lumber game differ fiction",
+                   "exchange rent bronze pole post hurry oppose drama eternal voice client state"
+               }.Select(m => new Mnemonic(m, Wordlist.English)).ToList();
+
+            this.FederationKeys = this.FederationMnemonics.Select(m => m.DeriveExtKey().PrivateKey).ToList();
+
+            List<PubKey> federationPubKeys = this.FederationKeys.Select(k => k.PubKey).ToList();
+
+            var consensusOptions = new PoAConsensusOptions(
+                maxBlockBaseSize: 1_000_000,
+                maxStandardVersion: 2,
+                maxStandardTxWeight: 100_000,
+                maxBlockSigopsCost: 20_000,
+                maxStandardTxSigopsCost: 20_000 / 5,
+                federationPublicKeys: federationPubKeys,
+                targetSpacingSeconds: 4, // For integration tests - avoid FastMining
+                votingEnabled: false
+            );
+
+            var buriedDeployments = new BuriedDeploymentsArray
+            {
+                [BuriedDeployments.BIP34] = 0,
+                [BuriedDeployments.BIP65] = 0,
+                [BuriedDeployments.BIP66] = 0
+            };
+
+            var bip9Deployments = new NoBIP9Deployments();
+
+            this.Consensus = new Consensus(
+                consensusFactory: consensusFactory,
+                consensusOptions: consensusOptions,
+                coinType: 400,
+                hashGenesisBlock: genesisBlock.GetHash(),
+                subsidyHalvingInterval: 210000,
+                majorityEnforceBlockUpgrade: 750,
+                majorityRejectBlockOutdated: 950,
+                majorityWindow: 1000,
+                buriedDeployments: buriedDeployments,
+                bip9Deployments: bip9Deployments,
+                bip34Hash: new uint256("0x000000000000024b89b42a942fe0d9fea3bb44ab7bd1b19115dd6a759c0808b8"),
+                ruleChangeActivationThreshold: 1916, // 95% of 2016
+                minerConfirmationWindow: 2016, // nPowTargetTimespan / nPowTargetSpacing
+                maxReorgLength: 0, // No max reorg limit on PoA networks.
+                defaultAssumeValid: null,
+                maxMoney: Money.Coins(20_000_000),
+                coinbaseMaturity: 1,
+                premineHeight: 2,
+                premineReward: Money.Coins(20_000_000),
+                proofOfWorkReward: Money.Coins(0),
+                powTargetTimespan: TimeSpan.FromDays(14), // two weeks
+                powTargetSpacing: TimeSpan.FromMinutes(1),
+                powAllowMinDifficultyBlocks: false,
+                powNoRetargeting: true,
+                powLimit: null,
+                minimumChainWork: null,
+                isProofOfStake: false,
+                lastPowBlock: 0,
+                proofOfStakeLimit: null,
+                proofOfStakeLimitV2: null,
+                proofOfStakeReward: Money.Zero
+            );
+
+            // Same as current smart contracts test networks to keep tests working
+            this.Base58Prefixes = new byte[12][];
+            this.Base58Prefixes[(int)Base58Type.PUBKEY_ADDRESS] = new byte[] { 55 }; // P
+            this.Base58Prefixes[(int)Base58Type.SCRIPT_ADDRESS] = new byte[] { 117 }; // p
+            this.Base58Prefixes[(int)Base58Type.SECRET_KEY] = new byte[] { (239) };
+            this.Base58Prefixes[(int)Base58Type.ENCRYPTED_SECRET_KEY_NO_EC] = new byte[] { 0x01, 0x42 };
+            this.Base58Prefixes[(int)Base58Type.ENCRYPTED_SECRET_KEY_EC] = new byte[] { 0x01, 0x43 };
+            this.Base58Prefixes[(int)Base58Type.EXT_PUBLIC_KEY] = new byte[] { (0x04), (0x35), (0x87), (0xCF) };
+            this.Base58Prefixes[(int)Base58Type.EXT_SECRET_KEY] = new byte[] { (0x04), (0x35), (0x83), (0x94) };
+            this.Base58Prefixes[(int)Base58Type.PASSPHRASE_CODE] = new byte[] { 0x2C, 0xE9, 0xB3, 0xE1, 0xFF, 0x39, 0xE2 };
+            this.Base58Prefixes[(int)Base58Type.CONFIRMATION_CODE] = new byte[] { 0x64, 0x3B, 0xF6, 0xA8, 0x9A };
+            this.Base58Prefixes[(int)Base58Type.STEALTH_ADDRESS] = new byte[] { 0x2b };
+            this.Base58Prefixes[(int)Base58Type.ASSET_ID] = new byte[] { 115 };
+            this.Base58Prefixes[(int)Base58Type.COLORED_ADDRESS] = new byte[] { 0x13 };
+
+            Bech32Encoder encoder = Encoders.Bech32("tb");
+            this.Bech32Encoders = new Bech32Encoder[2];
+            this.Bech32Encoders[(int)Bech32Type.WITNESS_PUBKEY_ADDRESS] = encoder;
+            this.Bech32Encoders[(int)Bech32Type.WITNESS_SCRIPT_ADDRESS] = encoder;
+
+            this.Checkpoints = new Dictionary<int, CheckpointInfo>();
+
+            this.DNSSeeds = new List<DNSSeedData>();
+            this.SeedNodes = new List<NetworkAddress>();
+
+            this.StandardScriptsRegistry = new SmartContractsStandardScriptsRegistry();
+
+            // TODO: Do we need Asserts for block hash
+        }
+    }
+}

--- a/src/Stratis.Sidechains.Networks/FederatedPegTest.cs
+++ b/src/Stratis.Sidechains.Networks/FederatedPegTest.cs
@@ -1,0 +1,151 @@
+﻿using System;
+using System.Collections.Generic;
+using NBitcoin;
+using NBitcoin.DataEncoders;
+using NBitcoin.Protocol;
+using Stratis.Bitcoin.Features.PoA;
+using Stratis.Bitcoin.Features.SmartContracts.PoA;
+using Stratis.SmartContracts.Networks.Policies;
+
+namespace Stratis.Sidechains.Networks
+{
+    /// <summary>
+    /// Right now, ripped nearly straight from <see cref="PoANetwork"/>.
+    /// </summary>
+    public class FederatedPegTest : PoANetwork
+    {
+        /// <summary> The name of the root folder containing the different federated peg blockchains.</summary>
+        private const string NetworkRootFolderName = "fedpeg";
+
+        /// <summary> The default name used for the federated peg configuration file. </summary>
+        private const string NetworkDefaultConfigFilename = "fedpeg.conf";
+
+        internal FederatedPegTest()
+        {
+            this.Name = "FederatedPegTest";
+            this.CoinTicker = "TFPG";
+            this.Magic = 0x522357B;
+            this.DefaultPort = 26179;
+            this.DefaultMaxOutboundConnections = 16;
+            this.DefaultMaxInboundConnections = 109;
+            this.RPCPort = 26175;
+            this.MaxTipAge = 2 * 60 * 60;
+            this.MinTxFee = 10000;
+            this.FallbackFee = 10000;
+            this.MinRelayTxFee = 10000;
+            this.RootFolderName = NetworkRootFolderName;
+            this.DefaultConfigFilename = NetworkDefaultConfigFilename;
+            this.MaxTimeOffsetSeconds = 25 * 60;
+
+            var consensusFactory = new SmartContractPoAConsensusFactory();
+
+            // Create the genesis block.
+            this.GenesisTime = 1544113232;
+            this.GenesisNonce = 56989;
+            this.GenesisBits = new Target(new uint256("0000ffff00000000000000000000000000000000000000000000000000000000"));
+            this.GenesisVersion = 1;
+            this.GenesisReward = Money.Zero;
+
+            string coinbaseText = "https://news.bitcoin.com/markets-update-cryptocurrencies-shed-billions-in-bloody-sell-off/";
+            Block genesisBlock = FederatedPegNetwork.CreateGenesis(consensusFactory, this.GenesisTime, this.GenesisNonce, this.GenesisBits, this.GenesisVersion, this.GenesisReward, coinbaseText);
+
+            this.Genesis = genesisBlock;
+
+            // Configure federation public keys used to sign blocks.
+            // Keep in mind that order in which keys are added to this list is important
+            // and should be the same for all nodes operating on this network.
+            var federationPubKeys = new List<PubKey>()
+            {
+                new PubKey("03e89abd3c9e791f4fb13ced638457c85beb4aff74d37b3fe031cd888f0f92989e"), // I
+                new PubKey("026b7b9092828f3bf9e73995bfa3547c3bcd3814f8101fac626b8349d9a6f0e534"), // J
+                new PubKey("02a8a565bf3c675aee4eb8585771c7517e358708faee4f9db2ed7502d7f9dae740"), // L
+                new PubKey("0248de019680c6f18e434547c8c9d48965b656b8e5e70c5a5564cfb1270db79a11"), // M
+                new PubKey("034bd1a94b0ae315f584ecd22b2ad8fa35056cc70862f33e3e08286f3bbe2207c4")  // P
+            };
+
+            var consensusOptions = new PoAConsensusOptions(
+                maxBlockBaseSize: 1_000_000,
+                maxStandardVersion: 2,
+                maxStandardTxWeight: 100_000,
+                maxBlockSigopsCost: 20_000,
+                maxStandardTxSigopsCost: 20_000 / 5,
+                federationPublicKeys: federationPubKeys,
+                targetSpacingSeconds: 16,
+                votingEnabled: false
+            );
+
+            var buriedDeployments = new BuriedDeploymentsArray
+            {
+                [BuriedDeployments.BIP34] = 0,
+                [BuriedDeployments.BIP65] = 0,
+                [BuriedDeployments.BIP66] = 0
+            };
+
+            var bip9Deployments = new NoBIP9Deployments();
+
+            this.Consensus = new Consensus(
+                consensusFactory: consensusFactory,
+                consensusOptions: consensusOptions,
+                coinType: 400,
+                hashGenesisBlock: genesisBlock.GetHash(),
+                subsidyHalvingInterval: 210000,
+                majorityEnforceBlockUpgrade: 750,
+                majorityRejectBlockOutdated: 950,
+                majorityWindow: 1000,
+                buriedDeployments: buriedDeployments,
+                bip9Deployments: bip9Deployments,
+                bip34Hash: new uint256("0x000000000000024b89b42a942fe0d9fea3bb44ab7bd1b19115dd6a759c0808b8"),
+                ruleChangeActivationThreshold: 1916, // 95% of 2016
+                minerConfirmationWindow: 2016, // nPowTargetTimespan / nPowTargetSpacing
+                maxReorgLength: 0, // No max reorg limit on PoA networks.
+                defaultAssumeValid: null,
+                maxMoney: Money.Coins(20_000_000),
+                coinbaseMaturity: 1,
+                premineHeight: 2,
+                premineReward: Money.Coins(20_000_000),
+                proofOfWorkReward: Money.Coins(0),
+                powTargetTimespan: TimeSpan.FromDays(14), // two weeks
+                powTargetSpacing: TimeSpan.FromMinutes(1),
+                powAllowMinDifficultyBlocks: false,
+                powNoRetargeting: true,
+                powLimit: null,
+                minimumChainWork: null,
+                isProofOfStake: false,
+                lastPowBlock: 0,
+                proofOfStakeLimit: null,
+                proofOfStakeLimitV2: null,
+                proofOfStakeReward: Money.Zero
+            );
+
+            // Same as current smart contracts test networks to keep tests working
+            this.Base58Prefixes = new byte[12][];
+            this.Base58Prefixes[(int)Base58Type.PUBKEY_ADDRESS] = new byte[] { 55 }; // P
+            this.Base58Prefixes[(int)Base58Type.SCRIPT_ADDRESS] = new byte[] { 117 }; // p
+            this.Base58Prefixes[(int)Base58Type.SECRET_KEY] = new byte[] { (239) };
+            this.Base58Prefixes[(int)Base58Type.ENCRYPTED_SECRET_KEY_NO_EC] = new byte[] { 0x01, 0x42 };
+            this.Base58Prefixes[(int)Base58Type.ENCRYPTED_SECRET_KEY_EC] = new byte[] { 0x01, 0x43 };
+            this.Base58Prefixes[(int)Base58Type.EXT_PUBLIC_KEY] = new byte[] { (0x04), (0x35), (0x87), (0xCF) };
+            this.Base58Prefixes[(int)Base58Type.EXT_SECRET_KEY] = new byte[] { (0x04), (0x35), (0x83), (0x94) };
+            this.Base58Prefixes[(int)Base58Type.PASSPHRASE_CODE] = new byte[] { 0x2C, 0xE9, 0xB3, 0xE1, 0xFF, 0x39, 0xE2 };
+            this.Base58Prefixes[(int)Base58Type.CONFIRMATION_CODE] = new byte[] { 0x64, 0x3B, 0xF6, 0xA8, 0x9A };
+            this.Base58Prefixes[(int)Base58Type.STEALTH_ADDRESS] = new byte[] { 0x2b };
+            this.Base58Prefixes[(int)Base58Type.ASSET_ID] = new byte[] { 115 };
+            this.Base58Prefixes[(int)Base58Type.COLORED_ADDRESS] = new byte[] { 0x13 };
+
+            Bech32Encoder encoder = Encoders.Bech32("tb");
+            this.Bech32Encoders = new Bech32Encoder[2];
+            this.Bech32Encoders[(int)Bech32Type.WITNESS_PUBKEY_ADDRESS] = encoder;
+            this.Bech32Encoders[(int)Bech32Type.WITNESS_SCRIPT_ADDRESS] = encoder;
+
+            this.Checkpoints = new Dictionary<int, CheckpointInfo>();
+
+            this.DNSSeeds = new List<DNSSeedData>();
+            this.SeedNodes = new List<NetworkAddress>();
+
+            this.StandardScriptsRegistry = new SmartContractsStandardScriptsRegistry();
+
+            Assert(this.Consensus.HashGenesisBlock == uint256.Parse("0x00008460b940e3e9c7415a07a54cb569a9f69adf790961f11de0c42aa6470708"));
+            Assert(this.Genesis.Header.HashMerkleRoot == uint256.Parse("0xb68311ebfee717754de683570de6e792a2149776381ed49df9cdf3383e59749d"));
+        }
+    }
+}

--- a/src/Stratis.Sidechains.Networks/Stratis.Sidechains.Networks.csproj
+++ b/src/Stratis.Sidechains.Networks/Stratis.Sidechains.Networks.csproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <DebugType>Full</DebugType>
+    <CodeAnalysisRuleSet>..\None.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Stratis.SmartContracts.Networks\Stratis.SmartContracts.Networks.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Sorry it's so big...

- Shouldn't touch FN / SC code except for solution.
- Adds .Sidechains.Networks project
- Adds .Features.FederatedPeg project
- Adds .Features.FederatedPeg.Tests project
- All tests pass

Is there any way to disable the CI just for `Stratis.Features.FederatedPeg.Tests`? Don't want to block others while we're still making these tests stable.

Will also slowly start moving over and improving the integration tests too.

In case you're wondering why do this:
- Sidechains moves faster. No package redeployment, no time lost amending code to keep up with breaking API changes between packages, easier debugging.
- Hopefully helps us think about how to best build the core FN components to let others (and ourselves) build on top of them.
- The long-term plan remains the same: to move smart contracts and sidechains out to their own repos when the API is a bit more locked-down

**NOTE: This code is more or less identical to what was in the sidechains repo, I don't expect it to be reviewed, more just check with everyone that this is okay to do. If you do come across style issues, just note 1 of them and I'll try and fix all of the same issue in the rest of the files.**
