### PR TITLE
[API] Fix null reference in IPExtension's Match method

### DIFF
--- a/src/Stratis.Bitcoin/Connection/ConnectionManager.cs
+++ b/src/Stratis.Bitcoin/Connection/ConnectionManager.cs
@@ -508,6 +508,32 @@ namespace Stratis.Bitcoin.Connection
 
             this.peerAddressManager.RemovePeer(ipEndpoint);
 
+            // There appears to be a race condition that causes the endpoint or endpoint's address property to be null when
+            // trying to remove it from the connection manager's add node collection.
+            if (ipEndpoint == null)
+            {
+                this.logger.LogTrace("(-)[IPENDPOINT_NULL]");
+                return;
+            }
+
+            if (ipEndpoint.Address == null)
+            {
+                this.logger.LogTrace("(-)[IPENDPOINT_ADDRESS_NULL]");
+                return;
+            }
+
+            if (this.ConnectionSettings.AddNode.Any(ip => ip == null))
+            {
+                this.logger.LogTrace("(-)[ADDNODE_CONTAINS_NULLS]");
+                return;
+            }
+
+            foreach (var endpoint in this.ConnectionSettings.AddNode.Where(a => a.Address == null))
+            {
+                this.logger.LogTrace("(-)[IPENDPOINT_ADDRESS_NULL]:{0}", endpoint);
+                return;
+            }
+
             // Create a copy of the nodes to remove. This avoids errors due to both modifying the collection and iterating it.
             List<IPEndPoint> matchingAddNodes = this.ConnectionSettings.AddNode.Where(p => p.Match(ipEndpoint)).ToList();
             foreach (IPEndPoint m in matchingAddNodes)

--- a/src/Stratis.Bitcoin/Connection/ConnectionManager.cs
+++ b/src/Stratis.Bitcoin/Connection/ConnectionManager.cs
@@ -513,25 +513,25 @@ namespace Stratis.Bitcoin.Connection
             if (ipEndpoint == null)
             {
                 this.logger.LogTrace("(-)[IPENDPOINT_NULL]");
-                return;
+                throw new ArgumentNullException(nameof(ipEndpoint));
             }
 
             if (ipEndpoint.Address == null)
             {
                 this.logger.LogTrace("(-)[IPENDPOINT_ADDRESS_NULL]");
-                return;
+                throw new ArgumentNullException(nameof(ipEndpoint.Address));
             }
 
             if (this.ConnectionSettings.AddNode.Any(ip => ip == null))
             {
                 this.logger.LogTrace("(-)[ADDNODE_CONTAINS_NULLS]");
-                return;
+                throw new ArgumentNullException("The addnode collection contains null entries.");
             }
 
             foreach (var endpoint in this.ConnectionSettings.AddNode.Where(a => a.Address == null))
             {
                 this.logger.LogTrace("(-)[IPENDPOINT_ADDRESS_NULL]:{0}", endpoint);
-                return;
+                throw new ArgumentNullException("The addnode collection contains endpoints with null addresses.");
             }
 
             // Create a copy of the nodes to remove. This avoids errors due to both modifying the collection and iterating it.


### PR DESCRIPTION
This fix relates to:

https://dev.azure.com/Stratisplatformuk/StratisBitcoinFullNode/_workitems/edit/3502

I was unable to reproduce this bug via various unit tests, so for now we need to protect against passing null endpoints to the Match method. I have also added extra logs so that we can determine when this is the case.