### PR TITLE
Fix for serializing DnsSeedMasterFile

### DIFF
--- a/src/Stratis.Bitcoin.Features.Dns.Tests/GivenADnsSeedMasterFile.cs
+++ b/src/Stratis.Bitcoin.Features.Dns.Tests/GivenADnsSeedMasterFile.cs
@@ -280,8 +280,7 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
             var domain = new Domain("stratis.test.com");
 
             var testResourceRecord = new IPAddressResourceRecord(domain, IPAddress.Parse("192.168.0.1"));
-            var masterFile = new DnsSeedMasterFile();
-            masterFile.Add(testResourceRecord);
+            var masterFile = new DnsSeedMasterFile(new List<IResourceRecord> { testResourceRecord });
 
             using (var stream = new MemoryStream())
             {
@@ -310,8 +309,7 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
             var domain = new Domain("stratis.test.com");
 
             var testResourceRecord = new IPAddressResourceRecord(domain, IPAddress.Parse("2001:db8:85a3:0:0:8a2e:370:7334"));
-            var masterFile = new DnsSeedMasterFile();
-            masterFile.Add(testResourceRecord);
+            var masterFile = new DnsSeedMasterFile(new List<IResourceRecord> { testResourceRecord });
 
             using (var stream = new MemoryStream())
             {
@@ -341,8 +339,7 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
             var cNameDomain = new Domain("www.stratis.test.com");
 
             var testResourceRecord = new CanonicalNameResourceRecord(domain, cNameDomain);
-            var masterFile = new DnsSeedMasterFile();
-            masterFile.Add(testResourceRecord);
+            var masterFile = new DnsSeedMasterFile(new List<IResourceRecord> { testResourceRecord });
 
             using (var stream = new MemoryStream())
             {
@@ -373,8 +370,8 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
             int preference = 10;
 
             var testResourceRecord = new MailExchangeResourceRecord(domain, preference, exchangeDomain);
-            var masterFile = new DnsSeedMasterFile();
-            masterFile.Add(testResourceRecord);
+            var masterFile = new DnsSeedMasterFile(new List<IResourceRecord> { testResourceRecord });
+
             using (var stream = new MemoryStream())
             {
                 // Act.
@@ -404,8 +401,7 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
             var nsDomain = new Domain("ns");
 
             var testResourceRecord = new NameServerResourceRecord(domain, nsDomain);
-            var masterFile = new DnsSeedMasterFile();
-            masterFile.Add(testResourceRecord);
+            var masterFile = new DnsSeedMasterFile(new List<IResourceRecord> { testResourceRecord });
 
             using (var stream = new MemoryStream())
             {
@@ -435,8 +431,7 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
             var nsDomain = new Domain("pointer.stratis.test.com");
 
             var testResourceRecord = new PointerResourceRecord(domain, nsDomain);
-            var masterFile = new DnsSeedMasterFile();
-            masterFile.Add(testResourceRecord);
+            var masterFile = new DnsSeedMasterFile(new List<IResourceRecord> { testResourceRecord });
 
             using (var stream = new MemoryStream())
             {
@@ -482,8 +477,7 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
                     expireInterval,
                     minimumTimeToLive);
 
-            var masterFile = new DnsSeedMasterFile();
-            masterFile.Add(testResourceRecord);
+            var masterFile = new DnsSeedMasterFile(new List<IResourceRecord> { testResourceRecord });
 
             using (var stream = new MemoryStream())
             {
@@ -524,11 +518,7 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
                     new IPAddressResourceRecord(new Domain(domainName), IPAddress.Parse("192.168.100.4"))
                 };
 
-            var masterFile = new DnsSeedMasterFile();
-            foreach (IResourceRecord testResourceRecord in testResourceRecords)
-            {
-                masterFile.Add(testResourceRecord);
-            }
+            var masterFile = new DnsSeedMasterFile(testResourceRecords);
 
             using (var stream = new MemoryStream())
             {

--- a/src/Stratis.Bitcoin.Features.Dns.Tests/GivenADnsSeedServer.cs
+++ b/src/Stratis.Bitcoin.Features.Dns.Tests/GivenADnsSeedServer.cs
@@ -638,11 +638,13 @@ namespace Stratis.Bitcoin.Features.Dns.Tests
                 source.Cancel();
             }).ReturnsAsync(1);
 
-            var masterFile = new DnsSeedMasterFile();
-            masterFile.Add(new IPAddressResourceRecord(new Domain("google.com"), IPAddress.Parse("192.168.0.1")));
-            masterFile.Add(new IPAddressResourceRecord(new Domain("google.com"), IPAddress.Parse("192.168.0.2")));
-            masterFile.Add(new IPAddressResourceRecord(new Domain("google.com"), IPAddress.Parse("192.168.0.3")));
-            masterFile.Add(new IPAddressResourceRecord(new Domain("google.com"), IPAddress.Parse("192.168.0.4")));
+            var masterFile = new DnsSeedMasterFile(new List<IResourceRecord>
+            {
+                new IPAddressResourceRecord(new Domain("google.com"), IPAddress.Parse("192.168.0.1")),
+                new IPAddressResourceRecord(new Domain("google.com"), IPAddress.Parse("192.168.0.2")),
+                new IPAddressResourceRecord(new Domain("google.com"), IPAddress.Parse("192.168.0.3")),
+                new IPAddressResourceRecord(new Domain("google.com"), IPAddress.Parse("192.168.0.4"))
+            });
 
             IAsyncLoopFactory asyncLoopFactory = new Mock<IAsyncLoopFactory>().Object;
             INodeLifetime nodeLifetime = new Mock<INodeLifetime>().Object;

--- a/src/Stratis.Bitcoin.Features.Dns/DnsSeedMasterFile.cs
+++ b/src/Stratis.Bitcoin.Features.Dns/DnsSeedMasterFile.cs
@@ -139,7 +139,8 @@ namespace Stratis.Bitcoin.Features.Dns
             var textWriter = new JsonTextWriter(new StreamWriter(stream));
             JsonSerializer serializer = this.CreateSerializer();
 
-            serializer.Serialize(textWriter, this.entries);
+            // Send a copy of the entries to the serializer because the collection can be modified during serialization.
+            serializer.Serialize(textWriter, this.entries.ToList());
             textWriter.Flush();
         }
     }

--- a/src/Stratis.Bitcoin.Features.Dns/DnsSeedMasterFile.cs
+++ b/src/Stratis.Bitcoin.Features.Dns/DnsSeedMasterFile.cs
@@ -46,6 +46,11 @@ namespace Stratis.Bitcoin.Features.Dns
         /// </summary>
         public DnsSeedMasterFile() { }
 
+        public DnsSeedMasterFile(IList<IResourceRecord> resourceRecords)
+        {
+            this.entries = resourceRecords;
+        }
+
         /// <summary>
         /// Identifies if the domain matches the entry.
         /// </summary>
@@ -78,15 +83,6 @@ namespace Stratis.Bitcoin.Features.Dns
             settings.Formatting = Formatting.Indented;
 
             return JsonSerializer.Create(settings);
-        }
-
-        /// <summary>
-        /// Adds a entry to the master file.
-        /// </summary>
-        /// <param name="entry">The resource record to add.</param>
-        public void Add(IResourceRecord entry)
-        {
-            this.entries.Add(entry);
         }
 
         /// <summary>
@@ -151,7 +147,7 @@ namespace Stratis.Bitcoin.Features.Dns
             if (count == 0)
             {
                 // Add SOA record for host.
-                this.Add(new StartOfAuthorityResourceRecord(new Domain(dnsSettings.DnsHostName), new Domain(dnsSettings.DnsNameServer), new Domain(dnsSettings.DnsMailBox.Replace('@', '.'))));
+                this.entries.Add(new StartOfAuthorityResourceRecord(new Domain(dnsSettings.DnsHostName), new Domain(dnsSettings.DnsNameServer), new Domain(dnsSettings.DnsMailBox.Replace('@', '.'))));
             }
 
             // Check if NS record exists for host.
@@ -159,7 +155,7 @@ namespace Stratis.Bitcoin.Features.Dns
             if (count == 0)
             {
                 // Add NS record for host.
-                this.Add(new NameServerResourceRecord(new Domain(dnsSettings.DnsHostName), new Domain(dnsSettings.DnsNameServer)));
+                this.entries.Add(new NameServerResourceRecord(new Domain(dnsSettings.DnsHostName), new Domain(dnsSettings.DnsNameServer)));
             }
         }
     }

