### PR TITLE
Fixed peer that were stuck

### DIFF
--- a/src/Stratis.Bitcoin/Connection/ConnectionManager.cs
+++ b/src/Stratis.Bitcoin/Connection/ConnectionManager.cs
@@ -234,8 +234,9 @@ namespace Stratis.Bitcoin.Connection
             {
                 var chainHeadersBehavior = peer.Behavior<ConsensusManagerBehavior>();
 
-                string peerHeights = $"(r/s):{(chainHeadersBehavior.BestReceivedTip != null ? chainHeadersBehavior.BestReceivedTip.Height.ToString() : peer.PeerVersion?.StartHeight + "*" ?? "-")}";
+                string peerHeights = $"(r/s/c):{(chainHeadersBehavior.BestReceivedTip != null ? chainHeadersBehavior.BestReceivedTip.Height.ToString() : peer.PeerVersion?.StartHeight + "*" ?? "-")}";
                 peerHeights += $"/{(chainHeadersBehavior.BestSentHeader != null ? chainHeadersBehavior.BestSentHeader.Height.ToString() : peer.PeerVersion?.StartHeight + "*" ?? "-")}";
+                peerHeights += $"/{chainHeadersBehavior.GetCachedItemsCount()}";
 
                 // TODO: Need a snapshot cache so that not only currently connected peers are summed
                 string peerTraffic = $"R/S MB: {peer.Counter.ReadBytes.BytesToMegaBytes()}/{peer.Counter.WrittenBytes.BytesToMegaBytes()}";
@@ -244,9 +245,8 @@ namespace Stratis.Bitcoin.Connection
 
                 string agent = peer.PeerVersion != null ? peer.PeerVersion.UserAgent : "[Unknown]";
                 peerBuilder.AppendLine(
-                    "Peer:" + (peer.RemoteSocketEndpoint + ", ").PadRight(LoggingConfiguration.ColumnLength + 15) +
-                    (" connected:" + (peer.Inbound ? "inbound" : "outbound") + ",").PadRight(LoggingConfiguration.ColumnLength + 7)
-                    + peerHeights.PadRight(LoggingConfiguration.ColumnLength + 7)
+                    (peer.Inbound ? "IN " : "OUT ") + "Peer:" + (peer.RemoteSocketEndpoint + ", ").PadRight(LoggingConfiguration.ColumnLength * 2)
+                    + peerHeights.PadRight(LoggingConfiguration.ColumnLength + 14)
                     + peerTraffic.PadRight(LoggingConfiguration.ColumnLength + 7)
                     + " agent:" + agent);
             }

