### PR TITLE
[FN] Move the APIPort location from settings to the Network class

### DIFF
--- a/src/NBitcoin/Network.cs
+++ b/src/NBitcoin/Network.cs
@@ -82,8 +82,8 @@ namespace NBitcoin
         /// 1-satoshi-fee transactions. It should be set above the real cost to you of processing a transaction.
         /// </summary>
         /// <remarks>
-        /// The <see cref="MinRelayTxFee"/> and <see cref="MinTxFee"/> are typically the same value to prevent dos attacks on the network. 
-        /// If <see cref="MinRelayTxFee"/> is less than <see cref="MinTxFee"/>, an attacker can broadcast a lot of transactions with fees between these two values, 
+        /// The <see cref="MinRelayTxFee"/> and <see cref="MinTxFee"/> are typically the same value to prevent dos attacks on the network.
+        /// If <see cref="MinRelayTxFee"/> is less than <see cref="MinTxFee"/>, an attacker can broadcast a lot of transactions with fees between these two values,
         /// which will lead to transactions filling the mempool without ever being mined.
         /// </remarks>
         public long MinTxFee { get; protected set; }
@@ -97,8 +97,8 @@ namespace NBitcoin
         /// The minimum fee under which transactions may be rejected from being relayed.
         /// </summary>
         /// <remarks>
-        /// The <see cref="MinRelayTxFee"/> and <see cref="MinTxFee"/> are typically the same value to prevent dos attacks on the network. 
-        /// If <see cref="MinRelayTxFee"/> is less than <see cref="MinTxFee"/>, an attacker can broadcast a lot of transactions with fees between these two values, 
+        /// The <see cref="MinRelayTxFee"/> and <see cref="MinTxFee"/> are typically the same value to prevent dos attacks on the network.
+        /// If <see cref="MinRelayTxFee"/> is less than <see cref="MinTxFee"/>, an attacker can broadcast a lot of transactions with fees between these two values,
         /// which will lead to transactions filling the mempool without ever being mined.
         /// </remarks>
         public long MinRelayTxFee { get; protected set; }
@@ -109,7 +109,12 @@ namespace NBitcoin
         public int RPCPort { get; protected set; }
 
         /// <summary>
-        /// The default port on which nodes of this network communicate with external clients. 
+        /// Port on which to listen for incoming API connections.
+        /// </summary>
+        public int DefaultAPIPort { get; protected set; }
+
+        /// <summary>
+        /// The default port on which nodes of this network communicate with external clients.
         /// </summary>
         public int DefaultPort { get; protected set; }
 
@@ -258,7 +263,7 @@ namespace NBitcoin
         /// Typically, 3 such genesis blocks need to be created when bootstrapping a new coin: for Main, Test and Reg networks.
         /// </summary>
         /// <param name="consensusFactory">
-        /// The consensus factory used to create transactions and blocks. 
+        /// The consensus factory used to create transactions and blocks.
         /// Use <see cref="PosConsensusFactory"/> for proof-of-stake based networks.
         /// </param>
         /// <param name="coinbaseText">
@@ -267,7 +272,7 @@ namespace NBitcoin
         /// It should be shorter than 92 characters.
         /// </param>
         /// <param name="target">
-        /// The difficulty target under which the hash of the block need to be. 
+        /// The difficulty target under which the hash of the block need to be.
         /// Some more details: As an example, the target for the Stratis Main network is 00000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff.
         /// To make it harder to mine the genesis block, have more zeros at the beginning (keeping the length the same). This will make the target smaller, so finding a number under it will be more difficult.
         /// To make it easier to mine the genesis block ,do the opposite. Example of an easy one: 00ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff.
@@ -277,7 +282,7 @@ namespace NBitcoin
         /// Specify how many coins to put in the genesis transaction's output. These coins are unspendable.
         /// </param>
         /// <param name="version">
-        /// The version of the transaction and the block header set in the genesis block. 
+        /// The version of the transaction and the block header set in the genesis block.
         /// </param>
         /// <example>
         /// The following example shows the creation of a genesis block.

--- a/src/Stratis.Bitcoin.Api.Tests/ApiSettingsTest.cs
+++ b/src/Stratis.Bitcoin.Api.Tests/ApiSettingsTest.cs
@@ -33,8 +33,8 @@ namespace Stratis.Bitcoin.Api.Tests
             ApiSettings settings = FullNodeSetup(nodeSettings);
 
             // Assert.
