### PR TITLE
Fix regression issues with Printhelp and BuildDefaultConfigurationFile

### DIFF
--- a/src/Stratis.Bitcoin/Builder/FullNodeBuilder.cs
+++ b/src/Stratis.Bitcoin/Builder/FullNodeBuilder.cs
@@ -165,6 +165,8 @@ namespace Stratis.Bitcoin.Builder
             // Print command-line help
             if (this.NodeSettings?.PrintHelpAndExit ?? false)
             {
+                NodeSettings.PrintHelp(this.Network);
+
                 foreach (IFeatureRegistration featureRegistration in this.Features.FeatureRegistrations)
                 {
                     MethodInfo printHelp = featureRegistration.FeatureType.GetMethod("PrintHelp", BindingFlags.Public | BindingFlags.Static);

--- a/src/Stratis.Bitcoin/Configuration/NodeSettings.cs
+++ b/src/Stratis.Bitcoin/Configuration/NodeSettings.cs
@@ -270,6 +270,8 @@ namespace Stratis.Bitcoin.Configuration
 
                 var builder = new StringBuilder();
 
+                BuildDefaultConfigurationFile(builder, this.Network);
+
                 foreach (IFeatureRegistration featureRegistration in features)
                 {
                     MethodInfo getDefaultConfiguration = featureRegistration.FeatureType.GetMethod("BuildDefaultConfigurationFile", BindingFlags.Public | BindingFlags.Static);


### PR DESCRIPTION
This PR:
1) Brings back printing of usage information and base settings
2) Building of the default configuration file as it relates to the base settings.