### PR TITLE
Change some comments on IWithdrawal

### DIFF
--- a/src/Stratis.Features.FederatedPeg/Interfaces/IWithdrawal.cs
+++ b/src/Stratis.Features.FederatedPeg/Interfaces/IWithdrawal.cs
@@ -5,7 +5,7 @@ using Stratis.Bitcoin.Utilities.JsonConverters;
 namespace Stratis.Features.FederatedPeg.Interfaces
 {
     /// <summary>
-    /// Represents a withdrawals made from a source chain to a target chain.
+    /// Represents a withdrawal made from a source chain to a target chain.
     /// </summary>
     public interface IWithdrawal
     {

--- a/src/Stratis.Features.FederatedPeg/Interfaces/IWithdrawal.cs
+++ b/src/Stratis.Features.FederatedPeg/Interfaces/IWithdrawal.cs
@@ -5,20 +5,19 @@ using Stratis.Bitcoin.Utilities.JsonConverters;
 namespace Stratis.Features.FederatedPeg.Interfaces
 {
     /// <summary>
-    /// Represents a withdrawals made from a sidechain mutlisig, with the aim of realising
-    /// a cross chain transfer.
+    /// Represents a withdrawals made from a source chain to a target chain.
     /// </summary>
     public interface IWithdrawal
     {
         /// <summary>
-        /// The Id (or hash) of the source transaction that originates the fund transfer.
+        /// The hash of the deposit transaction from the source chain.
         /// </summary>
         [JsonConverter(typeof(UInt256JsonConverter))]
         uint256 DepositId { get; }
 
         /// <summary>
-        /// The Id (or hash) of the source transaction that originated the fund
-        /// transfer causing this withdrawal.
+        /// The hash of the withdrawal transaction to the target chain.
+        /// This can be null until the trx is fully signed.
         /// </summary>
         [JsonConverter(typeof(UInt256JsonConverter))]
         uint256 Id { get; }
@@ -30,17 +29,17 @@ namespace Stratis.Features.FederatedPeg.Interfaces
         Money Amount { get; }
 
         /// <summary>
-        /// The target address, on the target chain, for the fund deposited on the multisig.
+        /// The target address, on the target chain, for the fund deposited on the multi-sig.
         /// </summary>
         string TargetAddress { get; }
 
         /// <summary>
-        /// The block number where the target deposit has been persisted.
+        /// The block number on the target chain where the withdrawal has been deposited.
         /// </summary>
         int BlockNumber { get; }
 
         /// <summary>
-        /// The hash of the block where the target deposit has been persisted.
+        /// The block hash on the target chain where the withdrawal has been deposited.
         /// </summary>
         [JsonConverter(typeof(UInt256JsonConverter))]
         uint256 BlockHash { get; }


### PR DESCRIPTION
I actually suggest this two fields should be swapped
```
        /// <summary>
        /// The hash of the deposit transaction from the source chain.
        /// </summary>
        [JsonConverter(typeof(UInt256JsonConverter))]
        uint256 DepositId { get; }

        /// <summary>
        /// The hash of the withdrawal transaction to the target chain.
        /// This can be null until the trx is fully signed.
        /// </summary>
        [JsonConverter(typeof(UInt256JsonConverter))]
        uint256 Id { get; }
```
Deposit should go to target and Withdraw should come from source
So it should be :

```
       /// <summary>
        /// The hash of the deposit transaction to the target chain.
        /// </summary>
        [JsonConverter(typeof(UInt256JsonConverter))]
        uint256 DepositId { get; }

        /// <summary>
        /// The hash of the withdrawal transaction from the source chain.
        /// </summary>
        [JsonConverter(typeof(UInt256JsonConverter))]
        uint256 WithdrawId { get; }
```
