### PR TITLE
[FN] Refactor- remove async from consensus rules

### DIFF
--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/CoinViews/CoinviewTests.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/CoinViews/CoinviewTests.cs
@@ -58,7 +58,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.CoinViews
         }
 
         [Fact]
-        public async Task TestRewindAsync()
+        public void TestRewindAsync()
         {
             uint256 tip = this.cachedCoinView.GetTipHash();
             Assert.Equal(this.chainIndexer.Genesis.HashBlock, tip);
@@ -117,7 +117,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.CoinViews
                 }
             }
 
-            await this.ValidateCoinviewIntegrityAsync(outPoints);
+            this.ValidateCoinviewIntegrity(outPoints);
 
             for (int i = 0; i < addChangesTimes; i++)
             {
@@ -126,12 +126,12 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.CoinViews
                 uint256 currentTip = this.cachedCoinView.GetTipHash();
 
                 if (currentTip == coinviewTipAfterHalf)
-                    await this.ValidateCoinviewIntegrityAsync(copyAfterHalfOfAdditions);
+                    this.ValidateCoinviewIntegrity(copyAfterHalfOfAdditions);
             }
 
             Assert.Equal(tipAfterOriginalCoinsCreation, this.cachedCoinView.GetTipHash());
 
-            await this.ValidateCoinviewIntegrityAsync(copyOfOriginalOutPoints);
+            this.ValidateCoinviewIntegrity(copyOfOriginalOutPoints);
         }
 
         private List<OutPoint> ConvertToListOfOutputPoints(List<UnspentOutputs> outputsList)
@@ -190,7 +190,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.CoinViews
             this.cachedCoinView.SaveChanges(unspent, original, previous.HashBlock, current.HashBlock, height);
         }
 
-        private async Task ValidateCoinviewIntegrityAsync(List<OutPoint> expectedAvailableOutPoints)
+        private void ValidateCoinviewIntegrity(List<OutPoint> expectedAvailableOutPoints)
         {
             foreach (IGrouping<uint256, OutPoint> outPointsGroup in expectedAvailableOutPoints.GroupBy(x => x.Hash))
             {

--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/CommonRules/BlockHeaderRuleTest.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/CommonRules/BlockHeaderRuleTest.cs
@@ -17,7 +17,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
         }
 
         [Fact]
-        public async Task BlockReceived_IsNextBlock_ValidationSucessAsync()
+        public void BlockReceived_IsNextBlock_ValidationSucessAsync()
         {
             TestRulesContext testContext = TestRulesContextFactory.CreateAsync(this.network);
             var blockHeaderRule = testContext.CreateRule<SetActivationDeploymentsPartialValidationRule>();
@@ -27,7 +27,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
             context.ValidationContext.BlockToValidate.Header.HashPrevBlock = testContext.ChainIndexer.Tip.HashBlock;
             context.ValidationContext.ChainedHeaderToValidate = new ChainedHeader(context.ValidationContext.BlockToValidate.Header, context.ValidationContext.BlockToValidate.Header.GetHash(), 0);
 
-            await blockHeaderRule.RunAsync(context);
+            blockHeaderRule.Run(context);
 
             Assert.NotNull(context.ValidationContext.ChainedHeaderToValidate);
             Assert.NotNull(context.Flags);

--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/CommonRules/BlockSizeRuleTest.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/CommonRules/BlockSizeRuleTest.cs
@@ -18,27 +18,27 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
         }
 
         [Fact]
-        public async Task RunAsync_BadBlockWeight_ThrowsBadBlockWeightConsensusErrorExceptionAsync()
+        public void RunAsync_BadBlockWeight_ThrowsBadBlockWeightConsensusErrorExceptionAsync()
         {
             this.ruleContext.ValidationContext.BlockToValidate = GenerateBlockWithWeight((int)(this.options.MaxBlockWeight / this.options.WitnessScaleFactor) + 1, TransactionOptions.All);
 
-            ConsensusErrorException exception = await Assert.ThrowsAsync<ConsensusErrorException>(() => this.consensusRules.RegisterRule<BlockSizeRule>().RunAsync(this.ruleContext));
+            ConsensusErrorException exception = Assert.Throws<ConsensusErrorException>(() => this.consensusRules.RegisterRule<BlockSizeRule>().Run(this.ruleContext));
 
             Assert.Equal(ConsensusErrors.BadBlockWeight, exception.ConsensusError);
         }
 
         [Fact]
-        public async Task RunAsync_ZeroTransactions_ThrowsBadBlockLengthConsensusErrorExceptionAsync()
+        public void RunAsync_ZeroTransactions_ThrowsBadBlockLengthConsensusErrorExceptionAsync()
         {
             this.ruleContext.ValidationContext.BlockToValidate = this.network.CreateBlock();
 
-            ConsensusErrorException exception = await Assert.ThrowsAsync<ConsensusErrorException>(() => this.consensusRules.RegisterRule<BlockSizeRule>().RunAsync(this.ruleContext));
+            ConsensusErrorException exception = Assert.Throws<ConsensusErrorException>(() => this.consensusRules.RegisterRule<BlockSizeRule>().Run(this.ruleContext));
 
             Assert.Equal(ConsensusErrors.BadBlockLength, exception.ConsensusError);
         }
 
         [Fact]
-        public async Task RunAsync_TransactionCountAboveMaxBlockBaseSize_ThrowsBadBlockLengthConsensusErrorExceptionAsync()
+        public void RunAsync_TransactionCountAboveMaxBlockBaseSize_ThrowsBadBlockLengthConsensusErrorExceptionAsync()
         {
             this.ruleContext.ValidationContext.BlockToValidate = this.network.CreateBlock();
 
@@ -52,13 +52,13 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
             // increase max block weight to be able to hit this if statement
             this.options.MaxBlockWeight = (uint) (blockWeight * 4) + 100;
 
-            ConsensusErrorException exception = await Assert.ThrowsAsync<ConsensusErrorException>(() => this.consensusRules.RegisterRule<BlockSizeRule>().RunAsync(this.ruleContext));
+            ConsensusErrorException exception = Assert.Throws<ConsensusErrorException>(() => this.consensusRules.RegisterRule<BlockSizeRule>().Run(this.ruleContext));
 
             Assert.Equal(ConsensusErrors.BadBlockLength, exception.ConsensusError);
         }
 
         [Fact]
-        public async Task RunAsync_BlockSizeAboveMaxBlockBaseSize_ThrowsBadBlockLengthConsensusErrorExceptionAsync()
+        public void RunAsync_BlockSizeAboveMaxBlockBaseSize_ThrowsBadBlockLengthConsensusErrorExceptionAsync()
         {
             this.ruleContext.ValidationContext.BlockToValidate = GenerateBlockWithWeight((int)this.options.MaxBlockBaseSize + 1, TransactionOptions.All);
             int blockWeight = this.CalculateBlockWeight(this.ruleContext.ValidationContext.BlockToValidate, TransactionOptions.All);
@@ -66,31 +66,31 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
             // increase max block weight to be able to hit this if statement
             this.options.MaxBlockWeight = (uint) (blockWeight * 4) + 1;
 
-            ConsensusErrorException exception = await Assert.ThrowsAsync<ConsensusErrorException>(() => this.consensusRules.RegisterRule<BlockSizeRule>().RunAsync(this.ruleContext));
+            ConsensusErrorException exception = Assert.Throws<ConsensusErrorException>(() => this.consensusRules.RegisterRule<BlockSizeRule>().Run(this.ruleContext));
 
             Assert.Equal(ConsensusErrors.BadBlockLength, exception.ConsensusError);
         }
 
         [Fact]
-        public async Task RunAsync_AtBlockWeight_BelowMaxBlockBaseSize_DoesNotThrowExceptionAsync()
+        public void RunAsync_AtBlockWeight_BelowMaxBlockBaseSize_DoesNotThrowExceptionAsync()
         {
             this.ruleContext.ValidationContext.BlockToValidate = GenerateBlockWithWeight((int)this.options.MaxBlockWeight / this.options.WitnessScaleFactor, TransactionOptions.All);
             this.options.MaxBlockBaseSize = this.options.MaxBlockWeight + 1000;
 
-            await this.consensusRules.RegisterRule<BlockSizeRule>().RunAsync(this.ruleContext);
+            this.consensusRules.RegisterRule<BlockSizeRule>().Run(this.ruleContext);
         }
 
         [Fact]
-        public async Task RunAsync_BelowBlockWeight_BelowMaxBlockBaseSize_DoesNotThrowExceptionAsync()
+        public void RunAsync_BelowBlockWeight_BelowMaxBlockBaseSize_DoesNotThrowExceptionAsync()
         {
             this.ruleContext.ValidationContext.BlockToValidate = GenerateBlockWithWeight((int)(this.options.MaxBlockWeight / this.options.WitnessScaleFactor) - 1, TransactionOptions.All);
             this.options.MaxBlockBaseSize = this.options.MaxBlockWeight + 1000;
 
-            await this.consensusRules.RegisterRule<BlockSizeRule>().RunAsync(this.ruleContext);
+            this.consensusRules.RegisterRule<BlockSizeRule>().Run(this.ruleContext);
         }
 
         [Fact]
-        public async Task TaskAsync_TransactionCountBelowLimit_DoesNotThrowExceptionAsync()
+        public void TaskAsync_TransactionCountBelowLimit_DoesNotThrowExceptionAsync()
         {
             this.ruleContext.ValidationContext.BlockToValidate = this.network.CreateBlock();
 
@@ -99,25 +99,25 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
                 this.ruleContext.ValidationContext.BlockToValidate.Transactions.Add(new Transaction());
             }
 
-            await this.consensusRules.RegisterRule<BlockSizeRule>().RunAsync(this.ruleContext);
+            this.consensusRules.RegisterRule<BlockSizeRule>().Run(this.ruleContext);
         }
 
         [Fact]
-        public async Task RunAsync_BlockAtMaxBlockBaseSize_DoesNotThrowExceptionAsync()
+        public void RunAsync_BlockAtMaxBlockBaseSize_DoesNotThrowExceptionAsync()
         {
             this.ruleContext.ValidationContext.BlockToValidate = GenerateBlockWithWeight((int)this.options.MaxBlockBaseSize, TransactionOptions.All);
             this.options.MaxBlockWeight = (this.options.MaxBlockBaseSize * 4) + 1000;
 
-            await this.consensusRules.RegisterRule<BlockSizeRule>().RunAsync(this.ruleContext);
+            this.consensusRules.RegisterRule<BlockSizeRule>().Run(this.ruleContext);
         }
 
         [Fact]
-        public async Task RunAsync_BlockBelowMaxBlockBaseSize_DoesNotThrowExceptionAsync()
+        public void RunAsync_BlockBelowMaxBlockBaseSize_DoesNotThrowExceptionAsync()
         {
             this.ruleContext.ValidationContext.BlockToValidate = GenerateBlockWithWeight((int)this.options.MaxBlockBaseSize - 1, TransactionOptions.All);
             this.options.MaxBlockWeight = (this.options.MaxBlockBaseSize * 4) + 1000;
 
-            await this.consensusRules.RegisterRule<BlockSizeRule>().RunAsync(this.ruleContext);
+            this.consensusRules.RegisterRule<BlockSizeRule>().Run(this.ruleContext);
         }
 
         private Block GenerateBlockWithWeight(int weight, TransactionOptions options)

--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/CommonRules/CalculateStakeRuleTest.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/CommonRules/CalculateStakeRuleTest.cs
@@ -16,7 +16,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
         }
 
         [Fact]
-        public async Task RunAsync_ProofOfStakeBlock_SetsStake_SetsNextWorkRequiredAsync()
+        public void RunAsync_ProofOfStakeBlock_SetsStake_SetsNextWorkRequiredAsync()
         {
             Block block = this.network.CreateBlock();
             Transaction transaction = this.network.CreateTransaction();
@@ -39,7 +39,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
                 .Returns(target)
                 .Verifiable();
 
-            await this.consensusRules.RegisterRule<CheckDifficultyHybridRule>().RunAsync(this.ruleContext);
+            this.consensusRules.RegisterRule<CheckDifficultyHybridRule>().Run(this.ruleContext);
 
             this.stakeValidator.Verify();
             Assert.NotNull(this.ruleContext as PosRuleContext);
@@ -51,7 +51,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
         }
 
         [Fact]
-        public async Task RunAsync_ProofOfWorkBlock_CheckPow_ValidPow_SetsStake_SetsNextWorkRequiredAsync()
+        public void RunAsync_ProofOfWorkBlock_CheckPow_ValidPow_SetsStake_SetsNextWorkRequiredAsync()
         {
             this.network = KnownNetworks.RegTest;
             this.ChainIndexer = MineChainWithHeight(2, this.network);
@@ -73,7 +73,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
                 .Returns(target)
                 .Verifiable();
 
-            await this.consensusRules.RegisterRule<CheckDifficultyHybridRule>().RunAsync(this.ruleContext);
+            this.consensusRules.RegisterRule<CheckDifficultyHybridRule>().Run(this.ruleContext);
 
             this.stakeValidator.Verify();
             Assert.NotNull((this.ruleContext as PosRuleContext));
@@ -85,7 +85,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
         }
 
         [Fact]
-        public async Task RunAsync_ProofOfWorkBlock_CheckPow_InValidPow_ThrowsHighHashConsensusErrorExceptionAsync()
+        public void RunAsync_ProofOfWorkBlock_CheckPow_InValidPow_ThrowsHighHashConsensusErrorExceptionAsync()
         {
             Block block = this.network.CreateBlock();
             Transaction transaction = this.network.CreateTransaction();
@@ -97,7 +97,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
                 ChainedHeaderToValidate = this.ChainIndexer.GetHeader(4)
             };
 
-            ConsensusErrorException exception = await Assert.ThrowsAsync<ConsensusErrorException>(() => this.consensusRules.RegisterRule<CheckDifficultyHybridRule>().RunAsync(this.ruleContext));
+            ConsensusErrorException exception = Assert.Throws<ConsensusErrorException>(() => this.consensusRules.RegisterRule<CheckDifficultyHybridRule>().Run(this.ruleContext));
 
             Assert.Equal(ConsensusErrors.HighHash, exception.ConsensusError);
         }

