### PR TITLE
[RPC] Support hex output for getblockheader method

### DIFF
--- a/src/Stratis.Bitcoin.Features.RPC.Tests/Controller/FullNodeControllerTest.cs
+++ b/src/Stratis.Bitcoin.Features.RPC.Tests/Controller/FullNodeControllerTest.cs
@@ -538,15 +538,6 @@ namespace Stratis.Bitcoin.Features.RPC.Tests.Controller
         }
 
         [Fact]
-        public void GetBlockHeader_NotUsingJsonFormat_ThrowsNotImplementedException()
-        {
-            Assert.Throws<NotImplementedException>(() =>
-            {
-                this.controller.GetBlockHeader("", false);
-            });
-        }
-
-        [Fact]
         public void GetBlockHeader_ChainNull_ReturnsNull()
         {
             this.chain = null;

--- a/src/Stratis.Bitcoin.Features.RPC.Tests/Controller/FullNodeControllerTest.cs
+++ b/src/Stratis.Bitcoin.Features.RPC.Tests/Controller/FullNodeControllerTest.cs
@@ -553,7 +553,7 @@ namespace Stratis.Bitcoin.Features.RPC.Tests.Controller
 
             this.controller = new FullNodeController(this.LoggerFactory.Object, this.pooledTransaction.Object, this.pooledGetUnspentTransaction.Object, this.getUnspentTransaction.Object, this.networkDifficulty.Object,
                 this.fullNode.Object, this.nodeSettings, this.network, this.chain, this.chainState.Object, this.connectionManager.Object);
-            BlockHeaderModel result = this.controller.GetBlockHeader("", true);
+            BlockHeaderModel result = (BlockHeaderModel)this.controller.GetBlockHeader("", true);
 
             Assert.Null(result);
         }
@@ -565,7 +565,7 @@ namespace Stratis.Bitcoin.Features.RPC.Tests.Controller
             ChainedHeader block = this.chain.GetBlock(2);
             string bits = GetBlockHeaderBits(block.Header);
 
-            BlockHeaderModel result = this.controller.GetBlockHeader(block.HashBlock.ToString(), true);
+            BlockHeaderModel result = (BlockHeaderModel)this.controller.GetBlockHeader(block.HashBlock.ToString(), true);
 
             Assert.NotNull(result);
             Assert.Equal((uint)block.Header.Version, result.Version);
@@ -579,7 +579,7 @@ namespace Stratis.Bitcoin.Features.RPC.Tests.Controller
         [Fact]
         public void GetBlockHeader_BlockHeaderNotFound_ReturnsNull()
         {
-            BlockHeaderModel result = this.controller.GetBlockHeader(new uint256(2562).ToString(), true);
+            BlockHeaderModel result = (BlockHeaderModel)this.controller.GetBlockHeader(new uint256(2562).ToString(), true);
 
             Assert.Null(result);
         }

--- a/src/Stratis.Bitcoin.Features.RPC/Controllers/FullNodeController.cs
+++ b/src/Stratis.Bitcoin.Features.RPC/Controllers/FullNodeController.cs
@@ -284,7 +284,7 @@ namespace Stratis.Bitcoin.Features.RPC.Controllers
                     }
                     else
                     {
-                        return blockHeader.ToHex(this.Network);
+                        return new HexModel(blockHeader.ToHex(this.Network));
                     }
                 }
             }
@@ -358,7 +358,7 @@ namespace Stratis.Bitcoin.Features.RPC.Controllers
             Block block = this.blockStore != null ? await this.blockStore.GetBlockAsync(uint256.Parse(blockHash)).ConfigureAwait(false) : null;
 
             if (verbosity == 0)
-                return block?.ToHex(this.Network);
+                return new HexModel(block?.ToHex(this.Network));
 
             return new BlockModel(block, this.Chain.GetBlock(block.GetHash()), this.Chain.Tip, this.Network, verbosity);
         }

--- a/src/Stratis.Bitcoin.Features.RPC/Controllers/FullNodeController.cs
+++ b/src/Stratis.Bitcoin.Features.RPC/Controllers/FullNodeController.cs
@@ -42,6 +42,9 @@ namespace Stratis.Bitcoin.Features.RPC.Controllers
         /// <summary>An interface implementation for the blockstore.</summary>
         private readonly IBlockStore blockStore;
 
