### PR TITLE
[Features] Added support for state in features

### DIFF
--- a/src/Stratis.Bitcoin.IntegrationTests/API/ApiSteps.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/API/ApiSteps.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
@@ -463,14 +464,18 @@ namespace Stratis.Bitcoin.IntegrationTests.API
             statusResponse.ProtocolVersion.Should().Be((uint)(statusNode.Settings.ProtocolVersion));
             statusResponse.RelayFee.Should().Be(statusNode.Settings.MinRelayTxFeeRate.FeePerK.ToUnit(MoneyUnit.BTC));
             statusResponse.DataDirectoryPath.Should().Be(statusNode.Settings.DataDir);
-            statusResponse.EnabledFeatures.Should().Contain("Stratis.Bitcoin.Base.BaseFeature");
-            statusResponse.EnabledFeatures.Should().Contain("Stratis.Bitcoin.Features.Api.ApiFeature");
-            statusResponse.EnabledFeatures.Should().Contain("Stratis.Bitcoin.Features.BlockStore.BlockStoreFeature");
-            statusResponse.EnabledFeatures.Should().Contain("Stratis.Bitcoin.Features.Consensus.PowConsensusFeature");
-            statusResponse.EnabledFeatures.Should().Contain("Stratis.Bitcoin.Features.MemoryPool.MempoolFeature");
-            statusResponse.EnabledFeatures.Should().Contain("Stratis.Bitcoin.Features.Miner.MiningFeature");
-            statusResponse.EnabledFeatures.Should().Contain("Stratis.Bitcoin.Features.RPC.RPCFeature");
-            statusResponse.EnabledFeatures.Should().Contain("Stratis.Bitcoin.Features.Wallet.WalletFeature");
+
+            List<string> featuresNamespaces = statusResponse.FeaturesData.Select(f => f.Namespace).ToList();
+            featuresNamespaces.Should().Contain("Stratis.Bitcoin.Base.BaseFeature");
+            featuresNamespaces.Should().Contain("Stratis.Bitcoin.Features.Api.ApiFeature");
+            featuresNamespaces.Should().Contain("Stratis.Bitcoin.Features.BlockStore.BlockStoreFeature");
+            featuresNamespaces.Should().Contain("Stratis.Bitcoin.Features.Consensus.PowConsensusFeature");
+            featuresNamespaces.Should().Contain("Stratis.Bitcoin.Features.MemoryPool.MempoolFeature");
+            featuresNamespaces.Should().Contain("Stratis.Bitcoin.Features.Miner.MiningFeature");
+            featuresNamespaces.Should().Contain("Stratis.Bitcoin.Features.RPC.RPCFeature");
+            featuresNamespaces.Should().Contain("Stratis.Bitcoin.Features.Wallet.WalletFeature");
+
+            statusResponse.FeaturesData.All(f => f.State == "Initialized").Should().BeTrue();
         }
 
         private void general_information_about_the_wallet_and_node_is_returned()

--- a/src/Stratis.Bitcoin.Tests/Builder/Feature/FeatureCollectionTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Builder/Feature/FeatureCollectionTest.cs
@@ -36,6 +36,8 @@ namespace Stratis.Bitcoin.Tests.Builder.Feature
             /// <inheritdoc />
             public bool InitializeBeforeBase { get; set; }
 
