### PR TITLE
[FN] Rename RPCPort to DefaultRPCPort

### DIFF
--- a/src/NBitcoin.Tests/NetworkTests.cs
+++ b/src/NBitcoin.Tests/NetworkTests.cs
@@ -90,7 +90,7 @@ namespace NBitcoin.Tests
             Assert.Equal(BitcoinMain.BitcoinDefaultConfigFilename, this.networkMain.DefaultConfigFilename);
             Assert.Equal(0xD9B4BEF9, this.networkMain.Magic);
             Assert.Equal(8333, this.networkMain.DefaultPort);
-            Assert.Equal(8332, this.networkMain.RPCPort);
+            Assert.Equal(8332, this.networkMain.DefaultRPCPort);
             Assert.Equal(BitcoinMain.BitcoinMaxTimeOffsetSeconds, this.networkMain.MaxTimeOffsetSeconds);
             Assert.Equal(BitcoinMain.BitcoinDefaultMaxTipAgeInSeconds, this.networkMain.MaxTipAge);
             Assert.Equal(1000, this.networkMain.MinTxFee);
@@ -172,7 +172,7 @@ namespace NBitcoin.Tests
             Assert.Equal(BitcoinMain.BitcoinDefaultConfigFilename, network.DefaultConfigFilename);
             Assert.Equal(0x0709110B.ToString(), network.Magic.ToString());
             Assert.Equal(18333, network.DefaultPort);
-            Assert.Equal(18332, network.RPCPort);
+            Assert.Equal(18332, network.DefaultRPCPort);
             Assert.Equal(BitcoinMain.BitcoinMaxTimeOffsetSeconds, network.MaxTimeOffsetSeconds);
             Assert.Equal(BitcoinMain.BitcoinDefaultMaxTipAgeInSeconds, network.MaxTipAge);
             Assert.Equal(1000, network.MinTxFee);
@@ -254,7 +254,7 @@ namespace NBitcoin.Tests
             Assert.Equal(BitcoinMain.BitcoinDefaultConfigFilename, network.DefaultConfigFilename);
             Assert.Equal(0xDAB5BFFA, network.Magic);
             Assert.Equal(18444, network.DefaultPort);
-            Assert.Equal(18332, network.RPCPort);
+            Assert.Equal(18332, network.DefaultRPCPort);
             Assert.Equal(BitcoinMain.BitcoinMaxTimeOffsetSeconds, network.MaxTimeOffsetSeconds);
             Assert.Equal(BitcoinMain.BitcoinDefaultMaxTipAgeInSeconds, network.MaxTipAge);
             Assert.Equal(1000, network.MinTxFee);
@@ -335,7 +335,7 @@ namespace NBitcoin.Tests
             Assert.Equal(StratisMain.StratisDefaultConfigFilename, network.DefaultConfigFilename);
             Assert.Equal(0x5223570.ToString(), network.Magic.ToString());
             Assert.Equal(16178, network.DefaultPort);
-            Assert.Equal(16174, network.RPCPort);
+            Assert.Equal(16174, network.DefaultRPCPort);
             Assert.Equal(StratisMain.StratisMaxTimeOffsetSeconds, network.MaxTimeOffsetSeconds);
             Assert.Equal(StratisMain.StratisDefaultMaxTipAgeInSeconds, network.MaxTipAge);
             Assert.Equal(10000, network.MinTxFee);
@@ -412,7 +412,7 @@ namespace NBitcoin.Tests
             Assert.Equal(StratisMain.StratisDefaultConfigFilename, network.DefaultConfigFilename);
             Assert.Equal(0x11213171.ToString(), network.Magic.ToString());
             Assert.Equal(26178, network.DefaultPort);
-            Assert.Equal(26174, network.RPCPort);
+            Assert.Equal(26174, network.DefaultRPCPort);
             Assert.Equal(StratisMain.StratisMaxTimeOffsetSeconds, network.MaxTimeOffsetSeconds);
             Assert.Equal(StratisMain.StratisDefaultMaxTipAgeInSeconds, network.MaxTipAge);
             Assert.Equal(10000, network.MinTxFee);
@@ -489,7 +489,7 @@ namespace NBitcoin.Tests
             Assert.Equal(StratisMain.StratisDefaultConfigFilename, network.DefaultConfigFilename);
             Assert.Equal(0xefc0f2cd, network.Magic);
             Assert.Equal(18444, network.DefaultPort);
