### PR TITLE
[FS] Order deposits out of MaturedBlocksSyncManager deterministically

### DIFF
--- a/src/Stratis.Features.FederatedPeg/TargetChain/MaturedBlocksSyncManager.cs
+++ b/src/Stratis.Features.FederatedPeg/TargetChain/MaturedBlocksSyncManager.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
+using NBitcoin;
+using Stratis.Features.FederatedPeg.Controllers;
 using Stratis.Features.FederatedPeg.Interfaces;
 using Stratis.Features.FederatedPeg.Models;
-using Stratis.Features.FederatedPeg.Controllers;
+using Stratis.Features.FederatedPeg.Wallet;
 
 namespace Stratis.Features.FederatedPeg.TargetChain
 {
@@ -112,6 +115,10 @@ namespace Stratis.Features.FederatedPeg.TargetChain
                 // Log what we've received.
                 foreach (MaturedBlockDepositsModel maturedBlockDeposit in matureBlockDeposits)
                 {
+                    // Order transactions in block deterministically
+                    maturedBlockDeposit.Deposits = maturedBlockDeposit.Deposits.OrderBy(x => x.Id,
+                        Comparer<uint256>.Create(DeterministicCoinOrdering.CompareUint256)).ToList();
+
                     foreach (IDeposit deposit in maturedBlockDeposit.Deposits)
                     {
                         this.logger.LogDebug("New deposit received BlockNumber={0}, TargetAddress='{1}', depositId='{2}', Amount='{3}'.",

--- a/src/Stratis.Features.FederatedPeg/Wallet/DeterministicCoinOrdering.cs
+++ b/src/Stratis.Features.FederatedPeg/Wallet/DeterministicCoinOrdering.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using NBitcoin;
 
 namespace Stratis.Features.FederatedPeg.Wallet
 {
@@ -53,6 +54,14 @@ namespace Stratis.Features.FederatedPeg.Wallet
             }
 
             return 0;
+        }
+
+        public static int CompareUint256(uint256 x, uint256 y)
+        {
+            if (x == y)
+                return 0;
+
+            return (x < y) ? -1 : 1;
         }
     }
 }


### PR DESCRIPTION
When blocks were coming in sometimes the deposits inside weren't in the correct order.