### PR TITLE
[FN] Allow Listeners to Swap to Different Ports If In-Use

### DIFF
--- a/src/Stratis.Bitcoin.Features.Api/ApiSettings.cs
+++ b/src/Stratis.Bitcoin.Features.Api/ApiSettings.cs
@@ -20,10 +20,10 @@ namespace Stratis.Bitcoin.Features.Api
         private readonly ILogger logger;
 
         /// <summary>URI to node's API interface.</summary>
-        public Uri ApiUri { get; set; }
+        public Uri ApiUri { get; private set; }
 
         /// <summary>Port of node's API interface.</summary>
-        public int ApiPort { get; set; }
+        public int ApiPort { get; private set; }
 
         /// <summary>URI to node's API interface.</summary>
         public Timer KeepaliveTimer { get; private set; }
@@ -91,6 +91,12 @@ namespace Stratis.Bitcoin.Features.Api
                     Interval = keepAlive * 1000
                 };
             }
+        }
+
+        public void SetPort(int port)
+        {
+            this.ApiPort = port;
+            this.ApiUri = new Uri($"{this.ApiUri.Scheme}://{this.ApiUri.Host}:{this.ApiPort}{this.ApiUri.PathAndQuery}");
         }
 
         /// <summary>Prints the help information on how to configure the API settings to the logger.</summary>

--- a/src/Stratis.Bitcoin.Features.Api/Program.cs
+++ b/src/Stratis.Bitcoin.Features.Api/Program.cs
@@ -40,7 +40,6 @@ namespace Stratis.Bitcoin.Features.Api
                     })
                 .UseContentRoot(Directory.GetCurrentDirectory())
                 .UseIISIntegration()
-                //.UseUrls(apiUri.ToString())
                 .ConfigureServices(collection =>
                 {
                     if (services == null)

--- a/src/Stratis.Bitcoin.Features.RPC/RpcSettings.cs
+++ b/src/Stratis.Bitcoin.Features.RPC/RpcSettings.cs
@@ -29,7 +29,7 @@ namespace Stratis.Bitcoin.Features.RPC
         public string RpcPassword { get; set; }
 
         /// <summary>TCP port for RPC interface.</summary>
-        public int RPCPort { get; set; }
+        public int RPCPort { get; private set; }
 
         /// <summary>Default bindings from config.</summary>
         public List<IPEndPoint> DefaultBindings { get; set; }
@@ -101,6 +101,23 @@ namespace Stratis.Bitcoin.Features.RPC
                     throw new ConfigurationException("Invalid rpcbind value");
                 }
             }
+        }
+
+        public void SetPort(int port)
+        {
+            foreach (var ip in this.DefaultBindings)
+            {
+                if (ip.Port == this.RPCPort)
+                    ip.Port = port;
+            }
+
+            foreach (var ip in this.Bind)
+            {
+                if (ip.Port == this.RPCPort)
+                    ip.Port = port;
+            }
+
+            this.RPCPort = port;
         }
 
         /// <summary>

--- a/src/Stratis.Bitcoin.IntegrationTests.Common/EnvironmentMockUpHelpers/CoreNode.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests.Common/EnvironmentMockUpHelpers/CoreNode.cs
@@ -284,11 +284,15 @@ namespace Stratis.Bitcoin.IntegrationTests.Common.EnvironmentMockUpHelpers
             {
                 StartStratisRunner();
 
-                var apiSettings = this.FullNode.NodeService<ApiSettings>();
-                var rpcSettings = this.FullNode.NodeService<RpcSettings>();
+                var apiSettings = this.FullNode.NodeService<ApiSettings>(true);
+                var rpcSettings = this.FullNode.NodeService<RpcSettings>(true);
 
-                this.ConfigParameters["rpcport"] = rpcSettings.RPCPort.ToString();
-                this.ConfigParameters["apiport"] = apiSettings.ApiPort.ToString();
+                if (rpcSettings != null)
+                    this.ConfigParameters["rpcport"] = rpcSettings.RPCPort.ToString();
+
+                if (apiSettings != null)
+                    this.ConfigParameters["apiport"] = apiSettings.ApiPort.ToString();
+
                 this.ConfigParameters["port"] = this.FullNode.ConnectionManager.ConnectionSettings.Port.ToString();
                 if (this.ConfigParameters["agentprefix"] == "node0")
                     this.ConfigParameters["agentprefix"] = "node" + this.ProtocolPort;

--- a/src/Stratis.Bitcoin/Configuration/Settings/ConnectionManagerSettings.cs
+++ b/src/Stratis.Bitcoin/Configuration/Settings/ConnectionManagerSettings.cs
@@ -161,6 +161,20 @@ namespace Stratis.Bitcoin.Configuration.Settings
             this.IsGateway = config.GetOrDefault<bool>("gateway", false, this.logger);
         }
 