-            Assert.Equal(ApiSettings.DefaultBitcoinApiPort, settings.ApiPort);
-            Assert.Equal(new Uri($"{ApiSettings.DefaultApiHost}:{ApiSettings.DefaultBitcoinApiPort}"), settings.ApiUri);
+            Assert.Equal(network.DefaultAPIPort, settings.ApiPort);
+            Assert.Equal(new Uri($"{ApiSettings.DefaultApiHost}:{network.DefaultAPIPort}"), settings.ApiUri);
         }
 
         /// <summary>
@@ -51,8 +51,8 @@ namespace Stratis.Bitcoin.Api.Tests
             ApiSettings settings = FullNodeSetup(nodeSettings);
 
             // Assert.
-            Assert.Equal(ApiSettings.DefaultStratisApiPort, settings.ApiPort);
-            Assert.Equal(new Uri($"{ApiSettings.DefaultApiHost}:{ApiSettings.DefaultStratisApiPort}"), settings.ApiUri);
+            Assert.Equal(network.DefaultAPIPort, settings.ApiPort);
+            Assert.Equal(new Uri($"{ApiSettings.DefaultApiHost}:{network.DefaultAPIPort}"), settings.ApiUri);
 
             settings.HttpsCertificateFilePath.Should().BeNull();
             settings.UseHttps.Should().BeFalse();
@@ -92,8 +92,8 @@ namespace Stratis.Bitcoin.Api.Tests
 
 
             // Assert.
-            Assert.Equal(ApiSettings.DefaultBitcoinApiPort, settings.ApiPort);
-            Assert.Equal(new Uri($"{customApiUri}:{ApiSettings.DefaultBitcoinApiPort}"), settings.ApiUri);
+            Assert.Equal(network.DefaultAPIPort, settings.ApiPort);
+            Assert.Equal(new Uri($"{customApiUri}:{network.DefaultAPIPort}"), settings.ApiUri);
         }
 
         /// <summary>
@@ -111,8 +111,8 @@ namespace Stratis.Bitcoin.Api.Tests
             ApiSettings settings = FullNodeSetup(nodeSettings);
 
             // Assert.
-            Assert.Equal(ApiSettings.DefaultStratisApiPort, settings.ApiPort);
-            Assert.Equal(new Uri($"{customApiUri}:{ApiSettings.DefaultStratisApiPort}"), settings.ApiUri);
+            Assert.Equal(network.DefaultAPIPort, settings.ApiPort);
+            Assert.Equal(new Uri($"{customApiUri}:{network.DefaultAPIPort}"), settings.ApiUri);
         }
 
         /// <summary>
@@ -168,7 +168,7 @@ namespace Stratis.Bitcoin.Api.Tests
             ApiSettings settings = FullNodeSetup(nodeSettings);
 
             // Assert.
-            Assert.Equal(ApiSettings.DefaultBitcoinApiPort, settings.ApiPort);
+            Assert.Equal(KnownNetworks.Main.DefaultAPIPort, settings.ApiPort);
         }
 
         /// <summary>
@@ -184,7 +184,7 @@ namespace Stratis.Bitcoin.Api.Tests
             ApiSettings settings = FullNodeSetup(nodeSettings);
 
             // Assert.
-            Assert.Equal(ApiSettings.TestBitcoinApiPort, settings.ApiPort);
+            Assert.Equal(KnownNetworks.TestNet.DefaultAPIPort, settings.ApiPort);
         }
 
         /// <summary>
@@ -200,7 +200,7 @@ namespace Stratis.Bitcoin.Api.Tests
             ApiSettings settings = FullNodeSetup(nodeSettings);
 
             // Assert.
-            Assert.Equal(ApiSettings.DefaultStratisApiPort, settings.ApiPort);
+            Assert.Equal(KnownNetworks.StratisMain.DefaultAPIPort, settings.ApiPort);
         }
 
         /// <summary>
@@ -216,7 +216,7 @@ namespace Stratis.Bitcoin.Api.Tests
             ApiSettings settings = FullNodeSetup(nodeSettings);
 
             // Assert.
-            Assert.Equal(ApiSettings.TestStratisApiPort, settings.ApiPort);
+            Assert.Equal(KnownNetworks.StratisTest.DefaultAPIPort, settings.ApiPort);
         }
 
         [Theory]

