### PR TITLE
[Wallet] Renamed SpendableAmount to GetUnspentAmount to avoid confusion

### DIFF
--- a/src/Stratis.Bitcoin.Features.SmartContracts/ReflectionExecutor/Controllers/SmartContractsController.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts/ReflectionExecutor/Controllers/SmartContractsController.cs
@@ -455,7 +455,7 @@ namespace Stratis.Bitcoin.Features.SmartContracts.ReflectionExecutor.Controllers
                 result.Add(new
                 {
                     grouping.Key.Address,
-                    Sum = grouping.Sum(x => x.Transaction.SpendableAmount(false))
+                    Sum = grouping.Sum(x => x.Transaction.GetUnspentAmount(false))
                 });
             }
             

--- a/src/Stratis.Bitcoin.Features.SmartContracts/Wallet/SmartContractWalletController.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts/Wallet/SmartContractWalletController.cs
@@ -59,7 +59,7 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Wallet
             return this.walletManager
                 .GetSpendableTransactionsInWallet(walletName)
                 .GroupBy(x => x.Address)
-                .Where(grouping => grouping.Sum(x => x.Transaction.SpendableAmount(true)) > 0)
+                .Where(grouping => grouping.Sum(x => x.Transaction.GetUnspentAmount(true)) > 0)
                 .Select(grouping => grouping.Key);
         }
 

--- a/src/Stratis.Bitcoin.Features.Wallet.Tests/TransactionDataTest.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet.Tests/TransactionDataTest.cs
@@ -28,7 +28,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
         }
 
         [Fact]
