### PR TITLE
Use Secp256k1.Net to verify ECDSA DER signature

### DIFF
--- a/src/Stratis.Bitcoin.Features.Consensus/FastSecp256k1.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/FastSecp256k1.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using Secp256k1Net;
+
+namespace Stratis.Bitcoin.Features.Consensus
+{
+    /// <summary>
+    /// Class utilizes Secp256k1.NET library to access optimized C library for EC operations on curve secp256k1
+    /// </summary>
+    public class FastSecp256k1
+    {
+        private const int PUBLIC_KEY_SIZE = 64;
+        private const int SIGNATURE_RSV_SIZE = 65;
+
+        private readonly Secp256k1 secp256k1;
+
+        public FastSecp256k1()
+        {
+            this.secp256k1 = new Secp256k1();
+        }
+
+        /// <summary>
+        /// Verify an ECDSA signature in DER format
+        /// </summary>
+        /// <param name="publicKey">Public key</param>
+        /// <param name="messageHash">32-byte message hash being verified</param>
+        /// <param name="signatureInDer">Signature being verified (in DER format)</param>
+        /// <returns>True if the signature is correct, false the signature is incorrect or unparseable.</returns>
+        public bool VerifyData(byte[] publicKey, byte[] messageHash, byte[] signatureInDer)
+        {
+            Span<byte> signature = new byte[SIGNATURE_RSV_SIZE];
+
+            if (!this.secp256k1.SignatureParseDer(signature, signatureInDer))
+            {
+                throw new InvalidOperationException("Unmanaged EC library failed to parse signature.");
+            }
+
+            Span<byte> parsedPublicKeyData = new byte[PUBLIC_KEY_SIZE];
+
+            if (!this.secp256k1.PublicKeyParse(parsedPublicKeyData, publicKey))
+            {
+                throw new InvalidOperationException("Unmanaged EC library failed to parse public key when verifying signature.");
+            }
+
+            return this.secp256k1.Verify(signature, messageHash, parsedPublicKeyData);
+        }
+    }
+
+}
+

--- a/src/Stratis.Bitcoin.Features.Consensus/Stratis.Bitcoin.Features.Consensus.csproj
+++ b/src/Stratis.Bitcoin.Features.Consensus/Stratis.Bitcoin.Features.Consensus.csproj
@@ -25,6 +25,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.1" />
+    <PackageReference Include="Secp256k1.Net.by.Mixitka" Version="0.1.0" />
     <PackageReference Include="Tracer.Fody" Version="2.2.0" />
   </ItemGroup>
 


### PR DESCRIPTION
* This is a minimal first step to use C# bindings for https://github.com/bitcoin-core/secp256k1 library ("Optimized C library for EC operations on curve secp256k1") instead of NBitcoin's implementation.
* Initial measurements show time speedup in range of 0.5 to 10 times.
* https://www.nuget.org/packages/Secp256k1.Net.by.Mixitka/ fork is currently used as https://github.com/MeadowSuite/Secp256k1.Net/pull/8 was not released yet.

TODO:
* https://github.com/bitcoin-core/secp256k1/blob/master/include/secp256k1.h#L35 - verify whether we need lock for the API
* Use Dependency Injection to get FastSecp256k1 class
* Dispose FastSecp256k1 resources (on application exit)
* Test on different architectures