--- a/src/Stratis.Bitcoin.Features.Api/ApiSettings.cs
+++ b/src/Stratis.Bitcoin.Features.Api/ApiSettings.cs
@@ -13,18 +13,6 @@ namespace Stratis.Bitcoin.Features.Api
     /// </summary>
     public class ApiSettings
     {
-        /// <summary>The default port used by the API when the node runs on the bitcoin network.</summary>
-        public const int DefaultBitcoinApiPort = 37220;
-
-        /// <summary>The default port used by the API when the node runs on the Stratis network.</summary>
-        public const int DefaultStratisApiPort = 37221;
-
-        /// <summary>The default port used by the API when the node runs on the bitcoin testnet network.</summary>
-        public const int TestBitcoinApiPort = 38220;
-
-        /// <summary>The default port used by the API when the node runs on the Stratis testnet network.</summary>
-        public const int TestStratisApiPort = 38221;
-
         /// <summary>The default port used by the API when the node runs on the Stratis network.</summary>
         public const string DefaultApiHost = "http://localhost";
 
@@ -48,10 +36,10 @@ namespace Stratis.Bitcoin.Features.Api
         /// Please refer to .Net Core documentation for usage: <seealso cref="https://docs.microsoft.com/en-us/dotnet/api/system.security.cryptography.x509certificates.x509certificate2.-ctor?view=netcore-2.1#System_Security_Cryptography_X509Certificates_X509Certificate2__ctor_System_Byte___" />.
         /// </remarks>
         public string HttpsCertificateFilePath { get; set; }
-        
+
         /// <summary>Use HTTPS or not.</summary>
         public bool UseHttps { get; set; }
-    
+
         /// <summary>
         /// Initializes an instance of the object from the node configuration.
         /// </summary>
@@ -60,7 +48,7 @@ namespace Stratis.Bitcoin.Features.Api
         {
             Guard.NotNull(nodeSettings, nameof(nodeSettings));
 
-            this.logger = nodeSettings.LoggerFactory.CreateLogger(typeof(ApiSettings).FullName);    
+            this.logger = nodeSettings.LoggerFactory.CreateLogger(typeof(ApiSettings).FullName);
 
             TextFileConfiguration config = nodeSettings.ConfigReader;
 
@@ -70,15 +58,15 @@ namespace Stratis.Bitcoin.Features.Api
             if (this.UseHttps && string.IsNullOrWhiteSpace(this.HttpsCertificateFilePath))
                 throw new ConfigurationException("The path to a certificate needs to be provided when using https. Please use the argument 'certificatefilepath' to provide it.");
 
-            var defaultApiHost = this.UseHttps 
-                ? DefaultApiHost.Replace(@"http://", @"https://") 
+            var defaultApiHost = this.UseHttps
+                ? DefaultApiHost.Replace(@"http://", @"https://")
                 : DefaultApiHost;
 
             string apiHost = config.GetOrDefault("apiuri", defaultApiHost, this.logger);
             var apiUri = new Uri(apiHost);
 
             // Find out which port should be used for the API.
-            int apiPort = config.GetOrDefault("apiport", GetDefaultPort(nodeSettings.Network), this.logger);
+            int apiPort = config.GetOrDefault("apiport", nodeSettings.Network.DefaultAPIPort, this.logger);
 
             // If no port is set in the API URI.
             if (apiUri.IsDefaultPort)
@@ -105,19 +93,6 @@ namespace Stratis.Bitcoin.Features.Api
             }
         }
 
-        /// <summary>
-        /// Determines the default API port.
-        /// </summary>
-        /// <param name="network">The network to use.</param>
-        /// <returns>The default API port.</returns>
-        private static int GetDefaultPort(Network network)
-        {
-            if (network.IsBitcoin())
-                return network.IsTest() ? TestBitcoinApiPort : DefaultBitcoinApiPort;
-            
-            return network.IsTest() ? TestStratisApiPort : DefaultStratisApiPort;
-        }
-
         /// <summary>Prints the help information on how to configure the API settings to the logger.</summary>
         /// <param name="network">The network to use.</param>
         public static void PrintHelp(Network network)
