### PR TITLE
[P2P] Track traffic of disconnected peers

### DIFF
--- a/src/NBitcoin/Protocol/PerformanceCounter.cs
+++ b/src/NBitcoin/Protocol/PerformanceCounter.cs
@@ -121,13 +121,13 @@ namespace NBitcoin
 
         public override string ToString()
         {
-            return Snapshot().ToString();
+            return this.Snapshot().ToString();
         }
 
         public void Add(PerformanceCounter counter)
         {
-            AddWritten(counter.WrittenBytes);
-            AddRead(counter.ReadBytes);
+            this.AddWritten(counter.WrittenBytes);
+            this.AddRead(counter.ReadBytes);
         }
     }
 }

--- a/src/Stratis.Bitcoin/Connection/ConnectionManager.cs
+++ b/src/Stratis.Bitcoin/Connection/ConnectionManager.cs
@@ -82,9 +82,10 @@ namespace Stratis.Bitcoin.Connection
 
         private IConsensusManager consensusManager;
 
-        private AsyncQueue<INetworkPeer> connectedPeersQueue;
+        private readonly AsyncQueue<INetworkPeer> connectedPeersQueue;
 
-        private PerformanceCounter disconnectedPerfCounter;
+        /// <summary>Traffic statistics from peers that have been disconnected.</summary> 
+        private readonly PerformanceCounter disconnectedPerfCounter;
 
         public ConnectionManager(IDateTimeProvider dateTimeProvider,
             ILoggerFactory loggerFactory,

--- a/src/Stratis.Bitcoin/Connection/IConnectionManager.cs
+++ b/src/Stratis.Bitcoin/Connection/IConnectionManager.cs
@@ -75,8 +75,9 @@ namespace Stratis.Bitcoin.Connection
         /// </summary>
         void RemoveNodeAddress(IPEndPoint ipEndpoint);
 
+        /// <summary>
+        /// The endpoints the node is listening on for inbound connections.
+        /// </summary>
         List<NetworkPeerServer> Servers { get; }
-
-        PerformanceCounter Counter { get; }
     }
 }

--- a/src/Stratis.Bitcoin/Connection/IConnectionManager.cs
+++ b/src/Stratis.Bitcoin/Connection/IConnectionManager.cs
@@ -76,5 +76,7 @@ namespace Stratis.Bitcoin.Connection
         void RemoveNodeAddress(IPEndPoint ipEndpoint);
 
         List<NetworkPeerServer> Servers { get; }
+
+        PerformanceCounter Counter { get; }
     }
 }

--- a/src/Stratis.Bitcoin/P2P/PeerConnector.cs
+++ b/src/Stratis.Bitcoin/P2P/PeerConnector.cs
@@ -282,6 +282,7 @@ namespace Stratis.Bitcoin.P2P
         /// <param name="peer">Peer that is being disposed.</param>
         private void OnPeerDisposed(INetworkPeer peer)
         {
+            this.connectionManager.Counter.Add(peer.Counter);
             this.RemovePeer(peer);
         }
 

--- a/src/Stratis.Bitcoin/P2P/PeerConnector.cs
+++ b/src/Stratis.Bitcoin/P2P/PeerConnector.cs
@@ -282,7 +282,6 @@ namespace Stratis.Bitcoin.P2P
         /// <param name="peer">Peer that is being disposed.</param>
         private void OnPeerDisposed(INetworkPeer peer)
         {
-            this.connectionManager.Counter.Add(peer.Counter);
             this.RemovePeer(peer);
         }
 


### PR DESCRIPTION
Performed manual testing by calling the `disconnect` API method. The resulting totals in the `ConnectionManager` counter are as expected (i.e. those of the disconnected peer(s)), and are still reflected in the console stats overall total accordingly.

Relates to VSTS 3008. There will still be a slight discrepancy between recorded traffic and 'on the wire' traffic, due to TCP overhead etc.