--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/CommonRules/CheckPosTransactionRuleTest.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/CommonRules/CheckPosTransactionRuleTest.cs
@@ -82,7 +82,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
         }
 
         [Fact]
-        public async Task RunAsync_BlockPassesCheckTransaction_DoesNotThrowExceptionAsync()
+        public void RunAsync_BlockPassesCheckTransaction_DoesNotThrowExceptionAsync()
         {
             var transaction = this.network.CreateTransaction();
             transaction.Inputs.Add(new TxIn()
@@ -106,11 +106,11 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
             ruleContext.ValidationContext.BlockToValidate.Transactions.Add(transaction);
             ruleContext.ValidationContext.BlockToValidate.Transactions.Add(transaction);
 
-            await this.consensusRules.RegisterRule<CheckPosTransactionRule>().RunAsync(ruleContext);
+            this.consensusRules.RegisterRule<CheckPosTransactionRule>().Run(ruleContext);
         }
 
         [Fact]
-        public async Task RunAsync_BlockFailsCheckTransaction_ThrowsBadTransactionEmptyOutputConsensusErrorExceptionAsync()
+        public void RunAsync_BlockFailsCheckTransaction_ThrowsBadTransactionEmptyOutputConsensusErrorExceptionAsync()
         {
             var validTransaction = this.network.CreateTransaction();
             validTransaction.Inputs.Add(new TxIn()
@@ -139,7 +139,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
             this.ruleContext.ValidationContext.BlockToValidate.Transactions.Add(validTransaction);
             this.ruleContext.ValidationContext.BlockToValidate.Transactions.Add(invalidTransaction);
 
-            ConsensusErrorException exception = await Assert.ThrowsAsync<ConsensusErrorException>(() => this.consensusRules.RegisterRule<CheckPosTransactionRule>().RunAsync(this.ruleContext));
+            ConsensusErrorException exception = Assert.Throws<ConsensusErrorException>(() => this.consensusRules.RegisterRule<CheckPosTransactionRule>().Run(this.ruleContext));
 
             Assert.Equal(ConsensusErrors.BadTransactionEmptyOutput, exception.ConsensusError);
         }

--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/CommonRules/CheckPowTransactionRuleTest.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/CommonRules/CheckPowTransactionRuleTest.cs
@@ -201,7 +201,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
         }
 
         [Fact]
-        public async Task RunAsync_BlockPassesCheckTransaction_DoesNotThrowExceptionAsync()
+        public void RunAsync_BlockPassesCheckTransaction_DoesNotThrowExceptionAsync()
         {
             var transaction = new Transaction();
             transaction.Inputs.Add(new TxIn(new OutPoint(), Script.FromBytesUnsafe(new string('A', 50).Select(c => (byte)c).ToArray())));
@@ -214,11 +214,11 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
 
             var rule = this.consensusRules.RegisterRule<CheckPowTransactionRule>();
 
-            await rule.RunAsync(this.ruleContext);
+            rule.Run(this.ruleContext);
         }
 
         [Fact]
-        public async Task RunAsync_BlockFailsCheckTransaction_ThrowsBadTransactionEmptyOutputConsensusErrorExceptionAsync()
+        public void RunAsync_BlockFailsCheckTransaction_ThrowsBadTransactionEmptyOutputConsensusErrorExceptionAsync()
         {
             var validTransaction = new Transaction();
             validTransaction.Inputs.Add(new TxIn(new OutPoint(), Script.FromBytesUnsafe(new string('A', 50).Select(c => (byte)c).ToArray())));
@@ -231,7 +231,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
             this.ruleContext.ValidationContext.BlockToValidate.Transactions.Add(validTransaction);
             this.ruleContext.ValidationContext.BlockToValidate.Transactions.Add(invalidTransaction);
 
-            ConsensusErrorException exception = await Assert.ThrowsAsync<ConsensusErrorException>(() => this.consensusRules.RegisterRule<CheckPowTransactionRule>().RunAsync(this.ruleContext));
+            ConsensusErrorException exception = Assert.Throws<ConsensusErrorException>(() => this.consensusRules.RegisterRule<CheckPowTransactionRule>().Run(this.ruleContext));
 
             Assert.Equal(ConsensusErrors.BadTransactionNoInput, exception.ConsensusError);
         }

--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/CommonRules/CheckSigOpsRuleTest.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/CommonRules/CheckSigOpsRuleTest.cs
@@ -17,7 +17,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
         }
 
         [Fact]
-        public async Task RunAsync_SingleTransactionInputSigOpsCountAboveThresHold_ThrowsBadBlockSigOpsConsensusErrorExceptionAsync()
+        public void RunAsync_SingleTransactionInputSigOpsCountAboveThresHold_ThrowsBadBlockSigOpsConsensusErrorExceptionAsync()
         {
             this.options.MaxBlockSigopsCost = 7;
             this.options.WitnessScaleFactor = 2;
@@ -27,13 +27,13 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
             transaction.Inputs.Add(new TxIn(new Script(op, op, op, op)));
             this.ruleContext.ValidationContext.BlockToValidate.Transactions.Add(transaction);
 
-            ConsensusErrorException exception = await Assert.ThrowsAsync<ConsensusErrorException>(() => this.consensusRules.RegisterRule<CheckSigOpsRule>().RunAsync(this.ruleContext));
+            ConsensusErrorException exception = Assert.Throws<ConsensusErrorException>(() => this.consensusRules.RegisterRule<CheckSigOpsRule>().Run(this.ruleContext));
 
             Assert.Equal(ConsensusErrors.BadBlockSigOps, exception.ConsensusError);
         }
 
         [Fact]
-        public async Task RunAsync_MultipleTransactionInputSigOpsCountAboveThresHold_ThrowsBadBlockSigOpsConsensusErrorExceptionAsync()
+        public void RunAsync_MultipleTransactionInputSigOpsCountAboveThresHold_ThrowsBadBlockSigOpsConsensusErrorExceptionAsync()
         {
             this.options.MaxBlockSigopsCost = 7;
             this.options.WitnessScaleFactor = 2;
@@ -44,13 +44,13 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
             transaction.Inputs.Add(new TxIn(new Script(op, op)));
             this.ruleContext.ValidationContext.BlockToValidate.Transactions.Add(transaction);
 
-            ConsensusErrorException exception = await Assert.ThrowsAsync<ConsensusErrorException>(() => this.consensusRules.RegisterRule<CheckSigOpsRule>().RunAsync(this.ruleContext));
+            ConsensusErrorException exception = Assert.Throws<ConsensusErrorException>(() => this.consensusRules.RegisterRule<CheckSigOpsRule>().Run(this.ruleContext));
 
             Assert.Equal(ConsensusErrors.BadBlockSigOps, exception.ConsensusError);
         }
 
         [Fact]
-        public async Task RunAsync_SingleTransactionOutputSigOpsCountAboveThresHold_ThrowsBadBlockSigOpsConsensusErrorExceptionAsync()
+        public void RunAsync_SingleTransactionOutputSigOpsCountAboveThresHold_ThrowsBadBlockSigOpsConsensusErrorExceptionAsync()
         {
             this.options.MaxBlockSigopsCost = 7;
             this.options.WitnessScaleFactor = 2;
@@ -60,13 +60,13 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
             transaction.Outputs.Add(new TxOut(new Money(1), new Script(op, op, op, op)));
             this.ruleContext.ValidationContext.BlockToValidate.Transactions.Add(transaction);
 
-            ConsensusErrorException exception = await Assert.ThrowsAsync<ConsensusErrorException>(() => this.consensusRules.RegisterRule<CheckSigOpsRule>().RunAsync(this.ruleContext));
+            ConsensusErrorException exception = Assert.Throws<ConsensusErrorException>(() => this.consensusRules.RegisterRule<CheckSigOpsRule>().Run(this.ruleContext));
 
             Assert.Equal(ConsensusErrors.BadBlockSigOps, exception.ConsensusError);
         }
 
         [Fact]
-        public async Task RunAsync_MultipleTransactionOutputSigOpsCountAboveThresHold_ThrowsBadBlockSigOpsConsensusErrorExceptionAsync()
+        public void RunAsync_MultipleTransactionOutputSigOpsCountAboveThresHold_ThrowsBadBlockSigOpsConsensusErrorExceptionAsync()
         {
             this.options.MaxBlockSigopsCost = 7;
             this.options.WitnessScaleFactor = 2;
@@ -77,13 +77,13 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
             transaction.Outputs.Add(new TxOut(new Money(1), new Script(op, op)));
             this.ruleContext.ValidationContext.BlockToValidate.Transactions.Add(transaction);
 
-            ConsensusErrorException exception = await Assert.ThrowsAsync<ConsensusErrorException>(() => this.consensusRules.RegisterRule<CheckSigOpsRule>().RunAsync(this.ruleContext));
+            ConsensusErrorException exception = Assert.Throws<ConsensusErrorException>(() => this.consensusRules.RegisterRule<CheckSigOpsRule>().Run(this.ruleContext));
 
             Assert.Equal(ConsensusErrors.BadBlockSigOps, exception.ConsensusError);
         }
 
         [Fact]
-        public async Task RunAsync_CombinedTransactionInputOutputSigOpsCountAboveThresHold_ThrowsBadBlockSigOpsConsensusErrorExceptionAsync()
+        public void RunAsync_CombinedTransactionInputOutputSigOpsCountAboveThresHold_ThrowsBadBlockSigOpsConsensusErrorExceptionAsync()
         {
             this.options.MaxBlockSigopsCost = 7;
             this.options.WitnessScaleFactor = 2;
@@ -94,13 +94,13 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
             transaction.Outputs.Add(new TxOut(new Money(1), new Script(op, op)));
             this.ruleContext.ValidationContext.BlockToValidate.Transactions.Add(transaction);
 
-            ConsensusErrorException exception = await Assert.ThrowsAsync<ConsensusErrorException>(() => this.consensusRules.RegisterRule<CheckSigOpsRule>().RunAsync(this.ruleContext));
+            ConsensusErrorException exception = Assert.Throws<ConsensusErrorException>(() => this.consensusRules.RegisterRule<CheckSigOpsRule>().Run(this.ruleContext));
 
             Assert.Equal(ConsensusErrors.BadBlockSigOps, exception.ConsensusError);
         }
 
         [Fact]
-        public async Task RunAsync_SingleTransactionInputSigOpsCountAtThresHold_DoesNotThrowExceptionAsync()
+        public void RunAsync_SingleTransactionInputSigOpsCountAtThresHold_DoesNotThrowExceptionAsync()
         {
             this.options.MaxBlockSigopsCost = 8;
             this.options.WitnessScaleFactor = 2;
@@ -110,11 +110,11 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
             transaction.Inputs.Add(new TxIn(new Script(op, op, op, op)));
             this.ruleContext.ValidationContext.BlockToValidate.Transactions.Add(transaction);
 
-            await this.consensusRules.RegisterRule<CheckSigOpsRule>().RunAsync(this.ruleContext);
+            this.consensusRules.RegisterRule<CheckSigOpsRule>().Run(this.ruleContext);
         }
 
         [Fact]
-        public async Task RunAsync_MultipleTransactionInputSigOpsCountAtThresHold_DoesNotThrowExceptionAsync()
+        public void RunAsync_MultipleTransactionInputSigOpsCountAtThresHold_DoesNotThrowExceptionAsync()
         {
             this.options.MaxBlockSigopsCost = 8;
             this.options.WitnessScaleFactor = 2;
@@ -125,11 +125,11 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
             transaction.Inputs.Add(new TxIn(new Script(op, op)));
             this.ruleContext.ValidationContext.BlockToValidate.Transactions.Add(transaction);
 
-            await this.consensusRules.RegisterRule<CheckSigOpsRule>().RunAsync(this.ruleContext);
+            this.consensusRules.RegisterRule<CheckSigOpsRule>().Run(this.ruleContext);
         }
 
         [Fact]
-        public async Task RunAsync_SingleTransactionOutputSigOpsCountAtThresHold_DoesNotThrowExceptionAsync()
+        public void RunAsync_SingleTransactionOutputSigOpsCountAtThresHold_DoesNotThrowExceptionAsync()
         {
             this.options.MaxBlockSigopsCost = 8;
             this.options.WitnessScaleFactor = 2;
@@ -139,11 +139,11 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
             transaction.Outputs.Add(new TxOut(new Money(1), new Script(op, op, op, op)));
             this.ruleContext.ValidationContext.BlockToValidate.Transactions.Add(transaction);
 
-            await this.consensusRules.RegisterRule<CheckSigOpsRule>().RunAsync(this.ruleContext);
+            this.consensusRules.RegisterRule<CheckSigOpsRule>().Run(this.ruleContext);
         }
 
         [Fact]
-        public async Task RunAsync_MultipleTransactionOutputSigOpsCountAtThresHold_DoesNotThrowExceptionAsync()
+        public void RunAsync_MultipleTransactionOutputSigOpsCountAtThresHold_DoesNotThrowExceptionAsync()
         {
             this.options.MaxBlockSigopsCost = 8;
             this.options.WitnessScaleFactor = 2;
@@ -154,11 +154,11 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
             transaction.Outputs.Add(new TxOut(new Money(1), new Script(op, op)));
             this.ruleContext.ValidationContext.BlockToValidate.Transactions.Add(transaction);
 
-            await this.consensusRules.RegisterRule<CheckSigOpsRule>().RunAsync(this.ruleContext);
+            this.consensusRules.RegisterRule<CheckSigOpsRule>().Run(this.ruleContext);
         }
 
         [Fact]