@@ -125,7 +100,7 @@ namespace Stratis.Bitcoin.Features.Api
             var builder = new StringBuilder();
 
             builder.AppendLine($"-apiuri=<string>                  URI to node's API interface. Defaults to '{ DefaultApiHost }'.");
-            builder.AppendLine($"-apiport=<0-65535>                Port of node's API interface. Defaults to { GetDefaultPort(network) }.");
+            builder.AppendLine($"-apiport=<0-65535>                Port of node's API interface. Defaults to { network.DefaultAPIPort }.");
             builder.AppendLine($"-keepalive=<seconds>              Keep Alive interval (set in seconds). Default: 0 (no keep alive).");
             builder.AppendLine($"-usehttps=<bool>                  Use https protocol on the API. Defaults to false.");
             builder.AppendLine($"-certificatefilepath=<string>     Path to the certificate used for https traffic encryption. Defaults to <null>. Password protected files are not supported. On MacOs, only p12 certificates can be used without password.");
@@ -143,8 +118,8 @@ namespace Stratis.Bitcoin.Features.Api
             builder.AppendLine("####API Settings####");
             builder.AppendLine($"#URI to node's API interface. Defaults to '{ DefaultApiHost }'.");
             builder.AppendLine($"#apiuri={ DefaultApiHost }");
-            builder.AppendLine($"#Port of node's API interface. Defaults to { GetDefaultPort(network) }.");
-            builder.AppendLine($"#apiport={ GetDefaultPort(network) }");
+            builder.AppendLine($"#Port of node's API interface. Defaults to { network.DefaultAPIPort }.");
+            builder.AppendLine($"#apiport={ network.DefaultAPIPort }");
             builder.AppendLine($"#Keep Alive interval (set in seconds). Default: 0 (no keep alive).");
             builder.AppendLine($"#keepalive=0");
             builder.AppendLine($"#Use HTTPS protocol on the API. Default is false.");

--- a/src/Stratis.Bitcoin.Features.PoA/PoANetwork.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/PoANetwork.cs
@@ -45,6 +45,7 @@ namespace Stratis.Bitcoin.Features.PoA
             this.DefaultMaxOutboundConnections = 16;
             this.DefaultMaxInboundConnections = 109;
             this.RPCPort = 16474;
+            this.DefaultAPIPort = 37221; // TODO: Confirm
             this.MaxTipAge = 2 * 60 * 60;
             this.MinTxFee = 10000;
             this.FallbackFee = 10000;

--- a/src/Stratis.Bitcoin.Networks/BitcoinMain.cs
+++ b/src/Stratis.Bitcoin.Networks/BitcoinMain.cs
@@ -26,6 +26,7 @@ namespace Stratis.Bitcoin.Networks
             this.DefaultMaxOutboundConnections = 8;
             this.DefaultMaxInboundConnections = 117;
             this.RPCPort = 8332;
+            this.DefaultAPIPort = 37220;
             this.MaxTimeOffsetSeconds = BitcoinMaxTimeOffsetSeconds;
             this.MaxTipAge = BitcoinDefaultMaxTipAgeInSeconds;
             this.MinTxFee = 1000;

--- a/src/Stratis.Bitcoin.Networks/BitcoinRegTest.cs
+++ b/src/Stratis.Bitcoin.Networks/BitcoinRegTest.cs
@@ -20,6 +20,7 @@ namespace Stratis.Bitcoin.Networks
             this.DefaultMaxOutboundConnections = 8;
             this.DefaultMaxInboundConnections = 117;
             this.RPCPort = 18332;
+            this.DefaultAPIPort = 38220;
             this.CoinTicker = "TBTC";
 
             // Create the genesis block.

--- a/src/Stratis.Bitcoin.Networks/BitcoinTest.cs
+++ b/src/Stratis.Bitcoin.Networks/BitcoinTest.cs
@@ -20,6 +20,7 @@ namespace Stratis.Bitcoin.Networks
             this.DefaultMaxOutboundConnections = 8;
             this.DefaultMaxInboundConnections = 117;
             this.RPCPort = 18332;
+            this.DefaultAPIPort = 38220;
             this.CoinTicker = "TBTC";
 
             var consensusFactory = new ConsensusFactory();

--- a/src/Stratis.Bitcoin.Networks/StratisMain.cs
+++ b/src/Stratis.Bitcoin.Networks/StratisMain.cs
@@ -44,6 +44,7 @@ namespace Stratis.Bitcoin.Networks
             this.DefaultMaxOutboundConnections = 16;
             this.DefaultMaxInboundConnections = 109;
             this.RPCPort = 16174;
