### PR TITLE
[RPC] Initial implementation of getblockchaininfo and getnetworkinfo

### DIFF
--- a/src/Stratis.Bitcoin.Features.RPC/Models/BlockchainInfoModel.cs
+++ b/src/Stratis.Bitcoin.Features.RPC/Models/BlockchainInfoModel.cs
@@ -1,0 +1,82 @@
+﻿using NBitcoin;
+using Newtonsoft.Json;
+
+namespace Stratis.Bitcoin.Features.RPC.Models
+{
+    // Bitcoin Core 0.17.0
+    //{
+    //  "chain": "xxxx",              (string) current network name as defined in BIP70(main, test, regtest)
+    // * "blocks": xxxxxx,             (numeric) the current number of blocks processed in the server
+    // * "headers": xxxxxx,            (numeric) the current number of headers we have validated
+    //  "bestblockhash": "...",       (string) the hash of the currently best block
+    //  "difficulty": xxxxxx,         (numeric) the current difficulty
+    // * "mediantime": xxxxxx,         (numeric) median time for the current best block
+    // * "verificationprogress": xxxx, (numeric) estimate of verification progress[0..1]
+    // * "initialblockdownload": xxxx, (bool) (debug information) estimate of whether this node is in Initial Block Download mode.
+    //  "chainwork": "xxxx"           (string) total amount of work in active chain, in hexadecimal
+    //  "size_on_disk": xxxxxx, (numeric) the estimated size of the block and undo files on disk
+    //  "pruned": xx, (boolean) if the blocks are subject to pruning
+    //  "pruneheight": xxxxxx, (numeric) lowest-height complete block stored (only present if pruning is enabled)
+    //  "automatic_pruning": xx,      (boolean) whether automatic pruning is enabled (only present if pruning is enabled)
+    //  "prune_target_size": xxxxxx,  (numeric) the target size used by pruning (only present if automatic pruning is enabled)
+    //  "softforks": [                (array) status of softforks in progress
+    //     {
+    //        "id": "xxxx",           (string) name of softfork
+    //        "version": xx,          (numeric) block version
+    //        "reject": {             (object) progress toward rejecting pre-softfork blocks
+    //           "status": xx,        (boolean) true if threshold reached
+    //        },
+    //     }, ...
+    //  ],
+    //  "bip9_softforks": {           (object) status of BIP9 softforks in progress
+    //     "xxxx" : {                 (string) name of the softfork
+    //        "status": "xxxx",       (string) one of "defined", "started", "locked_in", "active", "failed"
+    //        "bit": xx,              (numeric) the bit(0-28) in the block version field used to signal this softfork (only for "started" status)
+    //        "startTime": xx,        (numeric) the minimum median time past of a block at which the bit gains its meaning
+    //        "timeout": xx,          (numeric) the median time past of a block at which the deployment is considered failed if not yet locked in
+    //        "since": xx,            (numeric) height of the first block to which the status applies
+    //        "statistics": {
+    //    (object)numeric statistics about BIP9 signalling for a softfork (only for "started" status)
+    //            "period": xx,        (numeric)the length in blocks of the BIP9 signalling period
+    //           "threshold": xx,     (numeric)the number of blocks with the version bit set required to activate the feature
+    //           "elapsed": xx,       (numeric)the number of blocks elapsed since the beginning of the current period
+    //           "count": xx,         (numeric)the number of blocks with the version bit set in the current period
+    //           "possible": xx(boolean) returns false if there are not enough blocks left in this period to pass activation threshold
+    //        }
+    //      }
+    //  }
+    //  "warnings" : "...",           (string) any network and blockchain warnings.
+    //}
+    public class BlockchainInfoModel
+    {
+        [JsonProperty(PropertyName = "chain")]
+        public string Chain { get; set; }
+
+        [JsonProperty(PropertyName = "blocks")]
+        public uint Blocks { get; set; }
+
+        [JsonProperty(PropertyName = "headers")]
+        public uint Headers { get; set; }
+
+        [JsonProperty(PropertyName = "bestblockhash")]
+        public uint256 BestBlockHash { get; set; }
+
+        [JsonProperty(PropertyName = "difficulty")]
+        public double Difficulty { get; set; }
+
+        [JsonProperty(PropertyName = "mediantime")]
+        public long MedianTime { get; set; }
+
+        [JsonProperty(PropertyName = "verificationprogress")]
+        public double VerificationProgress { get; set; }
+
+        [JsonProperty(PropertyName = "initialblockdownload")]
+        public bool IsInitialBlockDownload { get; set; }
+
+        [JsonProperty(PropertyName = "chainwork")]
+        public uint256 Chainwork { get; set; }
+
+        [JsonProperty(PropertyName = "pruned")]
+        public bool IsPruned { get; set; }
+    }
+}

