### PR TITLE
Optimised code using arrays by avoiding LINQ and using Buffer.Copy

### DIFF
--- a/src/NBitcoin/DataEncoders/Base58Encoder.cs
+++ b/src/NBitcoin/DataEncoders/Base58Encoder.cs
@@ -140,9 +140,9 @@ namespace NBitcoin.DataEncoders
             for(int y = i; y < encoded.Length && encoded[y] == pszBase58[0]; y++)
                 nLeadingZeros++;
 
-
             result = new byte[nLeadingZeros + vchTmp.Length];
-            Array.Copy(vchTmp.Reverse().ToArray(), 0, result, nLeadingZeros, vchTmp.Length);
+            Array.Copy(vchTmp, 0, result, nLeadingZeros, vchTmp.Length);
+            Array.Reverse(result);
             return result;
         }
     }

--- a/src/NBitcoin/Target.cs
+++ b/src/NBitcoin/Target.cs
@@ -159,15 +159,14 @@ namespace NBitcoin
         {
             byte[] array = input.ToByteArray();
 
-            int missingZero = 32 - array.Length;
+            int destinationArrayOffset = 32 - array.Length;
+            byte[] result = new byte[32];
 
-            if(missingZero < 0)
+            if (destinationArrayOffset < 0)
                 throw new InvalidOperationException("Awful bug, this should never happen");
 
-            if(missingZero != 0)
-                return new uint256(new byte[missingZero].Concat(array), false);
-
-            return new uint256(array, false);
+           Buffer.BlockCopy(array, 0, result, destinationArrayOffset, result.Length - destinationArrayOffset);
+            return new uint256(result, false);
         }
 
         public override string ToString()

--- a/src/Stratis.Bitcoin.Features.BlockStore/Models/BlockTransactionDetailsModel.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/Models/BlockTransactionDetailsModel.cs
@@ -13,7 +13,11 @@ namespace Stratis.Bitcoin.Features.BlockStore.Models
 
         public BlockTransactionDetailsModel(Block block, Network network, ChainBase chain) : base(block, chain)
         {
-            this.Transactions = block.Transactions.Select(trx => new TransactionVerboseModel(trx, network)).ToArray();
+            this.Transactions = new TransactionVerboseModel[block.Transactions.Count];
+            for (int i = 0; i < block.Transactions.Count; i++)
+            {
+                this.Transactions[i] = new TransactionVerboseModel(block.Transactions[i], network);
+            }
         }
 
         public BlockTransactionDetailsModel()

--- a/src/Stratis.Bitcoin.Features.Consensus/CoinViews/CachedCoinView.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/CoinViews/CachedCoinView.cs
@@ -410,7 +410,7 @@ namespace Stratis.Bitcoin.Features.Consensus.CoinViews
                         UnspentOutputs clone = unspent.Clone();
 
                         // We take the original items that are in cache and put them in rewind data.
-                        clone.Outputs = cacheItem.UnspentOutputs.Outputs.ToArray();
+                        Array.Copy(cacheItem.UnspentOutputs.Outputs, 0, clone.Outputs, 0, clone.Outputs.Length);
 
                         this.logger.LogTrace("Modifying transaction '{0}' in OutputsToRestore rewind data.", unspent.TransactionId);
                         rewindData.OutputsToRestore.Add(clone);

--- a/src/Stratis.Bitcoin.Features.RPC/Controllers/RPCController.cs
+++ b/src/Stratis.Bitcoin.Features.RPC/Controllers/RPCController.cs
@@ -182,7 +182,7 @@ namespace Stratis.Bitcoin.Features.RPC.Controllers
                         }
                     }
 
-                    string method = $"{descriptor.ActionName} {string.Join(" ", parameters.ToArray())}";
+                    string method = $"{descriptor.ActionName} {string.Join(" ", parameters)}";
 
                     listMethods.Add(new Models.RpcCommandModel { Command = method.Trim(), Description = description });
                 }

--- a/src/Stratis.Bitcoin.Features.RPC/RPCClient.Wallet.cs
+++ b/src/Stratis.Bitcoin.Features.RPC/RPCClient.Wallet.cs
@@ -522,11 +522,7 @@ namespace Stratis.Bitcoin.Features.RPC
             if (outpoints == null || outpoints.Length == 0)
                 return;
 
-            var parameters = new List<object>();
-            parameters.Add(unlock);
             var array = new JArray();
-            parameters.Add(array);
-
             foreach (OutPoint outp in outpoints)
             {
                 var obj = new JObject();
@@ -535,6 +531,7 @@ namespace Stratis.Bitcoin.Features.RPC
                 array.Add(obj);
             }
 
+            var parameters = new object[] { unlock, array };
             await SendCommandAsync(RPCOperations.lockunspent, parameters.ToArray()).ConfigureAwait(false);
         }
 
