### PR TITLE
[Wallet] Added the index of a transaction in the block 

### DIFF
--- a/src/Stratis.Bitcoin.Features.Wallet/Controllers/WalletController.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Controllers/WalletController.cs
@@ -417,7 +417,8 @@ namespace Stratis.Bitcoin.Features.Wallet.Controllers
                                     Amount = relatedOutputs.Sum(o => o.Transaction.Amount) - transaction.Amount,
                                     Id = transaction.SpendingDetails.TransactionId,
                                     Timestamp = transaction.SpendingDetails.CreationTime,
-                                    ConfirmedInBlock = transaction.SpendingDetails.BlockHeight
+                                    ConfirmedInBlock = transaction.SpendingDetails.BlockHeight,
+                                    BlockIndex = transaction.SpendingDetails.BlockIndex,
                                 };
 
                                 transactionItems.Add(stakingItem);
@@ -441,7 +442,8 @@ namespace Stratis.Bitcoin.Features.Wallet.Controllers
                                 Amount = transaction.Amount,
                                 Id = transaction.Id,
                                 Timestamp = transaction.CreationTime,
-                                ConfirmedInBlock = transaction.BlockHeight
+                                ConfirmedInBlock = transaction.BlockHeight,
+                                BlockIndex = transaction.BlockIndex
                             };
 
                             transactionItems.Add(receivedItem);
@@ -458,6 +460,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Controllers
                                 Id = spendingTransactionId,
                                 Timestamp = transaction.SpendingDetails.CreationTime,
                                 ConfirmedInBlock = transaction.SpendingDetails.BlockHeight,
+                                BlockIndex = transaction.SpendingDetails.BlockIndex,
                                 Amount = Money.Zero
                             };
 

--- a/src/Stratis.Bitcoin.Features.Wallet/Controllers/WalletController.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Controllers/WalletController.cs
@@ -418,7 +418,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Controllers
                                     Id = transaction.SpendingDetails.TransactionId,
                                     Timestamp = transaction.SpendingDetails.CreationTime,
                                     ConfirmedInBlock = transaction.SpendingDetails.BlockHeight,
-                                    BlockIndex = transaction.SpendingDetails.BlockIndex,
+                                    BlockIndex = transaction.SpendingDetails.BlockIndex
                                 };
 
                                 transactionItems.Add(stakingItem);

--- a/src/Stratis.Bitcoin.Features.Wallet/Models/WalletHistoryModel.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Models/WalletHistoryModel.cs
@@ -80,6 +80,12 @@ namespace Stratis.Bitcoin.Features.Wallet.Models
         [JsonProperty(PropertyName = "timestamp")]
         [JsonConverter(typeof(DateTimeOffsetConverter))]
         public DateTimeOffset Timestamp { get; set; }
+
+        /// <summary>
+        /// The index of this transaction in the block in which it is contained.
+        /// </summary>
+        [JsonProperty(PropertyName = "blockIndex", NullValueHandling = NullValueHandling.Ignore)]
+        public int? BlockIndex { get; set; }
     }
 
     public class PaymentDetailModel

--- a/src/Stratis.Bitcoin.Features.Wallet/Wallet.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Wallet.cs
@@ -928,6 +928,12 @@ namespace Stratis.Bitcoin.Features.Wallet
         public uint256 BlockHash { get; set; }
 
         /// <summary>
+        /// The index of this transaction in the block in which it is contained.
+        /// </summary>
+        [JsonProperty(PropertyName = "blockIndex", NullValueHandling = NullValueHandling.Ignore)]
+        public int? BlockIndex { get; set; }
+
+        /// <summary>
         /// Gets or sets the creation time.
         /// </summary>
         [JsonProperty(PropertyName = "creationTime")]
@@ -1061,6 +1067,12 @@ namespace Stratis.Bitcoin.Features.Wallet
         /// </summary>
         [JsonProperty(PropertyName = "blockHeight", NullValueHandling = NullValueHandling.Ignore)]
         public int? BlockHeight { get; set; }
+
+        /// <summary>
+        /// The index of this transaction in the block in which it is contained.
+        /// </summary>
+        [JsonProperty(PropertyName = "blockIndex", NullValueHandling = NullValueHandling.Ignore)]
+        public int? BlockIndex { get; set; }
 
         /// <summary>
         /// A value indicating whether this is a coin stake transaction or not.

--- a/src/Stratis.Bitcoin.Features.Wallet/WalletManager.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/WalletManager.cs
@@ -1048,6 +1048,7 @@ namespace Stratis.Bitcoin.Features.Wallet
                     IsCoinStake = transaction.IsCoinStake == false ? (bool?)null : true,
                     BlockHeight = blockHeight,
                     BlockHash = block?.GetHash(),