-        public async Task RunAsync_CombinedTransactionInputOutputSigOpsCountAtThresHold_DoesNotThrowExceptionAsync()
+        public void RunAsync_CombinedTransactionInputOutputSigOpsCountAtThresHold_DoesNotThrowExceptionAsync()
         {
             this.options.MaxBlockSigopsCost = 8;
             this.options.WitnessScaleFactor = 2;
@@ -169,11 +169,11 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
             transaction.Outputs.Add(new TxOut(new Money(1), new Script(op, op)));
             this.ruleContext.ValidationContext.BlockToValidate.Transactions.Add(transaction);
 
-            await this.consensusRules.RegisterRule<CheckSigOpsRule>().RunAsync(this.ruleContext);
+            this.consensusRules.RegisterRule<CheckSigOpsRule>().Run(this.ruleContext);
         }
 
         [Fact]
-        public async Task RunAsync_SingleTransactionInputSigOpsCountBelowThreshold_DoesNotThrowExceptionAsync()
+        public void RunAsync_SingleTransactionInputSigOpsCountBelowThreshold_DoesNotThrowExceptionAsync()
         {
             this.options.MaxBlockSigopsCost = 9;
             this.options.WitnessScaleFactor = 2;
@@ -183,11 +183,11 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
             transaction.Inputs.Add(new TxIn(new Script(op, op, op, op)));
             this.ruleContext.ValidationContext.BlockToValidate.Transactions.Add(transaction);
 
-            await this.consensusRules.RegisterRule<CheckSigOpsRule>().RunAsync(this.ruleContext);
+            this.consensusRules.RegisterRule<CheckSigOpsRule>().Run(this.ruleContext);
         }
 
         [Fact]
-        public async Task RunAsync_MultipleTransactionInputSigOpsCountBelowThreshold_DoesNotThrowExceptionAsync()
+        public void RunAsync_MultipleTransactionInputSigOpsCountBelowThreshold_DoesNotThrowExceptionAsync()
         {
             this.options.MaxBlockSigopsCost = 9;
             this.options.WitnessScaleFactor = 2;
@@ -198,11 +198,11 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
             transaction.Inputs.Add(new TxIn(new Script(op, op)));
             this.ruleContext.ValidationContext.BlockToValidate.Transactions.Add(transaction);
 
-            await this.consensusRules.RegisterRule<CheckSigOpsRule>().RunAsync(this.ruleContext);
+            this.consensusRules.RegisterRule<CheckSigOpsRule>().Run(this.ruleContext);
         }
 
         [Fact]
-        public async Task RunAsync_SingleTransactionOutputSigOpsCountBelowThreshold_DoesNotThrowExceptionAsync()
+        public void RunAsync_SingleTransactionOutputSigOpsCountBelowThreshold_DoesNotThrowExceptionAsync()
         {
             this.options.MaxBlockSigopsCost = 9;
             this.options.WitnessScaleFactor = 2;
@@ -212,11 +212,11 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
             transaction.Outputs.Add(new TxOut(new Money(1), new Script(op, op, op, op)));
             this.ruleContext.ValidationContext.BlockToValidate.Transactions.Add(transaction);
 
-            await this.consensusRules.RegisterRule<CheckSigOpsRule>().RunAsync(this.ruleContext);
+            this.consensusRules.RegisterRule<CheckSigOpsRule>().Run(this.ruleContext);
         }
 
         [Fact]
-        public async Task RunAsync_MultipleTransactionOutputSigOpsCountBelowThreshold_DoesNotThrowExceptionAsync()
+        public void RunAsync_MultipleTransactionOutputSigOpsCountBelowThreshold_DoesNotThrowExceptionAsync()
         {
             this.options.MaxBlockSigopsCost = 9;
             this.options.WitnessScaleFactor = 2;
@@ -227,11 +227,11 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
             transaction.Outputs.Add(new TxOut(new Money(1), new Script(op, op)));
             this.ruleContext.ValidationContext.BlockToValidate.Transactions.Add(transaction);
 
-            await this.consensusRules.RegisterRule<CheckSigOpsRule>().RunAsync(this.ruleContext);
+            this.consensusRules.RegisterRule<CheckSigOpsRule>().Run(this.ruleContext);
         }
 
         [Fact]
-        public async Task RunAsync_CombinedTransactionInputOutputSigOpsCountBelowThreshold_DoesNotThrowExceptionAsync()
+        public void RunAsync_CombinedTransactionInputOutputSigOpsCountBelowThreshold_DoesNotThrowExceptionAsync()
         {
             this.options.MaxBlockSigopsCost = 9;
             this.options.WitnessScaleFactor = 2;
@@ -242,7 +242,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
             transaction.Outputs.Add(new TxOut(new Money(1), new Script(op, op)));
             this.ruleContext.ValidationContext.BlockToValidate.Transactions.Add(transaction);
 
-            await this.consensusRules.RegisterRule<CheckSigOpsRule>().RunAsync(this.ruleContext);
+            this.consensusRules.RegisterRule<CheckSigOpsRule>().Run(this.ruleContext);
         }
     }
 }

--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/CommonRules/CoinbaseHeightRuleTest.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/CommonRules/CoinbaseHeightRuleTest.cs
@@ -14,7 +14,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
         }
 
         [Fact]
-        public async Task RunAsync_BestBlockAvailable_BadCoinBaseHeight_ThrowsBadCoinbaseHeightConsensusErrorExceptionAsync()
+        public void RunAsync_BestBlockAvailable_BadCoinBaseHeight_ThrowsBadCoinbaseHeightConsensusErrorExceptionAsync()
         {
             Block blockToValidate = this.network.CreateBlock();
 
@@ -25,13 +25,13 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
             transaction.Inputs.Add(new TxIn(new Script(Op.GetPushOp(3))));
             this.ruleContext.ValidationContext.BlockToValidate.Transactions.Add(transaction);
 
-            ConsensusErrorException exception = await Assert.ThrowsAsync<ConsensusErrorException>(() => this.consensusRules.RegisterRule<CoinbaseHeightRule>().RunAsync(this.ruleContext));
+            ConsensusErrorException exception = Assert.Throws<ConsensusErrorException>(() => this.consensusRules.RegisterRule<CoinbaseHeightRule>().Run(this.ruleContext));
 
             Assert.Equal(ConsensusErrors.BadCoinbaseHeight, exception.ConsensusError);
         }
 
         [Fact]
-        public async Task RunAsync_BestBlockUnAvailable_BadCoinBaseHeight_ThrowsBadCoinbaseHeightConsensusErrorExceptionAsync()
+        public void RunAsync_BestBlockUnAvailable_BadCoinBaseHeight_ThrowsBadCoinbaseHeightConsensusErrorExceptionAsync()
         {
             Block blockToValidate = this.network.CreateBlock();
             
@@ -42,13 +42,13 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
             transaction.Inputs.Add(new TxIn(new Script(Op.GetPushOp(3))));
             this.ruleContext.ValidationContext.BlockToValidate.Transactions.Add(transaction);
 
-            ConsensusErrorException exception = await Assert.ThrowsAsync<ConsensusErrorException>(() => this.consensusRules.RegisterRule<CoinbaseHeightRule>().RunAsync(this.ruleContext));
+            ConsensusErrorException exception = Assert.Throws<ConsensusErrorException>(() => this.consensusRules.RegisterRule<CoinbaseHeightRule>().Run(this.ruleContext));
 
             Assert.Equal(ConsensusErrors.BadCoinbaseHeight, exception.ConsensusError);
         }
 
         [Fact]
-        public async Task RunAsync_CorrectCoinBaseHeight_DoesNotThrowExceptionAsync()
+        public void RunAsync_CorrectCoinBaseHeight_DoesNotThrowExceptionAsync()
         {
             Block blockToValidate = this.network.CreateBlock();
 
@@ -59,7 +59,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
             transaction.Inputs.Add(new TxIn(new Script(Op.GetPushOp(4))));
             this.ruleContext.ValidationContext.BlockToValidate.Transactions.Add(transaction);
 
-            await this.consensusRules.RegisterRule<CoinbaseHeightRule>().RunAsync(this.ruleContext);
+            this.consensusRules.RegisterRule<CoinbaseHeightRule>().Run(this.ruleContext);
         }
     }
 }

--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/CommonRules/EnsureCoinbaseRuleTest.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/CommonRules/EnsureCoinbaseRuleTest.cs
@@ -9,17 +9,17 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
     public class EnsureCoinbaseRuleTest : TestConsensusRulesUnitTestBase
     {
         [Fact]
-        public async Task RunAsync_BlockWithoutTransactions_ThrowsBadCoinbaseMissingConsensusErrorExceptionAsync()
+        public void RunAsync_BlockWithoutTransactions_ThrowsBadCoinbaseMissingConsensusErrorExceptionAsync()
         {
             this.ruleContext.ValidationContext.BlockToValidate = this.network.CreateBlock();
 
-            ConsensusErrorException exception = await Assert.ThrowsAsync<ConsensusErrorException>(() => this.consensusRules.RegisterRule<EnsureCoinbaseRule>().RunAsync(this.ruleContext));
+            ConsensusErrorException exception = Assert.Throws<ConsensusErrorException>(() => this.consensusRules.RegisterRule<EnsureCoinbaseRule>().Run(this.ruleContext));
 
             Assert.Equal(ConsensusErrors.BadCoinbaseMissing, exception.ConsensusError);
         }
 
         [Fact]
-        public async Task RunAsync_FirstTransactionIsNotCoinbase_ThrowsBadCoinbaseMissingConsensusErrorExceptionAsync()
+        public void RunAsync_FirstTransactionIsNotCoinbase_ThrowsBadCoinbaseMissingConsensusErrorExceptionAsync()
         {
             this.ruleContext.ValidationContext.BlockToValidate = this.network.CreateBlock();
 
@@ -27,13 +27,13 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
             Assert.False(transaction.IsCoinBase);
             this.ruleContext.ValidationContext.BlockToValidate.Transactions.Add(transaction);
 
-            ConsensusErrorException exception = await Assert.ThrowsAsync<ConsensusErrorException>(() => this.consensusRules.RegisterRule<EnsureCoinbaseRule>().RunAsync(this.ruleContext));
+            ConsensusErrorException exception = Assert.Throws<ConsensusErrorException>(() => this.consensusRules.RegisterRule<EnsureCoinbaseRule>().Run(this.ruleContext));
 
             Assert.Equal(ConsensusErrors.BadCoinbaseMissing, exception.ConsensusError);
         }
 
         [Fact]
-        public async Task RunAsync_MultipleCoinsBaseTransactions_ThrowsBadMultipleCoinbaseConsensusErrorExceptionAsync()
+        public void RunAsync_MultipleCoinsBaseTransactions_ThrowsBadMultipleCoinbaseConsensusErrorExceptionAsync()
         {
             this.ruleContext.ValidationContext.BlockToValidate = this.network.CreateBlock();
 
@@ -45,13 +45,13 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
             this.ruleContext.ValidationContext.BlockToValidate.Transactions.Add(transaction);
             this.ruleContext.ValidationContext.BlockToValidate.Transactions.Add(transaction);
 
-            ConsensusErrorException exception = await Assert.ThrowsAsync<ConsensusErrorException>(() => this.consensusRules.RegisterRule<EnsureCoinbaseRule>().RunAsync(this.ruleContext));
+            ConsensusErrorException exception = Assert.Throws<ConsensusErrorException>(() => this.consensusRules.RegisterRule<EnsureCoinbaseRule>().Run(this.ruleContext));
 
             Assert.Equal(ConsensusErrors.BadMultipleCoinbase, exception.ConsensusError);
         }
 
         [Fact]
-        public async Task RunAsync_SingleCoinBaseTransaction_DoesNotThrowExceptionAsync()
+        public void RunAsync_SingleCoinBaseTransaction_DoesNotThrowExceptionAsync()
         {
             this.ruleContext.ValidationContext.BlockToValidate = this.network.CreateBlock();
 
@@ -63,7 +63,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
             this.ruleContext.ValidationContext.BlockToValidate.Transactions.Add(transaction);
             this.ruleContext.ValidationContext.BlockToValidate.Transactions.Add(new Transaction());
 
-            await this.consensusRules.RegisterRule<EnsureCoinbaseRule>().RunAsync(this.ruleContext);
+            this.consensusRules.RegisterRule<EnsureCoinbaseRule>().Run(this.ruleContext);
         }
     }
 }

--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/CommonRules/PosCoinstakeRuleTest.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/CommonRules/PosCoinstakeRuleTest.cs
@@ -14,7 +14,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
         }
 
         [Fact]
-        public async Task RunAsync_ProofOfStakeBlock_CoinBaseNotEmpty_NoOutputsOnTransaction_ThrowsBadStakeBlockConsensusErrorExceptionAsync()
+        public void RunAsync_ProofOfStakeBlock_CoinBaseNotEmpty_NoOutputsOnTransaction_ThrowsBadStakeBlockConsensusErrorExceptionAsync()
         {
             this.ruleContext.ValidationContext.BlockToValidate.Transactions.Add(new Transaction());
 
@@ -30,13 +30,13 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
 
             Assert.True(BlockStake.IsProofOfStake(this.ruleContext.ValidationContext.BlockToValidate));
 
-            ConsensusErrorException exception = await Assert.ThrowsAsync<ConsensusErrorException>(() => this.consensusRules.RegisterRule<PosCoinstakeRule>().RunAsync(this.ruleContext));
+            ConsensusErrorException exception = Assert.Throws<ConsensusErrorException>(() => this.consensusRules.RegisterRule<PosCoinstakeRule>().Run(this.ruleContext));
 
             Assert.Equal(ConsensusErrors.BadStakeBlock, exception.ConsensusError);
         }
 
         [Fact]
