### PR TITLE
Fix Ensure_Peer_CanDiscover_Address_From_ConnectedPeers_And_Connect_ToThem

### DIFF
--- a/src/Stratis.Bitcoin.IntegrationTests/Connectivity/ConnectivityTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/Connectivity/ConnectivityTests.cs
@@ -11,6 +11,7 @@ using Stratis.Bitcoin.IntegrationTests.Common;
 using Stratis.Bitcoin.IntegrationTests.Common.EnvironmentMockUpHelpers;
 using Stratis.Bitcoin.Networks;
 using Stratis.Bitcoin.P2P;
+using Stratis.Bitcoin.Utilities.Extensions;
 using Xunit;
 
 namespace Stratis.Bitcoin.IntegrationTests.Connectivity
@@ -35,7 +36,6 @@ namespace Stratis.Bitcoin.IntegrationTests.Connectivity
         /// Peer A_1 now also connects to Peer B_2
         /// </summary>
         [Fact]
-        [Trait("Unstable", "True")]
         public void Ensure_Peer_CanDiscover_Address_From_ConnectedPeers_And_Connect_ToThem()
         {
             using (NodeBuilder builder = NodeBuilder.Create(this))
@@ -44,26 +44,29 @@ namespace Stratis.Bitcoin.IntegrationTests.Connectivity
                 CoreNode nodeGroupB_1 = builder.CreateStratisPowNode(this.powNetwork, "nodeGroupB_1").EnablePeerDiscovery().Start();
                 CoreNode nodeGroupB_2 = builder.CreateStratisPowNode(this.powNetwork, "nodeGroupB_2").EnablePeerDiscovery().Start();
 
-                // Connect group 2 nodes.
-                TestHelper.WaitLoop(() => nodeGroupB_1.FullNode.NodeService<IPeerAddressManager>().Peers.Count == 0);
+                // Connect B_1 to B_2.
                 nodeGroupB_1.FullNode.NodeService<IPeerAddressManager>().AddPeer(nodeGroupB_2.Endpoint, IPAddress.Loopback);
                 TestHelper.WaitLoop(() => TestHelper.IsNodeConnectedTo(nodeGroupB_1, nodeGroupB_2));
-
-                // Connect group 1 to group 2
-                // This will add all nodeGroupB_1's addresses which includes nodeGroupB_2 to nodeGroupA_1
-                nodeGroupA_1.FullNode.NodeService<IPeerAddressManager>().AddPeer(nodeGroupB_1.Endpoint, IPAddress.Loopback);
-                TestHelper.WaitLoop(() => TestHelper.IsNodeConnectedTo(nodeGroupA_1, nodeGroupB_1));
-
-                // First check that B_2 now has more than the initial connection to B_1
-                TestHelper.WaitLoop(() => nodeGroupB_2.FullNode.ConnectionManager.ConnectedPeers.Count() > 1);
-
-                // Ensure that B_2 got connected to via either A_1 or A_2
                 TestHelper.WaitLoop(() =>
                 {
-                    if (TestHelper.IsNodeConnectedTo(nodeGroupA_1, nodeGroupB_2))
-                        return true;
-                    return false;
+                    return nodeGroupB_1.FullNode.NodeService<IPeerAddressManager>().Peers.Any(p => p.Endpoint.Match(nodeGroupB_2.Endpoint));
                 });
+
+                // Connect group A_1 to B_1
+                // A_1 will receive B_1's addresses which includes B_2.
+                TestHelper.Connect(nodeGroupA_1, nodeGroupB_1);
+
+                //Wait until A_1 contains both B_1 and B_2's addresses in its address manager.
+                TestHelper.WaitLoop(() =>
+                 {
+                     var result = nodeGroupA_1.FullNode.NodeService<IPeerAddressManager>().Peers.Any(p => p.Endpoint.Match(nodeGroupB_1.Endpoint));
+                     if (result)
+                         return nodeGroupA_1.FullNode.NodeService<IPeerAddressManager>().Peers.Any(p => p.Endpoint.Match(nodeGroupB_2.Endpoint));
+                     return false;
+                 });
+
+                // Wait until A_1 connected to B_2.
+                TestHelper.WaitLoop(() => TestHelper.IsNodeConnectedTo(nodeGroupA_1, nodeGroupB_2));
             }
         }
 

--- a/src/Stratis.Bitcoin/P2P/PeerSelector.cs
+++ b/src/Stratis.Bitcoin/P2P/PeerSelector.cs
@@ -49,7 +49,8 @@ namespace Stratis.Bitcoin.P2P
         /// last 60 seconds.
         /// </para>
         /// </summary>
