### PR TITLE
[Logs] Added an endpoint to get the enabled log rules

### DIFF
--- a/src/Stratis.Bitcoin.IntegrationTests/LogLevelsTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/LogLevelsTests.cs
@@ -1,27 +1,19 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
-using Castle.Components.DictionaryAdapter;
-using DBreeze.Utils;
 using FluentAssertions;
 using Flurl;
 using Flurl.Http;
 using NBitcoin;
-using NBitcoin.DataEncoders;
 using Newtonsoft.Json;
 using NLog;
 using NLog.Config;
 using NLog.Targets;
-using NSubstitute;
+using NLog.Targets.Wrappers;
 using Stratis.Bitcoin.Controllers.Models;
-using Stratis.Bitcoin.Features.BlockStore.Models;
-using Stratis.Bitcoin.Features.Wallet.Models;
-using Stratis.Bitcoin.IntegrationTests.Common;
-using Stratis.Bitcoin.IntegrationTests.Common.ReadyData;
 using Stratis.Bitcoin.IntegrationTests.Common.EnvironmentMockUpHelpers;
 using Stratis.Bitcoin.Networks;
 using Stratis.Bitcoin.Utilities.JsonErrors;
@@ -54,9 +46,9 @@ namespace Stratis.Bitcoin.IntegrationTests
         private void ConfigLogManager()
         {
             this.rules = LogManager.Configuration.LoggingRules;
-            this.rules.Add(new LoggingRule("logging1", LogLevel.Info, new FileTarget("file1") { FileName = "file1.txt" }));
-            this.rules.Add(new LoggingRule("logging2", LogLevel.Fatal, new FileTarget("file2") { FileName = "file2.txt" }));
-            this.rules.Add(new LoggingRule("logging3", LogLevel.Trace, new FileTarget("file3") { FileName = "file3.txt" }));
+            this.rules.Add(new LoggingRule("logging1", LogLevel.Info, new AsyncTargetWrapper(new FileTarget("file1") { FileName = "file1.txt" })));
+            this.rules.Add(new LoggingRule("logging2", LogLevel.Fatal, new AsyncTargetWrapper(new FileTarget("file2") { FileName = "file2.txt" })));
+            this.rules.Add(new LoggingRule("logging3", LogLevel.Trace, new AsyncTargetWrapper(new FileTarget("file3") { FileName = "file3.txt" })));
         }
 
         [Fact]
@@ -209,6 +201,31 @@ namespace Stratis.Bitcoin.IntegrationTests
                 this.rules.Single(r => r.LoggerNamePattern == ruleName1).Levels.Should().ContainInOrder(new[] { LogLevel.Error, LogLevel.Fatal });
                 this.rules.Single(r => r.LoggerNamePattern == ruleName2).Levels.Should().ContainInOrder(new[] { LogLevel.Error, LogLevel.Fatal });
                 this.rules.Single(r => r.LoggerNamePattern == ruleName3).Levels.Should().ContainInOrder(new[] { LogLevel.Error, LogLevel.Fatal });
+            }
+        }
+
+        [Fact]
+        public async Task GetLogRulesAsync()
+        {
+            string ruleName1 = "logging1";
+            string ruleName2 = "logging2";
+            string ruleName3 = "logging3";
+            
+            using (NodeBuilder builder = NodeBuilder.Create(this))
+            {
+                // Arrange.
+                CoreNode node = builder.CreateStratisPosNode(this.network).Start();
+                this.ConfigLogManager();
+
+                // Act.
+                List<LogRuleModel> rules = await $"http://localhost:{node.ApiPort}/api"
+                    .AppendPathSegment("node/logrules")
+                    .GetJsonAsync<List<LogRuleModel>>();
+
+                // Assert.
+                rules.Should().Contain(r => r.RuleName == ruleName1 && r.LogLevel == "Info" && r.FileName.Contains("file1.txt"));
+                rules.Should().Contain(r => r.RuleName == ruleName2 && r.LogLevel == "Fatal" && r.FileName.Contains("file2.txt"));
+                rules.Should().Contain(r => r.RuleName == ruleName3 && r.LogLevel == "Trace" && r.FileName.Contains("file3.txt"));
             }
         }
     }