+                    BlockIndex = block?.Transactions.FindIndex(t => t.GetHash() == transactionHash),
                     Id = transactionHash,
                     CreationTime = DateTimeOffset.FromUnixTimeSeconds(block?.Header.Time ?? transaction.Time),
                     Index = index,
@@ -1074,6 +1075,7 @@ namespace Stratis.Bitcoin.Features.Wallet
                 {
                     foundTransaction.BlockHeight = blockHeight;
                     foundTransaction.BlockHash = block?.GetHash();
+                    foundTransaction.BlockIndex = block?.Transactions.FindIndex(t => t.GetHash() == transactionHash);
                 }
 
                 // Update the block time.
@@ -1111,6 +1113,8 @@ namespace Stratis.Bitcoin.Features.Wallet
             Guard.NotNull(transaction, nameof(transaction));
             Guard.NotNull(paidToOutputs, nameof(paidToOutputs));
 
+            uint256 transactionHash = transaction.GetHash();
+
             // Get the transaction being spent.
             TransactionData spentTransaction = this.scriptToAddressLookup.Values.Distinct().SelectMany(v => v.Transactions)
                 .SingleOrDefault(t => (t.Id == spendingTransactionId) && (t.Index == spendingTransactionIndex));
@@ -1146,10 +1150,11 @@ namespace Stratis.Bitcoin.Features.Wallet
 
                 var spendingDetails = new SpendingDetails
                 {
-                    TransactionId = transaction.GetHash(),
+                    TransactionId = transactionHash,
                     Payments = payments,
                     CreationTime = DateTimeOffset.FromUnixTimeSeconds(block?.Header.Time ?? transaction.Time),
                     BlockHeight = blockHeight,
+                    BlockIndex = block?.Transactions.FindIndex(t => t.GetHash() == transactionHash),
                     Hex = this.walletSettings.SaveTransactionHex ? transaction.ToHex() : null,
                     IsCoinStake = transaction.IsCoinStake == false ? (bool?)null : true
                 };
@@ -1171,6 +1176,7 @@ namespace Stratis.Bitcoin.Features.Wallet
                 if (block != null)
                 {
                     spentTransaction.SpendingDetails.CreationTime = DateTimeOffset.FromUnixTimeSeconds(block.Header.Time);
+                    spentTransaction.BlockIndex = block?.Transactions.FindIndex(t => t.GetHash() == transactionHash);
                 }
             }
 

--- a/src/Stratis.Bitcoin.Features.Wallet/WalletRPCController.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/WalletRPCController.cs
@@ -206,17 +206,19 @@ namespace Stratis.Bitcoin.Features.Wallet
             // Get the block hash from the transaction in the wallet.
             TransactionData transactionFromWallet = null;
             uint256 blockHash = null;
-            int? blockHeight;
+            int? blockHeight, blockIndex;
 
             if (receivedTransactions.Any())
             {
                 blockHeight = receivedTransactions.First().BlockHeight;
+                blockIndex = receivedTransactions.First().BlockIndex;
                 blockHash = receivedTransactions.First().BlockHash;
                 transactionFromWallet = receivedTransactions.First();
             }
             else
             {
                 blockHeight = sendTransactions.First().SpendingDetails.BlockHeight;
+                blockIndex = sendTransactions.First().SpendingDetails.BlockIndex;
                 blockHash = blockHeight != null ? this.Chain.GetBlock(blockHeight.Value).HashBlock : null;
             }
 
@@ -268,7 +270,7 @@ namespace Stratis.Bitcoin.Features.Wallet
                 Confirmations = blockHeight != null ? this.ConsensusManager.Tip.Height - blockHeight.Value + 1 : 0,
                 Isgenerated = isGenerated ? true : (bool?) null,
                 BlockHash = blockHash,
-                BlockIndex = block?.Transactions.FindIndex(t => t.GetHash() == trxid),
+                BlockIndex = blockIndex ?? block?.Transactions.FindIndex(t => t.GetHash() == trxid),
                 BlockTime = block?.Header.BlockTime.ToUnixTimeSeconds(),
                 TransactionId = uint256.Parse(txid),
                 TransactionTime = transactionTime.ToUnixTimeSeconds(),


### PR DESCRIPTION
The index of a transaction in a block is useful for smart contracts and some RPC methods.

😑  Added it under the name `blockIndex`, which isn't particularly nice, but txindex is taken by something else, and bitcoin uses blockIndex as well.

Related to https://github.com/stratisproject/StratisBitcoinFullNode/issues/2823.