### PR TITLE
Performance improvements to the RewindDataIndexCache

### DIFF
--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/CoinViews/RewindDataIndexCacheTest.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/CoinViews/RewindDataIndexCacheTest.cs
@@ -72,7 +72,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.CoinViews
 
             await rewindDataIndexCache.InitializeAsync(20, coinViewMock.Object);
 
-            rewindDataIndexCache.Save(new Dictionary<string, int>() { { $"{ new uint256(21) }-{ 0 }", 21}});
+            rewindDataIndexCache.Save(new Dictionary<RewindDataIndexItem, int>() { { new RewindDataIndexItem(new uint256(21), 0), 21}});
             var items = rewindDataIndexCache.GetMemberValue("items") as ConcurrentDictionary<string, int>;
 
             items.Should().HaveCount(23);

--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/CoinViews/RewindDataIndexCacheTest.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/CoinViews/RewindDataIndexCacheTest.cs
@@ -38,7 +38,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.CoinViews
 
             await rewindDataIndexCache.InitializeAsync(5, coinViewMock.Object);
 
-            var items = rewindDataIndexCache.GetMemberValue("items") as ConcurrentDictionary<string, int>;
+            var items = rewindDataIndexCache.GetMemberValue("items") as Dictionary<RewindDataIndexItem, int>;
 
             items.Should().HaveCount(10);
             this.CheckCache(items, 5, 1);
@@ -55,7 +55,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.CoinViews
 
             await rewindDataIndexCache.InitializeAsync(20, coinViewMock.Object);
 
-            var items = rewindDataIndexCache.GetMemberValue("items") as ConcurrentDictionary<string, int>;
+            var items = rewindDataIndexCache.GetMemberValue("items") as Dictionary<RewindDataIndexItem, int>;
 
             items.Should().HaveCount(22);
             this.CheckCache(items, 20, 10);
@@ -73,7 +73,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.CoinViews
             await rewindDataIndexCache.InitializeAsync(20, coinViewMock.Object);
 
             rewindDataIndexCache.Save(new Dictionary<RewindDataIndexItem, int>() { { new RewindDataIndexItem(new uint256(21), 0), 21}});
-            var items = rewindDataIndexCache.GetMemberValue("items") as ConcurrentDictionary<string, int>;
+            var items = rewindDataIndexCache.GetMemberValue("items") as Dictionary<RewindDataIndexItem, int>;
 
             items.Should().HaveCount(23);
             this.CheckCache(items, 21, 10);
@@ -91,7 +91,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.CoinViews
             await rewindDataIndexCache.InitializeAsync(20, coinViewMock.Object);
 
             rewindDataIndexCache.Flush(15);
-            var items = rewindDataIndexCache.GetMemberValue("items") as ConcurrentDictionary<string, int>;
+            var items = rewindDataIndexCache.GetMemberValue("items") as Dictionary<RewindDataIndexItem, int>;
 
             items.Should().HaveCount(12);
             this.CheckCache(items, 15, 9);
@@ -109,16 +109,16 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.CoinViews
             await rewindDataIndexCache.InitializeAsync(20, coinViewMock.Object);
 
             await rewindDataIndexCache.Remove(19, coinViewMock.Object);
-            var items = rewindDataIndexCache.GetMemberValue("items") as ConcurrentDictionary<string, int>;
+            var items = rewindDataIndexCache.GetMemberValue("items") as Dictionary<RewindDataIndexItem, int>;
 
             items.Should().HaveCount(22);
             this.CheckCache(items, 19, 9);
         }
 
 