--- a/src/Stratis.Bitcoin.IntegrationTests/LogLevelsTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/LogLevelsTests.cs
@@ -226,6 +226,9 @@ namespace Stratis.Bitcoin.IntegrationTests
                 rules.Should().Contain(r => r.RuleName == ruleName1 && r.LogLevel == "Info" && r.FileName.Contains("file1.txt"));
                 rules.Should().Contain(r => r.RuleName == ruleName2 && r.LogLevel == "Fatal" && r.FileName.Contains("file2.txt"));
                 rules.Should().Contain(r => r.RuleName == ruleName3 && r.LogLevel == "Trace" && r.FileName.Contains("file3.txt"));
+
+                // Addtionally, there is always a node.txt file by default.
+                rules.Should().Contain(r => r.FileName.Contains("node.txt"));
             }
         }
     }

--- a/src/Stratis.Bitcoin.IntegrationTests/LogLevelsTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/LogLevelsTests.cs
@@ -223,12 +223,12 @@ namespace Stratis.Bitcoin.IntegrationTests
                     .GetJsonAsync<List<LogRuleModel>>();
 
                 // Assert.
-                rules.Should().Contain(r => r.RuleName == ruleName1 && r.LogLevel == "Info" && r.FileName.Contains("file1.txt"));
-                rules.Should().Contain(r => r.RuleName == ruleName2 && r.LogLevel == "Fatal" && r.FileName.Contains("file2.txt"));
-                rules.Should().Contain(r => r.RuleName == ruleName3 && r.LogLevel == "Trace" && r.FileName.Contains("file3.txt"));
+                rules.Should().Contain(r => r.RuleName == ruleName1 && r.LogLevel == "Info" && r.Filename.Contains("file1.txt"));
+                rules.Should().Contain(r => r.RuleName == ruleName2 && r.LogLevel == "Fatal" && r.Filename.Contains("file2.txt"));
+                rules.Should().Contain(r => r.RuleName == ruleName3 && r.LogLevel == "Trace" && r.Filename.Contains("file3.txt"));
 
                 // Addtionally, there is always a node.txt file by default.
-                rules.Should().Contain(r => r.FileName.Contains("node.txt"));
+                rules.Should().Contain(r => r.Filename.Contains("node.txt"));
             }
         }
     }

--- a/src/Stratis.Bitcoin/Controllers/Models/LogRuleModel.cs
+++ b/src/Stratis.Bitcoin/Controllers/Models/LogRuleModel.cs
@@ -1,4 +1,6 @@
-﻿namespace Stratis.Bitcoin.Controllers.Models
+﻿using Newtonsoft.Json;
+
+namespace Stratis.Bitcoin.Controllers.Models
 {
     /// <summary>
     /// A class representing a log rule as found in NLog.config.
@@ -8,16 +10,19 @@
         /// <summary>
         /// The name of the rule.
         /// </summary>
+        [JsonProperty(PropertyName = "ruleName")]
         public string RuleName { get; set; }
 
         /// <summary>
         /// The log level.
         /// </summary>
+        [JsonProperty(PropertyName = "logLevel")]
         public string LogLevel { get; set; }
 
         /// <summary>
         /// The full path of the log file.
         /// </summary>
-        public string FileName { get; set; }
+        [JsonProperty(PropertyName = "filename", NullValueHandling = NullValueHandling.Ignore)]
+        public string Filename { get; set; }
     }
 }