-        public void IsSpendableWithTransactionHavingSpendingDetailsReturnsFalse()
+        public void IsSpentWithTransactionHavingSpendingDetailsReturnsTrue()
         {
             var transaction = new TransactionData
             {
@@ -39,7 +39,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
         }
 
         [Fact]
-        public void IsSpendableWithTransactionHavingNoSpendingDetailsReturnsTrue()
+        public void IsSpentWithTransactionHavingNoSpendingDetailsReturnsFalse()
         {
             var transaction = new TransactionData
             {
@@ -50,7 +50,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
         }
 
         [Fact]
-        public void SpendableAmountNotConfirmedOnlyGivenNoSpendingDetailsReturnsTransactionAmount()
+        public void UnspentAmountNotConfirmedOnlyGivenNoSpendingDetailsReturnsTransactionAmount()
         {
             var transaction = new TransactionData
             {
@@ -58,13 +58,13 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
                 Amount = new Money(15)
             };
 
-            Money result = transaction.SpendableAmount(false);
+            Money result = transaction.GetUnspentAmount(false);
 
             Assert.Equal(new Money(15), result);
         }
 
         [Fact]
-        public void SpendableAmountNotConfirmedOnlyGivenBeingConfirmedAndSpentConfirmedReturnsZero()
+        public void UnspentAmountNotConfirmedOnlyGivenBeingConfirmedAndSpentConfirmedReturnsZero()
         {
             var transaction = new TransactionData
             {
@@ -73,13 +73,13 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
                 BlockHeight = 15
             };
 
-            Money result = transaction.SpendableAmount(false);
+            Money result = transaction.GetUnspentAmount(false);
 
             Assert.Equal(Money.Zero, result);
         }
 
         [Fact]
-        public void SpendableAmountNotConfirmedOnlyGivenBeingConfirmedAndSpentUnconfirmedReturnsZero()
+        public void UnspentAmountNotConfirmedOnlyGivenBeingConfirmedAndSpentUnconfirmedReturnsZero()
         {
             var transaction = new TransactionData
             {
@@ -88,13 +88,13 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
                 BlockHeight = 15
             };
 
-            Money result = transaction.SpendableAmount(false);
+            Money result = transaction.GetUnspentAmount(false);
 
             Assert.Equal(Money.Zero, result);
         }
 
         [Fact]
-        public void SpendableAmountConfirmedOnlyGivenBeingConfirmedAndSpentUnconfirmedReturnsZero()
+        public void UnspentAmountConfirmedOnlyGivenBeingConfirmedAndSpentUnconfirmedReturnsZero()
         {
             var transaction = new TransactionData
             {
@@ -103,13 +103,13 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
                 BlockHeight = 15
             };
 
-            Money result = transaction.SpendableAmount(true);
+            Money result = transaction.GetUnspentAmount(true);
 
             Assert.Equal(Money.Zero, result);
         }
 
         [Fact]
-        public void SpendableAmountNotConfirmedOnlyGivenBeingUnConfirmedAndSpentUnconfirmedReturnsZero()
+        public void UnspentAmountNotConfirmedOnlyGivenBeingUnConfirmedAndSpentUnconfirmedReturnsZero()
         {
             var transaction = new TransactionData
             {
@@ -117,26 +117,26 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
                 Amount = new Money(15),
             };
 
-            Money result = transaction.SpendableAmount(false);
+            Money result = transaction.GetUnspentAmount(false);
 
             Assert.Equal(Money.Zero, result);
         }
 
         [Fact]
-        public void SpendableAmountConfirmedOnlyGivenNoSpendingDetailsReturnsZero()
+        public void UnspentAmountConfirmedOnlyGivenNoSpendingDetailsReturnsZero()
         {
             var transaction = new TransactionData
             {
                 SpendingDetails = null
             };
 
-            Money result = transaction.SpendableAmount(true);
+            Money result = transaction.GetUnspentAmount(true);
 
             Assert.Equal(Money.Zero, result);
         }
 
         [Fact]
-        public void SpendableAmountConfirmedOnlyGivenBeingConfirmedAndSpentConfirmedReturnsZero()
+        public void UnspentAmountConfirmedOnlyGivenBeingConfirmedAndSpentConfirmedReturnsZero()
         {
             var transaction = new TransactionData
             {
@@ -145,13 +145,13 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
                 BlockHeight = 15
             };
 
-            Money result = transaction.SpendableAmount(true);
+            Money result = transaction.GetUnspentAmount(true);
 
             Assert.Equal(Money.Zero, result);
         }
 
         [Fact]
-        public void SpendableAmountConfirmedOnlyGivenBeingUnConfirmedAndSpentUnconfirmedReturnsZero()
+        public void UnspentAmountConfirmedOnlyGivenBeingUnConfirmedAndSpentUnconfirmedReturnsZero()
         {
             var transaction = new TransactionData
             {
@@ -159,13 +159,13 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
                 Amount = new Money(15),
             };
 
-            Money result = transaction.SpendableAmount(true);
+            Money result = transaction.GetUnspentAmount(true);
 
             Assert.Equal(Money.Zero, result);
         }
 
         [Fact]
-        public void SpendableAmountConfirmedOnlyGivenSpendableAndConfirmedReturnsAmount()
+        public void UnspentAmountConfirmedOnlyGivenSpendableAndConfirmedReturnsAmount()
         {
             var transaction = new TransactionData
             {
@@ -174,7 +174,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
                 BlockHeight = 15
             };
 
-            Money result = transaction.SpendableAmount(true);
+            Money result = transaction.GetUnspentAmount(true);
 
             Assert.Equal(new Money(15), result);
         }

--- a/src/Stratis.Bitcoin.Features.Wallet/Wallet.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Wallet.cs
@@ -308,7 +308,7 @@ namespace Stratis.Bitcoin.Features.Wallet
 
             // Get a list of all the inputs spent in this transaction.
             List<TransactionData> inputsSpentInTransaction = allTransactions.Where(t => t.SpendingDetails?.TransactionId == transactionId).ToList();
-            
+
             if (!inputsSpentInTransaction.Any())
             {
                 throw new WalletException("Not a sent transaction");
@@ -319,7 +319,7 @@ namespace Stratis.Bitcoin.Features.Wallet
 
             // The change is the output paid into one of our addresses. We make sure to exclude the output received to one of
             // our addresses if this transaction is self-sent.
-            IEnumerable<TransactionData> changeOutput = allTransactions.Where(t => t.Id == transactionId && spendingTransaction.Payments.All(p => p.OutputIndex != t.Index)).ToList(); 
+            IEnumerable<TransactionData> changeOutput = allTransactions.Where(t => t.Id == transactionId && spendingTransaction.Payments.All(p => p.OutputIndex != t.Index)).ToList();
 
             Money inputsAmount = new Money(inputsSpentInTransaction.Sum(i => i.Amount));
             Money outputsAmount = new Money(spendingTransaction.Payments.Sum(p => p.Amount) + changeOutput.Sum(c => c.Amount));
@@ -670,8 +670,8 @@ namespace Stratis.Bitcoin.Features.Wallet
             List<TransactionData> allTransactions = this.ExternalAddresses.SelectMany(a => a.Transactions)
                 .Concat(this.InternalAddresses.SelectMany(i => i.Transactions)).ToList();
 
-            long confirmed = allTransactions.Sum(t => t.SpendableAmount(true));
-            long total = allTransactions.Sum(t => t.SpendableAmount(false));
+            long confirmed = allTransactions.Sum(t => t.GetUnspentAmount(true));
+            long total = allTransactions.Sum(t => t.GetUnspentAmount(false));
 
             return (confirmed, total - confirmed);
         }
@@ -898,8 +898,8 @@ namespace Stratis.Bitcoin.Features.Wallet
         {
             List<TransactionData> allTransactions = this.Transactions.ToList();
 
-            long confirmed = allTransactions.Sum(t => t.SpendableAmount(true));
-            long total = allTransactions.Sum(t => t.SpendableAmount(false));
+            long confirmed = allTransactions.Sum(t => t.GetUnspentAmount(true));
+            long total = allTransactions.Sum(t => t.GetUnspentAmount(false));
 
             return (confirmed, total - confirmed);
         }
@@ -1029,7 +1029,7 @@ namespace Stratis.Bitcoin.Features.Wallet
         /// <param name="confirmedOnly">A value indicating whether we only want confirmed amount.</param>
         /// <returns>The total amount that has not been spent.</returns>
         [NoTrace]
-        public Money SpendableAmount(bool confirmedOnly)
+        public Money GetUnspentAmount(bool confirmedOnly)
         {
             // The spendable balance is 0 if the output is spent or it needs to be confirmed to be considered.
             if (this.IsSpent() || (confirmedOnly && !this.IsConfirmed()))


### PR DESCRIPTION
Gave a new name to this method as the previous name implied that the method returns amount that is spendable, but in reality the method returns the amount that has not yet been spent.
The amount that has not been spent is not necessarily spendable so the method was renamed to avoid confusion.