+            this.DefaultAPIPort = 37221;
             this.MaxTipAge = 2 * 60 * 60;
             this.MinTxFee = 10000;
             this.FallbackFee = 10000;

--- a/src/Stratis.Bitcoin.Networks/StratisRegTest.cs
+++ b/src/Stratis.Bitcoin.Networks/StratisRegTest.cs
@@ -26,6 +26,7 @@ namespace Stratis.Bitcoin.Networks
             this.DefaultMaxOutboundConnections = 16;
             this.DefaultMaxInboundConnections = 109;
             this.RPCPort = 18442;
+            this.DefaultAPIPort = 38221;
             this.CoinTicker = "TSTRAT";
 
             var powLimit = new Target(new uint256("7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"));

--- a/src/Stratis.Bitcoin.Networks/StratisTest.cs
+++ b/src/Stratis.Bitcoin.Networks/StratisTest.cs
@@ -30,6 +30,7 @@ namespace Stratis.Bitcoin.Networks
             this.DefaultMaxOutboundConnections = 16;
             this.DefaultMaxInboundConnections = 109;
             this.RPCPort = 26174;
+            this.DefaultAPIPort = 38221;
             this.CoinTicker = "TSTRAT";
 
             var powLimit = new Target(new uint256("0000ffff00000000000000000000000000000000000000000000000000000000"));

--- a/src/Stratis.Sidechains.Networks/CirrusV2/CirrusMain.cs
+++ b/src/Stratis.Sidechains.Networks/CirrusV2/CirrusMain.cs
@@ -27,6 +27,7 @@ namespace Stratis.Sidechains.Networks.CirrusV2
             this.DefaultMaxOutboundConnections = 16;
             this.DefaultMaxInboundConnections = 109;
             this.RPCPort = 16175;
+            this.DefaultAPIPort = 37221; // TODO: Confirm
             this.MaxTipAge = 2 * 60 * 60;
             this.MinTxFee = 10000;
             this.FallbackFee = 10000;

--- a/src/Stratis.Sidechains.Networks/CirrusV2/CirrusRegTest.cs
+++ b/src/Stratis.Sidechains.Networks/CirrusV2/CirrusRegTest.cs
@@ -33,6 +33,7 @@ namespace Stratis.Sidechains.Networks.CirrusV2
             this.DefaultMaxOutboundConnections = 16;
             this.DefaultMaxInboundConnections = 109;
             this.RPCPort = 26175;
+            this.DefaultAPIPort = 38221; // TODO: Confirm
             this.MaxTipAge = 2 * 60 * 60;
             this.MinTxFee = 10000;
             this.FallbackFee = 10000;

--- a/src/Stratis.Sidechains.Networks/CirrusV2/CirrusTest.cs
+++ b/src/Stratis.Sidechains.Networks/CirrusV2/CirrusTest.cs
@@ -27,6 +27,7 @@ namespace Stratis.Sidechains.Networks.CirrusV2
             this.DefaultMaxOutboundConnections = 16;
             this.DefaultMaxInboundConnections = 109;
             this.RPCPort = 26175;
+            this.DefaultAPIPort = 38221; // TODO: Confirm
             this.MaxTipAge = 2 * 60 * 60;
             this.MinTxFee = 10000;
             this.FallbackFee = 10000;

--- a/src/Stratis.Sidechains.Networks/FederatedPegMain.cs
+++ b/src/Stratis.Sidechains.Networks/FederatedPegMain.cs
@@ -31,6 +31,7 @@ namespace Stratis.Sidechains.Networks
             this.DefaultMaxOutboundConnections = 16;
             this.DefaultMaxInboundConnections = 109;
             this.RPCPort = 16175;
+            this.DefaultAPIPort = 37221; // TODO: Confirm
             this.MaxTipAge = 2 * 60 * 60;
             this.MinTxFee = 10000;
             this.FallbackFee = 10000;

--- a/src/Stratis.Sidechains.Networks/FederatedPegRegTest.cs
+++ b/src/Stratis.Sidechains.Networks/FederatedPegRegTest.cs
@@ -36,6 +36,7 @@ namespace Stratis.Sidechains.Networks
             this.DefaultMaxOutboundConnections = 16;
             this.DefaultMaxInboundConnections = 109;
             this.RPCPort = 26175;
