### PR TITLE
[Wallet] Added actual spendable amount to the balance call

### DIFF
--- a/src/Stratis.Bitcoin.Features.Consensus/StakeValidator.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/StakeValidator.cs
@@ -169,7 +169,13 @@ namespace Stratis.Bitcoin.Features.Consensus
             }
 
             // This is used in tests to allow quickly mining blocks.
-            if (consensus.PosNoRetargeting)
+            if (!proofOfStake && consensus.PowNoRetargeting) 
+            {
+                this.logger.LogTrace("(-)[NO_POW_RETARGET]:'{0}'", lastPowPosBlock.Header.Bits);
+                return lastPowPosBlock.Header.Bits;
+            }
+
+            if (proofOfStake && consensus.PosNoRetargeting)
             {
                 this.logger.LogTrace("(-)[NO_POS_RETARGET]:'{0}'", lastPowPosBlock.Header.Bits);
                 return lastPowPosBlock.Header.Bits;

--- a/src/Stratis.Bitcoin.Features.SmartContracts/Wallet/SmartContractWalletController.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts/Wallet/SmartContractWalletController.cs
@@ -129,7 +129,7 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Wallet
 
                 // Represents a sublist of transactions associated with receive addresses + a sublist of already spent transactions associated with change addresses.
                 // In effect, we filter out 'change' transactions that are not spent, as we don't want to show these in the history.
-                List<FlatHistory> history = items.Where(t => !t.Address.IsChangeAddress() || (t.Address.IsChangeAddress() && !t.Transaction.IsSpendable())).ToList();
+                List<FlatHistory> history = items.Where(t => !t.Address.IsChangeAddress() || (t.Address.IsChangeAddress() && t.Transaction.IsSpent())).ToList();
 
                 foreach (FlatHistory item in history)
                 {

--- a/src/Stratis.Bitcoin.Features.Wallet.Tests/HdAccountTest.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet.Tests/HdAccountTest.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using NBitcoin;
+using Stratis.Bitcoin.Networks;
 using Xunit;
 
 namespace Stratis.Bitcoin.Features.Wallet.Tests
@@ -250,13 +251,13 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
             account.InternalAddresses.Add(new HdAddress { Index = 6, Transactions = null });
             account.InternalAddresses.Add(new HdAddress { Index = 6, Transactions = new List<TransactionData> { new TransactionData { Id = new uint256(19), Index = 12, SpendingDetails = new SpendingDetails() } } });
 
-            IEnumerable<TransactionData> result = account.GetSpendableTransactions();
+            IEnumerable<UnspentOutputReference> result = account.GetSpendableTransactions(100, new StratisTest(), 0);
 
             Assert.Equal(2, result.Count());
-            Assert.Equal(8, result.ElementAt(0).Index);
-            Assert.Equal(new uint256(18), result.ElementAt(0).Id);
-            Assert.Equal(11, result.ElementAt(1).Index);
-            Assert.Equal(new uint256(18), result.ElementAt(1).Id);
+            Assert.Equal(8, result.ElementAt(0).Transaction.Index);
+            Assert.Equal(new uint256(18), result.ElementAt(0).Transaction.Id);
+            Assert.Equal(11, result.ElementAt(1).Transaction.Index);
+            Assert.Equal(new uint256(18), result.ElementAt(1).Transaction.Id);
         }
 
         [Fact]
@@ -266,7 +267,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
             account.ExternalAddresses.Add(new HdAddress { Index = 2, Transactions = new List<TransactionData> { new TransactionData { Id = new uint256(15), Index = 7, SpendingDetails = new SpendingDetails() } } });
             account.InternalAddresses.Add(new HdAddress { Index = 4, Transactions = new List<TransactionData> { new TransactionData { Id = new uint256(15), Index = 10, SpendingDetails = new SpendingDetails() } } });
 
-            IEnumerable<TransactionData> result = account.GetSpendableTransactions();
+            IEnumerable<UnspentOutputReference> result = account.GetSpendableTransactions(100, new StratisTest(), 0);
 
             Assert.Empty(result);
         }

