### PR TITLE
Improve rewind data index to use an OutPoint instead of a string index

### DIFF
--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/CoinViews/RewindDataIndexCacheTest.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/CoinViews/RewindDataIndexCacheTest.cs
@@ -38,7 +38,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.CoinViews
 
             rewindDataIndexCache.Initialize(5, coinViewMock.Object);
 
-            var items = rewindDataIndexCache.GetMemberValue("items") as ConcurrentDictionary<string, int>;
+            var items = rewindDataIndexCache.GetMemberValue("items") as ConcurrentDictionary<OutPoint, int>;
 
             items.Should().HaveCount(10);
             this.CheckCache(items, 5, 1);
@@ -55,7 +55,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.CoinViews
 
             rewindDataIndexCache.Initialize(20, coinViewMock.Object);
 
-            var items = rewindDataIndexCache.GetMemberValue("items") as ConcurrentDictionary<string, int>;
+            var items = rewindDataIndexCache.GetMemberValue("items") as ConcurrentDictionary<OutPoint, int>;
 
             items.Should().HaveCount(22);
             this.CheckCache(items, 20, 10);
@@ -72,8 +72,8 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.CoinViews
 
             rewindDataIndexCache.Initialize(20, coinViewMock.Object);
 
-            rewindDataIndexCache.Save(new Dictionary<string, int>() { { $"{ new uint256(21) }-{ 0 }", 21}});
-            var items = rewindDataIndexCache.GetMemberValue("items") as ConcurrentDictionary<string, int>;
+            rewindDataIndexCache.Save(new Dictionary<OutPoint, int>() { { new OutPoint(new uint256(21),0 ), 21}});
+            var items = rewindDataIndexCache.GetMemberValue("items") as ConcurrentDictionary<OutPoint, int>;
 
             items.Should().HaveCount(23);
             this.CheckCache(items, 21, 10);
@@ -91,7 +91,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.CoinViews
             rewindDataIndexCache.Initialize(20, coinViewMock.Object);
 
             rewindDataIndexCache.Flush(15);
-            var items = rewindDataIndexCache.GetMemberValue("items") as ConcurrentDictionary<string, int>;
+            var items = rewindDataIndexCache.GetMemberValue("items") as ConcurrentDictionary<OutPoint, int>;
 
             items.Should().HaveCount(12);
             this.CheckCache(items, 15, 9);
@@ -109,16 +109,16 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.CoinViews
             rewindDataIndexCache.Initialize(20, coinViewMock.Object);
 
             rewindDataIndexCache.Remove(19, coinViewMock.Object);
-            var items = rewindDataIndexCache.GetMemberValue("items") as ConcurrentDictionary<string, int>;
+            var items = rewindDataIndexCache.GetMemberValue("items") as ConcurrentDictionary<OutPoint, int>;
 
             items.Should().HaveCount(22);
             this.CheckCache(items, 19, 9);
         }
 
 
