### PR TITLE
[FN] Recognize possible language ambiguity for particular word selections

### DIFF
--- a/src/Stratis.Bitcoin.IntegrationTests/Wallet/WalletOperationsTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/Wallet/WalletOperationsTests.cs
@@ -255,7 +255,11 @@ namespace Stratis.Bitcoin.IntegrationTests.Wallet
             // Check the mnemonic returned.
             response = response.Replace("\"", "");
             response.Split(" ").Length.Should().Be(12);
-            Wordlist.AutoDetectLanguage(response).Should().Be(Language.ChineseTraditional);
+            Language detectedLanguage = Wordlist.AutoDetectLanguage(response);
+
+            // Relax the test due to the potential language ambiguity of the words returned.
+            detectedLanguage.Should().Match(p => p.Equals(Language.ChineseTraditional) || p.Equals(Language.ChineseSimplified));
+
             response.Should().Be(mnemonic);
 
             // Check a wallet file has been created.


### PR DESCRIPTION
Addresses the occasionally failing test case `CreateWalletWith12WordsChineseMnemonicAsync`.

Due to the randomness of word selection a sequence of word could be generated that are identified as `ChineseSimplified` (versus the expected `ChineseTraditional`).

This test is therefore relaxed to allow both.