--- a/src/Stratis.Bitcoin.Features.Wallet.Tests/HdAccountTest.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet.Tests/HdAccountTest.cs
@@ -251,7 +251,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
             account.InternalAddresses.Add(new HdAddress { Index = 6, Transactions = null });
             account.InternalAddresses.Add(new HdAddress { Index = 6, Transactions = new List<TransactionData> { new TransactionData { Id = new uint256(19), Index = 12, SpendingDetails = new SpendingDetails() } } });
 
-            IEnumerable<UnspentOutputReference> result = account.GetSpendableTransactions(100, new StratisTest(), 0);
+            IEnumerable<UnspentOutputReference> result = account.GetSpendableTransactions(100, 10, 0);
 
             Assert.Equal(2, result.Count());
             Assert.Equal(8, result.ElementAt(0).Transaction.Index);
@@ -267,7 +267,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
             account.ExternalAddresses.Add(new HdAddress { Index = 2, Transactions = new List<TransactionData> { new TransactionData { Id = new uint256(15), Index = 7, SpendingDetails = new SpendingDetails() } } });
             account.InternalAddresses.Add(new HdAddress { Index = 4, Transactions = new List<TransactionData> { new TransactionData { Id = new uint256(15), Index = 10, SpendingDetails = new SpendingDetails() } } });
 
-            IEnumerable<UnspentOutputReference> result = account.GetSpendableTransactions(100, new StratisTest(), 0);
+            IEnumerable<UnspentOutputReference> result = account.GetSpendableTransactions(100, 10, 0);
 
             Assert.Empty(result);
         }

--- a/src/Stratis.Bitcoin.Features.Wallet.Tests/TransactionDataTest.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet.Tests/TransactionDataTest.cs
@@ -35,7 +35,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
                 SpendingDetails = new SpendingDetails()
             };
 
-            Assert.False(transaction.IsSpendable());
+            Assert.True(transaction.IsSpent());
         }
 
         [Fact]
@@ -46,7 +46,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
                 SpendingDetails = null
             };
 
-            Assert.True(transaction.IsSpendable());
+            Assert.False(transaction.IsSpent());
         }
 
         [Fact]

--- a/src/Stratis.Bitcoin.Features.Wallet.Tests/WalletControllerTest.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet.Tests/WalletControllerTest.cs
@@ -1281,8 +1281,8 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
 
             var accountsBalances = new List<AccountBalance>
             {
-                new AccountBalance { Account = account, AmountConfirmed = new Money(130000), AmountUnconfirmed = new Money(35000) },
-                new AccountBalance { Account = account2, AmountConfirmed = new Money(108000), AmountUnconfirmed = new Money(139000) }
+                new AccountBalance { Account = account, AmountConfirmed = new Money(130000), AmountUnconfirmed = new Money(35000), SpendableAmount = new Money(130000) },
+                new AccountBalance { Account = account2, AmountConfirmed = new Money(108000), AmountUnconfirmed = new Money(139000), SpendableAmount = new Money(108000) }
             };
 
             var mockWalletManager = new Mock<IWalletManager>();
@@ -1306,6 +1306,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
             Assert.Equal(account.HdPath, resultingBalance.HdPath);
             Assert.Equal(new Money(130000), resultingBalance.AmountConfirmed);
             Assert.Equal(new Money(35000), resultingBalance.AmountUnconfirmed);
+            Assert.Equal(new Money(130000), resultingBalance.SpendableAmount);
 
             resultingBalance = model.AccountsBalances[1];
             Assert.Equal(this.Network.Consensus.CoinType, (int)resultingBalance.CoinType);
@@ -1313,6 +1314,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
             Assert.Equal(account2.HdPath, resultingBalance.HdPath);
             Assert.Equal(new Money(108000), resultingBalance.AmountConfirmed);
             Assert.Equal(new Money(139000), resultingBalance.AmountUnconfirmed);
