### PR TITLE
Change tests to return async Task instead of async void

### DIFF
--- a/src/Stratis.Bitcoin.Features.MemoryPool.Tests/MempoolValidatorTest.cs
+++ b/src/Stratis.Bitcoin.Features.MemoryPool.Tests/MempoolValidatorTest.cs
@@ -21,7 +21,7 @@ namespace Stratis.Bitcoin.Features.MemoryPool.Tests
         }
 
         [Fact]
-        public async void CheckFinalTransaction_WithElapsedLockTime_ReturnsTrueAsync()
+        public async Task CheckFinalTransaction_WithElapsedLockTime_ReturnsTrueAsync()
         {
             string dataDir = GetTestDirectoryPath(this);
 
@@ -417,7 +417,7 @@ namespace Stratis.Bitcoin.Features.MemoryPool.Tests
         }
 
         [Fact]
-        public async void AcceptToMemoryPool_TxIsCoinbase_ReturnsFalseAsync()
+        public async Task AcceptToMemoryPool_TxIsCoinbase_ReturnsFalseAsync()
         {
             string dataDir = GetTestDirectoryPath(this);
 
@@ -446,7 +446,7 @@ namespace Stratis.Bitcoin.Features.MemoryPool.Tests
         }
 
         [Fact]
-        public async void AcceptToMemoryPool_TxIsCoinbaseWithInvalidSize_ReturnsFalseAsync()
+        public async Task AcceptToMemoryPool_TxIsCoinbaseWithInvalidSize_ReturnsFalseAsync()
         {
             string dataDir = GetTestDirectoryPath(this);
 
@@ -478,7 +478,7 @@ namespace Stratis.Bitcoin.Features.MemoryPool.Tests
         }
 
         [Fact]
-        public async void AcceptToMemoryPool_TxIsCoinstake_ReturnsFalseAsync()
+        public async Task AcceptToMemoryPool_TxIsCoinstake_ReturnsFalseAsync()
         {
             string dataDir = GetTestDirectoryPath(this);
 
@@ -511,7 +511,7 @@ namespace Stratis.Bitcoin.Features.MemoryPool.Tests
         }
 
         [Fact]
-        public async void AcceptToMemoryPool_TxIsNonStandardVersionUnsupported_ReturnsFalseAsync()
+        public async Task AcceptToMemoryPool_TxIsNonStandardVersionUnsupported_ReturnsFalseAsync()
         {
             string dataDir = GetTestDirectoryPath(this);
 
@@ -552,7 +552,7 @@ namespace Stratis.Bitcoin.Features.MemoryPool.Tests
         }
 
         [Fact]
-        public async void AcceptToMemoryPool_TxIsNonStandardTransactionSizeInvalid_ReturnsFalseAsync()
+        public async Task AcceptToMemoryPool_TxIsNonStandardTransactionSizeInvalid_ReturnsFalseAsync()
         {
             string dataDir = GetTestDirectoryPath(this);
 
@@ -584,7 +584,7 @@ namespace Stratis.Bitcoin.Features.MemoryPool.Tests
         }
 
         [Fact]
-        public async void AcceptToMemoryPool_TxIsNonStandardInputScriptSigsLengthInvalid_ReturnsFalseAsync()
+        public async Task AcceptToMemoryPool_TxIsNonStandardInputScriptSigsLengthInvalid_ReturnsFalseAsync()
         {
             string dataDir = GetTestDirectoryPath(this);
 
@@ -622,7 +622,7 @@ namespace Stratis.Bitcoin.Features.MemoryPool.Tests
         }
 
         [Fact]
-        public async void AcceptToMemoryPool_TxIsNonStandardScriptSigIsPushOnly_ReturnsFalseAsync()
+        public async Task AcceptToMemoryPool_TxIsNonStandardScriptSigIsPushOnly_ReturnsFalseAsync()
         {
             string dataDir = GetTestDirectoryPath(this);
 
@@ -658,7 +658,7 @@ namespace Stratis.Bitcoin.Features.MemoryPool.Tests
         }
 
         [Fact]
-        public async void AcceptToMemoryPool_TxIsNonStandardScriptTemplateIsNull_ReturnsFalseAsync()
+        public async Task AcceptToMemoryPool_TxIsNonStandardScriptTemplateIsNull_ReturnsFalseAsync()
         {
             string dataDir = GetTestDirectoryPath(this);
 
@@ -683,7 +683,7 @@ namespace Stratis.Bitcoin.Features.MemoryPool.Tests
         }
 
         [Fact]