--- a/src/Stratis.Bitcoin.Features.RPC/Models/NetworkInfoModel.cs
+++ b/src/Stratis.Bitcoin.Features.RPC/Models/NetworkInfoModel.cs
@@ -1,0 +1,69 @@
+﻿using Newtonsoft.Json;
+
+namespace Stratis.Bitcoin.Features.RPC.Models
+{
+    // Bitcoin Core 0.17.0
+    //    {
+    //  "version": xxxxx,                      (numeric) the server version
+    //  "subversion": "/Satoshi:x.x.x/",     (string) the server subversion string
+    //  "protocolversion": xxxxx,              (numeric) the protocol version
+    //  "localservices": "xxxxxxxxxxxxxxxx", (string) the services we offer to the network
+    //  "localrelay": true|false,              (bool) true if transaction relay is requested from peers
+    //  "timeoffset": xxxxx,                   (numeric) the time offset
+    //  "connections": xxxxx,                  (numeric) the number of connections
+    //  "networkactive": true|false,           (bool) whether p2p networking is enabled
+    //  "networks": [                          (array) information per network
+    //  {
+    //    "name": "xxx",                     (string) network(ipv4, ipv6 or onion)
+    //    "limited": true|false,               (boolean) is the network limited using -onlynet?
+    //    "reachable": true|false,             (boolean) is the network reachable?
+    //    "proxy": "host:port"               (string) the proxy that is used for this network, or empty if none
+    //    "proxy_randomize_credentials": true|false, (string) Whether randomized credentials are used
+    //  }
+    //  ,...
+    //  ],
+    // * "relayfee": x.xxxxxxxx,                (numeric) minimum relay fee for transactions in BTC/kB
+    // * "incrementalfee": x.xxxxxxxx,          (numeric) minimum fee increment for mempool limiting or BIP 125 replacement in BTC/kB
+    //  "localaddresses": [                    (array) list of local addresses
+    //  {
+    //    "address": "xxxx",                 (string) network address
+    //    "port": xxx,                         (numeric) network port
+    //    "score": xxx(numeric) relative score
+    //  }
+    //  ,...
+    //  ]
+    //  "warnings": "..."                    (string) any network and blockchain warnings
+    //}
+    public class NetworkInfoModel
+    {
+        [JsonProperty(PropertyName = "version")]
+        public uint Version { get; set; }
+
+        [JsonProperty(PropertyName = "subversion")]
+        public string SubVersion { get; set; }
+
+        [JsonProperty(PropertyName = "protocolversion")]
+        public uint ProtocolVersion { get; set; }
+
+        [JsonProperty(PropertyName = "localservices")]
+        public string LocalServices { get; set; }
+
+        [JsonProperty(PropertyName = "localrelay")]
+        public bool IsLocalRelay { get; set; }
+
+        [JsonProperty(PropertyName = "timeoffset")]
+        public long TimeOffset { get; set; }
+
+        [JsonProperty(PropertyName = "connections", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public int? Connections { get; set; }
+
+        [JsonProperty(PropertyName = "networkactive")]
+        public bool IsNetworkActive { get; set; }
+
+        [JsonProperty(PropertyName = "relayfee")]
+        public decimal RelayFee { get; set; }
+
+        [JsonProperty(PropertyName = "incrementalfee")]
+        public decimal IncrementalFee { get; set; }
+    }
+}

--- a/src/Stratis.Bitcoin.IntegrationTests/API/ApiSteps.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/API/ApiSteps.cs
@@ -422,7 +422,7 @@ namespace Stratis.Bitcoin.IntegrationTests.API
         {
             var commands = JsonDataSerializer.Instance.Deserialize<List<RpcCommandModel>>(this.responseText);
 
-            commands.Count.Should().Be(27);
+            commands.Count.Should().Be(29);
             commands.Should().Contain(x => x.Command == "stop");
             commands.Should().Contain(x => x.Command == "getrawtransaction <txid> [<verbose>] [<blockhash>]");
             commands.Should().Contain(x => x.Command == "gettxout <txid> <vout> [<includemempool>]");
@@ -447,6 +447,8 @@ namespace Stratis.Bitcoin.IntegrationTests.API
             commands.Should().Contain(x => x.Command == "walletpassphrase <passphrase> <timeout>");
             commands.Should().Contain(x => x.Command == "listunspent [<minconfirmations>] [<maxconfirmations>] [<addressesjson>]");
             commands.Should().Contain(x => x.Command == "sendmany <fromaccount> <addressesjson> [<minconf>] [<comment>] [<subtractfeefromjson>] [<isreplaceable>] [<conftarget>] [<estimatemode>]");
+            commands.Should().Contain(x => x.Command == "getblockchaininfo");
+            commands.Should().Contain(x => x.Command == "getnetworkinfo");
         }
 
         private void status_information_is_returned()

--- a/src/Stratis.Bitcoin.IntegrationTests/RPC/RPCTestsMutable.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/RPC/RPCTestsMutable.cs
@@ -319,5 +319,31 @@ namespace Stratis.Bitcoin.IntegrationTests.RPC
                 action.Should().Throw<RPCException>().Which.RPCCode.Should().Be(RPCErrorCode.RPC_WALLET_ERROR);
             }
         }
