### PR TITLE
Performance improvements to CachedCoinView

### DIFF
--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/CoinViews/CoinViewStackTest.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/CoinViews/CoinViewStackTest.cs
@@ -137,7 +137,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.CoinViews
                 throw new NotImplementedException();
             }
 
-            public Task SaveChangesAsync(IList<UnspentOutputs> unspentOutputs, IEnumerable<TxOut[]> originalOutputs, uint256 oldBlockHash, uint256 nextBlockHash, int height, List<RewindData> rewindDataList = null)
+            public Task SaveChangesAsync(IEnumerable<UnspentOutputs> unspentOutputs, IEnumerable<TxOut[]> originalOutputs, uint256 oldBlockHash, uint256 nextBlockHash, int height, IEnumerable<RewindData> rewindDataList = null)
             {
                 throw new NotImplementedException();
             }
@@ -177,7 +177,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.CoinViews
                 throw new NotImplementedException();
             }
 
-            public Task SaveChangesAsync(IList<UnspentOutputs> unspentOutputs, IEnumerable<TxOut[]> originalOutputs, uint256 oldBlockHash, uint256 nextBlockHash, int height, List<RewindData> rewindDataList = null)
+            public Task SaveChangesAsync(IEnumerable<UnspentOutputs> unspentOutputs, IEnumerable<TxOut[]> originalOutputs, uint256 oldBlockHash, uint256 nextBlockHash, int height, IEnumerable<RewindData> rewindDataList = null)
             {
                 throw new NotImplementedException();
             }
@@ -217,7 +217,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.CoinViews
                 throw new NotImplementedException();
             }
 
-            public Task SaveChangesAsync(IList<UnspentOutputs> unspentOutputs, IEnumerable<TxOut[]> originalOutputs, uint256 oldBlockHash, uint256 nextBlockHash, int height, List<RewindData> rewindDataList = null)
+            public Task SaveChangesAsync(IEnumerable<UnspentOutputs> unspentOutputs, IEnumerable<TxOut[]> originalOutputs, uint256 oldBlockHash, uint256 nextBlockHash, int height, IEnumerable<RewindData> rewindDataList = null)
             {
                 throw new NotImplementedException();
             }

--- a/src/Stratis.Bitcoin.Features.Consensus/CoinViews/CoinView.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/CoinViews/CoinView.cs
@@ -36,7 +36,7 @@ namespace Stratis.Bitcoin.Features.Consensus.CoinViews
         /// <param name="nextBlockHash">Block hash of the tip of the coinview after the change is applied.</param>
         /// <param name="height">The height of the block.</param>
         /// <param name="rewindDataList">List of rewind data items to be persisted. This should only be used when calling <see cref="DBreezeCoinView.SaveChangesAsync" />.</param>
-        Task SaveChangesAsync(IList<UnspentOutputs> unspentOutputs, IEnumerable<TxOut[]> originalOutputs, uint256 oldBlockHash, uint256 nextBlockHash, int height, List<RewindData> rewindDataList = null);
+        Task SaveChangesAsync(IEnumerable<UnspentOutputs> unspentOutputs, IEnumerable<TxOut[]> originalOutputs, uint256 oldBlockHash, uint256 nextBlockHash, int height, IEnumerable<RewindData> rewindDataList = null);
 
         /// <summary>
         /// Obtains information about unspent outputs for specific transactions and also retrieves information about the coinview's tip.

--- a/src/Stratis.Bitcoin.Features.Consensus/CoinViews/DBreezeCoinView.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/CoinViews/DBreezeCoinView.cs
@@ -199,7 +199,7 @@ namespace Stratis.Bitcoin.Features.Consensus.CoinViews
         }
 
         /// <inheritdoc />
