### PR TITLE
[Tests] Fix Buffer_50Kb_For_1MB_BlockSize

### DIFF
--- a/src/Stratis.Bitcoin.Features.SmartContracts.Tests/BlockBufferGeneratorTests.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts.Tests/BlockBufferGeneratorTests.cs
@@ -20,8 +20,8 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Tests
             BlockDefinitionOptions optionsFromNetwork = new MinerSettings(new NodeSettings(new SmartContractsRegTest())).BlockDefinitionOptions;
             BlockDefinitionOptions newOptions = this.bufferGenerator.GetOptionsWithBuffer(optionsFromNetwork);
 
-            Assert.Equal((uint) 950_000, newOptions.BlockMaxWeight);
-            Assert.Equal((uint) 950_000, newOptions.BlockMaxSize);
+            Assert.Equal((uint)950_000, newOptions.BlockMaxWeight);
+            Assert.Equal((uint)950_000, newOptions.BlockMaxSize);
         }
     }
 }

--- a/src/Stratis.Bitcoin.Features.SmartContracts.Tests/Consensus/Rules/TestRulesContext.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts.Tests/Consensus/Rules/TestRulesContext.cs
@@ -87,7 +87,6 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Tests.Consensus.Rules
             testRulesContext.LoggerFactory.AddConsoleWithFilters();
             testRulesContext.DateTimeProvider = DateTimeProvider.Default;
 
-            network.Consensus.Options = new ConsensusOptions();
             new FullNodeBuilderConsensusExtension.PowConsensusRulesRegistration().RegisterRules(network.Consensus);
 
             ConsensusSettings consensusSettings = new ConsensusSettings(testRulesContext.NodeSettings);

--- a/src/Stratis.Bitcoin.Features.SmartContracts.Tests/SigningContractTests.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts.Tests/SigningContractTests.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using NBitcoin;
-using NBitcoin.Crypto;
+﻿using NBitcoin.Crypto;
 using Stratis.SmartContracts.Networks;
 using Xunit;
 


### PR DESCRIPTION
Very trivial fix... one of the test context creators was overriding the consensus options.