+
+        [Fact]
+        public void TestRpcGetBlockInfo()
+        {
+            using (NodeBuilder builder = NodeBuilder.Create(this))
+            {
+                Network network = new BitcoinRegTest();
+                var node = builder.CreateStratisPowNode(new BitcoinRegTest()).WithReadyBlockchainData(ReadyBlockchain.BitcoinRegTest150Miner).Start();
+                RPCClient rpcClient = node.CreateRPCClient();
+                var response = rpcClient.SendCommand(RPCOperations.getblockchaininfo);
+                response.ResultString.Should().NotBeNullOrEmpty();
+            }
+        }
+
+        [Fact]
+        public void TestRpcGetNetworkInfo()
+        {
+            using (NodeBuilder builder = NodeBuilder.Create(this))
+            {
+                Network network = new BitcoinRegTest();
+                var node = builder.CreateStratisPowNode(new BitcoinRegTest()).WithReadyBlockchainData(ReadyBlockchain.BitcoinRegTest150Miner).Start();
+                RPCClient rpcClient = node.CreateRPCClient();
+                var response = rpcClient.SendCommand(RPCOperations.getnetworkinfo);
+                response.ResultString.Should().NotBeNullOrEmpty();
+            }
+        }
     }
 }


### PR DESCRIPTION
`getinfo` is deprecated in newer versions of bitcoin core. I've moved some of its functionality to these new methods and added some additional capability as well.

NBXplorer uses the newer `getblockchaininfo` and `getnetworkinfo` to retreive node status information. This PR is not a complete implementation of the new RPC methods but hopefully will be enough for NBXplorer. Partly addresses #3306 

I will add to this PR if I find I need additional fields for these RPC calls.