+            Assert.Equal(new Money(108000), resultingBalance.SpendableAmount);
         }
 
         [Fact]

--- a/src/Stratis.Bitcoin.Features.Wallet.Tests/WalletManagerTest.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet.Tests/WalletManagerTest.cs
@@ -2611,17 +2611,29 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
                 firstAccount.ExternalAddresses.ElementAt(i).Transactions.Add(new TransactionData { Amount = 10 });
             }
 
-            Assert.Equal(0, firstAccount.GetSpendableAmount().ConfirmedAmount);
-            Assert.Equal(40, firstAccount.GetSpendableAmount().UnConfirmedAmount);
+            Assert.Equal(0, firstAccount.GetBalances().ConfirmedAmount);
+            Assert.Equal(40, firstAccount.GetBalances().UnConfirmedAmount);
         }
 
         [Fact]
         public void GetAccountBalancesReturnsCorrectAccountBalances()
         {
+
             // Arrange.
             DataFolder dataFolder = CreateDataFolder(this);
 
-            var walletManager = new WalletManager(this.LoggerFactory.Object, this.Network, new Mock<ConcurrentChain>().Object, new WalletSettings(NodeSettings.Default(this.Network)),
+            // Initialize chain object.
+            var chain = new ConcurrentChain(KnownNetworks.StratisMain);
+            uint nonce = RandomUtils.GetUInt32();
+            var block = this.Network.CreateBlock();
+            block.AddTransaction(new Transaction());
+            block.UpdateMerkleRoot();
+            block.Header.HashPrevBlock = chain.Genesis.HashBlock;
+            block.Header.Nonce = nonce;
+            block.Header.BlockTime = DateTimeOffset.Now;
+            chain.SetTip(block.Header);
+
+            var walletManager = new WalletManager(this.LoggerFactory.Object, this.Network, chain, new WalletSettings(NodeSettings.Default(this.Network)),
                 dataFolder, new Mock<IWalletFeePolicy>().Object, new Mock<IAsyncLoopFactory>().Object, new NodeLifetime(), DateTimeProvider.Default, new ScriptAddressReader());
 
             HdAccount account = WalletTestsHelpers.CreateAccount("account 1");
@@ -2694,8 +2706,8 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
                 firstAccount.ExternalAddresses.ElementAt(i).Transactions.Add(new TransactionData { Amount = 10, BlockHeight = 10 });
             }
 
-            Assert.Equal(40, firstAccount.GetSpendableAmount().ConfirmedAmount);
-            Assert.Equal(0, firstAccount.GetSpendableAmount().UnConfirmedAmount);
+            Assert.Equal(40, firstAccount.GetBalances().ConfirmedAmount);
+            Assert.Equal(0, firstAccount.GetBalances().UnConfirmedAmount);
         }
 
         [Fact]
@@ -2719,8 +2731,8 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
                 firstAccount.ExternalAddresses.ElementAt(i).Transactions.Add(new TransactionData { Amount = 10, BlockHeight = 10, SpendingDetails = new SpendingDetails() });
             }
 
-            Assert.Equal(0, firstAccount.GetSpendableAmount().ConfirmedAmount);
-            Assert.Equal(0, firstAccount.GetSpendableAmount().UnConfirmedAmount);
+            Assert.Equal(0, firstAccount.GetBalances().ConfirmedAmount);
+            Assert.Equal(0, firstAccount.GetBalances().UnConfirmedAmount);
         }
 
         [Fact]
@@ -2750,8 +2762,8 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
                 firstAccount.ExternalAddresses.ElementAt(i).Transactions.Add(new TransactionData { Amount = 10, BlockHeight = 10 });
             }
 
-            Assert.Equal(40, firstAccount.GetSpendableAmount().ConfirmedAmount);
-            Assert.Equal(0, firstAccount.GetSpendableAmount().UnConfirmedAmount);
+            Assert.Equal(40, firstAccount.GetBalances().ConfirmedAmount);
+            Assert.Equal(0, firstAccount.GetBalances().UnConfirmedAmount);
         }
 
         [Fact]
