### PR TITLE
Fix cold staking keys lookup initialization

### DIFF
--- a/src/Stratis.Bitcoin.Features.ColdStaking/ColdStakingManager.cs
+++ b/src/Stratis.Bitcoin.Features.ColdStaking/ColdStakingManager.cs
@@ -233,7 +233,8 @@ namespace Stratis.Bitcoin.Features.ColdStaking
             account = wallet.AddNewAccount(walletPassword, this.coinType, this.dateTimeProvider.GetTimeOffset(), accountIndex, accountName);
 
             // Maintain at least one unused address at all times. This will ensure that wallet recovery will also work.
-            account.CreateAddresses(wallet.Network, 1, false);
+            IEnumerable<HdAddress> newAddresses = account.CreateAddresses(wallet.Network, 1, false);
+            this.UpdateKeysLookupLocked(newAddresses);
 
             // Save the changes to the file.
             this.SaveWallet(wallet);
@@ -266,7 +267,9 @@ namespace Stratis.Bitcoin.Features.ColdStaking
             if (address == null)
             {
                 this.logger.LogTrace("No unused address exists on account '{0}'. Adding new address.", account.Name);
-                address = account.CreateAddresses(wallet.Network, 1).First();
+                IEnumerable<HdAddress> newAddresses = account.CreateAddresses(wallet.Network, 1);
+                this.UpdateKeysLookupLocked(newAddresses);
+                address = newAddresses.First();
             }
 
             this.logger.LogTrace("(-):'{0}'", address.Address);

--- a/src/Stratis.Bitcoin.IntegrationTests/Wallet/ColdWalletTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/Wallet/ColdWalletTests.cs
@@ -126,12 +126,10 @@ namespace Stratis.Bitcoin.IntegrationTests.Wallet
                 // Set up cold staking account on cold wallet.
                 coldWalletManager.GetOrCreateColdStakingAccount(WalletName, true, Password);
                 HdAddress coldWalletAddress = coldWalletManager.GetFirstUnusedColdStakingAddress(WalletName, true);
-                coldWalletManager.UpdateKeysLookupLocked(new[] { coldWalletAddress });
 
                 // Set up cold staking account on hot wallet.
                 hotWalletManager.GetOrCreateColdStakingAccount(WalletName, false, Password);
                 HdAddress hotWalletAddress = hotWalletManager.GetFirstUnusedColdStakingAddress(WalletName, false);
-                hotWalletManager.UpdateKeysLookupLocked(new[] { hotWalletAddress });
 
                 int maturity = (int)stratisSender.FullNode.Network.Consensus.CoinbaseMaturity;
                 TestHelper.MineBlocks(stratisSender, maturity + 16, true);


### PR DESCRIPTION
This PR adds key lookup initialization at the point where new cold staking addresses are created.

Previously cold staking transactions would be omitted from the wallet unless the wallet had been reloaded between address creation and address usage - i.e. cold staking balances may remain 0.

The unit tests had not detected this issue due to the keys lookup initialization that had been present in the tests themselves. That initialization has been removed from the tests as part of this fix.