-        public async void AcceptToMemoryPool_TxIsNonStandardOutputIsDust_ReturnsFalseAsync()
+        public async Task AcceptToMemoryPool_TxIsNonStandardOutputIsDust_ReturnsFalseAsync()
         {
             string dataDir = GetTestDirectoryPath(this);
 
@@ -709,7 +709,7 @@ namespace Stratis.Bitcoin.Features.MemoryPool.Tests
         }
 
         [Fact]
-        public async void AcceptToMemoryPool_TxIsNonStandardOutputNotSingleReturn_ReturnsFalseAsync()
+        public async Task AcceptToMemoryPool_TxIsNonStandardOutputNotSingleReturn_ReturnsFalseAsync()
         {
             string dataDir = GetTestDirectoryPath(this);
 
@@ -738,7 +738,7 @@ namespace Stratis.Bitcoin.Features.MemoryPool.Tests
         }
 
         [Fact]
-        public async void AcceptToMemoryPool_TxFinalCannotMine_ReturnsFalseAsync()
+        public async Task AcceptToMemoryPool_TxFinalCannotMine_ReturnsFalseAsync()
         {
             string dataDir = GetTestDirectoryPath(this);
 
@@ -775,7 +775,7 @@ namespace Stratis.Bitcoin.Features.MemoryPool.Tests
         }
 
         [Fact]
-        public async void AcceptToMemoryPool_TxAlreadyExists_ReturnsFalseAsync()
+        public async Task AcceptToMemoryPool_TxAlreadyExists_ReturnsFalseAsync()
         {
             string dataDir = GetTestDirectoryPath(this);
 
@@ -803,7 +803,7 @@ namespace Stratis.Bitcoin.Features.MemoryPool.Tests
         }
 
         [Fact(Skip = "It does not seem to be possible for this test case to separately test the AlreadyKnown error condition, as the equivalent InPool check precedes it in the validator.")]
-        public async void AcceptToMemoryPool_TxAlreadyHaveCoins_ReturnsFalseAsync()
+        public async Task AcceptToMemoryPool_TxAlreadyHaveCoins_ReturnsFalseAsync()
         {
             string dataDir = GetTestDirectoryPath(this);
 
@@ -838,7 +838,7 @@ namespace Stratis.Bitcoin.Features.MemoryPool.Tests
         }
 
         [Fact]
-        public async void AcceptToMemoryPool_TxMissingInputs_ReturnsFalseAsync()
+        public async Task AcceptToMemoryPool_TxMissingInputs_ReturnsFalseAsync()
         {
             string dataDir = GetTestDirectoryPath(this);
 
@@ -868,7 +868,7 @@ namespace Stratis.Bitcoin.Features.MemoryPool.Tests
         }
 
         [Fact]
-        public async void AcceptToMemoryPool_TxInputsAreBad_ReturnsFalseAsync()
+        public async Task AcceptToMemoryPool_TxInputsAreBad_ReturnsFalseAsync()
         {
             string dataDir = GetTestDirectoryPath(this);
 
@@ -898,7 +898,7 @@ namespace Stratis.Bitcoin.Features.MemoryPool.Tests
         }
 
         [Fact]
-        public async void AcceptToMemoryPool_NonBIP68CanMine_ReturnsFalseAsync()
+        public async Task AcceptToMemoryPool_NonBIP68CanMine_ReturnsFalseAsync()
         {
             string dataDir = GetTestDirectoryPath(this);
 
@@ -948,7 +948,7 @@ namespace Stratis.Bitcoin.Features.MemoryPool.Tests
         }
 
         [Fact(Skip = "This is triggering the wrong error case. Also awaiting fix for issue #2470")]
-        public async void AcceptToMemoryPool_TxExcessiveSigOps_ReturnsFalseAsync()
+        public async Task AcceptToMemoryPool_TxExcessiveSigOps_ReturnsFalseAsync()
         {
             string dataDir = GetTestDirectoryPath(this);
 
@@ -985,7 +985,7 @@ namespace Stratis.Bitcoin.Features.MemoryPool.Tests
         }
 
         [Fact]
