### PR TITLE
Add block version summary to "deploymentflags" API

### DIFF
--- a/src/Stratis.Bitcoin/Base/Deployments/Models/ThresholdStateModel.cs
+++ b/src/Stratis.Bitcoin/Base/Deployments/Models/ThresholdStateModel.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using Newtonsoft.Json;
 
 namespace Stratis.Bitcoin.Base.Deployments.Models
@@ -49,6 +50,18 @@ namespace Stratis.Bitcoin.Base.Deployments.Models
         /// </summary>
         [JsonProperty(PropertyName = "votes")]
         public int Votes { get; set; }
+
+        /// <summary>
+        /// The total number of blocks in the last confirmation window.
+        /// </summary>
+        [JsonProperty(PropertyName = "blocks")]
+        public int Blocks { get; set; }
+
+        /// <summary>
+        /// A summary of block version counts in the last confirmation window.
+        /// </summary>
+        [JsonProperty(PropertyName = "versions")]
+        public Dictionary<string, int> HexVersions { get; set; }
 
         /// <summary>
         /// Activation vote threshold for this BIP9 deployment.

--- a/src/Stratis.Bitcoin/Base/Deployments/ThresholdConditionCache.cs
+++ b/src/Stratis.Bitcoin/Base/Deployments/ThresholdConditionCache.cs
@@ -89,6 +89,9 @@ namespace Stratis.Bitcoin.Base.Deployments
                 ChainedHeader periodStartsHeader = indexPrev.GetAncestor(indexPrev.Height - (currentHeight % period));
                 int periodEndsHeight = periodStartsHeader.Height + period;
 
+                var hexVersions = new Dictionary<string, int>();
+                int totalBlocks = 0;
+
                 while (indexPrev != periodStartsHeader)
                 {
                     if (this.Condition(indexPrev, deploymentIndex))
@@ -96,13 +99,24 @@ namespace Stratis.Bitcoin.Base.Deployments
                         votes++;
                     }
 
+                    totalBlocks++;
+
+                    string hexVersion = indexPrev.Header.Version.ToString("X8");
+
+                    if (!hexVersions.TryGetValue(hexVersion, out int count))
+                        count = 0;
+
+                    hexVersions[hexVersion] = count + 1;
+
                     indexPrev = indexPrev.Previous;
                 }
 
                 thresholdStateModels.Add(new ThresholdStateModel()
                 {
                     DeploymentIndex = deploymentIndex,
+                    Blocks = totalBlocks,
                     Votes = votes,
+                    HexVersions = hexVersions,
                     TimeStart = timeStart,
                     TimeTimeOut = timeTimeout,
                     Threshold = threshold,


### PR DESCRIPTION
This PR adds a summary of block versions to the deployment endpoint.