-        IEnumerable<PeerAddress> Connected();
+        /// <param name="enableThrottle">If <c>true</c> then the selector will filter results from the last 60 seconds (true by default).</param>
+        IEnumerable<PeerAddress> Connected(bool enableThrottle);
 
         /// <summary>Returns peers that are not banned.</summary>
         IEnumerable<PeerAddress> NotBanned();
@@ -66,7 +67,8 @@ namespace Stratis.Bitcoin.P2P
         /// last 60 seconds.
         /// </para>
         /// </summary>
-        IEnumerable<PeerAddress> Handshaked();
+        /// <param name="enableThrottle">If <c>true</c> then the selector will filter results from the last 60 seconds (true by default).</param>
+        IEnumerable<PeerAddress> Handshaked(bool enableThrottle);
 
         /// <summary>
         /// <para>
@@ -271,7 +273,7 @@ namespace Stratis.Bitcoin.P2P
 
             var peersToReturn = new List<PeerAddress>();
 
-            List<PeerAddress> connectedAndHandshaked = this.Connected().Concat(this.Handshaked()).OrderBy(p => this.random.Next()).ToList();
+            List<PeerAddress> connectedAndHandshaked = this.Connected(false).Concat(this.Handshaked(false)).OrderBy(p => this.random.Next()).ToList();
             List<PeerAddress> freshAndAttempted = this.Attempted().Concat(this.Fresh()).OrderBy(p => this.random.Next()).ToList();
 
             // If there are connected and/or handshaked peers in the address list,
@@ -351,11 +353,12 @@ namespace Stratis.Bitcoin.P2P
 
         /// <inheritdoc/>
         [NoTrace]
-        public IEnumerable<PeerAddress> Connected()
+        public IEnumerable<PeerAddress> Connected(bool enableThrottle = true)
         {
-            return this.peerAddresses.Values.Where(p => p.Connected &&
-                                                        p.LastConnectionSuccess < this.dateTimeProvider.GetUtcNow().AddSeconds(-60) &&
-                                                        !this.IsBanned(p));
+            var result = this.peerAddresses.Values.Where(p => p.Connected && !this.IsBanned(p));
+            if (enableThrottle)
+                return result.Where(p => p.LastConnectionSuccess < this.dateTimeProvider.GetUtcNow().AddSeconds(-60));
+            return result;
         }
 
         /// <inheritdoc/>
@@ -367,11 +370,12 @@ namespace Stratis.Bitcoin.P2P
 
         /// <inheritdoc/>
         [NoTrace]
-        public IEnumerable<PeerAddress> Handshaked()
+        public IEnumerable<PeerAddress> Handshaked(bool enableThrottle = true)
         {
-            return this.peerAddresses.Values.Where(p => p.Handshaked &&
-                                                        p.LastConnectionHandshake < this.dateTimeProvider.GetUtcNow().AddSeconds(-60) &&
-                                                        !this.IsBanned(p));
+            var result = this.peerAddresses.Values.Where(p => p.Handshaked && !this.IsBanned(p));
+            if (enableThrottle)
+                return result.Where(p => p.LastConnectionHandshake < this.dateTimeProvider.GetUtcNow().AddSeconds(-60));
+            return result;
         }
 
         /// <summary>

--- a/src/Stratis.Bitcoin/P2P/PeerSelector.cs
+++ b/src/Stratis.Bitcoin/P2P/PeerSelector.cs
@@ -50,7 +50,7 @@ namespace Stratis.Bitcoin.P2P
         /// </para>
         /// </summary>
         /// <param name="enableThrottle">If <c>true</c> then the selector will filter results from the last 60 seconds (true by default).</param>
-        IEnumerable<PeerAddress> Connected(bool enableThrottle);
+        IEnumerable<PeerAddress> Connected(bool enableThrottle = true);
 
         /// <summary>Returns peers that are not banned.</summary>
         IEnumerable<PeerAddress> NotBanned();
@@ -68,7 +68,7 @@ namespace Stratis.Bitcoin.P2P
         /// </para>
         /// </summary>
         /// <param name="enableThrottle">If <c>true</c> then the selector will filter results from the last 60 seconds (true by default).</param>
-        IEnumerable<PeerAddress> Handshaked(bool enableThrottle);
+        IEnumerable<PeerAddress> Handshaked(bool enableThrottle = true);
 
         /// <summary>
         /// <para>


### PR DESCRIPTION
The issue here was that when we select peers for GetAddrPayload we filter them out by checking when last we connected or handshaked due a 60 second delay. We don't need to filter them in this instance.