### PR TITLE
Pass config params into node on creation.

### DIFF
--- a/src/Stratis.Bitcoin.IntegrationTests.Common/EnvironmentMockUpHelpers/NodeBuilder.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests.Common/EnvironmentMockUpHelpers/NodeBuilder.cs
@@ -184,7 +184,7 @@ namespace Stratis.Bitcoin.IntegrationTests.Common.EnvironmentMockUpHelpers
             string dataDir = configParameters["datadir"];
 
             configParameters.ToList().ForEach(p => this.ConfigParameters[p.Key] = p.Value);
-            return CreateNode(new CustomNodeRunner(dataDir, callback, network, protocolVersion, configParameters, agent, minProtocolVersion), configFileName);
+            return CreateNode(new CustomNodeRunner(dataDir, callback, network, protocolVersion, configParameters, agent, minProtocolVersion), configFileName, configParameters: configParameters);
         }
 
         protected string GetNextDataFolderName(string folderName = null)

--- a/src/Stratis.Bitcoin.IntegrationTests/CustomNodeBuilderTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/CustomNodeBuilderTests.cs
@@ -27,7 +27,7 @@ namespace Stratis.Bitcoin.IntegrationTests
             this.network = new BitcoinRegTest();
         }
 
-        [Fact(Skip = "Investigate PeerConnector shutdown timeout issue")]
+        [Fact]
         public void CanOverrideOnlyApiPort()
         {
             var extraParams = new NodeConfigParameters { { "apiport", "12345" } };
@@ -132,7 +132,7 @@ namespace Stratis.Bitcoin.IntegrationTests
             }
         }
 
-        [Fact(Skip = "Investigate PeerConnector shutdown timeout issue")]
+        [Fact]
         public void CanUseCustomConfigFileFromParams()
         {
             var specialConf = "special.conf";


### PR DESCRIPTION
-Adding configParameters explicitly to node constructor
-(configParameters passed into the NodeRunner are private and not accessible)
-Fixes 2/4 tests in CustomNodeBuilderTests (these have had Skip attribute removed)

![image](https://user-images.githubusercontent.com/30984080/54704865-7f242000-4b33-11e9-8e50-47d0fe31982a.png)

Preferred: @dangershony @bokobza 