-        public async void AcceptToMemoryPool_TxFeeInvalidLessThanMin_ReturnsFalseAsync()
+        public async Task AcceptToMemoryPool_TxFeeInvalidLessThanMin_ReturnsFalseAsync()
         {
             string dataDir = GetTestDirectoryPath(this);
 
@@ -1017,7 +1017,7 @@ namespace Stratis.Bitcoin.Features.MemoryPool.Tests
         }
 
         [Fact(Skip = "Implementation not finished, it is not triggering the correct code path.")]
-        public async void AcceptToMemoryPool_TxFeeInvalidInsufficentPriorityForFree_ReturnsFalseAsync()
+        public async Task AcceptToMemoryPool_TxFeeInvalidInsufficentPriorityForFree_ReturnsFalseAsync()
         {
             string dataDir = GetTestDirectoryPath(this);
 
@@ -1051,7 +1051,7 @@ namespace Stratis.Bitcoin.Features.MemoryPool.Tests
         }
 
         [Fact]
-        public async void AcceptToMemoryPool_TxFeeInvalidAbsurdlyHighFee_ReturnsFalseAsync()
+        public async Task AcceptToMemoryPool_TxFeeInvalidAbsurdlyHighFee_ReturnsFalseAsync()
         {
             string dataDir = GetTestDirectoryPath(this);
 
@@ -1080,7 +1080,7 @@ namespace Stratis.Bitcoin.Features.MemoryPool.Tests
         }
 
         [Fact]
-        public async void AcceptToMemoryPool_TxTooManyAncestors_ReturnsFalseAsync()
+        public async Task AcceptToMemoryPool_TxTooManyAncestors_ReturnsFalseAsync()
         {
             string dataDir = GetTestDirectoryPath(this);
 
@@ -1118,7 +1118,7 @@ namespace Stratis.Bitcoin.Features.MemoryPool.Tests
         }
 
         [Fact]
-        public async void AcceptToMemoryPool_TxAncestorsConflictSpend_ReturnsFalseAsync()
+        public async Task AcceptToMemoryPool_TxAncestorsConflictSpend_ReturnsFalseAsync()
         {
             string dataDir = GetTestDirectoryPath(this);
 
@@ -1160,7 +1160,7 @@ namespace Stratis.Bitcoin.Features.MemoryPool.Tests
         }
 
         [Fact]
-        public async void AcceptToMemoryPool_TxReplacementInsufficientFees_ReturnsFalseAsync()
+        public async Task AcceptToMemoryPool_TxReplacementInsufficientFees_ReturnsFalseAsync()
         {
             string dataDir = GetTestDirectoryPath(this);
 
@@ -1220,7 +1220,7 @@ namespace Stratis.Bitcoin.Features.MemoryPool.Tests
         }
 
         [Fact(Skip = "This may need to be converted to an integration test as it seems to require mining to get it to work properly.")]
-        public async void AcceptToMemoryPool_TxReplacementTooManyReplacements_ReturnsFalseAsync()
+        public async Task AcceptToMemoryPool_TxReplacementTooManyReplacements_ReturnsFalseAsync()
         {
             string dataDir = GetTestDirectoryPath(this);
 
@@ -1379,7 +1379,7 @@ namespace Stratis.Bitcoin.Features.MemoryPool.Tests
         }
 
         [Fact]
-        public async void AcceptToMemoryPool_TxReplacementAddsUnconfirmed_ReturnsFalseAsync()
+        public async Task AcceptToMemoryPool_TxReplacementAddsUnconfirmed_ReturnsFalseAsync()
         {
             string dataDir = GetTestDirectoryPath(this);
 
@@ -1448,7 +1448,7 @@ namespace Stratis.Bitcoin.Features.MemoryPool.Tests
         }
 
         [Fact]
-        public async void AcceptToMemoryPool_TxPowConsensusCheckInputBadTransactionInBelowOut_ReturnsFalseAsync()
+        public async Task AcceptToMemoryPool_TxPowConsensusCheckInputBadTransactionInBelowOut_ReturnsFalseAsync()
         {
             string dataDir = GetTestDirectoryPath(this);
 
@@ -1478,13 +1478,13 @@ namespace Stratis.Bitcoin.Features.MemoryPool.Tests
         }
 
         [Fact(Skip = "Not clear how to test this without triggering In Below Out check instead.")]
