### PR TITLE
Use the better of the same two tokens

### DIFF
--- a/src/Stratis.Bitcoin.Features.Miner/Staking/PosMinting.cs
+++ b/src/Stratis.Bitcoin.Features.Miner/Staking/PosMinting.cs
@@ -285,7 +285,7 @@ namespace Stratis.Bitcoin.Features.Miner.Staking
             {
                 try
                 {
-                    await this.GenerateBlocksAsync(walletSecret, this.stakeCancellationTokenSource.Token)
+                    await this.GenerateBlocksAsync(walletSecret, token)
                         .ConfigureAwait(false);
                 }
                 catch (OperationCanceledException)


### PR DESCRIPTION
This commit does not change how the code works. `token` local variable is used instead of `this.stakeCancellationTokenSource.Token` member variable  so that `token` is no longer unused variable.

Fixes #3307