+            this.DefaultAPIPort = 38221; // TODO: Confirm
             this.MaxTipAge = 2 * 60 * 60;
             this.MinTxFee = 10000;
             this.FallbackFee = 10000;

--- a/src/Stratis.Sidechains.Networks/FederatedPegTest.cs
+++ b/src/Stratis.Sidechains.Networks/FederatedPegTest.cs
@@ -30,6 +30,7 @@ namespace Stratis.Sidechains.Networks
             this.DefaultMaxOutboundConnections = 16;
             this.DefaultMaxInboundConnections = 109;
             this.RPCPort = 26175;
+            this.DefaultAPIPort = 38221; // TODO: Confirm
             this.MaxTipAge = 2 * 60 * 60;
             this.MinTxFee = 10000;
             this.FallbackFee = 10000;

--- a/src/Stratis.SmartContracts.Networks/SmartContractPosRegTest.cs
+++ b/src/Stratis.SmartContracts.Networks/SmartContractPosRegTest.cs
@@ -25,6 +25,7 @@ namespace Stratis.SmartContracts.Networks
             this.DefaultMaxOutboundConnections = 16;
             this.DefaultMaxInboundConnections = 109;
             this.RPCPort = 18332;
+            this.DefaultAPIPort = 38221; // TODO: Confirm
             this.MaxTipAge = SmartContractNetwork.BitcoinDefaultMaxTipAgeInSeconds;
             this.MinTxFee = 1000;
             this.FallbackFee = 20000;

--- a/src/Stratis.SmartContracts.Networks/SmartContractPosTest.cs
+++ b/src/Stratis.SmartContracts.Networks/SmartContractPosTest.cs
@@ -22,6 +22,7 @@ namespace Stratis.SmartContracts.Networks
             this.DefaultMaxOutboundConnections = 16;
             this.DefaultMaxInboundConnections = 109;
             this.RPCPort = 18332;
+            this.DefaultAPIPort = 38221; // TODO: Confirm
             this.MaxTipAge = SmartContractNetwork.BitcoinDefaultMaxTipAgeInSeconds;
             this.MinTxFee = 1000;
             this.FallbackFee = 20000;

--- a/src/Stratis.SmartContracts.Networks/SmartContractsRegTest.cs
+++ b/src/Stratis.SmartContracts.Networks/SmartContractsRegTest.cs
@@ -25,6 +25,7 @@ namespace Stratis.SmartContracts.Networks
             this.DefaultMaxOutboundConnections = 16;
             this.DefaultMaxInboundConnections = 109;
             this.RPCPort = 18332;
+            this.DefaultAPIPort = 38221; // TODO: Confirm
             this.MaxTipAge = SmartContractNetwork.BitcoinDefaultMaxTipAgeInSeconds;
             this.MinTxFee = 1000;
             this.FallbackFee = 20000;

--- a/src/Stratis.SmartContracts.Networks/SmartContractsTest.cs
+++ b/src/Stratis.SmartContracts.Networks/SmartContractsTest.cs
@@ -22,6 +22,7 @@ namespace Stratis.SmartContracts.Networks
             this.DefaultMaxOutboundConnections = 16;
             this.DefaultMaxInboundConnections = 109;
             this.RPCPort = 18332;
+            this.DefaultAPIPort = 38221; // TODO: Confirm
             this.MaxTipAge = SmartContractNetwork.BitcoinDefaultMaxTipAgeInSeconds;
             this.MinTxFee = 1000;
             this.FallbackFee = 20000;


### PR DESCRIPTION
Previously we relied on `GetDefaultPort` in the `ApiSettings` class.

This PR fills in each network's `DefaultAPIPort` field with the value that `int GetDefaultPort(Network network)` would have produced and then removes the `GetDefaultPort` method:

```
        private static int GetDefaultPort(Network network)	
        {	
            if (network.IsBitcoin())	
                return network.IsTest() ? TestBitcoinApiPort : DefaultBitcoinApiPort;	

             return network.IsTest() ? TestStratisApiPort : DefaultStratisApiPort;	
        }
```

**IMPORTANT**

Verifying/updating API port values will be left for a separate PR.

The idea is not to have any unexpected side-effects in this PR.