### PR TITLE
Improve error message when connecting to banned peer using Swagger API

### DIFF
--- a/src/Stratis.Bitcoin.Tests/Connection/ConnectionManagerControllerTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Connection/ConnectionManagerControllerTest.cs
@@ -15,15 +15,17 @@ namespace Stratis.Bitcoin.Tests.Controllers
         private readonly Mock<IConnectionManager> connectionManager;
         private ConnectionManagerController controller;
         private readonly Mock<ILoggerFactory> mockLoggerFactory;
+        private readonly Mock<IPeerBanning> peerBanning;
 
         public ConnectionManagerControllerTest()
         {
             this.connectionManager = new Mock<IConnectionManager>();
+            this.peerBanning = new Mock<IPeerBanning>();
             this.mockLoggerFactory = new Mock<ILoggerFactory>();
             this.mockLoggerFactory.Setup(i => i.CreateLogger(It.IsAny<string>())).Returns(new Mock<ILogger>().Object);
             this.connectionManager.Setup(i => i.Network)
                 .Returns(KnownNetworks.StratisTest);
-            this.controller = new ConnectionManagerController(this.connectionManager.Object, this.LoggerFactory.Object);
+            this.controller = new ConnectionManagerController(this.connectionManager.Object, this.LoggerFactory.Object, this.peerBanning.Object);
         }
 
         [Fact]

--- a/src/Stratis.Bitcoin.Tests/Connection/ConnectionManagerTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Connection/ConnectionManagerTest.cs
@@ -19,15 +19,17 @@ namespace Stratis.Bitcoin.Tests.Connection
         private readonly Mock<IConnectionManager> connectionManager;
         private ConnectionManagerController controller;
         private readonly Mock<ILoggerFactory> mockLoggerFactory;
+        private readonly Mock<IPeerBanning> peerBanning;
 
         public ConnectionManagerSettingsTest()
         {
             this.connectionManager = new Mock<IConnectionManager>();
+            this.peerBanning = new Mock<IPeerBanning>();
             this.mockLoggerFactory = new Mock<ILoggerFactory>();
             this.mockLoggerFactory.Setup(i => i.CreateLogger(It.IsAny<string>())).Returns(new Mock<ILogger>().Object);
             this.connectionManager.Setup(i => i.Network)
                 .Returns(KnownNetworks.StratisTest);
-            this.controller = new ConnectionManagerController(this.connectionManager.Object, this.LoggerFactory.Object);
+            this.controller = new ConnectionManagerController(this.connectionManager.Object, this.LoggerFactory.Object, this.peerBanning.Object);
         }
 
         [Fact]

--- a/src/Stratis.Bitcoin/Connection/ConnectionManager.cs
+++ b/src/Stratis.Bitcoin/Connection/ConnectionManager.cs
@@ -87,8 +87,6 @@ namespace Stratis.Bitcoin.Connection
         /// <summary>Traffic statistics from peers that have been disconnected.</summary>
         private readonly PerformanceCounter disconnectedPerfCounter;
 
-        public IPeerBanning PeerBanning { get; private set; }
-
         public ConnectionManager(IDateTimeProvider dateTimeProvider,
             ILoggerFactory loggerFactory,
             Network network,
@@ -118,7 +116,6 @@ namespace Stratis.Bitcoin.Connection
             this.ConnectionSettings = connectionSettings;
             this.networkPeerDisposer = new NetworkPeerDisposer(this.loggerFactory);
             this.Servers = new List<NetworkPeerServer>();
-            this.PeerBanning = new PeerBanning(this, loggerFactory, dateTimeProvider, peerAddressManager);
 
             this.Parameters = parameters;
             this.Parameters.ConnectCancellation = this.nodeLifetime.ApplicationStopping;
@@ -407,9 +404,6 @@ namespace Stratis.Bitcoin.Connection
         {
             Guard.NotNull(ipEndpoint, nameof(ipEndpoint));
 
-            if (this.PeerBanning.IsBanned(ipEndpoint))
-                throw new InvalidOperationException("Can't perform 'addnode' for a banned peer.");
-
             this.peerAddressManager.AddPeer(ipEndpoint.MapToIpv6(), IPAddress.Loopback);
 
             if (!this.ConnectionSettings.AddNode.Any(p => p.Match(ipEndpoint)))
@@ -448,9 +442,6 @@ namespace Stratis.Bitcoin.Connection
 
         public async Task<INetworkPeer> ConnectAsync(IPEndPoint ipEndpoint)
         {
-            if (this.PeerBanning.IsBanned(ipEndpoint))
-                throw new InvalidOperationException("Can't connect to a banned peer.");
-
             var existingConnection = this.connectedPeers.FirstOrDefault(connectedPeer => connectedPeer.PeerEndPoint.Match(ipEndpoint));
 
             if (existingConnection != null)


### PR DESCRIPTION
This PR provides the following error via Swagger:

```
{
  "errors": [
    {
      "status": 400,
      "message": "Can't perform 'addnode' for a banned peer.",
      "description": "System.InvalidOperationException: Can't perform 'addnode' for a banned peer.\r\n   at Stratis.Bitcoin.Connection.ConnectionManager.AddNodeAddress(IPEndPoint ipEndpoint) in E:\\Public\\StratisBitcoinFullNode\\src\\Stratis.Bitcoin\\Connection\\ConnectionManager.cs:line 413\r\n   at Stratis.Bitcoin.Connection.ConnectionManagerController.AddNodeRPC(String endpointStr, String command) in E:\\Public\\StratisBitcoinFullNode\\src\\Stratis.Bitcoin\\Connection\\ConnectionManagerController.cs:line 46\r\n   at Stratis.Bitcoin.Connection.ConnectionManagerController.AddNodeAPI(String endpoint, String command) in E:\\Public\\StratisBitcoinFullNode\\src\\Stratis.Bitcoin\\Connection\\ConnectionManagerController.cs:line 81"
    }
  ]
}
```

See https://github.com/stratisproject/StratisBitcoinFullNode/pull/3277.