### PR TITLE
[FS] Remove GetMaturedDepositsAsync exception

### DIFF
--- a/src/Stratis.Features.FederatedPeg.Tests/MaturedBlocksProviderTests.cs
+++ b/src/Stratis.Features.FederatedPeg.Tests/MaturedBlocksProviderTests.cs
@@ -63,10 +63,10 @@ namespace Stratis.Features.FederatedPeg.Tests
             // Makes every block a matured block.
             var maturedBlocksProvider = new MaturedBlocksProvider(this.loggerFactory, this.depositExtractor, this.consensusManager);
 
-            List<MaturedBlockDepositsModel> deposits = await maturedBlocksProvider.GetMaturedDepositsAsync(0, 10);
+            Result<List<MaturedBlockDepositsModel>> depositsResult = await maturedBlocksProvider.GetMaturedDepositsAsync(0, 10);
 
             // Expect the number of matured deposits to equal the number of blocks.
-            Assert.Equal(10, deposits.Count);
+            Assert.Equal(10, depositsResult.Value.Count);
         }
     }
 }

--- a/src/Stratis.Features.FederatedPeg/Controllers/FederationGatewayController.cs
+++ b/src/Stratis.Features.FederatedPeg/Controllers/FederationGatewayController.cs
@@ -71,10 +71,16 @@ namespace Stratis.Features.FederatedPeg.Controllers
 
             try
             {
-                List<MaturedBlockDepositsModel> deposits = await this.maturedBlocksProvider.GetMaturedDepositsAsync(
+                Result<List<MaturedBlockDepositsModel>> depositsResult = await this.maturedBlocksProvider.GetMaturedDepositsAsync(
                     blockRequest.BlockHeight, blockRequest.MaxBlocksToSend).ConfigureAwait(false);
 
-                return this.Json(deposits);
+                if (depositsResult.IsSuccess)
+                {
+                    return this.Json(depositsResult.Value);
+                }
+
+                this.logger.LogTrace("Error calling /api/FederationGateway/{0}: {1}.", FederationGatewayRouteEndPoint.GetMaturedBlockDeposits, depositsResult.Error);
+                return ErrorHelpers.BuildErrorResponse(HttpStatusCode.BadRequest, $"Could not re-sync matured block deposits: {depositsResult.Error}", depositsResult.Error);
             }
             catch (Exception e)
             {

--- a/src/Stratis.Features.FederatedPeg/SourceChain/MaturedBlocksProvider.cs
+++ b/src/Stratis.Features.FederatedPeg/SourceChain/MaturedBlocksProvider.cs
@@ -21,7 +21,7 @@ namespace Stratis.Features.FederatedPeg.SourceChain
         /// <param name="maxBlocks">The number of blocks to retrieve.</param>
         /// <returns>A list of mature block deposits.</returns>
         /// <exception cref="InvalidOperationException">Thrown if the blocks are not mature or not found.</exception>
-        Task<List<MaturedBlockDepositsModel>> GetMaturedDepositsAsync(int blockHeight, int maxBlocks);
+        Task<Result<List<MaturedBlockDepositsModel>>> GetMaturedDepositsAsync(int blockHeight, int maxBlocks);
     }
 
     public class MaturedBlocksProvider : IMaturedBlocksProvider
@@ -41,7 +41,7 @@ namespace Stratis.Features.FederatedPeg.SourceChain
         }
 
         /// <inheritdoc />
-        public async Task<List<MaturedBlockDepositsModel>> GetMaturedDepositsAsync(int blockHeight, int maxBlocks)
+        public async Task<Result<List<MaturedBlockDepositsModel>>> GetMaturedDepositsAsync(int blockHeight, int maxBlocks)
         {
             ChainedHeader consensusTip = this.consensusManager.Tip;
 
@@ -49,7 +49,9 @@ namespace Stratis.Features.FederatedPeg.SourceChain
 
             if (blockHeight > matureTipHeight)
             {
-                throw new InvalidOperationException($"Block height {blockHeight} submitted is not mature enough. Blocks less than a height of {matureTipHeight} can be processed.");
+                // We need to return a Result type here to explicitly indicate failure and the reason for failure.
+                // This is an expected condition so we can avoid throwing an exception here.
+                return Result<List<MaturedBlockDepositsModel>>.Fail($"Block height {blockHeight} submitted is not mature enough. Blocks less than a height of {matureTipHeight} can be processed.");
             }
 
             var maturedBlocks = new List<MaturedBlockDepositsModel>();
@@ -78,7 +80,7 @@ namespace Stratis.Features.FederatedPeg.SourceChain
                 }
             }
 
-            return maturedBlocks;
+            return Result<List<MaturedBlockDepositsModel>>.Ok(maturedBlocks);
         }
     }
 }

--- a/src/Stratis.Features.FederatedPeg/SourceChain/Result.cs
+++ b/src/Stratis.Features.FederatedPeg/SourceChain/Result.cs
@@ -1,0 +1,32 @@
+﻿namespace Stratis.Features.FederatedPeg.SourceChain
+{
+    /// <summary>
+    /// A generic result type.
+    /// </summary>
+    /// <typeparam name="T">The type of the value to return if the result was successful.</typeparam>
+    public struct Result<T>
+    {
+        public bool IsFailure { get; }
+        public bool IsSuccess { get; }
+        public string Error { get; }
+        public T Value { get; }
+
+        internal Result(bool isFailure, T value, string error)
+        {
+            this.IsFailure = isFailure;
+            this.IsSuccess = !isFailure;
+            this.Value = value;
+            this.Error = error;
+        }
+
+        public static Result<T> Ok(T value)
+        {
+            return new Result<T>(false, value, null);
+        }
+
+        public static Result<T> Fail(string error)
+        {
+            return new Result<T>(true, default(T), error);
+        }
+    }
+}


### PR DESCRIPTION
Modified the return type to `Result` so that we can explicitly indicate the expected failure of a call and return an error message which contains information related to the call. Considered returning `null` but we also need to know the current matured block height at which the request failed.

API still needs to return an error response, otherwise behaviour on the API caller end is different.

Still need to handle exceptions as there are other places they can be thrown.