### PR TITLE
ConnectAndSync test helper times out too quickly

### DIFF
--- a/src/Stratis.Bitcoin.IntegrationTests.Common/TestHelper.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests.Common/TestHelper.cs
@@ -485,7 +485,7 @@ namespace Stratis.Bitcoin.IntegrationTests.Common
                 Connect(thisNode, coreNode);
 
             foreach (CoreNode coreNode in to)
-                WaitLoop(() => AreNodesSynced(thisNode, coreNode, ignoreMempool));
+                WaitLoop(() => AreNodesSynced(thisNode, coreNode, ignoreMempool), waitTimeSeconds: 120);
         }
 
         /// <summary>


### PR DESCRIPTION
Some test cases take more than one minute to complete `ConnectAndSync`. This increases the timeout from one minute to two minutes. For instance this will fix the test cases `CanHandleReorgs` and `ConsensusManager_Fork_Occurs_Node_Gets_Disconnected_Due_To_InvalidStakeDepth` which time out when not being run in debug mode.