--- a/src/Stratis.Bitcoin/Controllers/Models/LogRuleModel.cs
+++ b/src/Stratis.Bitcoin/Controllers/Models/LogRuleModel.cs
@@ -1,0 +1,23 @@
+﻿namespace Stratis.Bitcoin.Controllers.Models
+{
+    /// <summary>
+    /// A class representing a log rule as found in NLog.config.
+    /// </summary>
+    public class LogRuleModel
+    {
+        /// <summary>
+        /// The name of the rule.
+        /// </summary>
+        public string RuleName { get; set; }
+
+        /// <summary>
+        /// The log level.
+        /// </summary>
+        public string LogLevel { get; set; }
+
+        /// <summary>
+        /// The full path of the log file.
+        /// </summary>
+        public string FileName { get; set; }
+    }
+}

--- a/src/Stratis.Bitcoin/Controllers/NodeController.cs
+++ b/src/Stratis.Bitcoin/Controllers/NodeController.cs
@@ -496,8 +496,13 @@ namespace Stratis.Bitcoin.Controllers
                 {
                     string filename = string.Empty;
 
+                    if (!rule.Targets.Any())
+                    {
+                        continue;
+                    }
+
                     // Retrieve the full path of the current rule's log file.
-                    if (rule.Targets.Any() && rule.Targets.First().GetType().Name == "AsyncTargetWrapper")
+                    if (rule.Targets.First().GetType().Name == "AsyncTargetWrapper")
                     {
                         WrapperTargetBase wrapper = (WrapperTargetBase) rule.Targets.First();
 
@@ -506,7 +511,7 @@ namespace Stratis.Bitcoin.Controllers
                             filename = ((FileTarget) wrapper.WrappedTarget).FileName.ToString();
                         }
                     }
-                    else if (rule.Targets.Any() && rule.Targets.First().GetType().Name == "FileTarget")
+                    else if (rule.Targets.First().GetType().Name == "FileTarget")
                     {
                         filename = ((FileTarget)rule.Targets.First()).FileName.ToString();
                     }
@@ -515,7 +520,7 @@ namespace Stratis.Bitcoin.Controllers
                     {
                         RuleName = rule.LoggerNamePattern,
                         LogLevel = rule.Levels.First().Name,
-                        FileName = filename
+                        Filename = filename
                     });
                 }
 

--- a/src/Stratis.Bitcoin/Controllers/NodeController.cs
+++ b/src/Stratis.Bitcoin/Controllers/NodeController.cs
@@ -506,6 +506,10 @@ namespace Stratis.Bitcoin.Controllers
                             filename = ((FileTarget) wrapper.WrappedTarget).FileName.ToString();
                         }
                     }