--- a/src/Stratis.Bitcoin.Features.Dns/DnsSeedMasterFile.cs
+++ b/src/Stratis.Bitcoin.Features.Dns/DnsSeedMasterFile.cs
@@ -140,6 +140,7 @@ namespace Stratis.Bitcoin.Features.Dns
             textWriter.Flush();
         }
 
+        /// <inheritdoc />
         public void Seed(DnsSettings dnsSettings)
         {
             // Check if SOA record exists for host.

--- a/src/Stratis.Bitcoin.Features.Dns/DnsSeedMasterFile.cs
+++ b/src/Stratis.Bitcoin.Features.Dns/DnsSeedMasterFile.cs
@@ -143,5 +143,24 @@ namespace Stratis.Bitcoin.Features.Dns
             serializer.Serialize(textWriter, this.entries.ToList());
             textWriter.Flush();
         }
+
+        public void Seed(DnsSettings dnsSettings)
+        {
+            // Check if SOA record exists for host.
+            int count = this.Get(new Question(new Domain(dnsSettings.DnsHostName), RecordType.SOA)).Count;
+            if (count == 0)
+            {
+                // Add SOA record for host.
+                this.Add(new StartOfAuthorityResourceRecord(new Domain(dnsSettings.DnsHostName), new Domain(dnsSettings.DnsNameServer), new Domain(dnsSettings.DnsMailBox.Replace('@', '.'))));
+            }
+
+            // Check if NS record exists for host.
+            count = this.Get(new Question(new Domain(dnsSettings.DnsHostName), RecordType.NS)).Count;
+            if (count == 0)
+            {
+                // Add NS record for host.
+                this.Add(new NameServerResourceRecord(new Domain(dnsSettings.DnsHostName), new Domain(dnsSettings.DnsNameServer)));
+            }
+        }
     }
 }

