### PR TITLE
Fix archive file null on logger startup

### DIFF
--- a/src/Stratis.Bitcoin/Configuration/Logging/LoggingConfiguration.cs
+++ b/src/Stratis.Bitcoin/Configuration/Logging/LoggingConfiguration.cs
@@ -130,8 +130,12 @@ namespace Stratis.Bitcoin.Configuration.Logging
                 FileTarget debugFileTarget = debugTarget is AsyncTargetWrapper ? (FileTarget)((debugTarget as AsyncTargetWrapper).WrappedTarget) : (FileTarget)debugTarget;
                 string currentFile = debugFileTarget.FileName.Render(new LogEventInfo { TimeStamp = DateTime.UtcNow });
                 debugFileTarget.FileName = Path.Combine(folder.LogPath, Path.GetFileName(currentFile));
-                string currentArchive = debugFileTarget.ArchiveFileName.Render(new LogEventInfo { TimeStamp = DateTime.UtcNow });
-                debugFileTarget.ArchiveFileName = Path.Combine(folder.LogPath, currentArchive);
+
+                if (debugFileTarget.ArchiveFileName != null)
+                {
+                    string currentArchive = debugFileTarget.ArchiveFileName.Render(new LogEventInfo {TimeStamp = DateTime.UtcNow});
+                    debugFileTarget.ArchiveFileName = Path.Combine(folder.LogPath, currentArchive);
+                }
             }
 
             // Remove rule that forbids logging before the logging is initialized.


### PR DESCRIPTION
Fix
```
Using launch settings from C:\Users\dan\Documents\GitHub\StratisBitcoinFullNode\src\Stratis.StratisD\Properties\launchSettings.json...
There was a problem initializing the node. Details: 'System.NullReferenceException: Object reference not set to an instance of an object.
   at Stratis.Bitcoin.Configuration.Logging.LoggingConfiguration.AddFilters(LogSettings settings, DataFolder dataFolder) in C:\Users\dan\Documents\GitHub\StratisBitcoinFullNode\src\Stratis.Bitcoin\Configuration\Logging\LoggingConfiguration.cs:line 133
   at Stratis.Bitcoin.Configuration.Logging.LoggingConfiguration.AddFilters(ILoggerFactory loggerFactory, LogSettings settings, DataFolder dataFolder) in C:\Users\dan\Documents\GitHub\StratisBitcoinFullNode\src\Stratis.Bitcoin\Configuration\Logging\LoggingConfiguration.cs:line 204
   at Stratis.Bitcoin.Configuration.NodeSettings..ctor(Network network, ProtocolVersion protocolVersion, String agent, String[] args, NetworksSelector networksSelector) in C:\Users\dan\Documents\GitHub\StratisBitcoinFullNode\src\Stratis.Bitcoin\Configuration\NodeSettings.cs:line 232
   at Stratis.StratisD.Program.Main(String[] args) in C:\Users\dan\Documents\GitHub\StratisBitcoinFullNode\src\Stratis.StratisD\Program.cs:line 26'

```