@@ -2781,8 +2793,8 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
                 firstAccount.ExternalAddresses.ElementAt(i).Transactions.Add(new TransactionData { Amount = 10 });
             }
 
-            Assert.Equal(0, firstAccount.GetSpendableAmount().ConfirmedAmount);
-            Assert.Equal(40, firstAccount.GetSpendableAmount().UnConfirmedAmount);
+            Assert.Equal(0, firstAccount.GetBalances().ConfirmedAmount);
+            Assert.Equal(40, firstAccount.GetBalances().UnConfirmedAmount);
         }
 
         [Fact]

--- a/src/Stratis.Bitcoin.Features.Wallet/AccountBalance.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/AccountBalance.cs
@@ -21,5 +21,10 @@ namespace Stratis.Bitcoin.Features.Wallet
         /// The balance of unconfirmed transactions.
         /// </summary>
         public Money AmountUnconfirmed { get; set; }
+
+        /// <summary>
+        /// The amount that has enough confirmations to be already spendable.
+        /// </summary>
+        public Money SpendableAmount { get; set; }
     }
 }

--- a/src/Stratis.Bitcoin.Features.Wallet/Controllers/WalletController.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Controllers/WalletController.cs
@@ -556,7 +556,8 @@ namespace Stratis.Bitcoin.Features.Wallet.Controllers
                         Name = account.Name,
                         HdPath = account.HdPath,
                         AmountConfirmed = balance.AmountConfirmed,
-                        AmountUnconfirmed = balance.AmountUnconfirmed
+                        AmountUnconfirmed = balance.AmountUnconfirmed,
+                        SpendableAmount = balance.SpendableAmount
                     });
                 }
 

--- a/src/Stratis.Bitcoin.Features.Wallet/Controllers/WalletController.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Controllers/WalletController.cs
@@ -384,7 +384,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Controllers
 
                     // Represents a sublist of transactions associated with receive addresses + a sublist of already spent transactions associated with change addresses.
                     // In effect, we filter out 'change' transactions that are not spent, as we don't want to show these in the history.
-                    List<FlatHistory> history = items.Where(t => !t.Address.IsChangeAddress() || (t.Address.IsChangeAddress() && !t.Transaction.IsSpendable())).ToList();
+                    List<FlatHistory> history = items.Where(t => !t.Address.IsChangeAddress() || (t.Address.IsChangeAddress() && t.Transaction.IsSpent())).ToList();
 
                     // Represents a sublist of 'change' transactions.
                     List<FlatHistory> allchange = items.Where(t => t.Address.IsChangeAddress()).ToList();

--- a/src/Stratis.Bitcoin.Features.Wallet/Models/WalletBalanceModel.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Models/WalletBalanceModel.cs
@@ -31,5 +31,8 @@ namespace Stratis.Bitcoin.Features.Wallet.Models
 
         [JsonProperty(PropertyName = "amountUnconfirmed")]
         public Money AmountUnconfirmed { get; set; }
+
+        [JsonProperty(PropertyName = "spendableAmount")]
+        public Money SpendableAmount { get; set; }
     }
 }

--- a/src/Stratis.Bitcoin.Features.Wallet/Wallet.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Wallet.cs
@@ -632,16 +632,6 @@ namespace Stratis.Bitcoin.Features.Wallet
         }
 
         /// <summary>
-        /// Gets a collection of transactions with spendable outputs.
-        /// </summary>
-        /// <returns></returns>
-        public IEnumerable<TransactionData> GetSpendableTransactions()
-        {
-            IEnumerable<HdAddress> addresses = this.GetCombinedAddresses();
-            return addresses.Where(r => r.Transactions != null).SelectMany(a => a.Transactions.Where(t => t.IsSpendable()));
-        }
-
-        /// <summary>
         /// Get the accounts total spendable value for both confirmed and unconfirmed UTXO.
         /// </summary>
         public (Money ConfirmedAmount, Money UnConfirmedAmount) GetSpendableAmount()