-        public async void AcceptToMemoryPool_TxPowConsensusCheckInputNegativeFee_ReturnsFalseAsync()
+        public async Task AcceptToMemoryPool_TxPowConsensusCheckInputNegativeFee_ReturnsFalseAsync()
         {
             // TODO: Execute failure case for CheckAllInputs CheckInputs PowCoinViewRule.CheckInputs NegativeFee
         }
 
         [Fact(Skip = "Making transactions with very large inputs/outputs pass validation is difficult, WIP.")]
-        public async void AcceptToMemoryPool_TxPowConsensusCheckInputFeeOutOfRange_ReturnsFalseAsync()
+        public async Task AcceptToMemoryPool_TxPowConsensusCheckInputFeeOutOfRange_ReturnsFalseAsync()
         {
             string dataDir = GetTestDirectoryPath(this);
 
@@ -1537,7 +1537,7 @@ namespace Stratis.Bitcoin.Features.MemoryPool.Tests
         }
 
         [Fact]
-        public async void AcceptToMemoryPool_TxContextVerifyP2SHScriptFailure_ReturnsFalseAsync()
+        public async Task AcceptToMemoryPool_TxContextVerifyP2SHScriptFailure_ReturnsFalseAsync()
         {
             string dataDir = GetTestDirectoryPath(this);
 
@@ -1566,7 +1566,7 @@ namespace Stratis.Bitcoin.Features.MemoryPool.Tests
         }
 
         [Fact]
-        public async void AcceptToMemoryPool_MemPoolFull_ReturnsFalseAsync()
+        public async Task AcceptToMemoryPool_MemPoolFull_ReturnsFalseAsync()
         {
             string dataDir = GetTestDirectoryPath(this);
 

--- a/src/Stratis.Bitcoin.IntegrationTests/RPC/RPCTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/RPC/RPCTests.cs
@@ -255,7 +255,7 @@ namespace Stratis.Bitcoin.IntegrationTests.RPC
         }
 
         [Fact]
-        public async void TestRpcBatchAsync()
+        public async Task TestRpcBatchAsync()
         {
             var rpcBatch = this.rpcTestFixture.RpcClient.PrepareBatch();
             var rpc1 = rpcBatch.SendCommandAsync("getpeerinfo");
@@ -270,7 +270,7 @@ namespace Stratis.Bitcoin.IntegrationTests.RPC
         }
 
         [Fact]
