### PR TITLE
[Wallet] Remove support for multiple account roots - part 1

### DIFF
--- a/src/Stratis.Bitcoin.Features.ColdStaking.Tests/ColdStakingControllerTest.cs
+++ b/src/Stratis.Bitcoin.Features.ColdStaking.Tests/ColdStakingControllerTest.cs
@@ -192,7 +192,7 @@ namespace Stratis.Bitcoin.Features.ColdStaking.Tests
         /// <returns>The spendable transaction that was added to the wallet.</returns>
         private Transaction AddSpendableTransactionToWallet(Wallet.Wallet wallet)
         {
-            HdAddress address = wallet.GetAllAddressesByCoinType(CoinType.Stratis).FirstOrDefault();
+            HdAddress address = wallet.GetAllAddresses().FirstOrDefault();
 
             Transaction transaction = this.Network.CreateTransaction();
 

--- a/src/Stratis.Bitcoin.Features.ColdStaking/ColdStakingManager.cs
+++ b/src/Stratis.Bitcoin.Features.ColdStaking/ColdStakingManager.cs
@@ -174,7 +174,7 @@ namespace Stratis.Bitcoin.Features.ColdStaking
             this.logger.LogTrace("({0}:'{1}',{2}:{3})", nameof(wallet), wallet.Name, nameof(isColdWalletAccount), isColdWalletAccount);
 
             var coinType = (CoinType)wallet.Network.Consensus.CoinType;
-            HdAccount account = wallet.GetAccountByCoinType(isColdWalletAccount ? ColdWalletAccountName : HotWalletAccountName, coinType);
+            HdAccount account = wallet.GetAccount(isColdWalletAccount ? ColdWalletAccountName : HotWalletAccountName);
             if (account == null)
             {
                 this.logger.LogTrace("(-)[ACCOUNT_DOES_NOT_EXIST]:null");
@@ -230,7 +230,7 @@ namespace Stratis.Bitcoin.Features.ColdStaking
                 accountName = HotWalletAccountName;
             }
 
-            account = wallet.AddNewAccount(walletPassword, this.coinType, this.dateTimeProvider.GetTimeOffset(), accountIndex, accountName);
+            account = wallet.AddNewAccount(walletPassword, this.dateTimeProvider.GetTimeOffset(), accountIndex, accountName);
 
             // Maintain at least one unused address at all times. This will ensure that wallet recovery will also work.
             IEnumerable<HdAddress> newAddresses = account.CreateAddresses(wallet.Network, 1, false);
@@ -501,7 +501,7 @@ namespace Stratis.Bitcoin.Features.ColdStaking
             UnspentOutputReference[] res = null;
             lock (this.lockObject)
             {
-                res = wallet.GetAllSpendableTransactions(this.coinType, this.chain.Tip.Height, confirmations,
+                res = wallet.GetAllSpendableTransactions(this.chain.Tip.Height, confirmations,
                     a => a.Index == (isColdWalletAccount ? ColdWalletAccountIndex : HotWalletAccountIndex)).ToArray();
             }
 

--- a/src/Stratis.Bitcoin.Features.Miner.Tests/PosMintingTest.cs
+++ b/src/Stratis.Bitcoin.Features.Miner.Tests/PosMintingTest.cs
@@ -216,7 +216,7 @@ namespace Stratis.Bitcoin.Features.Miner.Tests
             };
             var milliseconds550MinutesAgo = (uint)Math.Max(this.chain.Tip.Header.Time - TimeSpan.FromMinutes(550).Milliseconds, 0);
             this.AddAccountWithSpendableOutputs(wallet);
-            var spendableTransactions = wallet.GetAllSpendableTransactions(CoinType.Stratis, this.chain.Tip.Height, 0).ToList();
+            var spendableTransactions = wallet.GetAllSpendableTransactions(this.chain.Tip.Height, 0).ToList();
 
             this.walletManager.Setup(w => w.GetSpendableTransactionsInWalletForStaking(It.IsAny<string>(), It.IsAny<int>()))
                 .Returns(spendableTransactions);

--- a/src/Stratis.Bitcoin.Features.SmartContracts/Wallet/SmartContractTransactionService.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts/Wallet/SmartContractTransactionService.cs
@@ -26,7 +26,6 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Wallet
         private readonly IWalletTransactionHandler walletTransactionHandler;
         private readonly IMethodParameterStringSerializer methodParameterStringSerializer;
         private readonly ICallDataSerializer callDataSerializer;
-        private readonly CoinType coinType;
         private readonly IAddressGenerator addressGenerator;
 
         public SmartContractTransactionService(
@@ -42,7 +41,6 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Wallet
             this.walletTransactionHandler = walletTransactionHandler;
             this.methodParameterStringSerializer = methodParameterStringSerializer;
             this.callDataSerializer = callDataSerializer;
-            this.coinType = (CoinType)network.Consensus.CoinType;
             this.addressGenerator = addressGenerator;
         }
 
@@ -79,7 +77,7 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Wallet
             if (!string.IsNullOrWhiteSpace(request.Sender))
             {
                 Features.Wallet.Wallet wallet = this.walletManager.GetWallet(request.WalletName);
-                HdAccount account = wallet.GetAccountByCoinType(request.AccountName, this.coinType);
+                HdAccount account = wallet.GetAccount(request.AccountName);
                 if (account == null)
                     return BuildCallContractTransactionResponse.Failed($"No account with the name '{request.AccountName}' could be found.");
 
@@ -140,7 +138,7 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Wallet
             if (!string.IsNullOrWhiteSpace(request.Sender))
             {
                 Features.Wallet.Wallet wallet = this.walletManager.GetWallet(request.WalletName);
-                HdAccount account = wallet.GetAccountByCoinType(request.AccountName, this.coinType);
+                HdAccount account = wallet.GetAccount(request.AccountName);
                 if (account == null)
                     return BuildCreateContractTransactionResponse.Failed($"No account with the name '{request.AccountName}' could be found.");
 

--- a/src/Stratis.Bitcoin.Features.Wallet.Tests/WalletTest.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet.Tests/WalletTest.cs
@@ -8,132 +8,66 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
     public class WalletTest : WalletTestBase
     {
         [Fact]
-        public void GetAccountsByCoinTypeReturnsAccountsFromWalletByCoinType()
-        {
-            var wallet = new Wallet();
-            wallet.AccountsRoot.Add(CreateAccountRootWithHdAccountHavingAddresses("StratisAccount", CoinType.Stratis));
-            wallet.AccountsRoot.Add(CreateAccountRootWithHdAccountHavingAddresses("BitcoinAccount", CoinType.Bitcoin));
-            wallet.AccountsRoot.Add(CreateAccountRootWithHdAccountHavingAddresses("StratisAccount2", CoinType.Stratis));
-
-            IEnumerable<HdAccount> result = wallet.GetAccountsByCoinType(CoinType.Stratis);
-
-            Assert.Equal(2, result.Count());
-            Assert.Equal("StratisAccount", result.ElementAt(0).Name);
-            Assert.Equal("StratisAccount2", result.ElementAt(1).Name);
-        }
-
-        [Fact]
-        public void GetAccountsByCoinTypeWithoutAccountsReturnsEmptyList()
+        public void GetAccountsWithoutAccountsReturnsEmptyList()
         {
             var wallet = new Wallet();
 
-            IEnumerable<HdAccount> result = wallet.GetAccountsByCoinType(CoinType.Stratis);
+            IEnumerable<HdAccount> result = wallet.GetAccounts();
 
             Assert.Empty(result);
         }
 
         [Fact]
-        public void GetAllTransactionsByCoinTypeReturnsTransactionsFromWalletByCoinType()
+        public void GetAllTransactionsReturnsTransactionsFromWallet()
         {
             var wallet = new Wallet();
             AccountRoot stratisAccountRoot = CreateAccountRootWithHdAccountHavingAddresses("StratisAccount", CoinType.Stratis);
-            AccountRoot bitcoinAccountRoot = CreateAccountRootWithHdAccountHavingAddresses("BitcoinAccount", CoinType.Bitcoin);
-            AccountRoot stratisAccountRoot2 = CreateAccountRootWithHdAccountHavingAddresses("StratisAccount2", CoinType.Stratis);
 
             TransactionData transaction1 = CreateTransaction(new uint256(1), new Money(15000), 1);
             TransactionData transaction2 = CreateTransaction(new uint256(2), new Money(91209), 1);
-            TransactionData transaction3 = CreateTransaction(new uint256(3), new Money(32145), 1);
-            TransactionData transaction4 = CreateTransaction(new uint256(4), new Money(654789), 1);
-            TransactionData transaction5 = CreateTransaction(new uint256(5), new Money(52387), 1);
-            TransactionData transaction6 = CreateTransaction(new uint256(6), new Money(879873), 1);
-
+            
             stratisAccountRoot.Accounts.ElementAt(0).InternalAddresses.ElementAt(0).Transactions.Add(transaction1);
             stratisAccountRoot.Accounts.ElementAt(0).ExternalAddresses.ElementAt(0).Transactions.Add(transaction2);
-            bitcoinAccountRoot.Accounts.ElementAt(0).InternalAddresses.ElementAt(0).Transactions.Add(transaction3);
-            bitcoinAccountRoot.Accounts.ElementAt(0).ExternalAddresses.ElementAt(0).Transactions.Add(transaction4);
-            stratisAccountRoot2.Accounts.ElementAt(0).InternalAddresses.ElementAt(0).Transactions.Add(transaction5);
-            stratisAccountRoot2.Accounts.ElementAt(0).ExternalAddresses.ElementAt(0).Transactions.Add(transaction6);
-
+            
             wallet.AccountsRoot.Add(stratisAccountRoot);
-            wallet.AccountsRoot.Add(bitcoinAccountRoot);
-            wallet.AccountsRoot.Add(stratisAccountRoot2);
+            
+            List<TransactionData> result = wallet.GetAllTransactions().ToList();
 
-            List<TransactionData> result = wallet.GetAllTransactionsByCoinType(CoinType.Stratis).ToList();
-
-            Assert.Equal(4, result.Count);
+            Assert.Equal(2, result.Count);
+            Assert.Equal(transaction1, result[1]);
             Assert.Equal(transaction2, result[0]);
-            Assert.Equal(transaction6, result[1]);
-            Assert.Equal(transaction1, result[2]);
-            Assert.Equal(transaction5, result[3]);
         }
 
         [Fact]
-        public void GetAllTransactionsByCoinTypeWithoutMatchingAccountReturnsEmptyList()
+        public void GetAllTransactionsWithoutAccountRootReturnsEmptyList()
         {
             var wallet = new Wallet();
-            AccountRoot bitcoinAccountRoot = CreateAccountRootWithHdAccountHavingAddresses("BitcoinAccount", CoinType.Bitcoin);
 
-            TransactionData transaction1 = CreateTransaction(new uint256(3), new Money(32145), 1);
-            TransactionData transaction2 = CreateTransaction(new uint256(4), new Money(654789), 1);
-
-            bitcoinAccountRoot.Accounts.ElementAt(0).InternalAddresses.ElementAt(0).Transactions.Add(transaction1);
-            bitcoinAccountRoot.Accounts.ElementAt(0).ExternalAddresses.ElementAt(0).Transactions.Add(transaction2);
-
-            wallet.AccountsRoot.Add(bitcoinAccountRoot);
-
-            List<TransactionData> result = wallet.GetAllTransactionsByCoinType(CoinType.Stratis).ToList();
+            List<TransactionData> result = wallet.GetAllTransactions().ToList();
 
             Assert.Empty(result);
         }
 
         [Fact]
-        public void GetAllTransactionsByCoinTypeWithoutAccountRootReturnsEmptyList()
-        {
-            var wallet = new Wallet();
-
-            List<TransactionData> result = wallet.GetAllTransactionsByCoinType(CoinType.Stratis).ToList();
-
-            Assert.Empty(result);
-        }
-
-        [Fact]
-        public void GetAllPubKeysByCoinTypeReturnsPubkeysFromWalletByCoinType()
+        public void GetAllPubKeysReturnsPubkeysFromWallet()
         {
             var wallet = new Wallet();
             AccountRoot stratisAccountRoot = CreateAccountRootWithHdAccountHavingAddresses("StratisAccount", CoinType.Stratis);
-            AccountRoot bitcoinAccountRoot = CreateAccountRootWithHdAccountHavingAddresses("BitcoinAccount", CoinType.Bitcoin);
-            AccountRoot stratisAccountRoot2 = CreateAccountRootWithHdAccountHavingAddresses("StratisAccount2", CoinType.Stratis);
             wallet.AccountsRoot.Add(stratisAccountRoot);
-            wallet.AccountsRoot.Add(bitcoinAccountRoot);
-            wallet.AccountsRoot.Add(stratisAccountRoot2);
 
-            List<Script> result = wallet.GetAllPubKeysByCoinType(CoinType.Stratis).ToList();
+            List<Script> result = wallet.GetAllPubKeys().ToList();
 
-            Assert.Equal(4, result.Count);
+            Assert.Equal(2, result.Count);
             Assert.Equal(stratisAccountRoot.Accounts.ElementAt(0).ExternalAddresses.ElementAt(0).ScriptPubKey, result[0]);
-            Assert.Equal(stratisAccountRoot2.Accounts.ElementAt(0).ExternalAddresses.ElementAt(0).ScriptPubKey, result[1]);
-            Assert.Equal(stratisAccountRoot.Accounts.ElementAt(0).InternalAddresses.ElementAt(0).ScriptPubKey, result[2]);
-            Assert.Equal(stratisAccountRoot2.Accounts.ElementAt(0).InternalAddresses.ElementAt(0).ScriptPubKey, result[3]);
+            Assert.Equal(stratisAccountRoot.Accounts.ElementAt(0).InternalAddresses.ElementAt(0).ScriptPubKey, result[1]);
         }
 
         [Fact]
-        public void GetAllPubKeysByCoinTypeWithoutMatchingCoinTypeReturnsEmptyList()
-        {
-            var wallet = new Wallet();
-            AccountRoot bitcoinAccountRoot = CreateAccountRootWithHdAccountHavingAddresses("BitcoinAccount", CoinType.Bitcoin);
-            wallet.AccountsRoot.Add(bitcoinAccountRoot);
-
-            List<Script> result = wallet.GetAllPubKeysByCoinType(CoinType.Stratis).ToList();
-
-            Assert.Empty(result);
-        }
-
-        [Fact]
-        public void GetAllPubKeysByCoinTypeWithoutAccountRootsReturnsEmptyList()
+        public void GetAllPubKeysWithoutAccountRootsReturnsEmptyList()
         {
             var wallet = new Wallet();
 
-            List<Script> result = wallet.GetAllPubKeysByCoinType(CoinType.Stratis).ToList();
+            List<Script> result = wallet.GetAllPubKeys().ToList();
 
             Assert.Empty(result);
         }

--- a/src/Stratis.Bitcoin.Features.Wallet/Controllers/WalletController.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Controllers/WalletController.cs
@@ -326,7 +326,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Controllers
                 {
                     Network = wallet.Network,
                     CreationTime = wallet.CreationTime,
-                    LastBlockSyncedHeight = wallet.AccountsRoot.Single(a => a.CoinType == this.coinType).LastBlockSyncedHeight,
+                    LastBlockSyncedHeight = wallet.AccountsRoot.Single().LastBlockSyncedHeight,
                     ConnectedNodes = this.connectionManager.ConnectedPeers.Count(),
                     ChainTip = this.chain.Tip.Height,
                     IsChainSynced = this.chain.IsDownloaded(),
@@ -1038,7 +1038,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Controllers
             try
             {
                 Wallet wallet = this.walletManager.GetWallet(request.WalletName);
-                HdAccount account = wallet.GetAccountByCoinType(request.AccountName, this.coinType);
+                HdAccount account = wallet.GetAccount(request.AccountName);
                 if (account == null)
                     throw new WalletException($"No account with the name '{request.AccountName}' could be found.");
 
@@ -1107,7 +1107,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Controllers
 
                     // Update the wallet and save it to the file system.
                     Wallet wallet = this.walletManager.GetWallet(request.WalletName);
-                    wallet.SetLastBlockDetailsByCoinType(this.coinType, chainedHeader);
+                    wallet.SetLastBlockDetails(chainedHeader);
                     this.walletManager.SaveWallet(wallet);
 
                     // Start the syncing process from the block before the earliest transaction was seen.

--- a/src/Stratis.Bitcoin.Features.Wallet/Wallet.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Wallet.cs
@@ -289,12 +289,11 @@ namespace Stratis.Bitcoin.Features.Wallet
         /// <summary>
         /// Calculates the fee paid by the user on a transaction sent.
         /// </summary>
-        /// <param name="coinType">Type of the coin to get transactions from.</param>
         /// <param name="transactionId">The transaction id to look for.</param>
         /// <returns>The fee paid.</returns>
-        public Money GetSentTransactionFee(CoinType coinType, uint256 transactionId)
+        public Money GetSentTransactionFee(uint256 transactionId)
         {
-            List<TransactionData> allTransactions = this.GetAllTransactionsByCoinType(coinType).ToList();
+            List<TransactionData> allTransactions = this.GetAllTransactions().ToList();
 
             // Get a list of all the inputs spent in this transaction.
             List<TransactionData> inputsSpentInTransaction = allTransactions.Where(t => t.SpendingDetails?.TransactionId == transactionId).ToList();

--- a/src/Stratis.Bitcoin.Features.Wallet/Wallet.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Wallet.cs
@@ -83,36 +83,32 @@ namespace Stratis.Bitcoin.Features.Wallet
         public ICollection<AccountRoot> AccountsRoot { get; set; }
 
         /// <summary>
-        /// Gets the accounts the wallet has for this type of coin.
+        /// Gets the accounts in the wallet.
         /// </summary>
-        /// <param name="coinType">Type of the coin.</param>
         /// <param name="accountFilter">An optional filter for filtering the accounts being returned.</param>
-        /// <returns>The accounts in the wallet corresponding to this type of coin.</returns>
-        public IEnumerable<HdAccount> GetAccountsByCoinType(CoinType coinType, Func<HdAccount, bool> accountFilter = null)
+        /// <returns>The accounts in the wallet.</returns>
+        public IEnumerable<HdAccount> GetAccounts(Func<HdAccount, bool> accountFilter = null)
         {
-            return this.AccountsRoot.Where(a => a.CoinType == coinType).SelectMany(a => a.Accounts).Where(accountFilter ?? NormalAccounts);
+            return this.AccountsRoot.SelectMany(a => a.Accounts).Where(accountFilter ?? NormalAccounts);
         }
 
         /// <summary>
         /// Gets an account from the wallet's accounts.
         /// </summary>
         /// <param name="accountName">The name of the account to retrieve.</param>
-        /// <param name="coinType">The type of the coin this account is for.</param>
         /// <returns>The requested account or <c>null</c> if the account does not exist.</returns>
-        public HdAccount GetAccountByCoinType(string accountName, CoinType coinType)
+        public HdAccount GetAccount(string accountName)
         {
-            AccountRoot accountRoot = this.AccountsRoot.SingleOrDefault(a => a.CoinType == coinType);
-            return accountRoot?.GetAccountByName(accountName);
+            return this.AccountsRoot.SingleOrDefault()?.GetAccountByName(accountName);
         }
 
         /// <summary>
         /// Update the last block synced height and hash in the wallet.
         /// </summary>
-        /// <param name="coinType">The type of the coin this account is for.</param>
         /// <param name="block">The block whose details are used to update the wallet.</param>
-        public void SetLastBlockDetailsByCoinType(CoinType coinType, ChainedHeader block)
+        public void SetLastBlockDetails(ChainedHeader block)
         {
-            AccountRoot accountRoot = this.AccountsRoot.SingleOrDefault(a => a.CoinType == coinType);
+            AccountRoot accountRoot = this.AccountsRoot.SingleOrDefault();
 
             if (accountRoot == null) return;
 
@@ -121,13 +117,12 @@ namespace Stratis.Bitcoin.Features.Wallet
         }
 
         /// <summary>
-        /// Gets all the transactions by coin type.
+        /// Gets all the transactions in the wallet.
         /// </summary>
-        /// <param name="coinType">Type of the coin.</param>
-        /// <returns></returns>
-        public IEnumerable<TransactionData> GetAllTransactionsByCoinType(CoinType coinType)
+        /// <returns>A list of all the transactions in the wallet.</returns>
+        public IEnumerable<TransactionData> GetAllTransactions()
         {
-            List<HdAccount> accounts = this.GetAccountsByCoinType(coinType).ToList();
+            List<HdAccount> accounts = this.GetAccounts().ToList();
 
             foreach (TransactionData txData in accounts.SelectMany(x => x.ExternalAddresses).SelectMany(x => x.Transactions))
             {
@@ -143,11 +138,10 @@ namespace Stratis.Bitcoin.Features.Wallet
         /// <summary>
         /// Gets all the pub keys contained in this wallet.
         /// </summary>
-        /// <param name="coinType">Type of the coin.</param>
-        /// <returns></returns>
-        public IEnumerable<Script> GetAllPubKeysByCoinType(CoinType coinType)
+        /// <returns>A list of all the public keys contained in the wallet.</returns>
+        public IEnumerable<Script> GetAllPubKeys()
         {
-            List<HdAccount> accounts = this.GetAccountsByCoinType(coinType).ToList();
+            List<HdAccount> accounts = this.GetAccounts().ToList();
 
             foreach (Script script in accounts.SelectMany(x => x.ExternalAddresses).Select(x => x.ScriptPubKey))
             {
@@ -163,12 +157,11 @@ namespace Stratis.Bitcoin.Features.Wallet
         /// <summary>
         /// Gets all the addresses contained in this wallet.
         /// </summary>
-        /// <param name="coinType">Type of the coin.</param>
         /// <param name="accountFilter">An optional filter for filtering the accounts being returned.</param>
         /// <returns>A list of all the addresses contained in this wallet.</returns>
-        public IEnumerable<HdAddress> GetAllAddressesByCoinType(CoinType coinType, Func<HdAccount, bool> accountFilter = null)
+        public IEnumerable<HdAddress> GetAllAddresses(Func<HdAccount, bool> accountFilter = null)
         {
-            List<HdAccount> accounts = this.GetAccountsByCoinType(coinType, accountFilter).ToList();
+            IEnumerable<HdAccount> accounts = this.GetAccounts(accountFilter);
 
             var allAddresses = new List<HdAddress>();
             foreach (HdAccount account in accounts)
@@ -187,16 +180,15 @@ namespace Stratis.Bitcoin.Features.Wallet
         /// </remarks>
         /// <seealso cref="https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki"/>
         /// <param name="password">The password used to decrypt the wallet's <see cref="EncryptedSeed"/>.</param>
-        /// <param name="coinType">The type of coin this account is for.</param>
         /// <param name="accountCreationTime">Creation time of the account to be created.</param>
         /// <param name="accountIndex">The index at which an account will be created. If left null, a new account will be created after the last used one.</param>
         /// <param name="accountName">The name of the account to be created. If left null, an account will be created according to the <see cref="Wallet.AccountNamePattern"/>.</param>
         /// <returns>A new HD account.</returns>
-        public HdAccount AddNewAccount(string password, CoinType coinType, DateTimeOffset accountCreationTime, int? accountIndex = null, string accountName = null)
+        public HdAccount AddNewAccount(string password, DateTimeOffset accountCreationTime, int? accountIndex = null, string accountName = null)
         {
             Guard.NotEmpty(password, nameof(password));
 
-            AccountRoot accountRoot = this.AccountsRoot.Single(a => a.CoinType == coinType);
+            AccountRoot accountRoot = this.AccountsRoot.Single();
             return accountRoot.AddNewAccount(password, this.EncryptedSeed, this.ChainCode, this.Network, accountCreationTime, accountIndex, accountName);
         }
 
@@ -208,14 +200,13 @@ namespace Stratis.Bitcoin.Features.Wallet
         /// According to BIP44, an account at index (i) can only be created when the account at index (i - 1) contains at least one transaction.
         /// </remarks>
         /// <seealso cref="https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki"/>
-        /// <param name="coinType">The type of coin this account is for.</param>
         /// <param name="extPubKey">The extended public key for the wallet<see cref="EncryptedSeed"/>.</param>
         /// <param name="accountIndex">Zero-based index of the account to add.</param>
         /// <param name="accountCreationTime">Creation time of the account to be created.</param>
         /// <returns>A new HD account.</returns>
-        public HdAccount AddNewAccount(CoinType coinType, ExtPubKey extPubKey, int accountIndex, DateTimeOffset accountCreationTime)
+        public HdAccount AddNewAccount(ExtPubKey extPubKey, int accountIndex, DateTimeOffset accountCreationTime)
         {
-            AccountRoot accountRoot = this.AccountsRoot.Single(a => a.CoinType == coinType);
+            AccountRoot accountRoot = this.AccountsRoot.Single();
             return accountRoot.AddNewAccount(extPubKey, accountIndex, this.Network, accountCreationTime);
         }
 
@@ -223,10 +214,10 @@ namespace Stratis.Bitcoin.Features.Wallet
         /// Gets the first account that contains no transaction.
         /// </summary>
         /// <returns>An unused account.</returns>
-        public HdAccount GetFirstUnusedAccount(CoinType coinType)
+        public HdAccount GetFirstUnusedAccount()
         {
             // Get the accounts root for this type of coin.
-            AccountRoot accountsRoot = this.AccountsRoot.Single(a => a.CoinType == coinType);
+            AccountRoot accountsRoot = this.AccountsRoot.Single();
 
             if (accountsRoot.Accounts.Any())
             {
@@ -284,14 +275,13 @@ namespace Stratis.Bitcoin.Features.Wallet
         /// <summary>
         /// Lists all spendable transactions from all accounts in the wallet.
         /// </summary>
-        /// <param name="coinType">Type of the coin to get transactions from.</param>
         /// <param name="currentChainHeight">Height of the current chain, used in calculating the number of confirmations.</param>
         /// <param name="confirmations">The number of confirmations required to consider a transaction spendable.</param>
         /// <param name="accountFilter">An optional filter for filtering the accounts being returned.</param>
         /// <returns>A collection of spendable outputs.</returns>
-        public IEnumerable<UnspentOutputReference> GetAllSpendableTransactions(CoinType coinType, int currentChainHeight, int confirmations = 0, Func<HdAccount, bool> accountFilter = null)
+        public IEnumerable<UnspentOutputReference> GetAllSpendableTransactions(int currentChainHeight, int confirmations = 0, Func<HdAccount, bool> accountFilter = null)
         {
-            IEnumerable<HdAccount> accounts = this.GetAccountsByCoinType(coinType, accountFilter);
+            IEnumerable<HdAccount> accounts = this.GetAccounts(accountFilter);
 
             return accounts.SelectMany(x => x.GetSpendableTransactions(currentChainHeight, this.Network.Consensus.CoinbaseMaturity, confirmations));
         }

--- a/src/Stratis.Bitcoin.Features.Wallet/WalletManager.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/WalletManager.cs
@@ -196,7 +196,7 @@ namespace Stratis.Bitcoin.Features.Wallet
             foreach (Wallet wallet in wallets)
             {
                 this.Load(wallet);
-                foreach (HdAccount account in wallet.GetAccountsByCoinType(this.coinType))
+                foreach (HdAccount account in wallet.GetAccounts())
                 {
                     this.AddAddressesToMaintainBuffer(account, false);
                     this.AddAddressesToMaintainBuffer(account, true);
@@ -269,7 +269,7 @@ namespace Stratis.Bitcoin.Features.Wallet
             // Generate multiple accounts and addresses from the get-go.
             for (int i = 0; i < WalletCreationAccountsCount; i++)
             {
-                HdAccount account = wallet.AddNewAccount(password, this.coinType, this.dateTimeProvider.GetTimeOffset());
+                HdAccount account = wallet.AddNewAccount(password, this.dateTimeProvider.GetTimeOffset());
                 IEnumerable<HdAddress> newReceivingAddresses = account.CreateAddresses(this.network, this.walletSettings.UnusedAddressesBuffer);
                 IEnumerable<HdAddress> newChangeAddresses = account.CreateAddresses(this.network, this.walletSettings.UnusedAddressesBuffer, true);
                 this.UpdateKeysLookupLocked(newReceivingAddresses.Concat(newChangeAddresses));
@@ -395,7 +395,7 @@ namespace Stratis.Bitcoin.Features.Wallet
                 HdAccount account;
                 lock (this.lockObject)
                 {
-                    account = wallet.AddNewAccount(password, this.coinType, this.dateTimeProvider.GetTimeOffset());
+                    account = wallet.AddNewAccount(password, this.dateTimeProvider.GetTimeOffset());
                 }
 
                 IEnumerable<HdAddress> newReceivingAddresses = account.CreateAddresses(this.network, this.walletSettings.UnusedAddressesBuffer);
@@ -436,7 +436,7 @@ namespace Stratis.Bitcoin.Features.Wallet
             HdAccount account;
             lock (this.lockObject)
             {
-                account = wallet.AddNewAccount(this.coinType, extPubKey, accountIndex, this.dateTimeProvider.GetTimeOffset());
+                account = wallet.AddNewAccount(extPubKey, accountIndex, this.dateTimeProvider.GetTimeOffset());
             }
 
             IEnumerable<HdAddress> newReceivingAddresses = account.CreateAddresses(this.network, this.walletSettings.UnusedAddressesBuffer);
@@ -490,7 +490,7 @@ namespace Stratis.Bitcoin.Features.Wallet
 
             lock (this.lockObject)
             {
-                account = wallet.GetFirstUnusedAccount(this.coinType);
+                account = wallet.GetFirstUnusedAccount();
 
                 if (account != null)
                 {
@@ -499,7 +499,7 @@ namespace Stratis.Bitcoin.Features.Wallet
                 }
 
                 // No unused account was found, create a new one.
-                account = wallet.AddNewAccount(password, this.coinType, this.dateTimeProvider.GetTimeOffset());
+                account = wallet.AddNewAccount(password, this.dateTimeProvider.GetTimeOffset());
                 IEnumerable<HdAddress> newReceivingAddresses = account.CreateAddresses(this.network, this.walletSettings.UnusedAddressesBuffer);
                 IEnumerable<HdAddress> newChangeAddresses = account.CreateAddresses(this.network, this.walletSettings.UnusedAddressesBuffer, true);
                 this.UpdateKeysLookupLocked(newReceivingAddresses.Concat(newChangeAddresses));
@@ -521,7 +521,7 @@ namespace Stratis.Bitcoin.Features.Wallet
             lock (this.lockObject)
             {
                 // Get the account.
-                HdAccount account = wallet.GetAccountByCoinType(accountReference.AccountName, this.coinType);
+                HdAccount account = wallet.GetAccount(accountReference.AccountName);
                 if (account == null)
                     throw new WalletException($"No account with the name '{accountReference.AccountName}' could be found.");
                 extPubKey = account.ExtendedPubKey;
@@ -560,7 +560,7 @@ namespace Stratis.Bitcoin.Features.Wallet
             lock (this.lockObject)
             {
                 // Get the account.
-                HdAccount account = wallet.GetAccountByCoinType(accountReference.AccountName, this.coinType);
+                HdAccount account = wallet.GetAccount(accountReference.AccountName);
                 if (account == null)
                     throw new WalletException($"No account with the name '{accountReference.AccountName}' could be found.");
 
@@ -610,7 +610,7 @@ namespace Stratis.Bitcoin.Features.Wallet
                 var accounts = new List<HdAccount>();
                 if (!string.IsNullOrEmpty(accountName))
                 {
-                    HdAccount account = wallet.GetAccountByCoinType(accountName, this.coinType);
+                    HdAccount account = wallet.GetAccount(accountName);
                     if (account == null)
                         throw new WalletException($"No account with the name '{accountName}' could be found.");
 
@@ -618,7 +618,7 @@ namespace Stratis.Bitcoin.Features.Wallet
                 }
                 else
                 {
-                    accounts.AddRange(wallet.GetAccountsByCoinType(this.coinType));
+                    accounts.AddRange(wallet.GetAccounts());
                 }
 
                 foreach (HdAccount account in accounts)
@@ -658,7 +658,7 @@ namespace Stratis.Bitcoin.Features.Wallet
                 var accounts = new List<HdAccount>();
                 if (!string.IsNullOrEmpty(accountName))
                 {
-                    HdAccount account = wallet.GetAccountByCoinType(accountName, this.coinType);
+                    HdAccount account = wallet.GetAccount(accountName);
                     if (account == null)
                         throw new WalletException($"No account with the name '{accountName}' could be found.");
 
@@ -666,7 +666,7 @@ namespace Stratis.Bitcoin.Features.Wallet
                 }
                 else
                 {
-                    accounts.AddRange(wallet.GetAccountsByCoinType(this.coinType));
+                    accounts.AddRange(wallet.GetAccounts());
                 }
 
                 foreach (HdAccount account in accounts)
@@ -712,7 +712,7 @@ namespace Stratis.Bitcoin.Features.Wallet
 
                 foreach (Wallet wallet in this.Wallets)
                 {
-                    hdAddress = wallet.GetAllAddressesByCoinType(this.coinType).FirstOrDefault(a => a.Address == address);
+                    hdAddress = wallet.GetAllAddresses().FirstOrDefault(a => a.Address == address);
                     if (hdAddress == null) continue;
 
                     (Money amountConfirmed, Money amountUnconfirmed) result = hdAddress.GetBalances();
@@ -753,7 +753,7 @@ namespace Stratis.Bitcoin.Features.Wallet
             HdAccount[] res = null;
             lock (this.lockObject)
             {
-                res = wallet.GetAccountsByCoinType(this.coinType).ToArray();
+                res = wallet.GetAccounts().ToArray();
             }
             return res;
         }
@@ -771,7 +771,7 @@ namespace Stratis.Bitcoin.Features.Wallet
             int res;
             lock (this.lockObject)
             {
-                res = this.Wallets.Min(w => w.AccountsRoot.SingleOrDefault(a => a.CoinType == this.coinType)?.LastBlockSyncedHeight) ?? 0;
+                res = this.Wallets.Min(w => w.AccountsRoot.Single().LastBlockSyncedHeight) ?? 0;
             }
 
             return res;
@@ -797,7 +797,7 @@ namespace Stratis.Bitcoin.Features.Wallet
             lock (this.lockObject)
             {
                 lastBlockSyncedHash = this.Wallets
-                    .Select(w => w.AccountsRoot.SingleOrDefault(a => a.CoinType == this.coinType))
+                    .Select(w => w.AccountsRoot.Single())
                     .Where(w => w != null)
                     .OrderBy(o => o.LastBlockSyncedHeight)
                     .FirstOrDefault()?.LastBlockSyncedHash;
@@ -835,7 +835,7 @@ namespace Stratis.Bitcoin.Features.Wallet
             UnspentOutputReference[] res = null;
             lock (this.lockObject)
             {
-                res = wallet.GetAllSpendableTransactions(this.coinType, this.chain.Tip.Height, confirmations, accountFilter).ToArray();
+                res = wallet.GetAllSpendableTransactions(this.chain.Tip.Height, confirmations, accountFilter).ToArray();
             }
 
             return res;
@@ -850,7 +850,7 @@ namespace Stratis.Bitcoin.Features.Wallet
             UnspentOutputReference[] res = null;
             lock (this.lockObject)
             {
-                HdAccount account = wallet.GetAccountByCoinType(walletAccountReference.AccountName, this.coinType);
+                HdAccount account = wallet.GetAccount(walletAccountReference.AccountName);
 
                 if (account == null)
                 {
@@ -1191,7 +1191,7 @@ namespace Stratis.Bitcoin.Features.Wallet
         {
             foreach (Wallet wallet in this.Wallets)
             {
-                foreach (HdAccount account in wallet.GetAccountsByCoinType(this.coinType, accountFilter ?? Wallet.NormalAccounts))
+                foreach (HdAccount account in wallet.GetAccounts(accountFilter ?? Wallet.NormalAccounts))
                 {
                     bool isChange;
                     if (account.ExternalAddresses.Any(address => address.ScriptPubKey == script))
@@ -1283,7 +1283,7 @@ namespace Stratis.Bitcoin.Features.Wallet
 
             lock (this.lockObject)
             {
-                wallet.SetLastBlockDetailsByCoinType(this.coinType, chainedHeader);
+                wallet.SetLastBlockDetails(chainedHeader);
             }
         }
 
@@ -1394,7 +1394,7 @@ namespace Stratis.Bitcoin.Features.Wallet
             {
                 foreach (Wallet wallet in this.Wallets)
                 {
-                    IEnumerable<HdAddress> addresses = wallet.GetAllAddressesByCoinType(this.coinType, a => true);
+                    IEnumerable<HdAddress> addresses = wallet.GetAllAddresses(a => true);
                     foreach (HdAddress address in addresses)
                     {
                         this.scriptToAddressLookup[address.ScriptPubKey] = address;
@@ -1471,7 +1471,7 @@ namespace Stratis.Bitcoin.Features.Wallet
 
                 foreach (Wallet wallet in this.Wallets)
                 {
-                    foreach (HdAddress address in wallet.GetAllAddressesByCoinType(this.coinType, a => true))
+                    foreach (HdAddress address in wallet.GetAllAddresses(a => true))
                     {
                         // Get the UTXOs that are unspent or spent but not confirmed.
                         // We only exclude from the list the confirmed spent UTXOs.
@@ -1512,7 +1512,7 @@ namespace Stratis.Bitcoin.Features.Wallet
         /// <inheritdoc />
         public int? GetEarliestWalletHeight()
         {
-            return this.Wallets.Min(w => w.AccountsRoot.Single(a => a.CoinType == this.coinType).LastBlockSyncedHeight);
+            return this.Wallets.Min(w => w.AccountsRoot.Single().LastBlockSyncedHeight);
         }
 
         /// <inheritdoc />
@@ -1534,7 +1534,7 @@ namespace Stratis.Bitcoin.Features.Wallet
 
             lock (this.lockObject)
             {
-                IEnumerable<HdAccount> accounts = wallet.GetAccountsByCoinType(this.coinType);
+                IEnumerable<HdAccount> accounts = wallet.GetAccounts();
                 foreach (HdAccount account in accounts)
                 {
                     foreach (HdAddress address in account.GetCombinedAddresses())
@@ -1584,7 +1584,7 @@ namespace Stratis.Bitcoin.Features.Wallet
 
             lock (this.lockObject)
             {
-                IEnumerable<HdAccount> accounts = wallet.GetAccountsByCoinType(this.coinType);
+                IEnumerable<HdAccount> accounts = wallet.GetAccounts();
                 foreach (HdAccount account in accounts)
                 {
                     foreach (HdAddress address in account.GetCombinedAddresses())
@@ -1616,7 +1616,7 @@ namespace Stratis.Bitcoin.Features.Wallet
 
             lock (this.lockObject)
             {
-                IEnumerable<HdAccount> accounts = wallet.GetAccountsByCoinType(this.coinType);
+                IEnumerable<HdAccount> accounts = wallet.GetAccounts();
                 foreach (HdAccount account in accounts)
                 {
                     foreach (HdAddress address in account.GetCombinedAddresses())

--- a/src/Stratis.Bitcoin.Features.Wallet/WalletRPCController.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/WalletRPCController.cs
@@ -278,7 +278,7 @@ namespace Stratis.Bitcoin.Features.Wallet
             if (sendTransactions.Any())
             {
                 Wallet wallet = this.walletManager.GetWallet(accountReference.WalletName);
-                feeSent = wallet.GetSentTransactionFee(wallet.AccountsRoot.First().CoinType, trxid);
+                feeSent = wallet.GetSentTransactionFee(trxid);
             }
 
             // Send transactions details.

--- a/src/Stratis.Bitcoin.IntegrationTests/ProofOfStakeSteps.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/ProofOfStakeSteps.cs
@@ -188,11 +188,7 @@ namespace Stratis.Bitcoin.IntegrationTests
         private List<TransactionData> GetTransactionsSnapshot()
         {
             // Enumerate to a list otherwise the enumerable can change during enumeration as new transactions are added to the wallet.
-            return this.PremineNodeWithCoins.FullNode.WalletManager().Wallets
-                .First()
-                .GetAllTransactionsByCoinType((CoinType)this.PremineNodeWithCoins.FullNode.Network.Consensus
-                    .CoinType)
-                .ToList();
+            return this.PremineNodeWithCoins.FullNode.WalletManager().Wallets.First().GetAllTransactions().ToList();
         }
     }
 }

--- a/src/Stratis.Bitcoin.IntegrationTests/Wallet/WalletOperationsTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/Wallet/WalletOperationsTests.cs
@@ -159,10 +159,10 @@ namespace Stratis.Bitcoin.IntegrationTests.Wallet
             wallet.Network.Should().Be(this.fixture.Node.FullNode.Network);
 
             // Check only one account is created.
-            wallet.GetAccountsByCoinType(CoinType.Stratis).Should().ContainSingle();
+            wallet.GetAccounts().Should().ContainSingle();
 
             // Check the created account.
-            HdAccount account = wallet.GetAccountsByCoinType(CoinType.Stratis).Single();
+            HdAccount account = wallet.GetAccounts().Single();
             account.Name.Should().Be("account 0");
             account.ExternalAddresses.Count().Should().Be(20);
             account.InternalAddresses.Count().Should().Be(20);
@@ -210,10 +210,10 @@ namespace Stratis.Bitcoin.IntegrationTests.Wallet
             wallet.Network.Should().Be(this.fixture.Node.FullNode.Network);
 
             // Check only one account is created.
-            wallet.GetAccountsByCoinType(CoinType.Stratis).Should().ContainSingle();
+            wallet.GetAccounts().Should().ContainSingle();
 
             // Check the created account.
-            HdAccount account = wallet.GetAccountsByCoinType(CoinType.Stratis).Single();
+            HdAccount account = wallet.GetAccounts().Single();
             account.Name.Should().Be("account 0");
             account.ExternalAddresses.Count().Should().Be(20);
             account.InternalAddresses.Count().Should().Be(20);
@@ -261,10 +261,10 @@ namespace Stratis.Bitcoin.IntegrationTests.Wallet
             wallet.Network.Should().Be(this.fixture.Node.FullNode.Network);
 
             // Check only one account is created.
-            wallet.GetAccountsByCoinType(CoinType.Stratis).Should().ContainSingle();
+            wallet.GetAccounts().Should().ContainSingle();
 
             // Check the created account.
-            HdAccount account = wallet.GetAccountsByCoinType(CoinType.Stratis).Single();
+            HdAccount account = wallet.GetAccounts().Single();
             account.Name.Should().Be("account 0");
             account.ExternalAddresses.Count().Should().Be(20);
             account.InternalAddresses.Count().Should().Be(20);
@@ -312,10 +312,10 @@ namespace Stratis.Bitcoin.IntegrationTests.Wallet
             wallet.Network.Should().Be(this.fixture.Node.FullNode.Network);
 
             // Check only one account is created.
-            wallet.GetAccountsByCoinType(CoinType.Stratis).Should().ContainSingle();
+            wallet.GetAccounts().Should().ContainSingle();
 
             // Check the created account.
-            HdAccount account = wallet.GetAccountsByCoinType(CoinType.Stratis).Single();
+            HdAccount account = wallet.GetAccounts().Single();
             account.Name.Should().Be("account 0");
             account.ExternalAddresses.Count().Should().Be(20);
             account.InternalAddresses.Count().Should().Be(20);
@@ -360,10 +360,10 @@ namespace Stratis.Bitcoin.IntegrationTests.Wallet
             wallet.Network.Should().Be(this.fixture.Node.FullNode.Network);
 
             // Check only one account is created.
-            wallet.GetAccountsByCoinType(CoinType.Stratis).Should().ContainSingle();
+            wallet.GetAccounts().Should().ContainSingle();
 
             // Check the created account.
-            HdAccount account = wallet.GetAccountsByCoinType(CoinType.Stratis).Single();
+            HdAccount account = wallet.GetAccounts().Single();
             account.Name.Should().Be("account 0");
             account.ExternalAddresses.Count().Should().Be(20);
             account.InternalAddresses.Count().Should().Be(20);
@@ -758,10 +758,10 @@ namespace Stratis.Bitcoin.IntegrationTests.Wallet
             wallet.Network.Should().Be(this.fixture.Node.FullNode.Network);
 
             // Check only one account is created.
-            wallet.GetAccountsByCoinType(CoinType.Stratis).Should().ContainSingle();
+            wallet.GetAccounts().Should().ContainSingle();
 
             // Check the created account.
-            HdAccount account = wallet.GetAccountsByCoinType(CoinType.Stratis).Single();
+            HdAccount account = wallet.GetAccounts().Single();
             account.Name.Should().Be("account 0");
             account.ExternalAddresses.Count().Should().Be(20);
             account.InternalAddresses.Count().Should().Be(20);
@@ -803,10 +803,10 @@ namespace Stratis.Bitcoin.IntegrationTests.Wallet
             wallet.Network.Should().Be(this.fixture.Node.FullNode.Network);
 
             // Check only one account is created.
-            wallet.GetAccountsByCoinType(CoinType.Stratis).Should().ContainSingle();
+            wallet.GetAccounts().Should().ContainSingle();
 
             // Check the created account.
-            HdAccount account = wallet.GetAccountsByCoinType(CoinType.Stratis).Single();
+            HdAccount account = wallet.GetAccounts().Single();
             account.Name.Should().Be("account 0");
             account.ExternalAddresses.Count().Should().Be(20);
             account.InternalAddresses.Count().Should().Be(20);


### PR DESCRIPTION
Originally the wallet was designed to reflect the nomenclature of HD wallets and derivation structures.
so we have a wallet that can have multiple account roots to be able to support any number of coins from within the same wallet.
In retrospect, this is a bad idea and wholly unnecessary: we'd never be able to run nodes for multiple coins at the same time and keep the wallet file sane.

The idea  is to remove the account root from the wallet file but rather have a wallet containing a coin type with a collection of accounts.

This change doesn't affect the wallet file, but rather removes support for multiple account roots.
Yet again, this is step 1.