--- a/src/Stratis.Bitcoin.Features.Dns/DnsSeedServer.cs
+++ b/src/Stratis.Bitcoin.Features.Dns/DnsSeedServer.cs
@@ -255,17 +255,18 @@ namespace Stratis.Bitcoin.Features.Dns
         /// masterfile is swapped for efficiency, rather than applying a merge operation to the existing masterfile, or clearing the existing
         /// masterfile and re-adding the peer entries (which could cause some interim DNS resolve requests to fail).
         /// </remarks>
-        /// <param name="masterFile">The new masterfile to swap in.</param>
-        public void SwapMasterfile(IMasterFile masterFile)
+        /// <param name="newMasterFile">The new masterfile to swap in.</param>
+        public void SwapMasterfile(IMasterFile newMasterFile)
         {
-            Guard.NotNull(masterFile, nameof(masterFile));
+            Guard.NotNull(newMasterFile, nameof(newMasterFile));
 
             lock (this.masterFileLock)
             {
-                this.masterFile = masterFile;
+                // Seed the new masterfile with SOA and NS resource records.
+                this.SeedMasterFile(newMasterFile);
 
-                // Seed with SOA and NS resource records when this is a new masterfile.
-                this.SeedMasterFile(masterFile);
+                // Perform the swap after seeding to avoid modifying the current masterfile.
+                this.masterFile = newMasterFile;
             }
         }
 

--- a/src/Stratis.Bitcoin.Features.Dns/DnsSeedServer.cs
+++ b/src/Stratis.Bitcoin.Features.Dns/DnsSeedServer.cs
@@ -431,21 +431,7 @@ namespace Stratis.Bitcoin.Features.Dns
         {
             this.logger.LogInformation("Seeding DNS masterfile with SOA and NS resource records: Host = {0}, Nameserver = {1}, Mailbox = {2}", this.dnsSettings.DnsHostName, this.dnsSettings.DnsNameServer, this.dnsSettings.DnsMailBox);
 
-            // Check if SOA record exists for host.
-            int count = this.MasterFile.Get(new Question(new Domain(this.dnsSettings.DnsHostName), RecordType.SOA)).Count;
-            if (count == 0)
-            {
-                // Add SOA record for host.
-                this.MasterFile.Add(new StartOfAuthorityResourceRecord(new Domain(this.dnsSettings.DnsHostName), new Domain(this.dnsSettings.DnsNameServer), new Domain(this.dnsSettings.DnsMailBox.Replace('@', '.'))));
-            }
-
-            // Check if NS record exists for host.
-            count = this.MasterFile.Get(new Question(new Domain(this.dnsSettings.DnsHostName), RecordType.NS)).Count;
-            if (count == 0)
-            {
-                // Add NS record for host.
-                this.MasterFile.Add(new NameServerResourceRecord(new Domain(this.dnsSettings.DnsHostName), new Domain(this.dnsSettings.DnsNameServer)));
-            }
+            this.MasterFile.Seed(this.dnsSettings);
         }
 
         /// <summary>

--- a/src/Stratis.Bitcoin.Features.Dns/DnsSeedServer.cs
+++ b/src/Stratis.Bitcoin.Features.Dns/DnsSeedServer.cs
@@ -181,7 +181,7 @@ namespace Stratis.Bitcoin.Features.Dns
                 else
                 {
                     // Seed with SOA and NS resource records when this is a new masterfile.
-                    this.SeedMasterFile();
+                    this.SeedMasterFile(this.MasterFile);
                 }
             }
 
@@ -265,7 +265,7 @@ namespace Stratis.Bitcoin.Features.Dns
                 this.masterFile = masterFile;
 
                 // Seed with SOA and NS resource records when this is a new masterfile.
-                this.SeedMasterFile();
+                this.SeedMasterFile(masterFile);
             }
         }
 
@@ -425,13 +425,14 @@ namespace Stratis.Bitcoin.Features.Dns
         }
 
         /// <summary>