+        /// <summary>A interface implementation for the initial block download state.</summary>
+        private readonly IInitialBlockDownloadState ibdState;
+
         public FullNodeController(
             ILoggerFactory loggerFactory,
             IPooledTransaction pooledTransaction = null,
@@ -55,7 +58,8 @@ namespace Stratis.Bitcoin.Features.RPC.Controllers
             IChainState chainState = null,
             Connection.IConnectionManager connectionManager = null,
             IConsensusManager consensusManager = null,
-            IBlockStore blockStore = null)
+            IBlockStore blockStore = null,
+            IInitialBlockDownloadState ibdState = null)
             : base(
                   fullNode: fullNode,
                   nodeSettings: nodeSettings,
@@ -71,6 +75,7 @@ namespace Stratis.Bitcoin.Features.RPC.Controllers
             this.getUnspentTransaction = getUnspentTransaction;
             this.networkDifficulty = networkDifficulty;
             this.blockStore = blockStore;
+            this.ibdState = ibdState;
         }
 
         /// <summary>
@@ -402,7 +407,7 @@ namespace Stratis.Bitcoin.Features.RPC.Controllers
                 Difficulty = this.GetNetworkDifficulty()?.Difficulty ?? 0.0,
                 MedianTime = this.ChainState?.ConsensusTip?.GetMedianTimePast().ToUnixTimeSeconds() ?? 0,
                 VerificationProgress = 0.0,
-                IsInitialBlockDownload = !this.ChainState?.IsAtBestChainTip ?? true,
+                IsInitialBlockDownload = this.ibdState?.IsInitialBlockDownload() ?? true,
                 Chainwork = this.ChainState?.ConsensusTip?.ChainWork,
                 IsPruned = false
             };

--- a/src/Stratis.Bitcoin.Features.RPC/Controllers/FullNodeController.cs
+++ b/src/Stratis.Bitcoin.Features.RPC/Controllers/FullNodeController.cs
@@ -264,31 +264,32 @@ namespace Stratis.Bitcoin.Features.RPC.Controllers
         /// <param name="hash">Hash of the block.</param>
         /// <param name="isJsonFormat">Indicates whether to provide data in Json or binary format.</param>
         /// <returns>The block header rpc format.</returns>
-        /// <exception cref="NotImplementedException">Thrown if isJsonFormat = false</exception>
         /// <remarks>The binary format is not supported with RPC.</remarks>
         [ActionName("getblockheader")]
         [ActionDescription("Gets the block header of the block identified by the hash.")]
-        public BlockHeaderModel GetBlockHeader(string hash, bool isJsonFormat = true)
+        public object GetBlockHeader(string hash, bool isJsonFormat = true)
         {
             Guard.NotNull(hash, nameof(hash));
 
             this.logger.LogDebug("RPC GetBlockHeader {0}", hash);
-
-            if (!isJsonFormat)
-            {
-                this.logger.LogError("Binary serialization is not supported for RPC '{0}'.", nameof(this.GetBlockHeader));
-                throw new NotImplementedException();
-            }
-
-            BlockHeaderModel model = null;
+            
             if (this.Chain != null)
             {
                 BlockHeader blockHeader = this.Chain.GetBlock(uint256.Parse(hash))?.Header;
                 if (blockHeader != null)
-                    model = new BlockHeaderModel(blockHeader);
+                {
+                    if (isJsonFormat)
+                    {
+                        return new BlockHeaderModel(blockHeader);
+                    }
+                    else
+                    {
+                        return blockHeader.ToHex(this.Network);
+                    }
+                }
             }
 
-            return model;
+            return null;
         }
 
         /// <summary>

--- a/src/Stratis.Bitcoin.IntegrationTests/RPC/RPCTestsMutable.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/RPC/RPCTestsMutable.cs
@@ -4,7 +4,9 @@ using System.Linq;
 using System.Threading;
 using FluentAssertions;
 using NBitcoin;
+using NBitcoin.DataEncoders;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using Stratis.Bitcoin.Features.RPC;
 using Stratis.Bitcoin.IntegrationTests.Common;
 using Stratis.Bitcoin.IntegrationTests.Common.EnvironmentMockUpHelpers;
