### PR TITLE
[Tests] Improve TestHelper.Connect

### DIFF
--- a/src/Stratis.Bitcoin.IntegrationTests.Common/TestHelper.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests.Common/TestHelper.cs
@@ -414,6 +414,8 @@ namespace Stratis.Bitcoin.IntegrationTests.Common
         {
             var cancellation = new CancellationTokenSource((int)TimeSpan.FromSeconds(30).TotalMilliseconds);
 
+            var isConnecting = false;
+
             WaitLoop(() =>
             {
                 try
@@ -421,11 +423,17 @@ namespace Stratis.Bitcoin.IntegrationTests.Common
                     if (IsNodeConnectedTo(thisNode, connectToNode))
                         return true;
 
-                    thisNode.CreateRPCClient().AddNode(connectToNode.Endpoint, true);
+                    // Don't try the same connection again until it failed or connected.
+                    if (!isConnecting)
+                    {
+                        thisNode.CreateRPCClient().AddNode(connectToNode.Endpoint, true);
+                        isConnecting = true;
+                    }
                 }
                 catch (Exception)
                 {
                     // The connect request failed, probably due to a web exception so try again.
+                    isConnecting = false;
                 }
 
                 return false;


### PR DESCRIPTION
I suspect that why some tests are failing on connect is because the RPC call to connect to another node won't wait for the connection to actually complete. So its possible that we will try the same connection again which will cause the node to disconnect the initial connection. This will cause the Connect method to go into a loop, eventually timing out.