### PR TITLE
[FS] Federation gateway nodes can start without adding the counterchain api params

### DIFF
--- a/src/Stratis.Features.FederatedPeg/FederationGatewaySettings.cs
+++ b/src/Stratis.Features.FederatedPeg/FederationGatewaySettings.cs
@@ -32,7 +32,7 @@ namespace Stratis.Features.FederatedPeg
         /// Changing <see cref="TransactionFee"/> affects both the deposit threshold on this chain and the withdrawal transaction fee on this chain.
         /// This value shouldn't be different for the 2 pegged chain nodes or deposits could be extracted that don't have the amount required to
         /// cover the withdrawal fee on the other chain.
-        /// 
+        ///
         /// TODO: This should be configurable on the Network level in the future, but individual nodes shouldn't be tweaking it.
         /// </remarks>
         public static readonly Money DefaultTransactionFee = Money.Coins(0.01m);
@@ -44,7 +44,7 @@ namespace Stratis.Features.FederatedPeg
         /// </summary>
         public const int StratisMainDepositStartBlock = 1_100_000;
 
-        public FederationGatewaySettings(NodeSettings nodeSettings)
+        public FederationGatewaySettings(NodeSettings nodeSettings, FederatedPegOptions federatedPegOptions = null)
         {
             Guard.NotNull(nodeSettings, nameof(nodeSettings));
 
@@ -74,7 +74,7 @@ namespace Stratis.Features.FederatedPeg
                 throw new ConfigurationException("Please make sure the public key passed as parameter was used to generate the multisig redeem script.");
             }
 
-            this.CounterChainApiPort = configReader.GetOrDefault(CounterChainApiPortParam, 0);
+            this.CounterChainApiPort = configReader.GetOrDefault(CounterChainApiPortParam, federatedPegOptions?.CounterChainNetwork.DefaultAPIPort ?? 0);
 
             // Federation IPs - These are required to receive and sign withdrawal transactions.
             string federationIpsRaw = configReader.GetOrDefault<string>(FederationIpsParam, null);


### PR DESCRIPTION
See https://stratisplatformuk.visualstudio.com/Sidechains/_workitems/edit/3378