### PR TITLE
NetworkPeerListener constructor fix

### DIFF
--- a/src/Stratis.Bitcoin.IntegrationTests.Common/EnvironmentMockUpHelpers/CoreNode.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests.Common/EnvironmentMockUpHelpers/CoreNode.cs
@@ -427,7 +427,7 @@ namespace Stratis.Bitcoin.IntegrationTests.Common.EnvironmentMockUpHelpers
                 DateTimeOffset before = DateTimeOffset.UtcNow;
                 await peer.SendMessageAsync(ping, cancellation).ConfigureAwait(false);
 
-                while ((await listener.ReceivePayloadAsync<PongPayload>(cancellation)).Nonce != ping.Nonce)
+                while ((await listener.ReceivePayloadAsync<PongPayload>(cancellation).ConfigureAwait(false)).Nonce != ping.Nonce)
                 {
                 }
 

--- a/src/Stratis.Bitcoin.IntegrationTests/Mempool/MemoryPoolTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/Mempool/MemoryPoolTests.cs
@@ -94,7 +94,7 @@ namespace Stratis.Bitcoin.IntegrationTests.Mempool
             }
         }
 
-        [Fact(Skip = "Working on fixing this after AsyncProvider PR gives intermittent results.")]
+        [Fact] //(Skip = "Working on fixing this after AsyncProvider PR gives intermittent results.")]
         public void MempoolReceiveFromManyNodes()
         {
             using (NodeBuilder builder = NodeBuilder.Create(this))

--- a/src/Stratis.Bitcoin/P2P/Peer/NetworkPeerListener.cs
+++ b/src/Stratis.Bitcoin/P2P/Peer/NetworkPeerListener.cs
@@ -29,11 +29,11 @@ namespace Stratis.Bitcoin.P2P.Peer
         /// <param name="peer">Connected network peer that we receive messages from.</param>
         public NetworkPeerListener(INetworkPeer peer, IAsyncProvider asyncProvider)
         {
-            this.messageProducerRegistration = peer.MessageProducer.AddMessageListener(this);
             this.peer = peer;
             this.asyncProvider = asyncProvider;
-
             this.asyncIncomingMessagesQueue = asyncProvider.CreateAsyncQueue<IncomingMessage>();
+
+            this.messageProducerRegistration = peer.MessageProducer.AddMessageListener(this);
         }
 
         /// <inheritdoc/>


### PR DESCRIPTION
asyncProvider.CreateAsyncQueue was called after peer.MessageProducer.AddMessageListener(this);

this caused race condition when a message arrived from a peer, between producer listener registration and asyncqueue creation