-            Assert.Equal(18442, network.RPCPort);
+            Assert.Equal(18442, network.DefaultRPCPort);
             Assert.Equal(StratisMain.StratisMaxTimeOffsetSeconds, network.MaxTimeOffsetSeconds);
             Assert.Equal(StratisMain.StratisDefaultMaxTipAgeInSeconds, network.MaxTipAge);
             Assert.Equal(10000, network.MinTxFee);

--- a/src/NBitcoin/Network.cs
+++ b/src/NBitcoin/Network.cs
@@ -106,7 +106,7 @@ namespace NBitcoin
         /// <summary>
         /// Port on which to listen for incoming RPC connections.
         /// </summary>
-        public int RPCPort { get; protected set; }
+        public int DefaultRPCPort { get; protected set; }
 
         /// <summary>
         /// The default port on which nodes of this network communicate with external clients. 

--- a/src/Stratis.Bitcoin.Features.PoA/PoANetwork.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/PoANetwork.cs
@@ -44,7 +44,7 @@ namespace Stratis.Bitcoin.Features.PoA
             this.DefaultPort = 16438;
             this.DefaultMaxOutboundConnections = 16;
             this.DefaultMaxInboundConnections = 109;
-            this.RPCPort = 16474;
+            this.DefaultRPCPort = 16474;
             this.MaxTipAge = 2 * 60 * 60;
             this.MinTxFee = 10000;
             this.FallbackFee = 10000;