+                    else if (rule.Targets.Any() && rule.Targets.First().GetType().Name == "FileTarget")
+                    {
+                        filename = ((FileTarget)rule.Targets.First()).FileName.ToString();
+                    }
 
                     rules.Add(new LogRuleModel
                     {

--- a/src/Stratis.Bitcoin/Controllers/NodeController.cs
+++ b/src/Stratis.Bitcoin/Controllers/NodeController.cs
@@ -9,6 +9,8 @@ using Microsoft.Extensions.Logging;
 using NBitcoin;
 using NLog;
 using NLog.Config;
+using NLog.Targets;
+using NLog.Targets.Wrappers;
 using Stratis.Bitcoin.Base;
 using Stratis.Bitcoin.Builder.Feature;
 using Stratis.Bitcoin.Configuration;
@@ -22,6 +24,7 @@ using Stratis.Bitcoin.Utilities.JsonErrors;
 using Stratis.Bitcoin.Utilities.ModelStateErrors;
 using ILogger = Microsoft.Extensions.Logging.ILogger;
 using LogLevel = NLog.LogLevel;
+using Target = NBitcoin.Target;
 
 namespace Stratis.Bitcoin.Controllers
 {
@@ -472,6 +475,56 @@ namespace Stratis.Bitcoin.Controllers
         }
 
         /// <summary>
+        /// Get the enabled log rules.
+        /// </summary>
+        /// <returns>A list of log rules.</returns>
+        [HttpGet]
+        [Route("logrules")]
+        public IActionResult GetLogRules()
+        {
+            // Checks the request is valid.
+            if (!this.ModelState.IsValid)
+            {
+                return ModelStateErrors.BuildErrorResponse(this.ModelState);
+            }
+
+            try
+            {
+                var rules = new List<LogRuleModel>();
+
+                foreach (LoggingRule rule in LogManager.Configuration.LoggingRules)
+                {
+                    string filename = string.Empty;
+
+                    // Retrieve the full path of the current rule's log file.
+                    if (rule.Targets.Any() && rule.Targets.First().GetType().Name == "AsyncTargetWrapper")
+                    {
+                        WrapperTargetBase wrapper = (WrapperTargetBase) rule.Targets.First();
+
+                        if (wrapper.WrappedTarget != null && wrapper.WrappedTarget.GetType().Name == "FileTarget")
+                        {
+                            filename = ((FileTarget) wrapper.WrappedTarget).FileName.ToString();
+                        }
+                    }
+
+                    rules.Add(new LogRuleModel
+                    {
+                        RuleName = rule.LoggerNamePattern,
+                        LogLevel = rule.Levels.First().Name,
+                        FileName = filename
+                    });
+                }
+
+                return this.Json(rules);
+            }
+            catch (Exception e)
+            {
+                this.logger.LogError("Exception occurred: {0}", e.ToString());
+                return ErrorHelpers.BuildErrorResponse(HttpStatusCode.BadRequest, e.Message, e.ToString());
+            }
+        }
+
+        /// <summary>
         /// Retrieves a transaction block given a valid hash.
         /// This function is used by other methods in this class and not explicitly by RPC/API.
         /// </summary>
@@ -499,7 +552,7 @@ namespace Stratis.Bitcoin.Controllers
         /// Retrieves the difficulty target of the full node's network.
         /// </summary>
         /// <param name="networkDifficulty">The network difficulty interface.</param>
-        /// <returns>A network difficulty <see cref="Target"/>. Returns <c>null</c> if fails.</returns>
+        /// <returns>A network difficulty <see cref="NBitcoin.Target"/>. Returns <c>null</c> if fails.</returns>
         internal static Target GetNetworkDifficulty(INetworkDifficulty networkDifficulty = null)
         {
             return networkDifficulty?.GetNetworkDifficulty();


### PR DESCRIPTION
Added the endpoint `GET api/node/logrules` to retrieve the log rules as they are enabled in the NLog.config file.

The result will look like so:
```
[
  {
    "ruleName": "Stratis.Bitcoin.Features.Api.*",
    "logLevel": "Debug",
    "filename": "'C:\\Users\\jerem\\AppData\\Roaming\\StratisNode\\stratis\\StratisTest\\Logs\\api.txt'"
  },
  {
    "ruleName": "Stratis.Bitcoin.Features.BlockStore.*",
    "logLevel": "Debug",
    "filename": "'C:\\Users\\jerem\\AppData\\Roaming\\StratisNode\\stratis\\StratisTest\\Logs\\blockstore.txt'"
  },
  {
    "ruleName": "Stratis.Bitcoin.Consensus.ConsensusManager",
    "logLevel": "Debug",
    "filename": "'C:\\Users\\jerem\\AppData\\Roaming\\StratisNode\\stratis\\StratisTest\\Logs\\CHTandCM.txt'"
  },
  {
    "ruleName": "Stratis.Bitcoin.Features.MemoryPool.*",
    "logLevel": "Trace",
    "filename": "'C:\\Users\\jerem\\AppData\\Roaming\\StratisNode\\stratis\\StratisTest\\Logs\\mempool.txt'"
  },
  {
    "ruleName": "Stratis.Bitcoin.*",
    "logLevel": "Info",
    "filename": "'C:\\Users\\jerem\\AppData\\Roaming\\StratisNode\\stratis\\StratisTest\\Logs\\node.txt'"
  }
]
```