--- a/src/Stratis.Bitcoin/Connection/ConnectionManager.cs
+++ b/src/Stratis.Bitcoin/Connection/ConnectionManager.cs
@@ -234,9 +234,10 @@ namespace Stratis.Bitcoin.Connection
             {
                 var chainHeadersBehavior = peer.Behavior<ConsensusManagerBehavior>();
 
-                string peerHeights = $"(r/s/c):{(chainHeadersBehavior.BestReceivedTip != null ? chainHeadersBehavior.BestReceivedTip.Height.ToString() : peer.PeerVersion?.StartHeight + "*" ?? "-")}";
-                peerHeights += $"/{(chainHeadersBehavior.BestSentHeader != null ? chainHeadersBehavior.BestSentHeader.Height.ToString() : peer.PeerVersion?.StartHeight + "*" ?? "-")}";
-                peerHeights += $"/{chainHeadersBehavior.GetCachedItemsCount()}";
+                string peerHeights = $"(r/s/c):" +
+                                     $"{(chainHeadersBehavior.BestReceivedTip != null ? chainHeadersBehavior.BestReceivedTip.Height.ToString() : peer.PeerVersion != null ? peer.PeerVersion.StartHeight + "*" : "-")}" +
+                                     $"/{(chainHeadersBehavior.BestSentHeader != null ? chainHeadersBehavior.BestSentHeader.Height.ToString() : peer.PeerVersion != null ? peer.PeerVersion.StartHeight + "*" : "-")}" +
+                                     $"/{chainHeadersBehavior.GetCachedItemsCount()}";
 
                 // TODO: Need a snapshot cache so that not only currently connected peers are summed
                 string peerTraffic = $"R/S MB: {peer.Counter.ReadBytes.BytesToMegaBytes()}/{peer.Counter.WrittenBytes.BytesToMegaBytes()}";

--- a/src/Stratis.Bitcoin/Connection/ConnectionManager.cs
+++ b/src/Stratis.Bitcoin/Connection/ConnectionManager.cs
@@ -245,7 +245,7 @@ namespace Stratis.Bitcoin.Connection
 
                 string agent = peer.PeerVersion != null ? peer.PeerVersion.UserAgent : "[Unknown]";
                 peerBuilder.AppendLine(
-                    (peer.Inbound ? "IN " : "OUT ") + "Peer:" + (peer.RemoteSocketEndpoint + ", ").PadRight(LoggingConfiguration.ColumnLength * 2)
+                    (peer.Inbound ? "IN  " : "OUT ") + "Peer:" + (peer.RemoteSocketEndpoint + ", ").PadRight(LoggingConfiguration.ColumnLength + 15)
                     + peerHeights.PadRight(LoggingConfiguration.ColumnLength + 14)
                     + peerTraffic.PadRight(LoggingConfiguration.ColumnLength + 7)
                     + " agent:" + agent);

--- a/src/Stratis.Bitcoin/Consensus/ChainedHeaderTree.cs
+++ b/src/Stratis.Bitcoin/Consensus/ChainedHeaderTree.cs
@@ -656,6 +656,7 @@ namespace Stratis.Bitcoin.Consensus
             {
                 if (this.TryFindLastValidatedHeader(headers, out ChainedHeader lastAlreadyValidatedHeader))
                 {
+                    this.logger.LogTrace("Some headers were already validated.");
                     this.AddOrReplacePeerTip(networkPeerId, lastAlreadyValidatedHeader.Header.GetHash());
                 }
 

--- a/src/Stratis.Bitcoin/Consensus/ChainedHeaderTree.cs
+++ b/src/Stratis.Bitcoin/Consensus/ChainedHeaderTree.cs
@@ -1116,16 +1116,16 @@ namespace Stratis.Bitcoin.Consensus
         private bool TryFindLastValidatedHeader(List<BlockHeader> headers, out ChainedHeader lastValidatedHeader)
         {
             lastValidatedHeader = null;
-            for (int i = 0; i < headers.Count; i++)
+            foreach (BlockHeader header in headers)
             {
-                uint256 currentBlockHash = headers[i].GetHash();
+                uint256 currentBlockHash = header.GetHash();
                 if (this.chainedHeadersByHash.TryGetValue(currentBlockHash, out ChainedHeader currentChainedHeader))
                 {
                     lastValidatedHeader = currentChainedHeader;
                 }
                 else
                 {
-                    // stop at the first header not found.
+                    // Stop at the first header not found.
                     break;
                 }
             }

--- a/src/Stratis.Bitcoin/Consensus/ConsensusManager.cs
+++ b/src/Stratis.Bitcoin/Consensus/ConsensusManager.cs
@@ -257,6 +257,12 @@ namespace Stratis.Bitcoin.Consensus
 
                 connectNewHeadersResult = this.chainedHeaderTree.ConnectNewHeaders(peerId, headers);
 
+                if (!this.peersByPeerId.ContainsKey(peerId))
+                {
+                    this.peersByPeerId.Add(peerId, peer);
+                    this.logger.LogTrace("New peer with ID {0} was added.", peerId);
+                }
+
                 if (connectNewHeadersResult == null)
                 {
                     this.logger.LogTrace("(-)[NO_HEADERS_CONNECTED]:null");
@@ -272,12 +278,6 @@ namespace Stratis.Bitcoin.Consensus
                 this.chainState.IsAtBestChainTip = this.IsConsensusConsideredToBeSyncedLocked();
 
                 this.blockPuller.NewPeerTipClaimed(peer, connectNewHeadersResult.Consumed);
-
-                if (!this.peersByPeerId.ContainsKey(peerId))
-                {
-                    this.peersByPeerId.Add(peerId, peer);
-                    this.logger.LogTrace("New peer with ID {0} was added.", peerId);
-                }
             }
 
             if (triggerDownload && (connectNewHeadersResult.DownloadTo != null))

--- a/src/Stratis.Bitcoin/Consensus/ConsensusManagerBehavior.cs
+++ b/src/Stratis.Bitcoin/Consensus/ConsensusManagerBehavior.cs
@@ -119,7 +119,7 @@ namespace Stratis.Bitcoin.Consensus
                     {
                         if (this.cachedHeaders[i].GetHash() == consumedHeaderHash)
                         {
-                            consumedCount = i;
+                            consumedCount = i + 1;
                             break;
                         }
                     }

--- a/src/Stratis.Bitcoin/Consensus/ConsensusManagerBehavior.cs
+++ b/src/Stratis.Bitcoin/Consensus/ConsensusManagerBehavior.cs
@@ -112,7 +112,7 @@ namespace Stratis.Bitcoin.Consensus
                     this.BestReceivedTip = result.Consumed;
                     this.UpdateBestSentHeader(this.BestReceivedTip);
 
-                    int consumedCount = this.GetConsumedHeadersCountLockedAsync(this.cachedHeaders, result.Consumed.Header);
+                    int consumedCount = this.GetConsumedHeadersCount(this.cachedHeaders, result.Consumed.Header);
 
                     this.cachedHeaders.RemoveRange(0, consumedCount);
                     int cacheSize = this.cachedHeaders.Count;
@@ -380,7 +380,7 @@ namespace Stratis.Bitcoin.Consensus
                 if (result.Consumed.HashBlock != headers.Last().GetHash())
                 {
                     // Some headers were not consumed, add to cache.
-                    int consumedCount = this.GetConsumedHeadersCountLockedAsync(headers, result.Consumed.Header);
+                    int consumedCount = this.GetConsumedHeadersCount(headers, result.Consumed.Header);
                     this.cachedHeaders.AddRange(headers.Skip(consumedCount));
 
                     this.logger.LogDebug("{0} out of {1} items were not consumed and added to cache.", headers.Count - consumedCount, headers.Count);
@@ -673,7 +673,7 @@ namespace Stratis.Bitcoin.Consensus
         /// <param name="headers">List of headers to use to get the consumed count.</param>
         /// <param name="consumedHeader">The consumed header reference.</param>
         /// <returns>The number of consumed cached items.</returns>
-        private int GetConsumedHeadersCountLockedAsync(List<BlockHeader> headers, BlockHeader consumedHeader)
+        private int GetConsumedHeadersCount(List<BlockHeader> headers, BlockHeader consumedHeader)
         {
             uint256 consumedHeaderHash = consumedHeader.GetHash();
 

--- a/src/Stratis.Bitcoin/Consensus/ConsensusManagerBehavior.cs
+++ b/src/Stratis.Bitcoin/Consensus/ConsensusManagerBehavior.cs
@@ -659,5 +659,10 @@ namespace Stratis.Bitcoin.Consensus
         {
             return new ConsensusManagerBehavior(this.chain, this.initialBlockDownloadState, this.consensusManager, this.peerBanning, this.loggerFactory);
         }
+
+        internal int GetCachedItemsCount()
+        {
+            return this.cachedHeaders.Count;
+        }
     }
 }

--- a/src/Stratis.Bitcoin/Consensus/ConsensusManagerBehavior.cs
+++ b/src/Stratis.Bitcoin/Consensus/ConsensusManagerBehavior.cs
@@ -112,7 +112,18 @@ namespace Stratis.Bitcoin.Consensus
                     this.BestReceivedTip = result.Consumed;
                     this.UpdateBestSentHeader(this.BestReceivedTip);
 
-                    int consumedCount = this.cachedHeaders.IndexOf(result.Consumed.Header) + 1;
+                    uint256 consumedHeaderHash = result.Consumed.Header.GetHash();
+                    int consumedCount = 0;
+
+                    for (int i = this.cachedHeaders.Count - 1; i >= 0; i--)
+                    {
+                        if (this.cachedHeaders[i].GetHash() == consumedHeaderHash)
+                        {
+                            consumedCount = i;
+                            break;
+                        }
+                    }
+
                     this.cachedHeaders.RemoveRange(0, consumedCount);
                     int cacheSize = this.cachedHeaders.Count;
 


### PR DESCRIPTION
moved the peersbyid.add call earlier
adjusted the peer console dump (added cacheHeaders information and compressed the Inbound/Outbound direction

UPDATE:
fixed a nasty bug that was causing peers to stuck (and potentially stuck node too)