+        public void SetPort(int port)
+        {
+            foreach (var ip in this.Bind)
+            {
+                if (ip.Endpoint.Port == this.Port)
+                    ip.Endpoint.Port = port;
+            }
+
+            if (this.ExternalEndpoint.Port == this.Port)
+                this.ExternalEndpoint.Port = port;
+
+            this.Port = port;
+        }
+
         /// <summary>
         /// Get the default configuration.
         /// </summary>

--- a/src/Stratis.Bitcoin/Connection/ConnectionManager.cs
+++ b/src/Stratis.Bitcoin/Connection/ConnectionManager.cs
@@ -147,7 +147,27 @@ namespace Stratis.Bitcoin.Connection
             }
 
             if (this.ConnectionSettings.Listen)
-                this.StartNodeServer();
+            {
+                bool retry = this.ConnectionSettings.Port == 0;
+                int retryCnt = retry ? 10 : 1;
+
+                while (retryCnt-- >= 0)
+                {
+                    try
+                    {
+                        if (retry)
+                            this.ConnectionSettings.SetPort(IpHelper.FindPort());
+
+                        this.StartNodeServer();
+
+                        break;
+                    }
+                    catch (SocketException) when (retryCnt != 0)
+                    {
+                        continue;
+                    }
+                }
+            }
 
             // If external IP address supplied this overrides all.
             if (this.ConnectionSettings.ExternalEndpoint != null)

--- a/src/Stratis.Bitcoin/Utilities/IpHelper.cs
+++ b/src/Stratis.Bitcoin/Utilities/IpHelper.cs
@@ -8,20 +8,15 @@ namespace Stratis.Bitcoin.Utilities
     public static class IpHelper
     {
         // Don't re-use ports.
-        private static HashSet<uint> usedPorts = new HashSet<uint>();
+        private static HashSet<int> usedPorts = new HashSet<int>();
 
-        /// <summary>
-        /// Find ports that are free to use.
-        /// </summary>
-        /// <param name="ports">A list of ports to checked or fill/replace as necessary.</param>
-        public static void FindPorts(int[] ports)
+        public static int FindPort()
         {
-            int i = 0;
             lock (usedPorts)
             {
-                while (i < ports.Length)
+                while (true)
                 {
-                    uint port = RandomUtils.GetUInt32() % 4000;
+                    int port = (int)(RandomUtils.GetUInt32() % 4000);
                     port = port + 10000;
                     if (usedPorts.Contains(port))
                         continue;
@@ -31,15 +26,24 @@ namespace Stratis.Bitcoin.Utilities
                         var l = new TcpListener(IPAddress.Loopback, (int)port);
                         l.Start();
                         l.Stop();
-                        ports[i] = (int)port;
                         usedPorts.Add(port);
-                        i++;
+                        return port;
                     }
                     catch (SocketException)
                     {
                     }
                 }
             }
+        }
+
+        /// <summary>
+        /// Find ports that are free to use.
+        /// </summary>
+        /// <param name="ports">A list of ports to checked or fill/replace as necessary.</param>
+        public static void FindPorts(int[] ports)
+        {
+            for (int i = 0; i < ports.Length; i++)
+                ports[i] = FindPort();
         }
     }
 }


### PR DESCRIPTION
Fixes the below test case (and similar test cases) from failing occasionally:

```
Failed   Stratis.Features.FederatedPeg.IntegrationTests.NodeSetupTests.MainChainFedNodesBuildAndSync
2019-04-11T06:53:58.6179775Z Error Message:
2019-04-11T06:53:58.6180916Z  System.AggregateException : One or more errors occurred. (Failed to bind to address http://[::1]:13259: address already in use.)
2019-04-11T06:53:58.6181909Z ---- System.IO.IOException : Failed to bind to address http://[::1]:13259: address already in use.
2019-04-11T06:53:58.6182629Z -------- Microsoft.AspNetCore.Connections.AddressInUseException : Address already in use
2019-04-11T06:53:58.6183304Z ------------ System.Net.Sockets.SocketException : Address already in use
2019-04-11T06:53:58.6184051Z Stack Trace:
2019-04-11T06:53:58.6184361Z    at Stratis.Bitcoin.Builder.FullNodeFeatureExecutor.Execute(Action`1 callback, Boolean disposing) in /vsts/agent/_work/1/s/src/Stratis.Bitcoin/Builder/FullNodeFeatureExecutor.cs:line 148
2019-04-11T06:53:58.6184904Z    at Stratis.Bitcoin.Builder.FullNodeFeatureExecutor.Initialize() in /vsts/agent/_work/1/s/src/Stratis.Bitcoin/Builder/FullNodeFeatureExecutor.cs:line 53
2019-04-11T06:53:58.6185065Z    at Stratis.Bitcoin.FullNode.Start() in /vsts/agent/_work/1/s/src/Stratis.Bitcoin/FullNode.cs:line 208
2019-04-11T06:53:58.6185790Z    at Stratis.Bitcoin.IntegrationTests.Common.Runners.NodeRunner.Start() in /vsts/agent/_work/1/s/src/Stratis.Bitcoin.IntegrationTests.Common/Runners/NodeRunner.cs:line 51
2019-04-11T06:53:58.6185952Z    at Stratis.Bitcoin.IntegrationTests.Common.EnvironmentMockUpHelpers.CoreNode.Start() in /vsts/agent/_work/1/s/src/Stratis.Bitcoin.IntegrationTests.Common/EnvironmentMockUpHelpers/CoreNode.cs:line 273
2019-04-11T06:53:58.6186081Z    at Stratis.Features.FederatedPeg.IntegrationTests.Utils.SidechainTestContext.StartMainNodes() in /vsts/agent/_work/1/s/src/Stratis.Features.FederatedPeg.IntegrationTests/Utils/SidechainTestContext.cs:line 134
2019-04-11T06:53:58.6186219Z    at Stratis.Features.FederatedPeg.IntegrationTests.NodeSetupTests.MainChainFedNodesBuildAndSync() in /vsts/agent/_work/1/s/src/Stratis.Features.FederatedPeg.IntegrationTests/NodeSetupTests.cs:line 21
2019-04-11T06:53:58.6186955Z ----- Inner Stack Trace -----
2019-04-11T06:53:58.6187387Z    at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.AddressBinder.BindEndpointAsync(ListenOptions endpoint, AddressBindContext context)
2019-04-11T06:53:58.6187549Z    at Microsoft.AspNetCore.Server.Kestrel.Core.ListenOptions.BindAsync(AddressBindContext context)
2019-04-11T06:53:58.6187917Z    at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.AddressBinder.AddressesStrategy.BindAsync(AddressBindContext context)
2019-04-11T06:53:58.6188078Z    at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.AddressBinder.BindAsync(IServerAddressesFeature addresses, KestrelServerOptions serverOptions, ILogger logger, Func`2 createBinding)
2019-04-11T06:53:58.6188459Z    at Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServer.StartAsync[TContext](IHttpApplication`1 application, CancellationToken cancellationToken)
2019-04-11T06:53:58.6188623Z    at Microsoft.AspNetCore.Hosting.Internal.WebHost.StartAsync(CancellationToken cancellationToken)
2019-04-11T06:53:58.6188983Z    at Microsoft.AspNetCore.Hosting.Internal.WebHost.Start()
2019-04-11T06:53:58.6189132Z    at Stratis.Bitcoin.Features.RPC.RPCFeature.InitializeAsync() in /vsts/agent/_work/1/s/src/Stratis.Bitcoin.Features.RPC/RPCFeature.cs:line 107
2019-04-11T06:53:58.6189580Z    at Stratis.Bitcoin.Builder.FullNodeFeatureExecutor.<>c.<Initialize>b__3_1(IFullNodeFeature service) in /vsts/agent/_work/1/s/src/Stratis.Bitcoin/Builder/FullNodeFeatureExecutor.cs:line 56
2019-04-11T06:53:58.6190021Z    at Stratis.Bitcoin.Builder.FullNodeFeatureExecutor.Execute(Action`1 callback, Boolean disposing) in /vsts/agent/_work/1/s/src/Stratis.Bitcoin/Builder/FullNodeFeatureExecutor.cs:line 130
2019-04-11T06:53:58.6190373Z ----- Inner Stack Trace -----
2019-04-11T06:53:58.6190753Z    at Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.SocketTransport.BindAsync()
2019-04-11T06:53:58.6190890Z    at Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServer.<>c__DisplayClass22_0`1.<<StartAsync>g__OnBind|0>d.MoveNext()
2019-04-11T06:53:58.6191484Z --- End of stack trace from previous location where exception was thrown ---
2019-04-11T06:53:58.6191905Z    at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.AddressBinder.BindEndpointAsync(ListenOptions endpoint, AddressBindContext context)
2019-04-11T06:53:58.6192244Z ----- Inner Stack Trace -----
2019-04-11T06:53:58.6192615Z    at System.Net.Sockets.Socket.UpdateStatusAfterSocketErrorAndThrowException(SocketError error, String callerName)
2019-04-11T06:53:58.6192765Z    at System.Net.Sockets.Socket.DoBind(EndPoint endPointSnapshot, SocketAddress socketAddress)
2019-04-11T06:53:58.6193122Z    at System.Net.Sockets.Socket.Bind(EndPoint localEP)
2019-04-11T06:53:58.6193244Z    at Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.SocketTransport.BindAsync()
```