### PR TITLE
[FS] Log warning for NotEnoughFunds in federation error.

### DIFF
--- a/src/Stratis.Features.FederatedPeg.Tests/WithdrawalTransactionBuilderTests.cs
+++ b/src/Stratis.Features.FederatedPeg.Tests/WithdrawalTransactionBuilderTests.cs
@@ -97,5 +97,32 @@ namespace Stratis.Features.FederatedPeg.Tests
             // Log out a warning in this case, not an error.
             this.logger.Verify(x=>x.Log<object>(LogLevel.Warning, It.IsAny<EventId>(), It.IsAny<object>(), null, It.IsAny<Func<object, Exception, string>>()));
         }
+
+        [Fact]
+        public void NotEnoughFundsLogWarning()
+        {
+            // Throw a 'no spendable transactions' exception
+            this.federationWalletTransactionHandler.Setup(x => x.BuildTransaction(It.IsAny<TransactionBuildContext>()))
+                .Throws(new WalletException(FederationWalletTransactionHandler.NotEnoughFundsMessage));
+
+            var txBuilder = new WithdrawalTransactionBuilder(
+                this.loggerFactory.Object,
+                this.network,
+                this.federationWalletManager.Object,
+                this.federationWalletTransactionHandler.Object,
+                this.federationGatewaySettings.Object
+            );
+
+            var recipient = new Recipient
+            {
+                Amount = Money.Coins(101),
+                ScriptPubKey = new Script()
+            };
+
+            Transaction ret = txBuilder.BuildWithdrawalTransaction(uint256.One, 100, recipient);
+
+            // Log out a warning in this case, not an error.
+            this.logger.Verify(x => x.Log<object>(LogLevel.Warning, It.IsAny<EventId>(), It.IsAny<object>(), null, It.IsAny<Func<object, Exception, string>>()));
+        }
     }
 }

--- a/src/Stratis.Features.FederatedPeg/TargetChain/WithdrawalTransactionBuilder.cs
+++ b/src/Stratis.Features.FederatedPeg/TargetChain/WithdrawalTransactionBuilder.cs
@@ -73,9 +73,11 @@ namespace Stratis.Features.FederatedPeg.TargetChain
             }
             catch (Exception error)
             {
-                if (error is WalletException walletException && walletException.Message == FederationWalletTransactionHandler.NoSpendableTransactionsMessage)
+                if (error is WalletException walletException && 
+                    (walletException.Message == FederationWalletTransactionHandler.NoSpendableTransactionsMessage
+                     || walletException.Message == FederationWalletTransactionHandler.NotEnoughFundsMessage))
                 {
-                    this.logger.LogWarning("No spendable transactions in the wallet. Should be resolved when a pending transaction is included in a block.");
+                    this.logger.LogWarning("Not enough spendable transactions in the wallet. Should be resolved when a pending transaction is included in a block.");
                 }
                 else
                 {

--- a/src/Stratis.Features.FederatedPeg/Wallet/FederationWalletTransactionHandler.cs
+++ b/src/Stratis.Features.FederatedPeg/Wallet/FederationWalletTransactionHandler.cs
@@ -37,6 +37,8 @@ namespace Stratis.Features.FederatedPeg.Wallet
     {
         public const string NoSpendableTransactionsMessage = "No spendable transactions found.";
 
+        public const string NotEnoughFundsMessage = "Not enough funds.";
+
         /// <summary>A threshold that if possible will limit the amount of UTXO sent to the <see cref="ICoinSelector"/>.</summary>
         /// <remarks>
         /// 500 is a safe number that if reached ensures the coin selector will not take too long to complete,
@@ -190,7 +192,7 @@ namespace Stratis.Features.FederatedPeg.Wallet
             long balance = context.UnspentOutputs.Sum(t => t.Transaction.Amount);
             long totalToSend = context.Recipients.Sum(s => s.Amount);
             if (balance < totalToSend)
-                throw new WalletException("Not enough funds.");
+                throw new WalletException(NotEnoughFundsMessage);
 
             if (context.SelectedInputs.Any())
             {


### PR DESCRIPTION
https://stratisplatformuk.visualstudio.com/StratisBitcoinFullNode/_workitems/edit/3545

@quantumagi you were right on this one... The wallet can get into a state where enough funds are locked up in pending transactions such that it requires time for these transactions to go through, and it isn't actually an error state.