### PR TITLE
Cancel CheckInputs in CoinViewRule

### DIFF
--- a/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/CoinviewRule.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/CoinviewRule.cs
@@ -102,7 +102,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Rules.CommonRules
                 this.CheckBlockReward(context, fees, index.Height, block);
 
                 // Start the Parallel loop on a thread so its result can be awaited rather than blocking
-                var checkInputsInParallel = Task.Run(() =>
+                Task<ParallelLoopResult> checkInputsInParallel = Task.Run(() =>
                 {
                     return Parallel.ForEach(checkInputs, (checkInput, state) =>
                     {

--- a/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/CoinviewRule.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/CoinviewRule.cs
@@ -114,7 +114,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Rules.CommonRules
 
                 });
 
-                ParallelLoopResult loopResult = await checkInputsInParallel;
+                ParallelLoopResult loopResult = await checkInputsInParallel.ConfigureAwait(false);
 
                 if (!loopResult.IsCompleted)
                 {

--- a/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/CoinviewRule.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/CoinviewRule.cs
@@ -91,8 +91,6 @@ namespace Stratis.Bitcoin.Features.Consensus.Rules.CommonRules
                             TxOut txout = view.GetOutputFor(input);
                             checkInputs.Add(() => this.CheckInput(tx, inputIndexCopy, txout, txData, input, flags));
                         }
-
-
                     }
                 }
 


### PR DESCRIPTION
Closes #1446.

Uses `Parallel.ForEach` to run each `CheckInput` in parallel. If a single `CheckInput` fails, the loop is stopped and no more inputs are checked.