--- a/src/Stratis.Bitcoin.Features.Wallet/Wallet.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Wallet.cs
@@ -293,7 +293,7 @@ namespace Stratis.Bitcoin.Features.Wallet
         {
             IEnumerable<HdAccount> accounts = this.GetAccountsByCoinType(coinType, accountFilter);
 
-            return accounts.SelectMany(x => x.GetSpendableTransactions(currentChainHeight, this.Network, confirmations));
+            return accounts.SelectMany(x => x.GetSpendableTransactions(currentChainHeight, this.Network.Consensus.CoinbaseMaturity, confirmations));
         }
     }
 
@@ -741,12 +741,12 @@ namespace Stratis.Bitcoin.Features.Wallet
         /// Lists all spendable transactions in the current account.
         /// </summary>
         /// <param name="currentChainHeight">The current height of the chain. Used for calculating the number of confirmations a transaction has.</param>
-        /// <param name="network">The network this account holds transactions for.</param>
+        /// <param name="coinbaseMaturity">The coinbase maturity after which a coinstake transaction is spendable.</param>
         /// <param name="confirmations">The minimum number of confirmations required for transactions to be considered.</param>
         /// <returns>A collection of spendable outputs that belong to the given account.</returns>
         /// <remarks>Note that coinbase and coinstake transaction outputs also have to mature with a sufficient number of confirmations before
         /// they are considered spendable. This is independent of the confirmations parameter.</remarks>
-        public IEnumerable<UnspentOutputReference> GetSpendableTransactions(int currentChainHeight, Network network, int confirmations = 0)
+        public IEnumerable<UnspentOutputReference> GetSpendableTransactions(int currentChainHeight, long coinbaseMaturity, int confirmations = 0)
         {
             // This will take all the spendable coins that belong to the account and keep the reference to the HdAddress and HdAccount.
             // This is useful so later the private key can be calculated just from a given UTXO.
@@ -770,7 +770,7 @@ namespace Stratis.Bitcoin.Features.Wallet
 
                     // This output can unconditionally be included in the results.
                     // Or this output is a CoinBase or CoinStake and has reached maturity.
-                    if ((!isCoinBase && !isCoinStake) || (confirmationCount > network.Consensus.CoinbaseMaturity))
+                    if ((!isCoinBase && !isCoinStake) || (confirmationCount > coinbaseMaturity))
                     {
                         yield return new UnspentOutputReference
                         {

--- a/src/Stratis.Bitcoin.Features.Wallet/Wallet.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Wallet.cs
@@ -857,7 +857,7 @@ namespace Stratis.Bitcoin.Features.Wallet
                 return new List<TransactionData>();
             }
 
-            return this.Transactions.Where(t => t.IsSpendable());
+            return this.Transactions.Where(t => !t.IsSpent());
         }
 
         /// <summary>
@@ -977,31 +977,30 @@ namespace Stratis.Bitcoin.Features.Wallet
         }
 
         /// <summary>
-        /// Indicates an output is spendable.
+        /// Indicates whether an output has been spent.
         /// </summary>
+        /// <returns>A value indicating whether an output has been spent.</returns>
         [NoTrace]
-        public bool IsSpendable()
+        public bool IsSpent()
         {
-            return this.SpendingDetails == null;
+            return this.SpendingDetails != null;
         }
 
