### PR TITLE
Re-introduce skipped test Notify_Completes_StartHashNotOnChain

### DIFF
--- a/src/Stratis.Bitcoin.Features.Notifications.Tests/BlockNotificationTest.cs
+++ b/src/Stratis.Bitcoin.Features.Notifications.Tests/BlockNotificationTest.cs
@@ -50,7 +50,7 @@ namespace Stratis.Bitcoin.Features.Notifications.Tests
         /// Tests that <see cref="BlockNotification.Notify(System.Threading.CancellationToken)"/> exits due
         /// to <see cref="BlockNotification.StartHash"/> not being on the chain and no blocks were signaled.
         /// </summary>
-        [Fact(Skip = RevisitWhenBlockNotificationFixed)]
+        [Fact]
         public void Notify_Completes_StartHashNotOnChain()
         {
             var startBlockId = new uint256(156);


### PR DESCRIPTION
Re-introduces the skipped test `Notify_Completes_StartHashNotOnChain`.