-        public async Task RunAsync_ProofOfStakeBlock_CoinBaseNotEmpty_TransactionNotEmpty_ThrowsBadStakeBlockConsensusErrorExceptionAsync()
+        public void RunAsync_ProofOfStakeBlock_CoinBaseNotEmpty_TransactionNotEmpty_ThrowsBadStakeBlockConsensusErrorExceptionAsync()
         {
             var transaction = this.network.CreateTransaction();
             transaction.Outputs.Add(new TxOut(new Money(1), (IDestination)null));
@@ -54,13 +54,13 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
 
             Assert.True(BlockStake.IsProofOfStake(this.ruleContext.ValidationContext.BlockToValidate));
 
-            ConsensusErrorException exception = await Assert.ThrowsAsync<ConsensusErrorException>(() => this.consensusRules.RegisterRule<PosCoinstakeRule>().RunAsync(this.ruleContext));
+            ConsensusErrorException exception = Assert.Throws<ConsensusErrorException>(() => this.consensusRules.RegisterRule<PosCoinstakeRule>().Run(this.ruleContext));
 
             Assert.Equal(ConsensusErrors.BadStakeBlock, exception.ConsensusError);
         }
 
         [Fact]
-        public async Task RunAsync_ProofOfStakeBlock_MultipleCoinStakeAfterSecondTransaction_ThrowsBadMultipleCoinstakeConsensusErrorExceptionAsync()
+        public void RunAsync_ProofOfStakeBlock_MultipleCoinStakeAfterSecondTransaction_ThrowsBadMultipleCoinstakeConsensusErrorExceptionAsync()
         {
             var transaction = this.network.CreateTransaction();
             transaction.Outputs.Add(new TxOut(Money.Zero, (IDestination)null));
@@ -79,13 +79,13 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
 
             Assert.True(BlockStake.IsProofOfStake(this.ruleContext.ValidationContext.BlockToValidate));
 
-            ConsensusErrorException exception = await Assert.ThrowsAsync<ConsensusErrorException>(() => this.consensusRules.RegisterRule<PosCoinstakeRule>().RunAsync(this.ruleContext));
+            ConsensusErrorException exception = Assert.Throws<ConsensusErrorException>(() => this.consensusRules.RegisterRule<PosCoinstakeRule>().Run(this.ruleContext));
 
             Assert.Equal(ConsensusErrors.BadMultipleCoinstake.Message, exception.ConsensusError.Message);
         }
 
         [Fact]
-        public async Task RunAsync_ProofOfStakeBlock_TransactionTimestampAfterBlockTimeStamp_ThrowsBlockTimeBeforeTrxConsensusErrorExceptionAsync()
+        public void RunAsync_ProofOfStakeBlock_TransactionTimestampAfterBlockTimeStamp_ThrowsBlockTimeBeforeTrxConsensusErrorExceptionAsync()
         {
             var transaction = this.network.CreateTransaction();
             transaction.Outputs.Add(new TxOut(Money.Zero, (IDestination)null));
@@ -106,13 +106,13 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
 
             Assert.True(BlockStake.IsProofOfStake(this.ruleContext.ValidationContext.BlockToValidate));
 
-            ConsensusErrorException exception = await Assert.ThrowsAsync<ConsensusErrorException>(() => this.consensusRules.RegisterRule<PosCoinstakeRule>().RunAsync(this.ruleContext));
+            ConsensusErrorException exception = Assert.Throws<ConsensusErrorException>(() => this.consensusRules.RegisterRule<PosCoinstakeRule>().Run(this.ruleContext));
 
             Assert.Equal(ConsensusErrors.BlockTimeBeforeTrx, exception.ConsensusError);
         }
 
         [Fact]
-        public async Task RunAsync_ProofOfWorkBlock_TransactionTimestampAfterBlockTimeStamp_ThrowsBlockTimeBeforeTrxConsensusErrorExceptionAsync()
+        public void RunAsync_ProofOfWorkBlock_TransactionTimestampAfterBlockTimeStamp_ThrowsBlockTimeBeforeTrxConsensusErrorExceptionAsync()
         {
             var transaction = this.network.CreateTransaction();
             transaction.Outputs.Add(new TxOut(Money.Zero, (IDestination)null));
@@ -123,13 +123,13 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
 
             Assert.True(BlockStake.IsProofOfWork(this.ruleContext.ValidationContext.BlockToValidate));
 
-            ConsensusErrorException exception = await Assert.ThrowsAsync<ConsensusErrorException>(() => this.consensusRules.RegisterRule<PosCoinstakeRule>().RunAsync(this.ruleContext));
+            ConsensusErrorException exception = Assert.Throws<ConsensusErrorException>(() => this.consensusRules.RegisterRule<PosCoinstakeRule>().Run(this.ruleContext));
 
             Assert.Equal(ConsensusErrors.BlockTimeBeforeTrx, exception.ConsensusError);
         }
 
         [Fact]
-        public async Task RunAsync_ProofOfStakeBlock_ValidBlock_DoesNotThrowExceptionAsync()
+        public void RunAsync_ProofOfStakeBlock_ValidBlock_DoesNotThrowExceptionAsync()
         {
             var transaction = this.network.CreateTransaction();
             transaction.Outputs.Add(new TxOut(Money.Zero, (IDestination)null));
@@ -151,11 +151,11 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
 
             Assert.True(BlockStake.IsProofOfStake(this.ruleContext.ValidationContext.BlockToValidate));
 
-            await this.consensusRules.RegisterRule<PosCoinstakeRule>().RunAsync(this.ruleContext);
+            this.consensusRules.RegisterRule<PosCoinstakeRule>().Run(this.ruleContext);
         }
 
         [Fact]
-        public async Task RunAsync_ProofOfWorkBlock_ValidBlock_DoesNotThrowExceptionAsync()
+        public void RunAsync_ProofOfWorkBlock_ValidBlock_DoesNotThrowExceptionAsync()
         {
             var transaction = this.network.CreateTransaction();
             transaction.Outputs.Add(new TxOut(Money.Zero, (IDestination)null));
@@ -165,7 +165,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
 
             Assert.True(BlockStake.IsProofOfWork(this.ruleContext.ValidationContext.BlockToValidate));
 
-            await this.consensusRules.RegisterRule<PosCoinstakeRule>().RunAsync(this.ruleContext);
+            this.consensusRules.RegisterRule<PosCoinstakeRule>().Run(this.ruleContext);
         }
     }
 }

--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/CommonRules/PosColdStakingRuleTest.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/CommonRules/PosColdStakingRuleTest.cs
@@ -32,7 +32,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
         /// <param name="inputsExceedOutputs">Tests the scenario where the input amount exceeds the output amount.</param>
         /// <param name="inputsWithoutOutputs">Tests the scenario where the some inputs have no incoming outputs.</param>
         /// <param name="expectedError">The error expected by running this test. Set to <c>null</c> if no error is expected.</param>