-        private void CheckCache(ConcurrentDictionary<string, int> items, int tip, int bottom)
+        private void CheckCache(Dictionary<RewindDataIndexItem, int> items, int tip, int bottom)
         {
-            foreach (KeyValuePair<string, int> keyValuePair in items)
+            foreach (KeyValuePair<RewindDataIndexItem, int> keyValuePair in items)
             {
                 Assert.True(keyValuePair.Value <= tip && keyValuePair.Value >= bottom);
             }

--- a/src/Stratis.Bitcoin.Features.Consensus/CoinViews/CachedCoinView.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/CoinViews/CachedCoinView.cs
@@ -375,7 +375,7 @@ namespace Stratis.Bitcoin.Features.Consensus.CoinViews
                 this.blockHeight = height;
                 this.blockHash = nextBlockHash;
                 var rewindData = new RewindData(oldBlockHash);
-                var indexItems = new Dictionary<string, int>();
+                var indexItems = new Dictionary<RewindDataIndexItem, int>();
 
                 foreach (UnspentOutputs unspent in unspentOutputs)
                 {
@@ -437,10 +437,18 @@ namespace Stratis.Bitcoin.Features.Consensus.CoinViews
 
                     if (this.rewindDataIndexCache != null)
                     {
-                        for (int i = 0; i < unspent.Outputs.Length; i++)
+                        for (uint i = 0; i < unspent.Outputs.Length; i++)
                         {
-                            string key = $"{unspent.TransactionId}-{i}";
-                            indexItems[key] = this.blockHeight;
+                            RewindDataIndexItem itemKey = new RewindDataIndexItem(unspent.TransactionId, i);
+
+                            if (!indexItems.ContainsKey(itemKey))
+                            {
+                                indexItems.Add(itemKey, this.blockHeight);
+                            }
+                            else
+                            {
+                                indexItems[itemKey] = this.blockHeight;
+                            }
                         }
                     }
 

--- a/src/Stratis.Bitcoin.Features.Consensus/ProvenBlockHeaders/IRewindDataIndexCache.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/ProvenBlockHeaders/IRewindDataIndexCache.cs
@@ -36,8 +36,8 @@ namespace Stratis.Bitcoin.Features.Consensus.ProvenBlockHeaders
         /// <summary>
         /// Saves rewind index data to cache.
         /// </summary>
-        /// <param name="indexData">The rewind index data, where key is TxId + N and value is a height of the rewind data.</param>
-        void Save(Dictionary<string, int> indexData);
+        /// <param name="indexData">The rewind index data, where key is RewindDataIndexItem (i.e. TxId + N) and value is a height of the rewind data.</param>
+        void Save(Dictionary<RewindDataIndexItem, int> indexData);
 
         /// <summary>
         /// Gets rewind data index from the cache (or if not found from the disk) by tx id and output index.
@@ -45,6 +45,6 @@ namespace Stratis.Bitcoin.Features.Consensus.ProvenBlockHeaders
         /// <param name="transactionId">The transaction id.</param>
         /// <param name="transactionOutputIndex">Index of the transaction output.</param>
         /// <returns>If found, rewind data index, else null.</returns>
-        int? Get(uint256 transactionId, int transactionOutputIndex);
+        int? Get(uint256 transactionId, uint transactionOutputIndex);
     }
 }