--- a/src/Stratis.Bitcoin.Features.RPC/RPCClient.cs
+++ b/src/Stratis.Bitcoin.Features.RPC/RPCClient.cs
@@ -18,9 +18,9 @@ using Stratis.Bitcoin.Utilities;
 namespace Stratis.Bitcoin.Features.RPC
 {
     /*
-        Category            Name                        Implemented 
+        Category            Name                        Implemented
         ------------------ --------------------------- -----------------------
-        ------------------ Overall control/query calls 
+        ------------------ Overall control/query calls
         control            getinfo
         control            help
         control            stop
@@ -165,18 +165,18 @@ namespace Stratis.Bitcoin.Features.RPC
         /// Use default bitcoin parameters to configure a RPCClient.
         /// </summary>
         /// <param name="network">The network used by the node. Must not be null.</param>
-        public RPCClient(Network network) : this(null as string, BuildUri(null, network.RPCPort), network)
+        public RPCClient(Network network) : this(null as string, BuildUri(null, network.DefaultRPCPort), network)
         {
         }
 
         [Obsolete("Use RPCClient(ConnectionString, string, Network)")]
         public RPCClient(NetworkCredential credentials, string host, Network network)
-            : this(credentials, BuildUri(host, network.RPCPort), network)
+            : this(credentials, BuildUri(host, network.DefaultRPCPort), network)
         {
         }
 
         public RPCClient(RPCCredentialString credentials, string host, Network network)
-            : this(credentials, BuildUri(host, network.RPCPort), network)
+            : this(credentials, BuildUri(host, network.DefaultRPCPort), network)
         {
         }
 
@@ -188,7 +188,7 @@ namespace Stratis.Bitcoin.Features.RPC
 
             if (address != null && network == null)
             {
-                network = NetworkRegistration.GetNetworks().FirstOrDefault(n => n.RPCPort == address.Port);
+                network = NetworkRegistration.GetNetworks().FirstOrDefault(n => n.DefaultRPCPort == address.Port);
                 if (network == null)
                     throw new ArgumentNullException("network");
             }
@@ -200,7 +200,7 @@ namespace Stratis.Bitcoin.Features.RPC
                 throw new ArgumentException("network parameter is required if you use default uri");
 
             if (address == null)
-                address = new Uri("http://127.0.0.1:" + network.RPCPort + "/");
+                address = new Uri("http://127.0.0.1:" + network.DefaultRPCPort + "/");
 
             if (credentials.UseDefault)
             {
@@ -310,7 +310,7 @@ namespace Stratis.Bitcoin.Features.RPC
         /// <param name="hostOrUri"></param>
         /// <param name="network"></param>
         public RPCClient(string authenticationString, string hostOrUri, Network network)
-            : this(authenticationString, BuildUri(hostOrUri, network.RPCPort), network)
+            : this(authenticationString, BuildUri(hostOrUri, network.DefaultRPCPort), network)
         {
         }
 

--- a/src/Stratis.Bitcoin.Features.RPC/RpcSettings.cs
+++ b/src/Stratis.Bitcoin.Features.RPC/RpcSettings.cs
@@ -70,7 +70,7 @@ namespace Stratis.Bitcoin.Features.RPC
             TextFileConfiguration config = nodeSettings.ConfigReader;
 
             this.Server = config.GetOrDefault<bool>("server", false, this.logger);
-            this.RPCPort = config.GetOrDefault<int>("rpcport", nodeSettings.Network.RPCPort, this.logger);
+            this.RPCPort = config.GetOrDefault<int>("rpcport", nodeSettings.Network.DefaultRPCPort, this.logger);
 
             if (this.Server)
             {
@@ -154,7 +154,7 @@ namespace Stratis.Bitcoin.Features.RPC
             builder.AppendLine($"-server=<0 or 1>          Accept command line and JSON-RPC commands. Default false.");
             builder.AppendLine($"-rpcuser=<string>         Username for JSON-RPC connections");
             builder.AppendLine($"-rpcpassword=<string>     Password for JSON-RPC connections");
-            builder.AppendLine($"-rpcport=<0-65535>        Listen for JSON-RPC connections on <port>. Default: {network.RPCPort}");
+            builder.AppendLine($"-rpcport=<0-65535>        Listen for JSON-RPC connections on <port>. Default: {network.DefaultRPCPort}");
             builder.AppendLine($"-rpcbind=<ip:port>        Bind to given address to listen for JSON-RPC connections. This option can be specified multiple times. Default: bind to all interfaces");
             builder.AppendLine($"-rpcallowip=<ip>          Allow JSON-RPC connections from specified source. This option can be specified multiple times.");
 

--- a/src/Stratis.Bitcoin.IntegrationTests/RPC/RpcBitcoinMutableTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/RPC/RpcBitcoinMutableTests.cs
@@ -15,7 +15,7 @@ using Xunit;
 namespace Stratis.Bitcoin.IntegrationTests.RPC
 {
     /// <summary>
-    /// These tests are for RPC tests that require modifying the chain/nodes. 
+    /// These tests are for RPC tests that require modifying the chain/nodes.
     /// Setup of the chain or nodes can be done in each test.
     /// </summary>
     public class RpcBitcoinMutableTests
@@ -382,7 +382,7 @@ namespace Stratis.Bitcoin.IntegrationTests.RPC
                 Assert.Throws<FileNotFoundException>(() => new RPCClient($"cookiefile={notFoundCookiePath}", new Uri("http://localhost/"), this.regTest));
 
                 rpcClient = new RPCClient("bla:bla", null as Uri, this.regTest);
-                Assert.Equal("http://127.0.0.1:" + this.regTest.RPCPort + "/", rpcClient.Address.AbsoluteUri);
+                Assert.Equal("http://127.0.0.1:" + this.regTest.DefaultRPCPort + "/", rpcClient.Address.AbsoluteUri);
 
                 rpcClient = node.CreateRPCClient();
                 rpcClient = rpcClient.PrepareBatch();

--- a/src/Stratis.Bitcoin.Networks/BitcoinMain.cs
+++ b/src/Stratis.Bitcoin.Networks/BitcoinMain.cs
@@ -25,7 +25,7 @@ namespace Stratis.Bitcoin.Networks
             this.DefaultPort = 8333;
             this.DefaultMaxOutboundConnections = 8;
             this.DefaultMaxInboundConnections = 117;
-            this.RPCPort = 8332;
+            this.DefaultRPCPort = 8332;
             this.MaxTimeOffsetSeconds = BitcoinMaxTimeOffsetSeconds;
             this.MaxTipAge = BitcoinDefaultMaxTipAgeInSeconds;
             this.MinTxFee = 1000;

--- a/src/Stratis.Bitcoin.Networks/BitcoinRegTest.cs
+++ b/src/Stratis.Bitcoin.Networks/BitcoinRegTest.cs
@@ -19,7 +19,7 @@ namespace Stratis.Bitcoin.Networks
             this.DefaultPort = 18444;
             this.DefaultMaxOutboundConnections = 8;
             this.DefaultMaxInboundConnections = 117;
-            this.RPCPort = 18332;
+            this.DefaultRPCPort = 18332;
             this.CoinTicker = "TBTC";
 
             // Create the genesis block.

--- a/src/Stratis.Bitcoin.Networks/BitcoinTest.cs
+++ b/src/Stratis.Bitcoin.Networks/BitcoinTest.cs
@@ -19,7 +19,7 @@ namespace Stratis.Bitcoin.Networks
             this.DefaultPort = 18333;
             this.DefaultMaxOutboundConnections = 8;
             this.DefaultMaxInboundConnections = 117;
-            this.RPCPort = 18332;
+            this.DefaultRPCPort = 18332;
             this.CoinTicker = "TBTC";
 
             var consensusFactory = new ConsensusFactory();

--- a/src/Stratis.Bitcoin.Networks/StratisMain.cs
+++ b/src/Stratis.Bitcoin.Networks/StratisMain.cs
@@ -43,7 +43,7 @@ namespace Stratis.Bitcoin.Networks
             this.DefaultPort = 16178;
             this.DefaultMaxOutboundConnections = 16;
             this.DefaultMaxInboundConnections = 109;
-            this.RPCPort = 16174;
+            this.DefaultRPCPort = 16174;
             this.MaxTipAge = 2 * 60 * 60;
             this.MinTxFee = 10000;
             this.FallbackFee = 10000;

--- a/src/Stratis.Bitcoin.Networks/StratisRegTest.cs
+++ b/src/Stratis.Bitcoin.Networks/StratisRegTest.cs
@@ -25,7 +25,7 @@ namespace Stratis.Bitcoin.Networks
             this.DefaultPort = 18444;
             this.DefaultMaxOutboundConnections = 16;
             this.DefaultMaxInboundConnections = 109;
-            this.RPCPort = 18442;
+            this.DefaultRPCPort = 18442;
             this.CoinTicker = "TSTRAT";
 
             var powLimit = new Target(new uint256("7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"));

--- a/src/Stratis.Bitcoin.Networks/StratisTest.cs
+++ b/src/Stratis.Bitcoin.Networks/StratisTest.cs
@@ -29,7 +29,7 @@ namespace Stratis.Bitcoin.Networks
             this.DefaultPort = 26178;
             this.DefaultMaxOutboundConnections = 16;
             this.DefaultMaxInboundConnections = 109;
-            this.RPCPort = 26174;
+            this.DefaultRPCPort = 26174;
             this.CoinTicker = "TSTRAT";
 
             var powLimit = new Target(new uint256("0000ffff00000000000000000000000000000000000000000000000000000000"));

--- a/src/Stratis.Sidechains.Networks/CirrusV2/CirrusMain.cs
+++ b/src/Stratis.Sidechains.Networks/CirrusV2/CirrusMain.cs
@@ -26,7 +26,7 @@ namespace Stratis.Sidechains.Networks.CirrusV2
             this.DefaultPort = 16179;
             this.DefaultMaxOutboundConnections = 16;
             this.DefaultMaxInboundConnections = 109;
-            this.RPCPort = 16175;
+            this.DefaultRPCPort = 16175;
             this.MaxTipAge = 2 * 60 * 60;
             this.MinTxFee = 10000;
             this.FallbackFee = 10000;

--- a/src/Stratis.Sidechains.Networks/CirrusV2/CirrusRegTest.cs
+++ b/src/Stratis.Sidechains.Networks/CirrusV2/CirrusRegTest.cs
@@ -32,7 +32,7 @@ namespace Stratis.Sidechains.Networks.CirrusV2
             this.DefaultPort = 26179;
             this.DefaultMaxOutboundConnections = 16;
             this.DefaultMaxInboundConnections = 109;
-            this.RPCPort = 26175;
+            this.DefaultRPCPort = 26175;
             this.MaxTipAge = 2 * 60 * 60;
             this.MinTxFee = 10000;
             this.FallbackFee = 10000;

--- a/src/Stratis.Sidechains.Networks/CirrusV2/CirrusTest.cs
+++ b/src/Stratis.Sidechains.Networks/CirrusV2/CirrusTest.cs
@@ -26,7 +26,7 @@ namespace Stratis.Sidechains.Networks.CirrusV2
             this.DefaultPort = 26179;
             this.DefaultMaxOutboundConnections = 16;
             this.DefaultMaxInboundConnections = 109;
-            this.RPCPort = 26175;
+            this.DefaultRPCPort = 26175;
             this.MaxTipAge = 2 * 60 * 60;
             this.MinTxFee = 10000;
             this.FallbackFee = 10000;

--- a/src/Stratis.Sidechains.Networks/FederatedPegMain.cs
+++ b/src/Stratis.Sidechains.Networks/FederatedPegMain.cs
@@ -30,7 +30,7 @@ namespace Stratis.Sidechains.Networks
             this.DefaultPort = 16179;
             this.DefaultMaxOutboundConnections = 16;
             this.DefaultMaxInboundConnections = 109;
-            this.RPCPort = 16175;
+            this.DefaultRPCPort = 16175;
             this.MaxTipAge = 2 * 60 * 60;
             this.MinTxFee = 10000;
             this.FallbackFee = 10000;

--- a/src/Stratis.Sidechains.Networks/FederatedPegRegTest.cs
+++ b/src/Stratis.Sidechains.Networks/FederatedPegRegTest.cs
@@ -35,7 +35,7 @@ namespace Stratis.Sidechains.Networks
             this.DefaultPort = 26179;
             this.DefaultMaxOutboundConnections = 16;
             this.DefaultMaxInboundConnections = 109;
-            this.RPCPort = 26175;
+            this.DefaultRPCPort = 26175;
             this.MaxTipAge = 2 * 60 * 60;
             this.MinTxFee = 10000;
             this.FallbackFee = 10000;

--- a/src/Stratis.Sidechains.Networks/FederatedPegTest.cs
+++ b/src/Stratis.Sidechains.Networks/FederatedPegTest.cs
@@ -29,7 +29,7 @@ namespace Stratis.Sidechains.Networks
             this.DefaultPort = 26179;
             this.DefaultMaxOutboundConnections = 16;
             this.DefaultMaxInboundConnections = 109;
-            this.RPCPort = 26175;
+            this.DefaultRPCPort = 26175;
             this.MaxTipAge = 2 * 60 * 60;
             this.MinTxFee = 10000;
             this.FallbackFee = 10000;

--- a/src/Stratis.SmartContracts.Networks/SmartContractPosRegTest.cs
+++ b/src/Stratis.SmartContracts.Networks/SmartContractPosRegTest.cs
@@ -24,7 +24,7 @@ namespace Stratis.SmartContracts.Networks
             this.DefaultPort = 18444;
             this.DefaultMaxOutboundConnections = 16;
             this.DefaultMaxInboundConnections = 109;
-            this.RPCPort = 18332;
+            this.DefaultRPCPort = 18332;
             this.MaxTipAge = SmartContractNetwork.BitcoinDefaultMaxTipAgeInSeconds;
             this.MinTxFee = 1000;
             this.FallbackFee = 20000;

--- a/src/Stratis.SmartContracts.Networks/SmartContractPosTest.cs
+++ b/src/Stratis.SmartContracts.Networks/SmartContractPosTest.cs
@@ -21,7 +21,7 @@ namespace Stratis.SmartContracts.Networks
             this.DefaultPort = 18333;
             this.DefaultMaxOutboundConnections = 16;
             this.DefaultMaxInboundConnections = 109;
-            this.RPCPort = 18332;
+            this.DefaultRPCPort = 18332;
             this.MaxTipAge = SmartContractNetwork.BitcoinDefaultMaxTipAgeInSeconds;
             this.MinTxFee = 1000;
             this.FallbackFee = 20000;

--- a/src/Stratis.SmartContracts.Networks/SmartContractsRegTest.cs
+++ b/src/Stratis.SmartContracts.Networks/SmartContractsRegTest.cs
@@ -24,7 +24,7 @@ namespace Stratis.SmartContracts.Networks
             this.DefaultPort = 18444;
             this.DefaultMaxOutboundConnections = 16;
             this.DefaultMaxInboundConnections = 109;
-            this.RPCPort = 18332;
+            this.DefaultRPCPort = 18332;
             this.MaxTipAge = SmartContractNetwork.BitcoinDefaultMaxTipAgeInSeconds;
             this.MinTxFee = 1000;
             this.FallbackFee = 20000;

--- a/src/Stratis.SmartContracts.Networks/SmartContractsTest.cs
+++ b/src/Stratis.SmartContracts.Networks/SmartContractsTest.cs
@@ -21,7 +21,7 @@ namespace Stratis.SmartContracts.Networks
             this.DefaultPort = 18333;
             this.DefaultMaxOutboundConnections = 16;
             this.DefaultMaxInboundConnections = 109;
-            this.RPCPort = 18332;
+            this.DefaultRPCPort = 18332;
             this.MaxTipAge = SmartContractNetwork.BitcoinDefaultMaxTipAgeInSeconds;
             this.MinTxFee = 1000;
             this.FallbackFee = 20000;


### PR DESCRIPTION
The `RPCPort` on the `Network` class is not intended to be used directly. This PR renames the field from `RPCPort` to `DefaultRPCPort` to clarify its purpose and align the naming with similarly named fields:

![image](https://user-images.githubusercontent.com/29645989/55456148-07292000-5632-11e9-8580-b441313e7bdd.png)