-        private async Task PosColdStakingRuleTestHelperAsync(bool isColdCoinStake, bool inputScriptPubKeysDiffer, bool outputScriptPubKeysDiffer,
+        private void PosColdStakingRuleTestHelperAsync(bool isColdCoinStake, bool inputScriptPubKeysDiffer, bool outputScriptPubKeysDiffer,
             bool badSecondOutput, bool inputsExceedOutputs, bool inputsWithoutOutputs, ConsensusError expectedError)
         {
             Block block = this.ruleContext.ValidationContext.BlockToValidate;
@@ -102,7 +102,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
             // If an error is expeected then capture the error and compare it against the expected error.
             if (expectedError != null)
             {
-                ConsensusErrorException exception = Assert.Throws<ConsensusErrorException>(() => rule.RunAsync(this.ruleContext).GetAwaiter().GetResult());
+                ConsensusErrorException exception = Assert.Throws<ConsensusErrorException>(() => rule.Run(this.ruleContext));
 
                 Assert.Equal(expectedError, exception.ConsensusError);
 
@@ -110,7 +110,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
             }
 
             // No error is expected. Attempt to run the rule normally.
-            await rule.RunAsync(this.ruleContext);
+            rule.Run(this.ruleContext);
         }
 
         /// <summary>
@@ -118,9 +118,9 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
         /// expected (an OP_RETURN followed by a compressed public key) and the input does not exceed the output. No exception should be thrown.
         /// </summary>
         [Fact]
-        public async Task PosColdStakeValidBlockDoesNotThrowExceptionAsync()
+        public void PosColdStakeValidBlockDoesNotThrowExceptionAsync()
         {
-            await PosColdStakingRuleTestHelperAsync(isColdCoinStake: true, inputScriptPubKeysDiffer: false, outputScriptPubKeysDiffer: false,
+            PosColdStakingRuleTestHelperAsync(isColdCoinStake: true, inputScriptPubKeysDiffer: false, outputScriptPubKeysDiffer: false,
                 badSecondOutput: false, inputsExceedOutputs: false, inputsWithoutOutputs: false, expectedError: null);
         }
 
@@ -128,9 +128,9 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
         /// Create a transaction where all inputs of this transaction are not using the same ScriptPubKeys. The validation should fail.
         /// </summary>
         [Fact]
-        public async Task PosColdStakeWithMismatchingScriptPubKeyInputsThrowExceptionAsync()
+        public void PosColdStakeWithMismatchingScriptPubKeyInputsThrowExceptionAsync()
         {
-            await PosColdStakingRuleTestHelperAsync(isColdCoinStake: true, inputScriptPubKeysDiffer: true, outputScriptPubKeysDiffer: false,
+            PosColdStakingRuleTestHelperAsync(isColdCoinStake: true, inputScriptPubKeysDiffer: true, outputScriptPubKeysDiffer: false,
                 badSecondOutput: false, inputsExceedOutputs: false, inputsWithoutOutputs: false, expectedError: ConsensusErrors.BadColdstakeInputs);
         }
 
@@ -139,9 +139,9 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
         /// from the input transactions. The validation should fail.
         /// </summary>
         [Fact]
-        public async Task PosColdStakeWithMismatchingScriptPubKeyOutputsThrowExceptionAsync()
+        public void PosColdStakeWithMismatchingScriptPubKeyOutputsThrowExceptionAsync()
         {
-            await PosColdStakingRuleTestHelperAsync(isColdCoinStake: true, inputScriptPubKeysDiffer: false, outputScriptPubKeysDiffer: true,
+            PosColdStakingRuleTestHelperAsync(isColdCoinStake: true, inputScriptPubKeysDiffer: false, outputScriptPubKeysDiffer: true,
                 badSecondOutput: false, inputsExceedOutputs: false, inputsWithoutOutputs: false, expectedError: ConsensusErrors.BadColdstakeOutputs);
         }
 
@@ -149,9 +149,9 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
         /// Create a transaction that has a second output that is not an OP_RETURN followed by data. The validation should fail.
         /// </summary>
         [Fact]
-        public async Task PosColdStakeWithBadSecondOutputThrowExceptionAsync()
+        public void PosColdStakeWithBadSecondOutputThrowExceptionAsync()
         {
-            await PosColdStakingRuleTestHelperAsync(isColdCoinStake: true, inputScriptPubKeysDiffer: false, outputScriptPubKeysDiffer: false,
+            PosColdStakingRuleTestHelperAsync(isColdCoinStake: true, inputScriptPubKeysDiffer: false, outputScriptPubKeysDiffer: false,
                 badSecondOutput: true, inputsExceedOutputs: false, inputsWithoutOutputs: false, expectedError: ConsensusErrors.BadColdstakeOutputs);
         }
 
@@ -160,9 +160,9 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
         /// outputs. The validation should fail.
         /// </summary>
         [Fact]
-        public async Task PosColdStakeWithOutputsExceedingInputsThrowExceptionAsync()
+        public void PosColdStakeWithOutputsExceedingInputsThrowExceptionAsync()
         {
-            await PosColdStakingRuleTestHelperAsync(isColdCoinStake: true, inputScriptPubKeysDiffer: false, outputScriptPubKeysDiffer: false,
+            PosColdStakingRuleTestHelperAsync(isColdCoinStake: true, inputScriptPubKeysDiffer: false, outputScriptPubKeysDiffer: false,
                 badSecondOutput: false, inputsExceedOutputs: true, inputsWithoutOutputs: false, expectedError: ConsensusErrors.BadColdstakeAmount);
         }
 
@@ -170,9 +170,9 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
         /// Create a transaction that is not a cold coin stake transaction but would otherwise fail all the tests. The validation should succeed.
         /// </summary>
         [Fact]
-        public async Task PosCoinStakeWhichIsNotColdCoinStakeDoesNotThrowExceptionAsync()
+        public void PosCoinStakeWhichIsNotColdCoinStakeDoesNotThrowExceptionAsync()
         {
-            await PosColdStakingRuleTestHelperAsync(isColdCoinStake: false, inputScriptPubKeysDiffer: true, outputScriptPubKeysDiffer: true,
+            PosColdStakingRuleTestHelperAsync(isColdCoinStake: false, inputScriptPubKeysDiffer: true, outputScriptPubKeysDiffer: true,
                 badSecondOutput: true, inputsExceedOutputs: true, inputsWithoutOutputs: false, expectedError: null);
         }
 
@@ -180,9 +180,9 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
         /// Create a transaction that is a cold coin stake transaction that has inputs without outputs. The validation should fail.
         /// </summary>
         [Fact]
-        public async Task PosCoinStakeWhichHasInputsWithoutOutputsThrowExceptionAsync()
+        public void PosCoinStakeWhichHasInputsWithoutOutputsThrowExceptionAsync()
         {
-            await PosColdStakingRuleTestHelperAsync(isColdCoinStake: true, inputScriptPubKeysDiffer: false, outputScriptPubKeysDiffer: false,
+            PosColdStakingRuleTestHelperAsync(isColdCoinStake: true, inputScriptPubKeysDiffer: false, outputScriptPubKeysDiffer: false,
                 badSecondOutput: false, inputsExceedOutputs: false, inputsWithoutOutputs: true, expectedError: ConsensusErrors.BadColdstakeInputs);
         }
     }

--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/CommonRules/PosTimeMaskRuleTest.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/CommonRules/PosTimeMaskRuleTest.cs
@@ -34,7 +34,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
         }
 
         [Fact]
-        public async Task RunAsync_ProofOfWorkTooHigh_ThrowsProofOfWorkTooHighConsensusErrorAsync()
+        public void RunAsync_ProofOfWorkTooHigh_ThrowsProofOfWorkTooHighConsensusErrorAsync()
         {
             var rule = this.CreateRule<PosTimeMaskRule>();
 
@@ -47,13 +47,13 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
             this.ruleContext.ValidationContext.BlockToValidate.Transactions[0].Time = (uint)(StratisBugFixPosFutureDriftRule.DriftingBugFixTimestamp);
             this.ruleContext.ValidationContext.ChainedHeaderToValidate = this.ChainIndexer.GetHeader(3);
 
-            ConsensusErrorException exception = await Assert.ThrowsAsync<ConsensusErrorException>(() => rule.RunAsync(this.ruleContext));
+            ConsensusErrorException exception = Assert.Throws<ConsensusErrorException>(() => rule.Run(this.ruleContext));
 
             Assert.Equal(ConsensusErrors.ProofOfWorkTooHigh, exception.ConsensusError);
         }
 
         [Fact]
-        public async Task RunAsync_StakeTimestampInvalid_BlockTimeNotTransactionTime_ThrowsStakeTimeViolationConsensusErrorAsync()
+        public void RunAsync_StakeTimestampInvalid_BlockTimeNotTransactionTime_ThrowsStakeTimeViolationConsensusErrorAsync()
         {
             var rule = this.CreateRule<PosTimeMaskRule>();
 
@@ -77,13 +77,13 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
 
             rule.FutureDriftRule = new StratisBugFixPosFutureDriftRule();
 
-            ConsensusErrorException exception = await Assert.ThrowsAsync<ConsensusErrorException>(() => rule.RunAsync(this.ruleContext));
+            ConsensusErrorException exception = Assert.Throws<ConsensusErrorException>(() => rule.Run(this.ruleContext));
 
             Assert.Equal(ConsensusErrors.StakeTimeViolation, exception.ConsensusError);
         }
 
         [Fact]
-        public async Task RunAsync_StakeTimestampInvalid_TransactionTimeDoesNotIncludeStakeTimestampMask_ThrowsStakeTimeViolationConsensusErrorAsync()
+        public void RunAsync_StakeTimestampInvalid_TransactionTimeDoesNotIncludeStakeTimestampMask_ThrowsStakeTimeViolationConsensusErrorAsync()
         {
             var rule = this.CreateRule<PosTimeMaskRule>();
 
@@ -106,7 +106,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
 
             rule.FutureDriftRule = new StratisBugFixPosFutureDriftRule();
 
-            ConsensusErrorException exception = await Assert.ThrowsAsync<ConsensusErrorException>(() => rule.RunAsync(this.ruleContext));
+            ConsensusErrorException exception = Assert.Throws<ConsensusErrorException>(() => rule.Run(this.ruleContext));
 
             Assert.Equal(ConsensusErrors.StakeTimeViolation, exception.ConsensusError);
         }
@@ -137,7 +137,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
         }
 
         [Fact]
-        public async Task RunAsync_ValidRuleContext_DoesNotThrowExceptionAsync()
+        public void RunAsync_ValidRuleContext_DoesNotThrowExceptionAsync()
         {
             var rule = this.CreateRule<PosTimeMaskRule>();
 
@@ -158,7 +158,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
 
             rule.FutureDriftRule = new StratisBugFixPosFutureDriftRule();
 
-            await rule.RunAsync(this.ruleContext);
+            rule.Run(this.ruleContext);
         }
 
         private void SetBlockStake(BlockFlag flg)

--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/CommonRules/PowCoinViewRuleTests.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/CommonRules/PowCoinViewRuleTests.cs
@@ -103,7 +103,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
 
                 rule.Initialize();
 
-                (rule as AsyncConsensusRule).RunAsync(ruleContext).GetAwaiter().GetResult();
+                rule.Run(ruleContext);
             }
             catch (Exception e)
             {

--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/CommonRules/SetActivationDeploymentsRuleTest.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/CommonRules/SetActivationDeploymentsRuleTest.cs
@@ -18,7 +18,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
         }
 
         [Fact]
-        public async Task RunAsync_ValidBlock_SetsConsensusFlagsAsync()
+        public void RunAsync_ValidBlock_SetsConsensusFlagsAsync()
         {
             this.nodeDeployments = new NodeDeployments(this.network, this.ChainIndexer);
             this.consensusRules = this.InitializeConsensusRules();
@@ -33,7 +33,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
             this.ruleContext.ValidationContext.BlockToValidate = block;
             this.ruleContext.ValidationContext.ChainedHeaderToValidate = this.ChainIndexer.Tip;
 
-            await this.consensusRules.RegisterRule<SetActivationDeploymentsPartialValidationRule>().RunAsync(this.ruleContext);
+            this.consensusRules.RegisterRule<SetActivationDeploymentsPartialValidationRule>().Run(this.ruleContext);
 
             Assert.NotNull(this.ruleContext.Flags);
             Assert.True(this.ruleContext.Flags.EnforceBIP30);

--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/CommonRules/TransactionLocktimeActivationRuleTest.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/CommonRules/TransactionLocktimeActivationRuleTest.cs
@@ -15,7 +15,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
         }
 
         [Fact]
-        public async Task RunAsync_DoesNotHaveBIP113Flag_TransactionNotFinal_ThrowsBadTransactionNonFinalConsensusErrorExceptionAsync()
+        public void RunAsync_DoesNotHaveBIP113Flag_TransactionNotFinal_ThrowsBadTransactionNonFinalConsensusErrorExceptionAsync()
         {
             this.ruleContext.Flags = new Base.Deployments.DeploymentFlags();
 
@@ -33,13 +33,13 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
 
             this.ruleContext.ValidationContext.BlockToValidate.Header.BlockTime = new DateTimeOffset(new DateTime(2018, 1, 1, 0, 0, 0, DateTimeKind.Utc));
 
-            ConsensusErrorException exception = await Assert.ThrowsAsync<ConsensusErrorException>(() => this.consensusRules.RegisterRule<TransactionLocktimeActivationRule>().RunAsync(this.ruleContext));
+            ConsensusErrorException exception = Assert.Throws<ConsensusErrorException>(() => this.consensusRules.RegisterRule<TransactionLocktimeActivationRule>().Run(this.ruleContext));
 
             Assert.Equal(ConsensusErrors.BadTransactionNonFinal, exception.ConsensusError);
         }
 
         [Fact]
-        public async Task RunAsync_HasBIP113Flag_TransactionNotFinal_ThrowsBadTransactionNonFinalConsensusErrorExceptionAsync()
+        public void RunAsync_HasBIP113Flag_TransactionNotFinal_ThrowsBadTransactionNonFinalConsensusErrorExceptionAsync()
         {
             this.ruleContext.Flags = new Base.Deployments.DeploymentFlags() { LockTimeFlags = Transaction.LockTimeFlags.MedianTimePast };
             this.ruleContext.Time = new DateTimeOffset(new DateTime(2018, 1, 1, 0, 0, 0, DateTimeKind.Utc));
@@ -56,13 +56,13 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
                 ChainedHeaderToValidate = this.ChainIndexer.GetHeader(4)
             };
 
-            ConsensusErrorException exception = await Assert.ThrowsAsync<ConsensusErrorException>(() => this.consensusRules.RegisterRule<TransactionLocktimeActivationRule>().RunAsync(this.ruleContext));
+            ConsensusErrorException exception = Assert.Throws<ConsensusErrorException>(() => this.consensusRules.RegisterRule<TransactionLocktimeActivationRule>().Run(this.ruleContext));
 
             Assert.Equal(ConsensusErrors.BadTransactionNonFinal, exception.ConsensusError);
         }
 
         [Fact]
-        public async Task RunAsync_DoesNotHaveBIP113Flag_TransactionFinal_DoesNotThrowExceptionAsync()
+        public void RunAsync_DoesNotHaveBIP113Flag_TransactionFinal_DoesNotThrowExceptionAsync()
         {
             this.ruleContext.Flags = new Base.Deployments.DeploymentFlags();
 
@@ -78,11 +78,11 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
 
             this.ruleContext.ValidationContext.BlockToValidate.Header.BlockTime = new DateTimeOffset(new DateTime(2018, 1, 1, 0, 0, 0, DateTimeKind.Utc));
             
-            await this.consensusRules.RegisterRule<TransactionLocktimeActivationRule>().RunAsync(this.ruleContext);
+            this.consensusRules.RegisterRule<TransactionLocktimeActivationRule>().Run(this.ruleContext);
         }
 
         [Fact]
-        public async Task RunAsync_HasBIP113Flag_TransactionFinal_DoesNotThrowExceptionAsync()
+        public void RunAsync_HasBIP113Flag_TransactionFinal_DoesNotThrowExceptionAsync()
         {
             this.ruleContext.Flags = new Base.Deployments.DeploymentFlags() { LockTimeFlags = Transaction.LockTimeFlags.MedianTimePast };
             this.ruleContext.Time = new DateTimeOffset(new DateTime(2018, 1, 1, 0, 0, 0, DateTimeKind.Utc));
@@ -97,7 +97,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
                 ChainedHeaderToValidate = this.ChainIndexer.GetHeader(4)
             };
 
-            await this.consensusRules.RegisterRule<TransactionLocktimeActivationRule>().RunAsync(this.ruleContext);
+            this.consensusRules.RegisterRule<TransactionLocktimeActivationRule>().Run(this.ruleContext);
         }
 
         private static Transaction CreateCoinStakeTransaction(Network network, Key key, int height, uint256 prevout)

--- a/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/BlockSizeRule.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/BlockSizeRule.cs
@@ -16,10 +16,10 @@ namespace Stratis.Bitcoin.Features.Consensus.Rules.CommonRules
         /// <exception cref="ConsensusErrors.BadBlockLength">The block length is larger than the allowed max block base size.</exception>
         /// <exception cref="ConsensusErrors.BadBlockLength">The amount of transactions inside the block is higher than the allowed max block base size.</exception>
         /// <exception cref="ConsensusErrors.BadBlockLength">The block does not contain any transactions.</exception>
-        public override Task RunAsync(RuleContext context)
+        public override void Run(RuleContext context)
         {
             if (context.SkipValidation)
-                return Task.CompletedTask;
+                return;
 
             var consensus = this.Parent.Network.Consensus;
 
@@ -44,8 +44,6 @@ namespace Stratis.Bitcoin.Features.Consensus.Rules.CommonRules
                 this.Logger.LogTrace("(-)[BAD_BLOCK_LEN]");
                 ConsensusErrors.BadBlockLength.Throw();
             }
-
-            return Task.CompletedTask;
         }
     }
 }

--- a/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/CheckDifficultyHybridRule.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/CheckDifficultyHybridRule.cs
@@ -24,10 +24,10 @@ namespace Stratis.Bitcoin.Features.Consensus.Rules.CommonRules
         /// <inheritdoc />
         /// <exception cref="ConsensusErrors.HighHash">Thrown if block doesn't have a valid PoW header.</exception>
         /// <exception cref="ConsensusErrors.BadDiffBits">Thrown if proof of stake is incorrect.</exception>
-        public override Task RunAsync(RuleContext context)
+        public override void Run(RuleContext context)
         {
             if (context.SkipValidation)
-                return Task.CompletedTask;
+                return;
 
             var posRuleContext = context as PosRuleContext;
 
@@ -53,8 +53,6 @@ namespace Stratis.Bitcoin.Features.Consensus.Rules.CommonRules
                 this.Logger.LogTrace("(-)[BAD_DIFF_BITS]");
                 ConsensusErrors.BadDiffBits.Throw();
             }
-
-            return Task.CompletedTask;
         }
     }
 }

--- a/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/CheckPosTransactionRule.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/CheckPosTransactionRule.cs
@@ -11,18 +11,16 @@ namespace Stratis.Bitcoin.Features.Consensus.Rules.CommonRules
     {
         /// <inheritdoc />
         /// <exception cref="ConsensusErros.BadTransactionEmptyOutput">The transaction output is empty.</exception>
-        public override Task RunAsync(RuleContext context)
+        public override void Run(RuleContext context)
         {
             if (context.SkipValidation)
-                return Task.CompletedTask;
+                return;
 
             Block block = context.ValidationContext.BlockToValidate;
 
             // Check transactions
             foreach (Transaction tx in block.Transactions)
                 this.CheckTransaction(tx);
-
-            return Task.CompletedTask;
         }
 
         public virtual void CheckTransaction(Transaction transaction)

--- a/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/CheckPowTransactionRule.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/CheckPowTransactionRule.cs
@@ -20,10 +20,10 @@ namespace Stratis.Bitcoin.Features.Consensus.Rules.CommonRules
         /// <exception cref="ConsensusErrors.BadTransactionDuplicateInputs">Thrown if any of transaction inputs are duplicate.</exception>
         /// <exception cref="ConsensusErrors.BadCoinbaseSize">Thrown if coinbase transaction is too small or too big.</exception>
         /// <exception cref="ConsensusErrors.BadTransactionNullPrevout">Thrown if transaction contains a null prevout.</exception>
-        public override Task RunAsync(RuleContext context)
+        public override void Run(RuleContext context)
         {
             if (context.SkipValidation)
-                return Task.CompletedTask;
+                return;
 
             Block block = context.ValidationContext.BlockToValidate;
             var options = this.Parent.Network.Consensus.Options;
@@ -31,8 +31,6 @@ namespace Stratis.Bitcoin.Features.Consensus.Rules.CommonRules
             // Check transactions
             foreach (Transaction tx in block.Transactions)
                 this.CheckTransaction(this.Parent.Network, options, tx);
-
-            return Task.CompletedTask;
         }
 
         public virtual void CheckTransaction(Network network, ConsensusOptions options, Transaction tx)

--- a/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/CheckSigOpsRule.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/CheckSigOpsRule.cs
@@ -10,10 +10,10 @@ namespace Stratis.Bitcoin.Features.Consensus.Rules.CommonRules
     {
         /// <inheritdoc />
         /// <exception cref="ConsensusErrors.BadBlockSigOps">The block contains more signature check operations than allowed.</exception>
-        public override Task RunAsync(RuleContext context)
+        public override void Run(RuleContext context)
         {
             if (context.SkipValidation)
-                return Task.CompletedTask;
+                return;
 
             Block block = context.ValidationContext.BlockToValidate;
             ConsensusOptions options = this.Parent.Network.Consensus.Options;
@@ -27,8 +27,6 @@ namespace Stratis.Bitcoin.Features.Consensus.Rules.CommonRules
                 this.Logger.LogTrace("(-)[BAD_BLOCK_SIGOPS]");
                 ConsensusErrors.BadBlockSigOps.Throw();
             }
-
-            return Task.CompletedTask;
         }
 
         private long GetLegacySigOpCount(Transaction tx)

--- a/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/CoinbaseHeightRule.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/CoinbaseHeightRule.cs
@@ -20,10 +20,10 @@ namespace Stratis.Bitcoin.Features.Consensus.Rules.CommonRules
     {
         /// <inheritdoc />
         /// <exception cref="ConsensusErrors.BadCoinbaseHeight">Thrown if coinbase doesn't start with serialized block height.</exception>
-        public override Task RunAsync(RuleContext context)
+        public override void Run(RuleContext context)
         {
             if (context.SkipValidation)
-                return Task.CompletedTask;
+                return;
 
             int newHeight = context.ValidationContext.ChainedHeaderToValidate.Height;
             Block block = context.ValidationContext.BlockToValidate;
@@ -35,8 +35,6 @@ namespace Stratis.Bitcoin.Features.Consensus.Rules.CommonRules
                 this.Logger.LogTrace("(-)[BAD_COINBASE_HEIGHT]");
                 ConsensusErrors.BadCoinbaseHeight.Throw();
             }
-
-            return Task.CompletedTask;
         }
 
         /// <summary>
@@ -67,16 +65,14 @@ namespace Stratis.Bitcoin.Features.Consensus.Rules.CommonRules
     public class CoinbaseHeightActivationRule : CoinbaseHeightRule
     {
         /// <inheritdoc />
-        public override Task RunAsync(RuleContext context)
+        public override void Run(RuleContext context)
         {
             DeploymentFlags deploymentFlags = context.Flags;
 
             if (deploymentFlags.EnforceBIP34)
             {
-                return base.RunAsync(context);
+                base.Run(context);
             }
-
-            return Task.CompletedTask;
         }
     }
 }

