### PR TITLE
Modified ArchiveFileName so that NLog will archive log files into the Logs folder

### DIFF
--- a/src/Stratis.Bitcoin/Configuration/Logging/LoggingConfiguration.cs
+++ b/src/Stratis.Bitcoin/Configuration/Logging/LoggingConfiguration.cs
@@ -130,6 +130,8 @@ namespace Stratis.Bitcoin.Configuration.Logging
                 FileTarget debugFileTarget = debugTarget is AsyncTargetWrapper ? (FileTarget)((debugTarget as AsyncTargetWrapper).WrappedTarget) : (FileTarget)debugTarget;
                 string currentFile = debugFileTarget.FileName.Render(new LogEventInfo { TimeStamp = DateTime.UtcNow });
                 debugFileTarget.FileName = Path.Combine(folder.LogPath, Path.GetFileName(currentFile));
+                string currentArchive = debugFileTarget.ArchiveFileName.Render(new LogEventInfo { TimeStamp = DateTime.UtcNow });
+                debugFileTarget.ArchiveFileName = Path.Combine(folder.LogPath, currentArchive);
             }
 
             // Remove rule that forbids logging before the logging is initialized.


### PR DESCRIPTION
When configuring NLog to auto-archive files it will  save the archived files to the bin folder rather than Logs folders.
This change modifies the ArchiveFileName in similar name as we modify log FileName.