@@ -557,10 +554,8 @@ namespace Stratis.Bitcoin.Features.RPC
         /// <param name="timeout">Timeout in seconds</param>
         public async Task WalletPassphraseAsync(string passphrase, int timeout)
         {
-            var parameters = new List<object>();
-            parameters.Add(passphrase);
-            parameters.Add(timeout);
-            await SendCommandAsync(RPCOperations.walletpassphrase, parameters.ToArray()).ConfigureAwait(false);
+            var parameters = new object[] {passphrase, timeout};
+            await SendCommandAsync(RPCOperations.walletpassphrase, parameters).ConfigureAwait(false);
         }
     
         /// <summary>

--- a/src/Stratis.Bitcoin/P2P/Protocol/Payloads/AddrPayload.cs
+++ b/src/Stratis.Bitcoin/P2P/Protocol/Payloads/AddrPayload.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using NBitcoin;
 using NBitcoin.Protocol;
 
@@ -25,7 +26,8 @@ namespace Stratis.Bitcoin.P2P.Protocol.Payloads
 
         public AddrPayload(NetworkAddress[] addresses)
         {
-            this.addresses = addresses.ToArray();
+            this.addresses = new NetworkAddress[addresses.Length];
+            Array.Copy(addresses, 0, this.addresses, 0, this.addresses.Length);
         }
 
         public override void ReadWriteCore(BitcoinStream stream)

--- a/src/Stratis.Bitcoin/Utilities/UnspentOutputs.cs
+++ b/src/Stratis.Bitcoin/Utilities/UnspentOutputs.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using System.Text;
 using NBitcoin;
 using NBitcoin.BitcoinCore;
@@ -52,7 +53,8 @@ namespace Stratis.Bitcoin.Utilities
             this.Time = unspent.Time;
             this.Height = unspent.Height;
             this.Version = unspent.Version;
-            this.Outputs = unspent.Outputs.ToArray();
+            this.Outputs = new TxOut[unspent.Outputs.Length];
+            Array.Copy(unspent.Outputs, 0, this.Outputs, 0, this.Outputs.Length);
         }
 
         /// <summary>


### PR DESCRIPTION
Performance characteristics of using Select(...).ToArray() vs. for loop

```
[Benchmark]
public string[] LinqSelectToArray_Current()
{
    string[] result = _bytes.Select(b => BitConverter.ToString(new byte[] {b})).ToArray();
    return result;
}

[Benchmark]
public string[] LinqSelectToArray_Proposed()
{
    string[] result = new string[_bytes.Length];

    for (int i = 0; i < _bytes.Length; i++)
    {
        result[i] = BitConverter.ToString(new byte[] {_bytes[i]});
    }

    return result;
}
```

|                     Method | Array Size|     Mean |     Error |    StdDev | Ratio | Rank | Gen 0/1k Op | Gen 1/1k Op | Gen 2/1k Op | Allocated Memory/Op |
|--------------------------- |-------------- |---------:|----------:|----------:|------:|-----:|------------:|------------:|------------:|--------------------:|
|  **LinqSelectToArray_Current** |             **32 elements** | **749.1 ns** |  **8.426 ns** |  **7.469 ns** |  **1.00** |    **1** |      **0.5655** |           **-** |           **-** |              **2376 B** |
|                            |               |          |           |           |       |      |             |             |             |                     |
| LinqSelectToArray_Proposed |             32 elements | 642.3 ns | 12.619 ns | 14.532 ns |  1.00 |    1 |      0.5541 |           - |           - |              2328 B |
|                            |               |          |           |           |       |      |             |             |             |                     |
|  **LinqSelectToArray_Current** |             **6 elements** | **200.8 ns** |  **3.101 ns** |  **2.901 ns** |  **1.00** |    **1** |      **0.1202** |           **-** |           **-** |               **504 B** |
|                            |               |          |           |           |       |      |             |             |             |                     |
| LinqSelectToArray_Proposed |             6 elements | 126.6 ns |  1.654 ns |  1.547 ns |  1.00 |    1 |      0.1087 |           - |           - |               456 B |

Using `ToArray()` as cloning mechanism

|            Method | Array Size |      Mean |     Error |    StdDev | Ratio | Rank | Gen 0/1k Op | Gen 1/1k Op | Gen 2/1k Op | Allocated Memory/Op |
|------------------ |-------------- |----------:|----------:|----------:|------:|-----:|------------:|------------:|------------:|--------------------:|
| **CopyArray_Current** |             **32 elements** | **51.687 ns** | **0.3557 ns** | **0.2970 ns** |  **1.00** |    **1** |      **0.0133** |           **-** |           **-** |                **56 B** |
|                   |               |           |           |           |       |      |             |             |             |                     |
| ToUInt32_Proposed |             32 elements |  9.848 ns | 0.1506 ns | 0.1409 ns |  1.00 |    1 |      0.0133 |           - |           - |                56 B |
|                   |               |           |           |           |       |      |             |             |             |                     |
| **CopyArray_Current** |             **6 elements** | **50.265 ns** | **0.2128 ns** | **0.1886 ns** |  **1.00** |    **1** |      **0.0076** |           **-** |           **-** |                **32 B** |
|                   |               |           |           |           |       |      |             |             |             |                     |
| ToUInt32_Proposed |             6 elements |  8.543 ns | 0.0939 ns | 0.0878 ns |  1.00 |    1 |      0.0076 |           - |           - |                32 B |