--- a/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/EnsureCoinbaseRule.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/EnsureCoinbaseRule.cs
@@ -12,10 +12,10 @@ namespace Stratis.Bitcoin.Features.Consensus.Rules.CommonRules
         /// <inheritdoc />
         /// <exception cref="ConsensusErrors.BadCoinbaseMissing">The coinbase transaction is missing in the block.</exception>
         /// <exception cref="ConsensusErrors.BadMultipleCoinbase">The block contains multiple coinbase transactions.</exception>
-        public override Task RunAsync(RuleContext context)
+        public override void Run(RuleContext context)
         {
             if (context.SkipValidation)
-                return Task.CompletedTask;
+                return;
 
             Block block = context.ValidationContext.BlockToValidate;
 
@@ -34,8 +34,6 @@ namespace Stratis.Bitcoin.Features.Consensus.Rules.CommonRules
                     ConsensusErrors.BadMultipleCoinbase.Throw();
                 }
             }
-
-            return Task.CompletedTask;
         }
     }
 }

--- a/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/LoadCoinviewRule.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/LoadCoinviewRule.cs
@@ -17,7 +17,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Rules.CommonRules
         private const int FlushRequiredThresholdSeconds = 2 * 24 * 60 * 60;
 
         /// <inheritdoc />
-        public override async Task RunAsync(RuleContext context)
+        public override void Run(RuleContext context)
         {
             uint256 oldBlockHash = context.ValidationContext.ChainedHeaderToValidate.Previous.HashBlock;
             uint256 nextBlockHash = context.ValidationContext.ChainedHeaderToValidate.HashBlock;
@@ -38,7 +38,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Rules.CommonRules
     public class LoadCoinviewRule : UtxoStoreConsensusRule
     {
         /// <inheritdoc />
-        public override async Task RunAsync(RuleContext context)
+        public override void Run(RuleContext context)
         {
             // Check that the current block has not been reorged.
             // Catching a reorg at this point will not require a rewind.

--- a/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/PosCoinstakeRule.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/PosCoinstakeRule.cs
@@ -27,10 +27,10 @@ namespace Stratis.Bitcoin.Features.Consensus.Rules.CommonRules
         /// <exception cref="ConsensusErrors.BadStakeBlock">The second transaction is not a coinstake transaction.</exception>
         /// <exception cref="ConsensusErrors.BadMultipleCoinstake">There are multiple coinstake tranasctions in the block.</exception>
         /// <exception cref="ConsensusErrors.BlockTimeBeforeTrx">The block contains a transaction with a timestamp after the block timestamp.</exception>
-        public override Task RunAsync(RuleContext context)
+        public override void Run(RuleContext context)
         {
             if (context.SkipValidation)
-                return Task.CompletedTask;
+                return;
 
             Block block = context.ValidationContext.BlockToValidate;
 
@@ -68,8 +68,6 @@ namespace Stratis.Bitcoin.Features.Consensus.Rules.CommonRules
                     ConsensusErrors.BlockTimeBeforeTrx.Throw();
                 }
             }
-
-            return Task.CompletedTask;
         }
     }
 }

--- a/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/PosCoinviewRule.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/PosCoinviewRule.cs
@@ -37,11 +37,11 @@ namespace Stratis.Bitcoin.Features.Consensus.Rules.CommonRules
 
         /// <inheritdoc />
         /// <summary>Compute and store the stake proofs.</summary>
-        public override async Task RunAsync(RuleContext context)
+        public override void Run(RuleContext context)
         {
             this.CheckAndComputeStake(context);
 
-            await base.RunAsync(context).ConfigureAwait(false);
+            base.Run(context);
             var posRuleContext = context as PosRuleContext;
             this.stakeChain.Set(context.ValidationContext.ChainedHeaderToValidate, posRuleContext.BlockStake);
         }

--- a/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/PosColdstakingRule.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/PosColdstakingRule.cs
@@ -43,7 +43,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Rules.CommonRules
         /// <exception cref="ConsensusErrors.BadColdstakeInputs">Thrown if the input scriptPubKeys mismatch.</exception>
         /// <exception cref="ConsensusErrors.BadColdstakeOutputs">Thrown if the output scriptPubKeys mismatch.</exception>
         /// <exception cref="ConsensusErrors.BadColdstakeAmount">Thrown if the total input is smaller or equal than the sum of outputs.</exception>
-        public override Task RunAsync(RuleContext context)
+        public override void Run(RuleContext context)
         {
             this.Logger.LogTrace("()");
 
@@ -56,7 +56,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Rules.CommonRules
             if (!(coinstakeTransaction?.IsColdCoinStake ?? false))
             {
                 this.Logger.LogTrace("(-)[SKIP_COLDSTAKE_RULE]");
-                return Task.CompletedTask;
+                return;
             }
 
             var posRuleContext = context as PosRuleContext;
@@ -112,8 +112,6 @@ namespace Stratis.Bitcoin.Features.Consensus.Rules.CommonRules
             }
 
             this.Logger.LogTrace("(-)");
-
-            return Task.CompletedTask;
         }
     }
 }

--- a/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/PosTimeMaskRule.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/PosTimeMaskRule.cs
@@ -26,10 +26,10 @@ namespace Stratis.Bitcoin.Features.Consensus.Rules.CommonRules
         /// <exception cref="ConsensusErrors.BlockTimestampTooEarly"> Thrown if the block timestamp is before the previous block timestamp.</exception>
         /// <exception cref="ConsensusErrors.StakeTimeViolation">Thrown if the coinstake timestamp is invalid.</exception>
         /// <exception cref="ConsensusErrors.ProofOfWorkTooHigh">The block's height is higher than the last allowed PoW block.</exception>
-        public override Task RunAsync(RuleContext context)
+        public override void Run(RuleContext context)
         {
             if (context.SkipValidation)
-                return Task.CompletedTask;
+                return;
 
             ChainedHeader chainedHeader = context.ValidationContext.ChainedHeaderToValidate;
             this.Logger.LogTrace("Height of block is {0}, block timestamp is {1}, previous block timestamp is {2}, block version is 0x{3:x}.", chainedHeader.Height, chainedHeader.Header.Time, chainedHeader.Previous?.Header.Time, chainedHeader.Header.Version);
@@ -58,8 +58,6 @@ namespace Stratis.Bitcoin.Features.Consensus.Rules.CommonRules
                 this.Logger.LogTrace("(-)[BAD_TIME]");
                 ConsensusErrors.StakeTimeViolation.Throw();
             }
-
-            return Task.CompletedTask;
         }
 
         /// <summary>

--- a/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/PowCoinviewRule.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/PowCoinviewRule.cs
@@ -87,11 +87,5 @@ namespace Stratis.Bitcoin.Features.Consensus.Rules.CommonRules
         {
             base.UpdateUTXOSet(context, transaction);
         }
-
-        /// <inheritdoc />
-        public override Task RunAsync(RuleContext context)
-        {
-            return base.RunAsync(context);
-        }
     }
 }

--- a/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/SetActivationDeploymentsPartialValidationRule.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/SetActivationDeploymentsPartialValidationRule.cs
@@ -9,12 +9,10 @@ namespace Stratis.Bitcoin.Features.Consensus.Rules.CommonRules
     {
         /// <inheritdoc />
         /// <exception cref="ConsensusErrors.InvalidPrevTip">The tip is invalid because a reorg has been detected.</exception>
-        public override Task RunAsync(RuleContext context)
+        public override void Run(RuleContext context)
         {
             // Calculate the consensus flags and check they are valid.
             context.Flags = this.Parent.NodeDeployments.GetFlags(context.ValidationContext.ChainedHeaderToValidate);
-
-            return Task.CompletedTask;
         }
     }
 
@@ -24,12 +22,10 @@ namespace Stratis.Bitcoin.Features.Consensus.Rules.CommonRules
     {
         /// <inheritdoc />
         /// <exception cref="ConsensusErrors.InvalidPrevTip">The tip is invalid because a reorg has been detected.</exception>
-        public override Task RunAsync(RuleContext context)
+        public override void Run(RuleContext context)
         {
             // Calculate the consensus flags and check they are valid.
             context.Flags = this.Parent.NodeDeployments.GetFlags(context.ValidationContext.ChainedHeaderToValidate);
-
-            return Task.CompletedTask;
         }
     }
 }

--- a/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/TransactionDuplicationActivationRule.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/TransactionDuplicationActivationRule.cs
@@ -18,7 +18,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Rules.CommonRules
     {
         /// <inheritdoc />>
         /// <exception cref="ConsensusErrors.BadTransactionBIP30"> Thrown if BIP30 is not passed.</exception>
-        public override Task RunAsync(RuleContext context)
+        public override void Run(RuleContext context)
         {
             if (!context.SkipValidation)
             {
@@ -42,8 +42,6 @@ namespace Stratis.Bitcoin.Features.Consensus.Rules.CommonRules
                 }
             }
             else this.Logger.LogTrace("BIP30 validation skipped for checkpointed block at height {0}.", context.ValidationContext.ChainedHeaderToValidate.Height);
-
-            return Task.CompletedTask;
         }
     }
 }

--- a/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/TransactionLocktimeActivationRule.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/TransactionLocktimeActivationRule.cs
@@ -18,10 +18,10 @@ namespace Stratis.Bitcoin.Features.Consensus.Rules.CommonRules
     {
         /// <inheritdoc />
         /// <exception cref="ConsensusErrors.BadTransactionNonFinal">Thrown if one or more transactions are not finalized.</exception>
-        public override Task RunAsync(RuleContext context)
+        public override void Run(RuleContext context)
         {
             if (context.SkipValidation)
-                return Task.CompletedTask;
+                return;
 
             DeploymentFlags deploymentFlags = context.Flags;
             int newHeight = context.ValidationContext.ChainedHeaderToValidate.Height;
@@ -41,8 +41,6 @@ namespace Stratis.Bitcoin.Features.Consensus.Rules.CommonRules
                     ConsensusErrors.BadTransactionNonFinal.Throw();
                 }
             }
-
-            return Task.CompletedTask;
         }
     }
 }

--- a/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/WitnessCommitmentsRule.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/WitnessCommitmentsRule.cs
@@ -19,10 +19,10 @@ namespace Stratis.Bitcoin.Features.Consensus.Rules.CommonRules
         /// <exception cref="ConsensusErrors.BadWitnessNonceSize">The witness nonce size is invalid.</exception>
         /// <exception cref="ConsensusErrors.BadWitnessMerkleMatch">The witness merkle commitment does not match the computed commitment.</exception>
         /// <exception cref="ConsensusErrors.UnexpectedWitness">The block does not expect witness transactions but contains a witness transaction.</exception>
-        public override Task RunAsync(RuleContext context)
+        public override void Run(RuleContext context)
         {
             if (context.SkipValidation)
-                return Task.CompletedTask;
+                return;
 
             DeploymentFlags deploymentFlags = context.Flags;
             Block block = context.ValidationContext.BlockToValidate;
@@ -82,8 +82,6 @@ namespace Stratis.Bitcoin.Features.Consensus.Rules.CommonRules
                     }
                 }
             }
-
-            return Task.CompletedTask;
         }
 
         /// <summary>

--- a/src/Stratis.Bitcoin.Features.Consensus/Rules/PowConsensusRuleEngine.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/Rules/PowConsensusRuleEngine.cs
@@ -81,9 +81,9 @@ namespace Stratis.Bitcoin.Features.Consensus.Rules
             }
         }
 