--- a/src/Stratis.Bitcoin.Features.Consensus/ProvenBlockHeaders/RewindDataIndexCache.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/ProvenBlockHeaders/RewindDataIndexCache.cs
@@ -93,7 +93,6 @@ namespace Stratis.Bitcoin.Features.Consensus.ProvenBlockHeaders
             {
                 for (uint outputIndex = 0; outputIndex < unspent.Outputs.Length; outputIndex++)
                 {
-                    string key = $"{unspent.TransactionId}-{outputIndex}";
                     RewindDataIndexItem itemKey = new RewindDataIndexItem(unspent.TransactionId, outputIndex);
 
                     lock (this.itemsLock)

--- a/src/Stratis.Bitcoin.Features.Consensus/ProvenBlockHeaders/RewindDataIndexCacheItem.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/ProvenBlockHeaders/RewindDataIndexCacheItem.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using NBitcoin;
+
+namespace Stratis.Bitcoin.Features.Consensus.ProvenBlockHeaders
+{
+    public class RewindDataIndexItem
+    {
+        public uint256 TransactionId { get; set; }
+        public uint TransactionOutputIndex { get; set; }
+
+        public RewindDataIndexItem(uint256 transactionId, uint transactionOutputIndex)
+        {
+            this.TransactionId = transactionId;
+            this.TransactionOutputIndex = transactionOutputIndex;
+        }
+
+        public override int GetHashCode()
+        {
+            return this.TransactionId.GetHashCode() + (int)this.TransactionOutputIndex;
+        }
+
+        public override bool Equals(object obj)
+        {
+            var item = obj as RewindDataIndexItem;
+            if (item == null)
+                return false;
+
+            return this.TransactionOutputIndex == item.TransactionOutputIndex &&
+                   this.TransactionId.Equals(item.TransactionId);
+        }
+    }
+}

--- a/src/Stratis.Bitcoin.Features.Consensus/Rules/ProvenHeaderRules/ProvenHeaderCoinstakeRule.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/Rules/ProvenHeaderRules/ProvenHeaderCoinstakeRule.cs
@@ -348,7 +348,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Rules.ProvenHeaderRules
             Transaction coinstake = header.Coinstake;
             TxIn input = coinstake.Inputs[0];
 
-            int? rewindDataIndex = this.PosParent.RewindDataIndexCache.Get(input.PrevOut.Hash, (int)input.PrevOut.N);
+            int? rewindDataIndex = this.PosParent.RewindDataIndexCache.Get(input.PrevOut.Hash, input.PrevOut.N);
             if (!rewindDataIndex.HasValue)
             {
                 this.Logger.LogTrace("(-)[NO_REWIND_DATA_INDEX_FOR_INPUT_PREVOUT]");


### PR DESCRIPTION
Primary motivation behind this change is a performance improvement as outlined below:


|                                 Method | ArraySize | LookupCount |            Mean |           Error |          StdDev | Ratio | Rank | Gen 0/1k Op | Gen 1/1k Op | Gen 2/1k Op | Allocated Memory/Op |
|--------------------------------------- |---------- |------------ |----------------:|----------------:|----------------:|------:|-----:|------------:|------------:|------------:|--------------------:|
|     **DictionaryWithStringKeyAdd_Current** |     **10000** |          **50** | **8,134,612.21 ns** | **135,792.3472 ns** | **127,020.2458 ns** |  **1.00** |    **1** |   **1562.5000** |    **578.1250** |    **281.2500** |           **8782030 B** |
|                                        |           |             |                 |                 |                 |       |      |             |             |             |                     |
|    DictionaryWithObjectKeyAdd_Proposed |     10000 |          50 |   506,217.26 ns |  10,072.2140 ns |   9,421.5552 ns |  1.00 |    1 |    210.9375 |    160.1563 |    159.1797 |            942259 B |
|                                        |           |             |                 |                 |                 |       |      |             |             |             |                     |
|   DictionaryWithStringKeyExist_Current |     10000 |          50 |       375.49 ns |       2.6040 ns |       2.4358 ns |  1.00 |    1 |      0.1864 |           - |           - |               784 B |
|                                        |           |             |                 |                 |                 |       |      |             |             |             |                     |
|  DictionaryWithObjectKeyExist_Proposed |     10000 |          50 |        20.59 ns |       0.1060 ns |       0.0991 ns |  1.00 |    1 |           - |           - |           - |                   - |
|                                        |           |             |                 |                 |                 |       |      |             |             |             |                     |
|  DictionaryWithStringKeyUpdate_Current |     10000 |          50 |    19,559.08 ns |      49.9271 ns |      41.6914 ns |  1.00 |    1 |      9.3384 |           - |           - |             39200 B |
|                                        |           |             |                 |                 |                 |       |      |             |             |             |                     |
| DictionaryWithObjectKeyUpdate_Proposed |     10000 |          50 |     1,429.46 ns |       5.1146 ns |       4.7842 ns |  1.00 |    1 |           - |           - |           - |                   - |
|                                        |           |             |                 |                 |                 |       |      |             |             |             |                     |
|  DictionaryWithStringKeyRemove_Current |     10000 |          50 |   733,154.18 ns |   6,026.9656 ns |   5,342.7481 ns |  1.00 |    1 |     76.1719 |     76.1719 |     76.1719 |            322216 B |
|                                        |           |             |                 |                 |                 |       |      |             |             |             |                     |
| DictionaryWithObjectKeyRemove_Proposed |     10000 |          50 |   368,923.53 ns |   1,661.2000 ns |   1,387.1772 ns |  1.00 |    1 |     76.6602 |     76.6602 |     76.6602 |            283016 B |