### PR TITLE
Optimize memory allocations in BlockMerkleRootRule.ComputeMerkleRoot()

### DIFF
--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/MerkleRootComputationTest.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/MerkleRootComputationTest.cs
@@ -17,7 +17,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests
                 new uint256("f4570fd8c54fded84b696ba3eb986a5421b0a41109dea6e10ba96aec70f78f00")
             };
             bool mutated;
-            uint256 root = ComputeMerkleRoot(leaves, out mutated);
+            uint256 root = BlockMerkleRootRule.ComputeMerkleRoot(leaves, out mutated);
 
             Assert.Equal("cd00f5d5aada62c8e49a9f01378998cbd016d04b725d0d8497877e5f75ffc722", root.ToString());
             Assert.False(mutated);
@@ -41,16 +41,10 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests
                 new uint256("ac2dcf5c46d9a801389b6c0630b435ce5c2fa850cfac5456f16937dd8ae697d3")
             };
             bool mutated;
-            uint256 root = this.ComputeMerkleRoot(leaves, out mutated);
+            uint256 root = BlockMerkleRootRule.ComputeMerkleRoot(leaves, out mutated);
 
             Assert.Equal("95aa5bba66381c3817df338895349acd3fc3e8ce226e04a5e2acbb53db18b9c0", root.ToString());
             Assert.True(mutated);
-        }
-
-        private uint256 ComputeMerkleRoot(List<uint256> leaves, out bool mutated)
-        {
-            KnownNetworks.Main.Consensus.Options = new PosConsensusOptions();
-            return BlockMerkleRootRule.ComputeMerkleRoot(leaves, out mutated);
         }
     }
 }

--- a/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/BlockMerkleRootRule.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/BlockMerkleRootRule.cs
@@ -93,6 +93,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Rules.CommonRules
             // Which position in inner is a hash that depends on the matching leaf.
             int matchLevel = -1;
             uint processedLeavesCount = 0;
+            var hash = new byte[64];
 
             // First process all leaves into subTreeHashes values.
             while (processedLeavesCount < leaves.Count)
@@ -118,7 +119,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Rules.CommonRules
                     }
                     if (!mutated)
                         mutated = subTreeHashes[level] == currentLeaveHash;
-                    var hash = new byte[64];
+                    
                     Buffer.BlockCopy(subTreeHashes[level].ToBytes(), 0, hash, 0, 32);
                     Buffer.BlockCopy(currentLeaveHash.ToBytes(), 0, hash, 32, 32);
                     currentLeaveHash = Hashes.Hash256(hash);
@@ -145,6 +146,8 @@ namespace Stratis.Bitcoin.Features.Consensus.Rules.CommonRules
 
                 root = subTreeHashes[level];
                 bool match = matchLevel == level;
+                var hashh = new byte[64];
+
                 while (processedLeavesCount != (((uint)1) << level))
                 {
                     // If we reach this point, hash is a subTreeHashes value that is not the top.
@@ -153,9 +156,10 @@ namespace Stratis.Bitcoin.Features.Consensus.Rules.CommonRules
                     if (match)
                         branch.Add(root);
 
-                    var hash = new byte[64];
-                    Buffer.BlockCopy(root.ToBytes(), 0, hash, 0, 32);
-                    Buffer.BlockCopy(root.ToBytes(), 0, hash, 32, 32);
+                    // Line was added to allocate once and not twice
+                    var rootBytes = root.ToBytes(); 
+                    Buffer.BlockCopy(rootBytes, 0, hash, 0, 32);
+                    Buffer.BlockCopy(rootBytes, 0, hash, 32, 32);
                     root = Hashes.Hash256(hash);
 
                     // Increment processedLeavesCount to the value it would have if two entries at this
@@ -176,7 +180,6 @@ namespace Stratis.Bitcoin.Features.Consensus.Rules.CommonRules
                             match = true;
                         }
 
-                        var hashh = new byte[64];
                         Buffer.BlockCopy(subTreeHashes[level].ToBytes(), 0, hashh, 0, 32);
                         Buffer.BlockCopy(root.ToBytes(), 0, hashh, 32, 32);
                         root = Hashes.Hash256(hashh);


### PR DESCRIPTION
Hi,

This PR reduces the number of memory allocations needed in `ComputeMerkleRoot()`.

I tried to measure it in very simplified manner:

```C#
[Fact]
public void MerkleRootComputationMutated()
{
	GC.TryStartNoGCRegion(200_000_000);
	long kbAtExecution = GC.GetTotalMemory(false) / 1024;

	for (int i = 0; i < 10_000; i++)
	{
		var leaves = new List<uint256>()
		{
			new uint256("281f5acb40a65640bc48b90b5296a87d09341e3510608b191c9bc3a511f8e436"),
			new uint256("d0249653efaaa999f0278bb390c0f4ec3e5465a10f35264ebcfbb6dd6a677abd"),
			new uint256("7897c117fddbf98ea9749cc868a9d1e663b198dd3ac0ae5837734007f0060b20"),
			new uint256("ced314892a97f342a136269e2842fd0dbd1cab1fa84557bc48420f7cf96f0bc7"),

			new uint256("5b98af3d7554916483bca1a52f16570a93f07c95d6aeb8d08b0794c86cf58128"),
			new uint256("5b98af3d7554916483bca1a52f16570a93f07c95d6aeb8d08b0794c86cf58128"),
			new uint256("5b98af3d7554916483bca1a52f16570a93f07c95d6aeb8d08b0794c86cf58128"),

			new uint256("91be5a63b4b70c8329f20960e49a8bd3adeb77fcbadf78014ac54efaf1647a31"),
			new uint256("ac2dcf5c46d9a801389b6c0630b435ce5c2fa850cfac5456f16937dd8ae697d3")
		};
		bool mutated;
		uint256 root = BlockMerkleRootRule.ComputeMerkleRoot(leaves, out mutated);

		Assert.Equal("95aa5bba66381c3817df338895349acd3fc3e8ce226e04a5e2acbb53db18b9c0", root.ToString());
		Assert.True(mutated);
	}

	long kbAfter1 = GC.GetTotalMemory(false) / 1024;
	GC.EndNoGCRegion();
	long kbAfter2 = GC.GetTotalMemory(true) / 1024;

	Trace.WriteLine(kbAtExecution + " Started with this kb.");
	Trace.WriteLine(kbAfter1 + " After the test.");
	Trace.WriteLine(kbAfter1 - kbAtExecution + " Amt. Added.");
	Trace.WriteLine(kbAfter2 + " Amt. After Collection");
	Trace.WriteLine(kbAfter2 - kbAfter1 + " Amt. Collected by GC.");
}

```

Results for original code:

```			
2831 Started with this kb.
164423 After the test.
161592 Amt. Added.
2840 Amt. After Collection
-161583 Amt. Collected by GC.			
```

Results for the modified code:

```
2805 Started with this kb.
147712 After the test.
144907 Amt. Added.
2840 Amt. After Collection
-144872 Amt. Collected by GC.
```

So the result for this test gives circa 9% in memory savings.

PS: `branch` list is used for debugging, I guess, as it is used in a write-only way using `branch.Add()` and it is not consumed anywhere.