-        public override async Task<ValidationContext> FullValidationAsync(ChainedHeader header, Block block)
+        public override ValidationContext FullValidationAsync(ChainedHeader header, Block block)
         {
-            ValidationContext result = await base.FullValidationAsync(header, block).ConfigureAwait(false);
+            ValidationContext result = base.FullValidationAsync(header, block);
 
             if ((result != null) && (result.Error == null))
             {

--- a/src/Stratis.Bitcoin.Features.PoA.Tests/Rules/PoAVotingCoinbaseOutputFormatRuleTests.cs
+++ b/src/Stratis.Bitcoin.Features.PoA.Tests/Rules/PoAVotingCoinbaseOutputFormatRuleTests.cs
@@ -27,7 +27,7 @@ namespace Stratis.Bitcoin.Features.PoA.Tests.Rules
             block.Transactions.Add(new Transaction());
             block.Transactions[0].AddOutput(Money.COIN, Script.Empty);
 
-            this.votingFormatRule.RunAsync(new RuleContext(new ValidationContext() {BlockToValidate = block}, DateTimeOffset.Now)).GetAwaiter().GetResult();
+            this.votingFormatRule.Run(new RuleContext(new ValidationContext() {BlockToValidate = block}, DateTimeOffset.Now));
         }
 
         [Fact]
@@ -43,7 +43,7 @@ namespace Stratis.Bitcoin.Features.PoA.Tests.Rules
             block.Transactions[0].AddOutput(Money.COIN, votingOutputScript);
 
             Assert.Throws<ConsensusErrorException>(() =>
-                this.votingFormatRule.RunAsync(new RuleContext(new ValidationContext() { BlockToValidate = block }, DateTimeOffset.Now)).GetAwaiter().GetResult());
+                this.votingFormatRule.Run(new RuleContext(new ValidationContext() { BlockToValidate = block }, DateTimeOffset.Now)));
         }
 
         [Fact]
@@ -62,7 +62,7 @@ namespace Stratis.Bitcoin.Features.PoA.Tests.Rules
             block.Transactions[0].AddOutput(Money.COIN, votingOutputScript);
 
             Assert.Throws<ConsensusErrorException>(() =>
-                this.votingFormatRule.RunAsync(new RuleContext(new ValidationContext() {BlockToValidate = block}, DateTimeOffset.Now)).GetAwaiter().GetResult());
+                this.votingFormatRule.Run(new RuleContext(new ValidationContext() {BlockToValidate = block}, DateTimeOffset.Now)));
         }
     }
 }

--- a/src/Stratis.Bitcoin.Features.PoA/Voting/ConsensusRules/PoAVotingCoinbaseOutputFormatRule.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/Voting/ConsensusRules/PoAVotingCoinbaseOutputFormatRule.cs
@@ -18,7 +18,7 @@ namespace Stratis.Bitcoin.Features.PoA.Voting.ConsensusRules
             base.Initialize();
         }
 
-        public override Task RunAsync(RuleContext context)
+        public override void Run(RuleContext context)
         {
             Transaction coinbase = context.ValidationContext.BlockToValidate.Transactions[0];
 
@@ -27,7 +27,7 @@ namespace Stratis.Bitcoin.Features.PoA.Voting.ConsensusRules
             if (votingDataBytes == null)
             {
                 this.Logger.LogTrace("(-)[NO_VOTING_DATA]");
-                return Task.CompletedTask;
+                return;
             }
 
             List<VotingData> votingDataList = this.votingDataEncoder.Decode(votingDataBytes);
@@ -38,7 +38,7 @@ namespace Stratis.Bitcoin.Features.PoA.Voting.ConsensusRules
                 PoAConsensusErrors.VotingDataInvalidFormat.Throw();
             }
 
-            return Task.CompletedTask;
+            return;
         }
     }
 }

--- a/src/Stratis.Bitcoin.Features.SmartContracts.Tests/Consensus/Rules/CanGetSenderRuleTest.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts.Tests/Consensus/Rules/CanGetSenderRuleTest.cs
@@ -68,7 +68,7 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Tests.Consensus.Rules
             // Block validation check works
             Block block = this.network.CreateBlock();
             block.AddTransaction(transaction);
-            this.rule.RunAsync(new RuleContext(new ValidationContext {BlockToValidate = block}, DateTimeOffset.Now));
+            this.rule.Run(new RuleContext(new ValidationContext {BlockToValidate = block}, DateTimeOffset.Now));
         }
 
         [Fact]
@@ -89,7 +89,7 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Tests.Consensus.Rules
             // Block validation check fails
             Block block = this.network.CreateBlock();
             block.AddTransaction(transaction);
-            Assert.ThrowsAnyAsync<ConsensusErrorException>(() => this.rule.RunAsync(new RuleContext(new ValidationContext { BlockToValidate = block }, DateTimeOffset.Now)));
+            Assert.ThrowsAny<ConsensusErrorException>(() => this.rule.Run(new RuleContext(new ValidationContext { BlockToValidate = block }, DateTimeOffset.Now)));
         }
     }
 }

--- a/src/Stratis.Bitcoin.Features.SmartContracts.Tests/Consensus/Rules/ContractValidationRuleTest.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts.Tests/Consensus/Rules/ContractValidationRuleTest.cs
@@ -56,7 +56,7 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Tests.Consensus.Rules
         }
 
         [Fact]
-        public async Task SmartContractFormatRule_SuccessAsync()
+        public void SmartContractFormatRule_SuccessAsync()
         {
             TestRulesContext testContext = TestRulesContextFactory.CreateAsync(this.network);
             ContractTransactionPartialValidationRule rule = testContext.CreateContractValidationRule();
@@ -95,11 +95,11 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Tests.Consensus.Rules
                transaction
             };
 
-            await rule.RunAsync(context);
+            rule.Run(context);
         }
 
         [Fact]
-        public async Task SmartContractFormatRule_MultipleOutputs_SuccessAsync()
+        public void SmartContractFormatRule_MultipleOutputs_SuccessAsync()
         {
             TestRulesContext testContext = TestRulesContextFactory.CreateAsync(this.network);
             ContractTransactionPartialValidationRule rule = testContext.CreateContractValidationRule();
@@ -145,14 +145,14 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Tests.Consensus.Rules
                 transaction
             };
 
-            await rule.RunAsync(context);
+            rule.Run(context);
         }
 
         /// <summary>
         /// In this test we supply a higher gas limit in our carrier than what we budgeted for in our transaction
         /// </summary>
         [Fact]
-        public async Task SmartContractFormatRule_FailureAsync()
+        public void SmartContractFormatRule_FailureAsync()
         {
             TestRulesContext testContext = TestRulesContextFactory.CreateAsync(this.network);
             ContractTransactionPartialValidationRule rule = testContext.CreateContractValidationRule();
@@ -194,7 +194,7 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Tests.Consensus.Rules
                 transaction
             };
 
-            await Assert.ThrowsAsync<ConsensusErrorException>(async () => await rule.RunAsync(context));
+            Assert.Throws<ConsensusErrorException>(() => rule.Run(context));
         }
     }
 }

--- a/src/Stratis.Bitcoin.Features.SmartContracts.Tests/Consensus/Rules/OpSpendRuleTest.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts.Tests/Consensus/Rules/OpSpendRuleTest.cs
@@ -20,7 +20,7 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Tests.Consensus.Rules
         }
 
         [Fact]
-        public async Task OpSpend_PreviousTransactionOpCall_SuccessAsync()
+        public void OpSpend_PreviousTransactionOpCall_SuccessAsync()
         {
             TestRulesContext testContext = TestRulesContextFactory.CreateAsync(this.network);
             OpSpendRule rule = testContext.CreateRule<OpSpendRule>();
@@ -47,11 +47,11 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Tests.Consensus.Rules
                 }
             };
 
-            await rule.RunAsync(context);
+            rule.Run(context);
         }
 
         [Fact]
-        public async Task OpSpend_PreviousTransactionNone_FailureAsync()
+        public void OpSpend_PreviousTransactionNone_FailureAsync()
         {
             TestRulesContext testContext = TestRulesContextFactory.CreateAsync(this.network);
             OpSpendRule rule = testContext.CreateRule<OpSpendRule>();
@@ -70,11 +70,11 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Tests.Consensus.Rules
                 }
             };
 
-            await Assert.ThrowsAsync<ConsensusErrorException>(async () => await rule.RunAsync(context));
+            Assert.Throws<ConsensusErrorException>(() => rule.Run(context));
         }
 
         [Fact]
-        public async Task OpSpend_PreviousTransactionOther_FailureAsync()
+        public void OpSpend_PreviousTransactionOther_FailureAsync()
         {
             TestRulesContext testContext = TestRulesContextFactory.CreateAsync(this.network);
             OpSpendRule rule = testContext.CreateRule<OpSpendRule>();
@@ -114,7 +114,7 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Tests.Consensus.Rules
                 }
             };
 
-            await Assert.ThrowsAsync<ConsensusErrorException>(async () => await rule.RunAsync(context));
+            Assert.Throws<ConsensusErrorException>(() => rule.Run(context));
         }
     }
 }

--- a/src/Stratis.Bitcoin.Features.SmartContracts.Tests/Consensus/Rules/TxOutSmartContractExecRuleTest.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts.Tests/Consensus/Rules/TxOutSmartContractExecRuleTest.cs
@@ -20,7 +20,7 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Tests.Consensus.Rules
         }
 
         [Fact]
-        public async Task TxOutSmartContractExec_AllTransactions_ValidationSuccessAsync()
+        public void TxOutSmartContractExec_AllTransactions_ValidationSuccessAsync()
         {
             TestRulesContext testContext = TestRulesContextFactory.CreateAsync(this.network);
             TxOutSmartContractExecRule rule = testContext.CreateRule<TxOutSmartContractExecRule>();
@@ -39,11 +39,11 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Tests.Consensus.Rules
                 }
             };
 
-            await rule.RunAsync(context);
+            rule.Run(context);
         }
 
         [Fact]
-        public async Task TxOutSmartContractExec_AllTransactions_ValidationFailAsync()
+        public void TxOutSmartContractExec_AllTransactions_ValidationFailAsync()
         {
             TestRulesContext testContext = TestRulesContextFactory.CreateAsync(this.network);
             TxOutSmartContractExecRule rule = testContext.CreateRule<TxOutSmartContractExecRule>();
@@ -65,7 +65,7 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Tests.Consensus.Rules
             };
 
             context.ValidationContext.BlockToValidate.Transactions = transactions;
-            await Assert.ThrowsAsync<ConsensusErrorException>(async () => await rule.RunAsync(context));
+            Assert.Throws<ConsensusErrorException>( () =>  rule.Run(context));
 
             transactions = new List<Transaction>
             {
@@ -80,7 +80,7 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Tests.Consensus.Rules
             };
 
             context.ValidationContext.BlockToValidate.Transactions = transactions;
-            await Assert.ThrowsAsync<ConsensusErrorException>(async () => await rule.RunAsync(context));
+            Assert.Throws<ConsensusErrorException>( () =>  rule.Run(context));
 
             transactions = new List<Transaction>
             {
@@ -95,7 +95,7 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Tests.Consensus.Rules
             };
 
             context.ValidationContext.BlockToValidate.Transactions = transactions;
-            await Assert.ThrowsAsync<ConsensusErrorException>(async () => await rule.RunAsync(context));
+            Assert.Throws<ConsensusErrorException>(() =>  rule.Run(context));
         }
 
         [Fact]
@@ -124,7 +124,7 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Tests.Consensus.Rules
             };
 
             context.ValidationContext.BlockToValidate.Transactions = transactions;
-            await Assert.ThrowsAsync<ConsensusErrorException>(async () => await rule.RunAsync(context));
+            Assert.Throws<ConsensusErrorException>(() => rule.Run(context));
 
             transactions = new List<Transaction>
             {
@@ -142,7 +142,7 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Tests.Consensus.Rules
             };
 
             context.ValidationContext.BlockToValidate.Transactions = transactions;
-            await rule.RunAsync(context);
+            rule.Run(context);
         }
     }
 }

--- a/src/Stratis.Bitcoin.Features.SmartContracts/PoA/Rules/SmartContractPoACoinviewRule.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts/PoA/Rules/SmartContractPoACoinviewRule.cs
@@ -55,9 +55,9 @@ namespace Stratis.Bitcoin.Features.SmartContracts.PoA.Rules
         }
 
         /// <inheritdoc />
-        public override async Task RunAsync(RuleContext context)
+        public override void Run(RuleContext context)
         {
-            await this.logic.RunAsync(base.RunAsync, context);
+            this.logic.Run(base.Run, context);
         }
 
         /// <inheritdoc/>

--- a/src/Stratis.Bitcoin.Features.SmartContracts/PoS/Rules/SmartContractPosCoinviewRule.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts/PoS/Rules/SmartContractPosCoinviewRule.cs
@@ -40,14 +40,14 @@ namespace Stratis.Bitcoin.Features.SmartContracts.PoS.Rules
 
         /// <inheritdoc />
         /// <summary>Compute and store the stake proofs.</summary>
-        public override async Task RunAsync(RuleContext context)
+        public override void Run(RuleContext context)
         {
             this.blockTxsProcessed = new List<Transaction>();
             this.refundCounter = 1;
 
             this.CheckAndComputeStake(context);
 
-            await base.RunAsync(context);
+            base.Run(context);
 
             this.stakeChain.Set(context.ValidationContext.ChainedHeaderToValidate, (context as PosRuleContext).BlockStake);
         }

--- a/src/Stratis.Bitcoin.Features.SmartContracts/Rules/AllowedScriptTypeRule.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts/Rules/AllowedScriptTypeRule.cs
@@ -19,7 +19,7 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Rules
             this.network = network;
         }
 
-        public override Task RunAsync(RuleContext context)
+        public override void Run(RuleContext context)
         {
             Block block = context.ValidationContext.BlockToValidate;
 
@@ -27,8 +27,6 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Rules
             {
                 this.CheckTransaction(transaction);
             }
-
-            return Task.CompletedTask;
         }
 
         public void CheckTransaction(MempoolValidationContext context)

--- a/src/Stratis.Bitcoin.Features.SmartContracts/Rules/CanGetSenderRule.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts/Rules/CanGetSenderRule.cs
@@ -21,7 +21,7 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Rules
             this.senderRetriever = senderRetriever;
         }
 