-        public async void TestRpcBatchWithUnknownMethodsReturnsArrayAsync()
+        public async Task TestRpcBatchWithUnknownMethodsReturnsArrayAsync()
         {
             var rpcBatch = this.rpcTestFixture.RpcClient.PrepareBatch();
             var unknownRpc = rpcBatch.SendCommandAsync("unknownmethod", "random");

--- a/src/Stratis.Bitcoin.IntegrationTests/RPC/RpcBitcoinImmutableTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/RPC/RpcBitcoinImmutableTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Linq;
+using System.Threading.Tasks;
 using NBitcoin;
 using Stratis.Bitcoin.Features.RPC;
 using Stratis.Bitcoin.Features.RPC.Exceptions;
@@ -65,7 +66,7 @@ namespace Stratis.Bitcoin.IntegrationTests.RPC
         /// <seealso cref="https://github.com/MetacoSA/NBitcoin/blob/master/NBitcoin.Tests/RPCClientTests.cs">NBitcoin test CanGetTxOutAsyncFromRPC</seealso>
         /// </summary>
         [Fact]
-        public async void GetTxOutAsyncWithValidTxThenReturnsCorrectUnspentTxAsync()
+        public async Task GetTxOutAsyncWithValidTxThenReturnsCorrectUnspentTxAsync()
         {
             RPCClient rpc = this.rpcTestFixture.RpcClient;
             UnspentCoin[] unspent = rpc.ListUnspent();

--- a/src/Stratis.Bitcoin.Tests/Utilities/AsyncExecutionEventTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Utilities/AsyncExecutionEventTest.cs
@@ -17,7 +17,7 @@ namespace Stratis.Bitcoin.Tests.Utilities
         /// are correct.
         /// </summary>
         [Fact]
-        public async void AsyncExecutionEvent_OnlyRegisteredCallbackIsCalled_Async()
+        public async Task AsyncExecutionEvent_OnlyRegisteredCallbackIsCalled_Async()
         {
             using (var executionEvent = new AsyncExecutionEvent<int, int>())
             {
@@ -144,7 +144,7 @@ namespace Stratis.Bitcoin.Tests.Utilities
         /// Checks that if multiple callbacks are registered, they are all called and they are called in correct order.
         /// </summary>
         [Fact]
-        public async void AsyncExecutionEvent_MultipleCallbacksExecutedInCorrectOrder_Async()
+        public async Task AsyncExecutionEvent_MultipleCallbacksExecutedInCorrectOrder_Async()
         {
             using (var executionEvent = new AsyncExecutionEvent<object, object>())
             {
@@ -203,7 +203,7 @@ namespace Stratis.Bitcoin.Tests.Utilities
         /// Checks that the callback method can unregister itself.
         /// </summary>
         [Fact]
-        public async void AsyncExecutionEvent_CanUnregisterFromCallback_Async()
+        public async Task AsyncExecutionEvent_CanUnregisterFromCallback_Async()
         {
             using (var executionEvent = new AsyncExecutionEvent<object, object>())
             {
@@ -245,7 +245,7 @@ namespace Stratis.Bitcoin.Tests.Utilities
         /// Checks that the callback method can unregister itself and dispose the execution event.
         /// </summary>
         [Fact]
-        public async void AsyncExecutionEvent_CanDisposeFromCallback_Async()
+        public async Task AsyncExecutionEvent_CanDisposeFromCallback_Async()
         {
             var executionEvent = new AsyncExecutionEvent<object, object>();
 

--- a/src/Stratis.Bitcoin.Tests/Utilities/AsyncManualResetEventTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Utilities/AsyncManualResetEventTest.cs
@@ -15,7 +15,7 @@ namespace Stratis.Bitcoin.Tests.Utilities
         private Random random = new Random();
 
         [Fact]
-        public async void AsyncManualResetEvent_WaitAsync()
+        public async Task AsyncManualResetEvent_WaitAsync()
         {
             var manualResetEvent = new AsyncManualResetEvent(false);
 
@@ -112,7 +112,7 @@ namespace Stratis.Bitcoin.Tests.Utilities
         }
 
         [Fact]
-        public async void AsyncManualResetEvent_CanBeCancelledAsync()
+        public async Task AsyncManualResetEvent_CanBeCancelledAsync()
         {
             var manualResetEvent = new AsyncManualResetEvent(false);
             var tokenSource = new CancellationTokenSource(500);
@@ -136,7 +136,7 @@ namespace Stratis.Bitcoin.Tests.Utilities
         /// This test simulates several tasks that wait for it's own event and set next one.
         /// </summary>
         [Fact]
-        public async void AsyncManualResetEvent_RingTriggeringAsync()
+        public async Task AsyncManualResetEvent_RingTriggeringAsync()
         {
             int tasksCount = 10;
             var cts = new CancellationTokenSource();

--- a/src/Stratis.Bitcoin.Tests/Utilities/AsyncQueueTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Utilities/AsyncQueueTest.cs
@@ -19,7 +19,7 @@ namespace Stratis.Bitcoin.Tests.Utilities
         /// Tests that <see cref="AsyncQueue{T}.Dispose"/> triggers cancellation inside the on-enqueue callback.
         /// </summary>
         [Fact]
-        public async void AsyncQueue_DisposeCancelsEnqueueAsync()
+        public async Task AsyncQueue_DisposeCancelsEnqueueAsync()
         {
             bool signal = false;
 
@@ -46,7 +46,7 @@ namespace Stratis.Bitcoin.Tests.Utilities
         /// are finished before returning to the caller.
         /// </summary>
         [Fact]
-        public async void AsyncQueue_DisposeCancelsAndWaitsEnqueueAsync()
+        public async Task AsyncQueue_DisposeCancelsAndWaitsEnqueueAsync()
         {
             bool signal = true;
 
@@ -72,7 +72,7 @@ namespace Stratis.Bitcoin.Tests.Utilities
         /// regardless of how many enqueue operations occur.
         /// </summary>
         [Fact]
-        public async void AsyncQueue_OnlyOneInstanceOfCallbackExecutesAsync()
+        public async Task AsyncQueue_OnlyOneInstanceOfCallbackExecutesAsync()
         {
             bool executingCallback = false;
 
@@ -148,7 +148,7 @@ namespace Stratis.Bitcoin.Tests.Utilities
         /// Tests that if the queue is disposed, not all items are necessarily processed.
         /// </summary>
         [Fact]
-        public async void AsyncQueue_DisposeCanDiscardItemsAsync()
+        public async Task AsyncQueue_DisposeCanDiscardItemsAsync()
         {
             int itemsToProcess = 100;
             int itemsProcessed = 0;
@@ -177,7 +177,7 @@ namespace Stratis.Bitcoin.Tests.Utilities
         /// when the passed cancellation token is cancelled.
         /// </summary>
         [Fact]
-        public async void AsyncQueue_DequeueCancellationAsync()
+        public async Task AsyncQueue_DequeueCancellationAsync()
         {
             int itemsToProcess = 50;
             int itemsProcessed = 0;
@@ -226,7 +226,7 @@ namespace Stratis.Bitcoin.Tests.Utilities
         /// and that it throws cancellation exception when the queue is disposed.
         /// </summary>
         [Fact]
-        public async void AsyncQueue_DequeueAndDisposeAsync()
+        public async Task AsyncQueue_DequeueAndDisposeAsync()
         {
             int itemsToProcess = 50;
 
@@ -286,7 +286,7 @@ namespace Stratis.Bitcoin.Tests.Utilities
         /// if it is called after the queue was disposed.
         /// </summary>
         [Fact]
-        public async void AsyncQueue_DequeueThrowsAfterDisposeAsync()
+        public async Task AsyncQueue_DequeueThrowsAfterDisposeAsync()
         {
             // Create a queue in blocking dequeue mode.
             var asyncQueue = new AsyncQueue<int>();
@@ -315,7 +315,7 @@ namespace Stratis.Bitcoin.Tests.Utilities
         /// two different threads safely.
         /// </summary>
         [Fact]
-        public async void AsyncQueue_DequeueParallelAsync()
+        public async Task AsyncQueue_DequeueParallelAsync()
         {
             int itemsToProcess = 50;
 
@@ -417,7 +417,7 @@ namespace Stratis.Bitcoin.Tests.Utilities
         /// Tests that <see cref="AsyncQueue{T}.Dispose"/> can be called from a callback.
         /// </summary>
         [Fact]
-        public async void AsyncQueue_CanDisposeFromCallback_Async()
+        public async Task AsyncQueue_CanDisposeFromCallback_Async()
         {
             bool firstRun = true;
             bool shouldBeFalse = false;

--- a/src/Stratis.Bitcoin.Tests/Utilities/ParallelAsyncTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Utilities/ParallelAsyncTest.cs
@@ -28,7 +28,7 @@ namespace Stratis.Bitcoin.Tests.Utilities
         }
 
         [Fact]
-        public async void ForEachAsync_TestDegreeOfParallelism_Async()
+        public async Task ForEachAsync_TestDegreeOfParallelism_Async()
         {
             int sum = 0;
 
@@ -46,7 +46,7 @@ namespace Stratis.Bitcoin.Tests.Utilities
         }
 
         [Fact]
-        public async void ForEachAsync_TestDegreeOfParallelism2_Async()
+        public async Task ForEachAsync_TestDegreeOfParallelism2_Async()
         {
             int sum = 0;
 
@@ -64,7 +64,7 @@ namespace Stratis.Bitcoin.Tests.Utilities
         }
 
         [Fact]
-        public async void ForEachAsync_DoesNothingWithEmptyCollection_Async()
+        public async Task ForEachAsync_DoesNothingWithEmptyCollection_Async()
         {
             var emptyList = new List<int>();
 
@@ -75,7 +75,7 @@ namespace Stratis.Bitcoin.Tests.Utilities
         }
 
         [Fact]
-        public async void ForEachAsync_CanBeCancelled_Async()
+        public async Task ForEachAsync_CanBeCancelled_Async()
         {
             var tokenSource = new CancellationTokenSource();
 


### PR DESCRIPTION
Though xUnit seems to support tests that return `async void` through a [custom synchronization context](https://github.com/xunit/xunit/blob/master/src/xunit.execution/Sdk/AsyncTestSyncContext.cs), best practices are to return `async Task` instead of `async void`.

I've deliberately excluded FedPeg tests which are being updated in a separate PR.