+        /// <summary>
+        /// Checks if the output is not spent, with the option to choose whether only confirmed ones are considered. 
+        /// </summary>
+        /// <param name="confirmedOnly">A value indicating whether we only want confirmed amount.</param>
+        /// <returns>The total amount that has not been spent.</returns>
         [NoTrace]
         public Money SpendableAmount(bool confirmedOnly)
         {
-            // This method only returns a UTXO that has no spending output.
-            // If a spending output exists (even if its not confirmed) this will return as zero balance.
-            if (this.IsSpendable())
+            // The spendable balance is 0 if the output is spent or it needs to be confirmed to be considered.
+            if (this.IsSpent() || (confirmedOnly && !this.IsConfirmed()))
             {
-                // If the 'confirmedOnly' flag is set check that the UTXO is confirmed.
-                if (confirmedOnly && !this.IsConfirmed())
-                {
-                    return Money.Zero;
-                }
-
-                return this.Amount;
+                return Money.Zero;
             }
 
-            return Money.Zero;
+            return this.Amount;
         }
     }
 

--- a/src/Stratis.Bitcoin.Features.Wallet/Wallet.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Wallet.cs
@@ -634,7 +634,7 @@ namespace Stratis.Bitcoin.Features.Wallet
         /// <summary>
         /// Get the accounts total spendable value for both confirmed and unconfirmed UTXO.
         /// </summary>
-        public (Money ConfirmedAmount, Money UnConfirmedAmount) GetSpendableAmount()
+        public (Money ConfirmedAmount, Money UnConfirmedAmount) GetBalances()
         {
             List<TransactionData> allTransactions = this.ExternalAddresses.SelectMany(a => a.Transactions)
                 .Concat(this.InternalAddresses.SelectMany(i => i.Transactions)).ToList();
@@ -863,7 +863,7 @@ namespace Stratis.Bitcoin.Features.Wallet
         /// <summary>
         /// Get the address total spendable value for both confirmed and unconfirmed UTXO.
         /// </summary>
-        public (Money confirmedAmount, Money unConfirmedAmount) GetSpendableAmount()
+        public (Money confirmedAmount, Money unConfirmedAmount) GetBalances()
         {
             List<TransactionData> allTransactions = this.Transactions.ToList();
 

--- a/src/Stratis.Bitcoin.Features.Wallet/WalletManager.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/WalletManager.cs
@@ -849,7 +849,7 @@ namespace Stratis.Bitcoin.Features.Wallet
                         $"Account '{walletAccountReference.AccountName}' in wallet '{walletAccountReference.WalletName}' not found.");
                 }
 
-                res = account.GetSpendableTransactions(this.chain.Tip.Height, this.network, confirmations).ToArray();
+                res = account.GetSpendableTransactions(this.chain.Tip.Height, this.network.Consensus.CoinbaseMaturity, confirmations).ToArray();
             }
 
             return res;

--- a/src/Stratis.Bitcoin.Features.Wallet/WalletManager.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/WalletManager.cs
@@ -671,13 +671,23 @@ namespace Stratis.Bitcoin.Features.Wallet
 
                 foreach (HdAccount account in accounts)
                 {
-                    (Money amountConfirmed, Money amountUnconfirmed) result = account.GetSpendableAmount();
+                    // Calculates the amount of spendable coins.
+                    UnspentOutputReference[] spendableBalance = account.GetSpendableTransactions(this.chain.Tip.Height, this.network.Consensus.CoinbaseMaturity).ToArray();
+                    Money spendableAmount = Money.Zero;
+                    foreach (UnspentOutputReference bal in spendableBalance)
+                    {
+                        spendableAmount += bal.Transaction.Amount;
+                    }
 
+                    // Get the total balances.
+                    (Money amountConfirmed, Money amountUnconfirmed) result = account.GetBalances();
+                    
                     balances.Add(new AccountBalance
                     {
                         Account = account,
                         AmountConfirmed = result.amountConfirmed,
-                        AmountUnconfirmed = result.amountUnconfirmed
+                        AmountUnconfirmed = result.amountUnconfirmed,
+                        SpendableAmount = spendableAmount
                     });
                 }
             }
@@ -705,7 +715,7 @@ namespace Stratis.Bitcoin.Features.Wallet
                     hdAddress = wallet.GetAllAddressesByCoinType(this.coinType).FirstOrDefault(a => a.Address == address);
                     if (hdAddress == null) continue;
 
