### PR TITLE
Fix GetFirstWalletBlockLocator

### DIFF
--- a/src/Stratis.Bitcoin.Features.LightWallet/LightWalletSyncManager.cs
+++ b/src/Stratis.Bitcoin.Features.LightWallet/LightWalletSyncManager.cs
@@ -96,7 +96,7 @@ namespace Stratis.Bitcoin.Features.LightWallet
                     // that in the wallet. the block locator will help finding
                     // a common fork and bringing the wallet back to a good
                     // state (behind the best chain)
-                    ICollection<uint256> locators = this.walletManager.GetFirstWalletBlockLocator();
+                    ICollection<uint256> locators = this.walletManager.ContainsWallets ? this.walletManager.GetFirstWalletBlockLocator() : new[] { this.chain.Tip.HashBlock };
                     var blockLocator = new BlockLocator { Blocks = locators.ToList() };
                     ChainedHeader fork = this.chain.FindFork(blockLocator);
                     this.walletManager.RemoveBlocks(fork);

--- a/src/Stratis.Bitcoin.Features.Wallet/WalletManager.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/WalletManager.cs
@@ -681,7 +681,7 @@ namespace Stratis.Bitcoin.Features.Wallet
 
                     // Get the total balances.
                     (Money amountConfirmed, Money amountUnconfirmed) result = account.GetBalances();
-                    
+
                     balances.Add(new AccountBalance
                     {
                         Account = account,
@@ -1500,7 +1500,7 @@ namespace Stratis.Bitcoin.Features.Wallet
         /// <inheritdoc />
         public ICollection<uint256> GetFirstWalletBlockLocator()
         {
-            return this.Wallets.First().BlockLocator;
+            return this.Wallets.FirstOrDefault()?.BlockLocator ?? new[] { this.network.GenesisHash };
         }
 
         /// <inheritdoc />

--- a/src/Stratis.Bitcoin.Features.Wallet/WalletManager.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/WalletManager.cs
@@ -1500,7 +1500,7 @@ namespace Stratis.Bitcoin.Features.Wallet
         /// <inheritdoc />
         public ICollection<uint256> GetFirstWalletBlockLocator()
         {
-            return this.Wallets.FirstOrDefault()?.BlockLocator ?? new[] { this.network.GenesisHash };
+            return this.Wallets.First().BlockLocator;
         }
 
         /// <inheritdoc />

--- a/src/Stratis.Bitcoin.Features.Wallet/WalletSyncManager.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/WalletSyncManager.cs
@@ -90,7 +90,7 @@ namespace Stratis.Bitcoin.Features.Wallet
                 // that in the wallet. The block locator will help finding
                 // a common fork and bringing the wallet back to a good
                 // state (behind the best chain).
-                ICollection<uint256> locators = this.walletManager.GetFirstWalletBlockLocator();
+                ICollection<uint256> locators = this.walletManager.ContainsWallets ? this.walletManager.GetFirstWalletBlockLocator() : new[] { this.chain.Tip.HashBlock };
                 var blockLocator = new BlockLocator { Blocks = locators.ToList() };
                 ChainedHeader fork = this.chain.FindFork(blockLocator);
                 this.walletManager.RemoveBlocks(fork);

--- a/src/Stratis.Bitcoin.IntegrationTests/Compatibility/StratisXTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/Compatibility/StratisXTests.cs
@@ -298,7 +298,7 @@ namespace Stratis.Bitcoin.IntegrationTests.Compatibility
 
                 stratisXRpc.SendCommand(RPCOperations.generate, 11);
 
-                var shortCancellationToken = new CancellationTokenSource(TimeSpan.FromMinutes(1)).Token;
+                var shortCancellationToken = new CancellationTokenSource(TimeSpan.FromMinutes(2)).Token;
 
                 // Without this there seems to be a race condition between the blocks all getting generated and SBFN syncing high enough to fall through the getbestblockhash check.
                 TestHelper.WaitLoop(() => stratisXRpc.GetBlockCount() >= 11, cancellationToken: shortCancellationToken);


### PR DESCRIPTION
Fixes a `Sequence contains no elements` error which occurs when the data directory contains no wallets.