### PR TITLE
[FS] Adjusting MaxReorg for CirrusV2 networks

### DIFF
--- a/src/Stratis.Sidechains.Networks/CirrusV2/CirrusMain.cs
+++ b/src/Stratis.Sidechains.Networks/CirrusV2/CirrusMain.cs
@@ -4,13 +4,12 @@ using System.Linq;
 using NBitcoin;
 using NBitcoin.DataEncoders;
 using Stratis.Bitcoin.Features.PoA;
-using Stratis.Bitcoin.Features.SmartContracts;
 using Stratis.Bitcoin.Features.SmartContracts.PoA;
 using Stratis.SmartContracts.Networks.Policies;
 
 namespace Stratis.Sidechains.Networks.CirrusV2
 {
-    public class CirrusMain : PoANetwork, ISignedCodePubKeyHolder
+    public class CirrusMain : PoANetwork
     {
         /// <summary> The name of the root folder containing the different federated peg blockchains.</summary>
         private const string NetworkRootFolderName = "cirrus";
@@ -18,13 +17,8 @@ namespace Stratis.Sidechains.Networks.CirrusV2
         /// <summary> The default name used for the federated peg configuration file. </summary>
         private const string NetworkDefaultConfigFilename = "cirrus.conf";
 
-        public PubKey SigningContractPubKey { get; }
-
         internal CirrusMain()
         {
-            // TODO: Replace with real secret key.
-            this.SigningContractPubKey = new Mnemonic("lava frown leave wedding virtual ghost sibling able mammal liar wide wisdom").DeriveExtKey().PrivateKey.PubKey;
-
             this.Name = nameof(CirrusMain);
             this.CoinTicker = "CRS";
             this.Magic = 0x522357A0; //
@@ -102,7 +96,7 @@ namespace Stratis.Sidechains.Networks.CirrusV2
                 bip34Hash: new uint256("0x000000000000024b89b42a942fe0d9fea3bb44ab7bd1b19115dd6a759c0808b8"),
                 ruleChangeActivationThreshold: 1916, // 95% of 2016
                 minerConfirmationWindow: 2016, // nPowTargetTimespan / nPowTargetSpacing
-                maxReorgLength: 0, // No max reorg limit on PoA networks.
+                maxReorgLength: 240, // 2 loops of PoA members
                 defaultAssumeValid: null,
                 maxMoney: Money.Coins(100_000_000),
                 coinbaseMaturity: 1,

--- a/src/Stratis.Sidechains.Networks/CirrusV2/CirrusRegTest.cs
+++ b/src/Stratis.Sidechains.Networks/CirrusV2/CirrusRegTest.cs
@@ -5,13 +5,12 @@ using NBitcoin;
 using NBitcoin.DataEncoders;
 using NBitcoin.Protocol;
 using Stratis.Bitcoin.Features.PoA;
-using Stratis.Bitcoin.Features.SmartContracts;
 using Stratis.Bitcoin.Features.SmartContracts.PoA;
 using Stratis.SmartContracts.Networks.Policies;
 
 namespace Stratis.Sidechains.Networks.CirrusV2
 {
-    public class CirrusRegTest : PoANetwork, ISignedCodePubKeyHolder
+    public class CirrusRegTest : PoANetwork
     {
         public IList<Mnemonic> FederationMnemonics { get; }
 
@@ -24,17 +23,10 @@ namespace Stratis.Sidechains.Networks.CirrusV2
         // public IList<Mnemonic> FederationMnemonics { get; }
         public IList<Key> FederationKeys { get; private set; }
 
-        public Key SigningContractPrivKey { get; }
-
-        public PubKey SigningContractPubKey { get; }
-
         internal CirrusRegTest()
         {
-            this.SigningContractPrivKey = new Mnemonic("lava frown leave wedding virtual ghost sibling able mammal liar wide wisdom").DeriveExtKey().PrivateKey;
-            this.SigningContractPubKey = this.SigningContractPrivKey.PubKey;
-
             this.Name = nameof(CirrusRegTest);
-            this.CoinTicker = "TFPG";
+            this.CoinTicker = "TCRS";
             this.Magic = 0x522357C;
             this.DefaultPort = 26179;
             this.DefaultMaxOutboundConnections = 16;
@@ -106,7 +98,7 @@ namespace Stratis.Sidechains.Networks.CirrusV2
                 bip34Hash: new uint256("0x000000000000024b89b42a942fe0d9fea3bb44ab7bd1b19115dd6a759c0808b8"),
                 ruleChangeActivationThreshold: 1916, // 95% of 2016
                 minerConfirmationWindow: 2016, // nPowTargetTimespan / nPowTargetSpacing
-                maxReorgLength: 0, // No max reorg limit on PoA networks.
+                maxReorgLength: 240, // 2 loops of PoA members
                 defaultAssumeValid: null,
                 maxMoney: Money.Coins(20_000_000),
                 coinbaseMaturity: 1,

--- a/src/Stratis.Sidechains.Networks/CirrusV2/CirrusTest.cs
+++ b/src/Stratis.Sidechains.Networks/CirrusV2/CirrusTest.cs
@@ -5,12 +5,11 @@ using NBitcoin.DataEncoders;
 using NBitcoin.Protocol;
 using Stratis.Bitcoin.Features.PoA;
 using Stratis.Bitcoin.Features.SmartContracts.PoA;
-using Stratis.Bitcoin.Features.SmartContracts;
 using Stratis.SmartContracts.Networks.Policies;
 
 namespace Stratis.Sidechains.Networks.CirrusV2
 {
-    public class CirrusTest : PoANetwork, ISignedCodePubKeyHolder
+    public class CirrusTest : PoANetwork
     {
         /// <summary> The name of the root folder containing the different federated peg blockchains.</summary>
         private const string NetworkRootFolderName = "cirrus";
@@ -18,13 +17,8 @@ namespace Stratis.Sidechains.Networks.CirrusV2
         /// <summary> The default name used for the federated peg configuration file. </summary>
         private const string NetworkDefaultConfigFilename = "cirrus.conf";
 
-        public PubKey SigningContractPubKey { get; }
-
         internal CirrusTest()
         {
-            // TODO: Replace with real secret key.
-            this.SigningContractPubKey = new Mnemonic("lava frown leave wedding virtual ghost sibling able mammal liar wide wisdom").DeriveExtKey().PrivateKey.PubKey;
-
             this.Name = nameof(CirrusTest);
             this.CoinTicker = "TCRS";
             this.Magic = 0x522357B;
@@ -100,7 +94,7 @@ namespace Stratis.Sidechains.Networks.CirrusV2
                 bip34Hash: new uint256("0x000000000000024b89b42a942fe0d9fea3bb44ab7bd1b19115dd6a759c0808b8"),
                 ruleChangeActivationThreshold: 1916, // 95% of 2016
                 minerConfirmationWindow: 2016, // nPowTargetTimespan / nPowTargetSpacing
-                maxReorgLength: 0, // No max reorg limit on PoA networks.
+                maxReorgLength: 240, // 2 loops of PoA members.
                 defaultAssumeValid: null,
                 maxMoney: Money.Coins(20_000_000),
                 coinbaseMaturity: 1,


### PR DESCRIPTION
Hey @noescape00 this is setting up a network that will potentially be used for the real Cirrus. 

Do you have any strong ideas about the max reorg for this network? I picked 240 using the heuristic of roughly 2 loops of the PoA members. Let me know what you're thinking