-                    (Money amountConfirmed, Money amountUnconfirmed) result = hdAddress.GetSpendableAmount();
+                    (Money amountConfirmed, Money amountUnconfirmed) result = hdAddress.GetBalances();
 
                     balance.AmountConfirmed = result.amountConfirmed;
                     balance.AmountUnconfirmed = result.amountUnconfirmed;

--- a/src/Stratis.Bitcoin.Features.Wallet/WalletRPCController.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/WalletRPCController.cs
@@ -349,8 +349,8 @@ namespace Stratis.Bitcoin.Features.Wallet
                             ScriptPubKeyHex = spendableTx.Transaction.ScriptPubKey.ToHex(),
                             RedeemScriptHex = null, // TODO: Currently don't support P2SH wallet addresses, review if we do.
                             Confirmations = spendableTx.Confirmations,
-                            IsSpendable = spendableTx.Transaction.IsSpendable(),
-                            IsSolvable = spendableTx.Transaction.IsSpendable() // If it's spendable we assume it's solvable.
+                            IsSpendable = !spendableTx.Transaction.IsSpent(),
+                            IsSolvable = !spendableTx.Transaction.IsSpent() // If it's spendable we assume it's solvable.
                         });
                     }
                 }

--- a/src/Stratis.Bitcoin.IntegrationTests/API/ApiSteps.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/API/ApiSteps.cs
@@ -282,7 +282,7 @@ namespace Stratis.Bitcoin.IntegrationTests.API
         {
             this.send_api_get_request($"{BalanceUri}?walletname={walletName}&AccountName=account {accountIndex}");
 
-            this.responseText.Should().Be("{\"balances\":[{\"accountName\":\"account " + accountIndex + "\",\"accountHdPath\":\"m/44'/105'/" + accountIndex + "'\",\"coinType\":105,\"amountConfirmed\":0,\"amountUnconfirmed\":0}]}");
+            this.responseText.Should().Be("{\"balances\":[{\"accountName\":\"account " + accountIndex + "\",\"accountHdPath\":\"m/44'/105'/" + accountIndex + "'\",\"coinType\":105,\"amountConfirmed\":0,\"amountUnconfirmed\":0,\"spendableAmount\":0}]}");
         }
 
         private void calling_general_info()

--- a/src/Stratis.Bitcoin.Networks/StratisTest.cs
+++ b/src/Stratis.Bitcoin.Networks/StratisTest.cs
@@ -70,7 +70,7 @@ namespace Stratis.Bitcoin.Networks
             {
                 [StratisBIP9Deployments.ColdStaking] = new BIP9DeploymentsParameters(2,
                     new DateTime(2018, 11, 1, 0, 0, 0, DateTimeKind.Utc),
-                    new DateTime(2019, 2, 1, 0, 0, 0, DateTimeKind.Utc))
+                    new DateTime(2019, 6, 1, 0, 0, 0, DateTimeKind.Utc))
             };
 
             this.Consensus = new NBitcoin.Consensus(


### PR DESCRIPTION
This is better reviewed commit by commit.
Closes https://github.com/stratisproject/StratisBitcoinFullNode/issues/2686.

The problem is that a call to get balances doesn't show how many coins are actually spendable at this moment. 
Rather, it shows the total amount of coins, confirmed and unconfirmed.
This adds a `spendableAmount` field to reflect how many coins are mature enough to be spendable.

so instead of
```
{
  "balances": [
    {
      "accountName": "account 0",
      "accountHdPath": "m/44'/105'/0'",
      "coinType": 105,
      "amountConfirmed": 31033100000000,
      "amountUnconfirmed": 0
    }
  ]
}
```
we'd have
```
{
  "balances": [
    {
      "accountName": "account 0",
      "accountHdPath": "m/44'/105'/0'",
      "coinType": 105,
      "amountConfirmed": 31033100000000,
      "amountUnconfirmed": 0,
      "spendableAmount": 30933104567800
    }
  ]
}
```