+            public string State { get; set; }
+
             public void LoadConfiguration()
             {
                 throw new NotImplementedException();

--- a/src/Stratis.Bitcoin.Tests/Builder/Feature/FeatureRegistrationTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Builder/Feature/FeatureRegistrationTest.cs
@@ -107,6 +107,8 @@ namespace Stratis.Bitcoin.Tests.Builder.Feature
         {
             public bool InitializeBeforeBase { get; set; }
 
+            public string State { get; set; }
+
             public void LoadConfiguration()
             {
                 throw new NotImplementedException();

--- a/src/Stratis.Bitcoin.Tests/Builder/Feature/FeaturesDependencyCheckingTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Builder/Feature/FeaturesDependencyCheckingTest.cs
@@ -24,6 +24,8 @@ namespace Stratis.Bitcoin.Tests.Builder.Feature
             /// <inheritdoc />
             public bool InitializeBeforeBase { get; set; }
 
+            public string State { get; set; }
+
             public void LoadConfiguration()
             {
                 throw new NotImplementedException();

--- a/src/Stratis.Bitcoin.Tests/Builder/Feature/FeaturesExtensionsTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Builder/Feature/FeaturesExtensionsTest.cs
@@ -22,6 +22,8 @@ namespace Stratis.Bitcoin.Tests.Builder.Feature
             /// <inheritdoc />
             public bool InitializeBeforeBase { get; set; }
 
+            public string State { get; set; }
+
             public void LoadConfiguration()
             {
                 throw new NotImplementedException();
@@ -52,6 +54,8 @@ namespace Stratis.Bitcoin.Tests.Builder.Feature
         {
             /// <inheritdoc />
             public bool InitializeBeforeBase { get; set; }
+
+            public string State { get; set; }
 
             public void LoadConfiguration()
             {

--- a/src/Stratis.Bitcoin.Tests/Builder/FullNodeServiceProviderTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Builder/FullNodeServiceProviderTest.cs
@@ -59,6 +59,8 @@ namespace Stratis.Bitcoin.Tests.Builder
             /// <inheritdoc />
             public bool InitializeBeforeBase { get; set; }
 
+            public string State { get; set; }
+
             public void LoadConfiguration()
             {
                 throw new NotImplementedException();
@@ -86,6 +88,8 @@ namespace Stratis.Bitcoin.Tests.Builder
         {
             /// <inheritdoc />
             public bool InitializeBeforeBase { get; set; }
+
+            public string State { get; set; }
 
             public void LoadConfiguration()
             {

--- a/src/Stratis.Bitcoin/Builder/Feature/FullNodeFeature.cs
+++ b/src/Stratis.Bitcoin/Builder/Feature/FullNodeFeature.cs
@@ -14,6 +14,11 @@ namespace Stratis.Bitcoin.Builder.Feature
         bool InitializeBeforeBase { get; set; }
 
         /// <summary>
+        /// The state in which the feature currently is.
+        /// </summary>
+        string State { get; set; }
+
+        /// <summary>
         /// Triggered when the FullNode host has fully started.
         /// </summary>
         Task InitializeAsync();
@@ -40,6 +45,9 @@ namespace Stratis.Bitcoin.Builder.Feature
     {
         /// <inheritdoc />
         public bool InitializeBeforeBase { get; set; }
+
+        /// <inheritdoc />
+        public string State { get; set; }
 
         /// <inheritdoc />
         public abstract Task InitializeAsync();

--- a/src/Stratis.Bitcoin/Builder/FullNodeFeatureExecutor.cs
+++ b/src/Stratis.Bitcoin/Builder/FullNodeFeatureExecutor.cs
@@ -49,7 +49,13 @@ namespace Stratis.Bitcoin.Builder
             try
             {
                 this.Execute(service => service.ValidateDependencies(this.node.Services));
-                this.Execute(service => service.InitializeAsync().GetAwaiter().GetResult());
+
+                this.Execute(service =>
+                {
+                    service.State = "Initializing";
+                    service.InitializeAsync().GetAwaiter().GetResult();
+                    service.State = "Initialized";
+                });
             }
             catch
             {
@@ -64,7 +70,12 @@ namespace Stratis.Bitcoin.Builder
         {
             try
             {
-                this.Execute(feature => feature.Dispose(), true);
+                this.Execute(feature =>
+                {
+                    feature.State = "Disposing";
+                    feature.Dispose();
+                    feature.State = "Disposed";
+                }, true);
             }
             catch
             {

--- a/src/Stratis.Bitcoin/Controllers/Models/StatusModel.cs
+++ b/src/Stratis.Bitcoin/Controllers/Models/StatusModel.cs
@@ -17,7 +17,7 @@ namespace Stratis.Bitcoin.Controllers.Models
         {
             this.InboundPeers = new List<ConnectedPeerModel>();
             this.OutboundPeers = new List<ConnectedPeerModel>();
-            this.EnabledFeatures = new List<string>();
+            this.FeaturesData = new List<FeatureData>();
         }
 
         /// <summary>The node's user agent that will be shared with peers in the version handshake.</summary>
@@ -49,7 +49,7 @@ namespace Stratis.Bitcoin.Controllers.Models
         public List<ConnectedPeerModel> OutboundPeers { get; set; }
 
         /// <summary>A collection of all the features enabled by this node.</summary>
-        public List<string> EnabledFeatures { get; set; }
+        public List<FeatureData> FeaturesData { get; set; }
 
         /// <summary>The path to the directory where the data is saved.</summary>
         public string DataDirectoryPath { get; set; }
@@ -71,6 +71,22 @@ namespace Stratis.Bitcoin.Controllers.Models
         public decimal RelayFee { get; set; }
 
         /// <summary>Returns the status of the node.</summary>
+        public string State { get; set; }
+    }
+
+    /// <summary>
+    /// Class containing some details about the features loaded by this node.
+    /// </summary>
+    public class FeatureData
+    {
+        /// <summary>
+        /// The namespace of the feature.
+        /// </summary>
+        public string Namespace { get; set; }
+
+        /// <summary>
+        /// The state in which the feature currently is.
+        /// </summary>
         public string State { get; set; }
     }
 }

--- a/src/Stratis.Bitcoin/Controllers/NodeController.cs
+++ b/src/Stratis.Bitcoin/Controllers/NodeController.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Net;
@@ -138,7 +139,11 @@ namespace Stratis.Bitcoin.Controllers
             // Add the list of features that are enabled.
             foreach (IFullNodeFeature feature in this.fullNode.Services.Features)
             {
-                model.EnabledFeatures.Add(feature.GetType().ToString());
+                model.FeaturesData.Add(new FeatureData
+                {
+                    Namespace = feature.GetType().ToString(),
+                    State = feature.State
+                });
             }
 
             // Include BlockStore Height if enabled


### PR DESCRIPTION
By calling `http://localhost:38221/api/node/status`, the user can see the state of the node but not the state of each individual feature.
We're sometimes interested in knowing the state of each feature.
In particular, when the consensus is rewinding or the wallet is loading, it'd be useful for Stratis Core to know not to call endpoints on these components.

Here is an example showing what would the response from `/api/node/status` called during node startup look like:
```
{
  "agent": "StratisNode",
  "version": "3.0.4.0",
  "network": "StratisTest",
  "coinTicker": "TSTRAT",
  "processId": 33936,
  "consensusHeight": 809658,
  "blockStoreHeight": 809658,
  "inboundPeers": [],
  "outboundPeers": [],
  "featuresData": [
    {
      "namespace": "Stratis.Bitcoin.Base.BaseFeature",
      "state": "Initialized"
    },
    {
      "namespace": "Stratis.Bitcoin.Features.BlockStore.BlockStoreFeature",
      "state": "Initialized"
    },
    {
      "namespace": "Stratis.Bitcoin.Features.Consensus.PosConsensusFeature",
      "state": "Initialized"
    },
    {
      "namespace": "Stratis.Bitcoin.Features.MemoryPool.MempoolFeature",
      "state": "Initialized"
    },
    {
      "namespace": "Stratis.Bitcoin.Features.ColdStaking.ColdStakingFeature",
      "state": "Initializing"
    },
    {
      "namespace": "Stratis.Bitcoin.Features.Miner.MiningFeature",
      "state": null
    },
    {
      "namespace": "Stratis.Bitcoin.Features.Api.ApiFeature",
      "state": "Initialized"
    },
    {
      "namespace": "Stratis.Bitcoin.Features.Apps.AppsFeature",
      "state": null
    },
    {
      "namespace": "Stratis.Bitcoin.Features.RPC.RPCFeature",
      "state": null
    }
  ],
  "dataDirectoryPath": "C:\\Users\\jerem\\AppData\\Roaming\\StratisNode\\stratis\\StratisTest",
  "runningTime": "00:00:31.7508920",
  "difficulty": 702394.6374745105,
  "protocolVersion": 70012,
  "testnet": true,
  "relayFee": 0.0001,
  "state": "Starting"
}
```