@@ -321,7 +323,31 @@ namespace Stratis.Bitcoin.IntegrationTests.RPC
         }
 
         [Fact]
-        public void TestRpcGetBlockInfo()
+        public void TestRpcGetBlockHeaderForBestBlockHashSuccessfull()
+        {
+            using (NodeBuilder builder = NodeBuilder.Create(this))
+            {
+                Network network = new BitcoinRegTest();
+                var node = builder.CreateStratisPowNode(new BitcoinRegTest()).WithReadyBlockchainData(ReadyBlockchain.BitcoinRegTest150Miner).Start();
+                RPCClient rpcClient = node.CreateRPCClient();
+                var aliceAddress = new Key().GetBitcoinSecret(network).GetAddress();
+
+                RPCClient rpcClient = node.CreateRPCClient();
+                var hash = rpcClient.GetBestBlockHash();
+
+                // false parameter is what NBitcoin sends, this causes STRAT to throw Unimplemented Exception
+                RPCResponse resp = rpcClient.SendCommand("getblockheader", hash, false); 
+
+                // This code should all be done by RPCClient
+                var header = rpcClient.Network.Consensus.ConsensusFactory.CreateBlockHeader();
+                var hex = Encoders.Hex.DecodeData(resp.Result.Value<string>());
+//                header.ReadWrite(new BitcoinStream(hex));
+//                return header;
+            }
+        }
+
+        [Fact]
+        public void TestRpcGetBlockchainInfo()
         {
             using (NodeBuilder builder = NodeBuilder.Create(this))
             {

--- a/src/Stratis.Bitcoin.IntegrationTests/RPC/RPCTestsMutable.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/RPC/RPCTestsMutable.cs
@@ -329,20 +329,20 @@ namespace Stratis.Bitcoin.IntegrationTests.RPC
             {
                 Network network = new BitcoinRegTest();
                 var node = builder.CreateStratisPowNode(new BitcoinRegTest()).WithReadyBlockchainData(ReadyBlockchain.BitcoinRegTest150Miner).Start();
-                RPCClient rpcClient = node.CreateRPCClient();
-                var aliceAddress = new Key().GetBitcoinSecret(network).GetAddress();
 
                 RPCClient rpcClient = node.CreateRPCClient();
                 var hash = rpcClient.GetBestBlockHash();
 
-                // false parameter is what NBitcoin sends, this causes STRAT to throw Unimplemented Exception
-                RPCResponse resp = rpcClient.SendCommand("getblockheader", hash, false); 
+                // get hex representation of block header
+                RPCResponse resp = rpcClient.SendCommand("getblockheader", hash.ToString(), false); 
 
-                // This code should all be done by RPCClient
+                // load header from hex representation
                 var header = rpcClient.Network.Consensus.ConsensusFactory.CreateBlockHeader();
-                var hex = Encoders.Hex.DecodeData(resp.Result.Value<string>());
-//                header.ReadWrite(new BitcoinStream(hex));
-//                return header;
+                var bytes = Encoders.Hex.DecodeData(resp.Result.Value<string>());
+                header.FromBytes(bytes);
+
+                // validate header has same hash as best block
+                header.GetHash().Should().Be(hash);
             }
         }
 

--- a/src/Stratis.Bitcoin/Controllers/Models/BlockHeaderModel.cs
+++ b/src/Stratis.Bitcoin/Controllers/Models/BlockHeaderModel.cs
@@ -1,10 +1,27 @@
 ﻿using NBitcoin;
 using NBitcoin.DataEncoders;
 using Newtonsoft.Json;
+using Stratis.Bitcoin.Controllers.Converters;
 using Stratis.Bitcoin.Utilities;
 
 namespace Stratis.Bitcoin.Controllers.Models
 {
+    [JsonConverter(typeof(ToStringJsonConverter))]
+    public class HexModel
+    {
+        public string Hex { get; set; }
+
+        public HexModel(string hex)
+        {
+            this.Hex = hex;
+        }
+
+        public override string ToString()
+        {
+            return this.Hex;
+        }
+    }
+
     /// <summary>
     /// Data structure for block headers.
     /// Copied from RPC


### PR DESCRIPTION
Fixes #3356 

Also small fix to getblockchaininfo RPC, correctly populate IsInitialBlockDownload.