-        /// Seeds the masterfile with the SOA and NS DNS records with the DNS specific settings.
+        /// Seeds the given masterfile with the SOA and NS DNS records with the DNS specific settings.
         /// </summary>
-        private void SeedMasterFile()
+        /// <param name="masterFile"></param>
+        private void SeedMasterFile(IMasterFile masterFile)
         {
             this.logger.LogInformation("Seeding DNS masterfile with SOA and NS resource records: Host = {0}, Nameserver = {1}, Mailbox = {2}", this.dnsSettings.DnsHostName, this.dnsSettings.DnsNameServer, this.dnsSettings.DnsMailBox);
 
-            this.MasterFile.Seed(this.dnsSettings);
+            masterFile.Seed(this.dnsSettings);
         }
 
         /// <summary>

--- a/src/Stratis.Bitcoin.Features.Dns/DnsSeedServer.cs
+++ b/src/Stratis.Bitcoin.Features.Dns/DnsSeedServer.cs
@@ -260,11 +260,11 @@ namespace Stratis.Bitcoin.Features.Dns
         {
             Guard.NotNull(newMasterFile, nameof(newMasterFile));
 
+            // Seed the new masterfile with SOA and NS resource records.
+            this.SeedMasterFile(newMasterFile);
+
             lock (this.masterFileLock)
             {
-                // Seed the new masterfile with SOA and NS resource records.
-                this.SeedMasterFile(newMasterFile);
-
                 // Perform the swap after seeding to avoid modifying the current masterfile.
                 this.masterFile = newMasterFile;
             }

--- a/src/Stratis.Bitcoin.Features.Dns/IMasterFile.cs
+++ b/src/Stratis.Bitcoin.Features.Dns/IMasterFile.cs
@@ -34,5 +34,10 @@ namespace Stratis.Bitcoin.Features.Dns
         /// </summary>
         /// <param name="stream">The stream to write the masterfile to.</param>
         void Save(Stream stream);
+
+        /// <summary>
+        /// Seeds the masterfile with the SOA and NS DNS records with the DNS specific settings.
+        /// </summary>
+        void Seed(DnsSettings dnsSettings);
     }
 }

--- a/src/Stratis.Bitcoin.Features.Dns/IMasterFile.cs
+++ b/src/Stratis.Bitcoin.Features.Dns/IMasterFile.cs
@@ -11,12 +11,6 @@ namespace Stratis.Bitcoin.Features.Dns
     public interface IMasterFile
     {
         /// <summary>
-        /// Adds <see cref="IResourceRecord"/> to the master file.
-        /// </summary>
-        /// <param name="entry">The resource record to add to the masterfile so that the IP address of the peer can be returned in a DNS resolve request.</param>
-        void Add(IResourceRecord entry);
-
-        /// <summary>
         /// Gets a list of resource records that match the question.
         /// </summary>
         /// <param name="question">The question to ask of the masterfile.</param>

--- a/src/Stratis.Bitcoin.Features.Dns/WhitelistManager.cs
+++ b/src/Stratis.Bitcoin.Features.Dns/WhitelistManager.cs
@@ -113,7 +113,8 @@ namespace Stratis.Bitcoin.Features.Dns
                 whitelist = whitelist.Where(p => !p.Endpoint.Match(this.externalEndpoint));
             }
 
-            IMasterFile masterFile = new DnsSeedMasterFile();
+            var resourceRecords = new List<IResourceRecord>();
+
             foreach (PeerAddress whitelistEntry in whitelist)
             {
                 if (this.peerBanning.IsBanned(whitelistEntry.Endpoint))
@@ -129,14 +130,16 @@ namespace Stratis.Bitcoin.Features.Dns
                 {
                     IPAddress ipv4Address = whitelistEntry.Endpoint.Address.MapToIPv4();
                     var resourceRecord = new IPAddressResourceRecord(domain, ipv4Address);
-                    masterFile.Add(resourceRecord);
+                    resourceRecords.Add(resourceRecord);
                 }
                 else
                 {
                     var resourceRecord = new IPAddressResourceRecord(domain, whitelistEntry.Endpoint.Address);
-                    masterFile.Add(resourceRecord);
+                    resourceRecords.Add(resourceRecord);
                 }
             }
+
+            IMasterFile masterFile = new DnsSeedMasterFile(resourceRecords);
 
             this.dnsServer.SwapMasterfile(masterFile);
         }


### PR DESCRIPTION
Fix for [3163](https://dev.azure.com/Stratisplatformuk/StratisBitcoinFullNode/_workitems/edit/3163). 

* Move the Seed method into `DnsSeedMasterFile` so that it is responsible for managing its own state.
* Remove the Add method to prevent the collection being modified externally.
* Seed the new masterfile _before_ swapping it. As this is only time the entries are modified, this should fix the serialization issue.
* Defensively, only serialize a copy of the entries.