-        public Task SaveChangesAsync(IList<UnspentOutputs> unspentOutputs, IEnumerable<TxOut[]> originalOutputs, uint256 oldBlockHash, uint256 nextBlockHash, int height, List<RewindData> rewindDataList = null)
+        public Task SaveChangesAsync(IEnumerable<UnspentOutputs> unspentOutputs, IEnumerable<TxOut[]> originalOutputs, uint256 oldBlockHash, uint256 nextBlockHash, int height, IEnumerable<RewindData> rewindDataList = null)
         {
             Task task = Task.Run(() =>
             {
@@ -265,7 +265,7 @@ namespace Stratis.Bitcoin.Features.Consensus.CoinViews
                             }
                         }
 
-                        insertedEntities += unspentOutputs.Count;
+                        insertedEntities += unspentOutputs.Count();
                         transaction.Commit();
                     }
                 }

--- a/src/Stratis.Bitcoin.Features.Consensus/CoinViews/InMemoryCoinView.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/CoinViews/InMemoryCoinView.cs
@@ -60,7 +60,7 @@ namespace Stratis.Bitcoin.Features.Consensus.CoinViews
         }
 
         /// <inheritdoc />
-        public Task SaveChangesAsync(IList<UnspentOutputs> unspentOutputs, IEnumerable<TxOut[]> originalOutputs, uint256 oldBlockHash, uint256 nextBlockHash, int height, List<RewindData> rewindDataList = null)
+        public Task SaveChangesAsync(IEnumerable<UnspentOutputs> unspentOutputs, IEnumerable<TxOut[]> originalOutputs, uint256 oldBlockHash, uint256 nextBlockHash, int height, IEnumerable<RewindData> rewindDataList = null)
         {
             Guard.NotNull(oldBlockHash, nameof(oldBlockHash));
             Guard.NotNull(nextBlockHash, nameof(nextBlockHash));

--- a/src/Stratis.Bitcoin.Features.MemoryPool/MemPoolCoinView.cs
+++ b/src/Stratis.Bitcoin.Features.MemoryPool/MemPoolCoinView.cs
@@ -54,8 +54,8 @@ namespace Stratis.Bitcoin.Features.MemoryPool
         public ICoinView Inner { get; }
 
         /// <inheritdoc />
-        public Task SaveChangesAsync(IList<UnspentOutputs> unspentOutputs, IEnumerable<TxOut[]> originalOutputs, uint256 oldBlockHash,
-            uint256 nextBlockHash, int height, List<RewindData> rewindDataList = null)
+        public Task SaveChangesAsync(IEnumerable<UnspentOutputs> unspentOutputs, IEnumerable<TxOut[]> originalOutputs, uint256 oldBlockHash,
+            uint256 nextBlockHash, int height, IEnumerable<RewindData> rewindDataList = null)
         {
             throw new NotImplementedException();
         }

--- a/src/Stratis.Bitcoin.Tests/Consensus/TestInMemoryCoinView.cs
+++ b/src/Stratis.Bitcoin.Tests/Consensus/TestInMemoryCoinView.cs
@@ -66,7 +66,7 @@ namespace Stratis.Bitcoin.Tests.Consensus
         }
 
         /// <inheritdoc />
-        public Task SaveChangesAsync(IList<UnspentOutputs> unspentOutputs, IEnumerable<TxOut[]> originalOutputs, uint256 oldBlockHash, uint256 nextBlockHash, int height, List<RewindData> rewindDataList = null)
+        public Task SaveChangesAsync(IEnumerable<UnspentOutputs> unspentOutputs, IEnumerable<TxOut[]> originalOutputs, uint256 oldBlockHash, uint256 nextBlockHash, int height, IEnumerable<RewindData> rewindDataList = null)
         {
             Guard.NotNull(oldBlockHash, nameof(oldBlockHash));
             Guard.NotNull(nextBlockHash, nameof(nextBlockHash));


### PR DESCRIPTION
Changing `SaveChangesAsync` method signature allowed for data to be passed without unnecessary evaluation to List or Array (e.g. calling `ToList()` or `ToArray()` respectively) 

The change results in data lazy evaluation and lower memory consumption.