-        private void CheckCache(ConcurrentDictionary<string, int> items, int tip, int bottom)
+        private void CheckCache(ConcurrentDictionary<OutPoint, int> items, int tip, int bottom)
         {
-            foreach (KeyValuePair<string, int> keyValuePair in items)
+            foreach (KeyValuePair<OutPoint, int> keyValuePair in items)
             {
                 Assert.True(keyValuePair.Value <= tip && keyValuePair.Value >= bottom);
             }

--- a/src/Stratis.Bitcoin.Features.Consensus/CoinViews/CachedCoinView.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/CoinViews/CachedCoinView.cs
@@ -376,7 +376,7 @@ namespace Stratis.Bitcoin.Features.Consensus.CoinViews
                 this.blockHeight = height;
                 this.blockHash = nextBlockHash;
                 var rewindData = new RewindData(oldBlockHash);
-                var indexItems = new Dictionary<string, int>();
+                var indexItems = new Dictionary<OutPoint, int>();
 
                 foreach (UnspentOutputs unspent in unspentOutputs)
                 {
@@ -440,7 +440,7 @@ namespace Stratis.Bitcoin.Features.Consensus.CoinViews
                     {
                         for (int i = 0; i < unspent.Outputs.Length; i++)
                         {
-                            string key = $"{unspent.TransactionId}-{i}";
+                            var key = new OutPoint(unspent.TransactionId, i);
                             indexItems[key] = this.blockHeight;
                         }
                     }

--- a/src/Stratis.Bitcoin.Features.Consensus/ProvenBlockHeaders/IRewindDataIndexCache.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/ProvenBlockHeaders/IRewindDataIndexCache.cs
@@ -37,7 +37,7 @@ namespace Stratis.Bitcoin.Features.Consensus.ProvenBlockHeaders
         /// Saves rewind index data to cache.
         /// </summary>
         /// <param name="indexData">The rewind index data, where key is TxId + N and value is a height of the rewind data.</param>
-        void Save(Dictionary<string, int> indexData);
+        void Save(Dictionary<OutPoint, int> indexData);
 
         /// <summary>
         /// Gets rewind data index from the cache (or if not found from the disk) by tx id and output index.

--- a/src/Stratis.Bitcoin.Features.Consensus/ProvenBlockHeaders/RewindDataIndexCache.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/ProvenBlockHeaders/RewindDataIndexCache.cs
@@ -18,7 +18,7 @@ namespace Stratis.Bitcoin.Features.Consensus.ProvenBlockHeaders
         /// Internal cache for rewind data index. Key is a TxId + N (N is an index of output in a transaction)
         /// and value is a rewind data index.
         /// </summary>
-        private readonly ConcurrentDictionary<string, int> items;
+        private readonly ConcurrentDictionary<OutPoint, int> items;
 
         /// <summary>
         /// Number of blocks to keep in cache after the flush.
@@ -37,7 +37,7 @@ namespace Stratis.Bitcoin.Features.Consensus.ProvenBlockHeaders
 
             this.network = network;
 
-            this.items = new ConcurrentDictionary<string, int>();
+            this.items = new ConcurrentDictionary<OutPoint, int>();
 
             this.performanceCounter = new BackendPerformanceCounter(dateTimeProvider);
         }
@@ -81,14 +81,14 @@ namespace Stratis.Bitcoin.Features.Consensus.ProvenBlockHeaders
             {
                 for (int outputIndex = 0; outputIndex < unspent.Outputs.Length; outputIndex++)
                 {
-                    string key = $"{unspent.TransactionId}-{outputIndex}";
+                    var key = new OutPoint(unspent.TransactionId,outputIndex);
                     this.items[key] = rewindHeight;
                 }
             }
         }
 
         /// <inheritdoc />
-        public async void Remove(int tipHeight, ICoinView coinView)
+        public void Remove(int tipHeight, ICoinView coinView)
         {
             this.Flush(tipHeight);
 
@@ -99,11 +99,11 @@ namespace Stratis.Bitcoin.Features.Consensus.ProvenBlockHeaders
         }
 
         /// <inheritdoc />
-        public void Save(Dictionary<string, int> indexData)
+        public void Save(Dictionary<OutPoint, int> indexData)
         {
             using (new StopwatchDisposable(o => this.performanceCounter.AddInsertTime(o)))
             {
-                foreach (KeyValuePair<string, int> indexRecord in indexData)
+                foreach (KeyValuePair<OutPoint, int> indexRecord in indexData)
                 {
                     this.items[indexRecord.Key] = indexRecord.Value;
                 }
@@ -115,8 +115,8 @@ namespace Stratis.Bitcoin.Features.Consensus.ProvenBlockHeaders
         {
             int heightToKeepItemsTo = tipHeight > this.numberOfBlocksToKeep ? tipHeight - this.numberOfBlocksToKeep : 1; ;
 
-            List<KeyValuePair<string, int>> listOfItems = this.items.ToList();
-            foreach (KeyValuePair<string, int> item in listOfItems)
+            List<KeyValuePair<OutPoint, int>> listOfItems = this.items.ToList();
+            foreach (KeyValuePair<OutPoint, int> item in listOfItems)
             {
                 if ((item.Value < heightToKeepItemsTo) || (item.Value > tipHeight))
                 {
@@ -128,7 +128,7 @@ namespace Stratis.Bitcoin.Features.Consensus.ProvenBlockHeaders
         /// <inheritdoc />
         public int? Get(uint256 transactionId, int transactionOutputIndex)
         {
-            string key = $"{transactionId}-{transactionOutputIndex}";
+            var key = new OutPoint(transactionId, transactionOutputIndex);
 
             if (this.items.TryGetValue(key, out int rewindDataIndex))
                 return rewindDataIndex;


### PR DESCRIPTION
This is a fix on the efficiency or rewind data index reported in this PR.
https://github.com/stratisproject/StratisBitcoinFullNode/pull/3383