-        public override Task RunAsync(RuleContext context)
+        public override void Run(RuleContext context)
         {
             Block block = context.ValidationContext.BlockToValidate;
             IList<Transaction> processedTxs = new List<Transaction>();
@@ -31,8 +31,6 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Rules
                 this.CheckTransactionInsideBlock(transaction, this.PowParent.UtxoSet, processedTxs);
                 processedTxs.Add(transaction);
             }
-
-            return Task.CompletedTask;
         }
 
         private void CheckTransactionInsideBlock(Transaction transaction, ICoinView coinView, IList<Transaction> blockTxs)

--- a/src/Stratis.Bitcoin.Features.SmartContracts/Rules/ContractTransactionChecker.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts/Rules/ContractTransactionChecker.cs
@@ -22,7 +22,7 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Rules
             this.callDataSerializer = callDataSerializer;
         }
 
-        public Task RunAsync(RuleContext context, IEnumerable<IContractTransactionValidationRule> rules)
+        public void Run(RuleContext context, IEnumerable<IContractTransactionValidationRule> rules)
         {
             Block block = context.ValidationContext.BlockToValidate;
 
@@ -32,8 +32,6 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Rules
             {
                 this.CheckTransaction(transaction, contractTransactionValidationRules, null);
             }
-
-            return Task.CompletedTask;
         }
 
         public void CheckTransaction(MempoolValidationContext context, IEnumerable<IContractTransactionValidationRule> rules)

--- a/src/Stratis.Bitcoin.Features.SmartContracts/Rules/ContractTransactionFullValidationRule.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts/Rules/ContractTransactionFullValidationRule.cs
@@ -24,9 +24,9 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Rules
             this.internalRules = internalRules;
         }
 
-        public override Task RunAsync(RuleContext context)
+        public override void Run(RuleContext context)
         {
-            return this.transactionChecker.RunAsync(context, this.internalRules);
+            this.transactionChecker.Run(context, this.internalRules);
         }
 
         public void CheckTransaction(MempoolValidationContext context)

--- a/src/Stratis.Bitcoin.Features.SmartContracts/Rules/ContractTransactionPartialValidationRule.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts/Rules/ContractTransactionPartialValidationRule.cs
@@ -24,9 +24,9 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Rules
             this.internalRules = internalRules;
         }
 
-        public override Task RunAsync(RuleContext context)
+        public override void Run(RuleContext context)
         {
-            return this.transactionChecker.RunAsync(context, this.internalRules);
+            this.transactionChecker.Run(context, this.internalRules);
         }
 
         public void CheckTransaction(MempoolValidationContext context)

--- a/src/Stratis.Bitcoin.Features.SmartContracts/Rules/OpSpendRule.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts/Rules/OpSpendRule.cs
@@ -13,7 +13,7 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Rules
     /// </summary>
     public class OpSpendRule : FullValidationConsensusRule
     {
-        public override Task RunAsync(RuleContext context)
+        public override void Run(RuleContext context)
         {
             Block block = context.ValidationContext.BlockToValidate;
 
@@ -39,8 +39,6 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Rules
                     this.Throw();
                 }
             }
-
-            return Task.CompletedTask;
         }
 
         private void Throw()

--- a/src/Stratis.Bitcoin.Features.SmartContracts/Rules/P2PKHNotContractRule.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts/Rules/P2PKHNotContractRule.cs
@@ -19,7 +19,7 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Rules
             this.stateRepositoryRoot = stateRepositoryRoot;
         }
 
-        public override Task RunAsync(RuleContext context)
+        public override void Run(RuleContext context)
         {
             Block block = context.ValidationContext.BlockToValidate;
 
@@ -27,8 +27,6 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Rules
             {
                 this.CheckTransaction(transaction);
             }
-
-            return Task.CompletedTask;
         }
 
         public void CheckTransaction(MempoolValidationContext context)

--- a/src/Stratis.Bitcoin.Features.SmartContracts/Rules/SmartContractCoinViewRuleLogic.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts/Rules/SmartContractCoinViewRuleLogic.cs
@@ -55,7 +55,7 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Rules
             this.receipts = new List<Receipt>();            
         }
 
-        public async Task RunAsync(Func<RuleContext, Task> baseRunAsync, RuleContext context)
+        public void Run(Action<RuleContext> baseRunAsync, RuleContext context)
         {
             this.blockTxsProcessed.Clear();
             this.receipts.Clear();
@@ -66,7 +66,7 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Rules
             byte[] blockRoot = ((ISmartContractBlockHeader)context.ValidationContext.ChainedHeaderToValidate.Previous.Header).HashStateRoot.ToBytes();
             this.mutableStateRepository = this.stateRepositoryRoot.GetSnapshotTo(blockRoot);
 
-            await baseRunAsync(context);
+            baseRunAsync(context);
 
             var blockHeader = (ISmartContractBlockHeader) block.Header;
 

--- a/src/Stratis.Bitcoin.Features.SmartContracts/Rules/SmartContractCoinviewRule.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts/Rules/SmartContractCoinviewRule.cs
@@ -60,9 +60,9 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Rules
         }
 
         /// <inheritdoc />
-        public override async Task RunAsync(RuleContext context)
+        public override void Run(RuleContext context)
         {
-            await this.logic.RunAsync(base.RunAsync, context);
+            this.logic.Run(base.Run, context);
         }
 
         /// <inheritdoc/>

--- a/src/Stratis.Bitcoin.Features.SmartContracts/Rules/TxOutSmartContractExecRule.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts/Rules/TxOutSmartContractExecRule.cs
@@ -13,7 +13,7 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Rules
     /// </summary>
     public class TxOutSmartContractExecRule : FullValidationConsensusRule, ISmartContractMempoolRule
     {
-        public override Task RunAsync(RuleContext context)
+        public override void Run(RuleContext context)
         {
             Block block = context.ValidationContext.BlockToValidate;
 
@@ -21,8 +21,6 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Rules
             {
                 this.CheckTransaction(transaction);
             }
-
-            return Task.CompletedTask;
         }
 
         public void CheckTransaction(MempoolValidationContext context)

--- a/src/Stratis.Bitcoin.IntegrationTests/CoinViewTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/CoinViewTests.cs
@@ -344,7 +344,7 @@ namespace Stratis.Bitcoin.IntegrationTests
             };
 
             this.network.Consensus.Options = new ConsensusOptions();
-            new WitnessCommitmentsRule().RunAsync(context).GetAwaiter().GetResult();
+            new WitnessCommitmentsRule().Run(context);
 
             var rule = new CheckPowTransactionRule();
             var options = this.network.Consensus.Options;

--- a/src/Stratis.Bitcoin.IntegrationTests/ConsensusManagerTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/ConsensusManagerTests.cs
@@ -88,7 +88,7 @@ namespace Stratis.Bitcoin.IntegrationTests
                 this.failcount = failcount;
             }
 
-            public override Task RunAsync(RuleContext context)
+            public override void Run(RuleContext context)
             {
                 if (this.failcount > 0)
                 {
@@ -98,8 +98,6 @@ namespace Stratis.Bitcoin.IntegrationTests
                         throw new ConsensusErrorException(new ConsensusError("error", "error"));
                     }
                 }
-
-                return Task.CompletedTask;
             }
         }
 

--- a/src/Stratis.Bitcoin/Consensus/DiConsensusRuleEngine.cs
+++ b/src/Stratis.Bitcoin/Consensus/DiConsensusRuleEngine.cs
@@ -70,12 +70,12 @@ namespace Stratis.Bitcoin.Consensus
             return this.implementation.IntegrityValidation(header, block);
         }
 
-        public Task<ValidationContext> PartialValidationAsync(ChainedHeader header, Block block)
+        public ValidationContext PartialValidationAsync(ChainedHeader header, Block block)
         {
             return this.implementation.PartialValidationAsync(header, block);
         }
 
-        public Task<ValidationContext> FullValidationAsync(ChainedHeader header, Block block)
+        public ValidationContext FullValidationAsync(ChainedHeader header, Block block)
         {
             return this.implementation.FullValidationAsync(header, block);
         }

--- a/src/Stratis.Bitcoin/Consensus/IConsensusRuleEngine.cs
+++ b/src/Stratis.Bitcoin/Consensus/IConsensusRuleEngine.cs
@@ -71,12 +71,12 @@ namespace Stratis.Bitcoin.Consensus
         /// <param name="header">The chained header that is going to be validated.</param>
         /// <param name="block">The block that is going to be validated.</param>
         /// <returns>Context that contains validation result related information.</returns>
-        Task<ValidationContext> PartialValidationAsync(ChainedHeader header, Block block);
+        ValidationContext PartialValidationAsync(ChainedHeader header, Block block);
 
         /// <summary>Execute full validation rules.</summary>
         /// <param name="header">The chained header that is going to be validated.</param>
         /// <param name="block">The block that is going to be validated.</param>
         /// <returns>Context that contains validation result related information.</returns>
-        Task<ValidationContext> FullValidationAsync(ChainedHeader header, Block block);
+        ValidationContext FullValidationAsync(ChainedHeader header, Block block);
     }
 }

--- a/src/Stratis.Bitcoin/Consensus/Rules/ConsensusRule.cs
+++ b/src/Stratis.Bitcoin/Consensus/Rules/ConsensusRule.cs
@@ -13,6 +13,13 @@ namespace Stratis.Bitcoin.Consensus.Rules
         public ConsensusRuleEngine Parent { get; set; }
 
         /// <summary>
+        /// Execute the logic in the current rule.
+        /// If the validation of the rule fails a <see cref="ConsensusErrorException"/> will be thrown.
+        /// </summary>
+        /// <param name="context">The context that has all info that needs to be validated.</param>
+        public abstract void Run(RuleContext context);
+
+        /// <summary>
         /// Allow a rule to initialize itself.
         /// The rule can verify that other rules are present using the <see cref="IConsensusRuleEngine.Rules"/>.
         /// The rule can internally initialize its state.
@@ -22,42 +29,19 @@ namespace Stratis.Bitcoin.Consensus.Rules
         }
     }
 
-    /// <summary>An abstract rule for implementing consensus rules.</summary>
-    public abstract class SyncConsensusRule : ConsensusRuleBase
-    {
-        /// <summary>
-        /// Execute the logic in the current rule.
-        /// If the validation of the rule fails a <see cref="ConsensusErrorException"/> will be thrown.
-        /// </summary>
-        /// <param name="context">The context that has all info that needs to be validated.</param>
-        public abstract void Run(RuleContext context);
-    }
-
-    /// <summary>An abstract rule for implementing consensus rules.</summary>
-    public abstract class AsyncConsensusRule : ConsensusRuleBase
-    {
-        /// <summary>
-        /// Execute the logic in the current rule in an async approach.
-        /// If the validation of the rule fails a <see cref="ConsensusErrorException"/> will be thrown.
-        /// </summary>
-        /// <param name="context">The context that has all info that needs to be validated.</param>
-        /// <returns>The execution task.</returns>
-        public abstract Task RunAsync(RuleContext context);
-    }
-
-    public abstract class HeaderValidationConsensusRule : SyncConsensusRule, IHeaderValidationConsensusRule
+    public abstract class HeaderValidationConsensusRule : ConsensusRuleBase, IHeaderValidationConsensusRule
     {
     }
 
-    public abstract class IntegrityValidationConsensusRule : SyncConsensusRule, IIntegrityValidationConsensusRule
+    public abstract class IntegrityValidationConsensusRule : ConsensusRuleBase, IIntegrityValidationConsensusRule
     {
     }
 
-    public abstract class PartialValidationConsensusRule : AsyncConsensusRule, IPartialValidationConsensusRule
+    public abstract class PartialValidationConsensusRule : ConsensusRuleBase, IPartialValidationConsensusRule
     {
     }
 
-    public abstract class FullValidationConsensusRule : AsyncConsensusRule, IFullValidationConsensusRule
+    public abstract class FullValidationConsensusRule : ConsensusRuleBase, IFullValidationConsensusRule
     {
     }
 }

--- a/src/Stratis.Bitcoin/Consensus/Validators/BlockValidator.cs
+++ b/src/Stratis.Bitcoin/Consensus/Validators/BlockValidator.cs
@@ -143,7 +143,7 @@ namespace Stratis.Bitcoin.Consensus.Validators
 
         private async Task OnEnqueueAsync(PartialValidationItem item, CancellationToken cancellationtoken)
         {
-            ValidationContext result = await this.consensusRules.PartialValidationAsync(item.ChainedHeader, item.Block).ConfigureAwait(false);
+            ValidationContext result = this.consensusRules.PartialValidationAsync(item.ChainedHeader, item.Block);
 
             try
             {
@@ -168,11 +168,11 @@ namespace Stratis.Bitcoin.Consensus.Validators
         }
 
         /// <inheritdoc />
-        public async Task<ValidationContext> ValidateAsync(ChainedHeader header, Block block)
+        public Task<ValidationContext> ValidateAsync(ChainedHeader header, Block block)
         {
-            ValidationContext result = await this.consensusRules.PartialValidationAsync(header, block).ConfigureAwait(false);
+            ValidationContext result = this.consensusRules.PartialValidationAsync(header, block);
 
-            return result;
+            return Task.FromResult(result);
         }
 
         /// <summary>
@@ -210,11 +210,11 @@ namespace Stratis.Bitcoin.Consensus.Validators
         }
 
         /// <inheritdoc />
-        public async Task<ValidationContext> ValidateAsync(ChainedHeader header, Block block)
+        public Task<ValidationContext> ValidateAsync(ChainedHeader header, Block block)
         {
-            ValidationContext result = await this.consensusRules.FullValidationAsync(header, block).ConfigureAwait(false);
+            ValidationContext result = this.consensusRules.FullValidationAsync(header, block);
 
-            return result;
+            return Task.FromResult(result);
         }
     }
 }


### PR DESCRIPTION
Having rules run in async has not benefit, especially that the db layer is not async anymore.

This is a PR to remove that asyncness from full and partial validation.  