### PR TITLE
[FS] Add locking to GetAsync

### DIFF
--- a/src/Stratis.Features.FederatedPeg/TargetChain/CrossChainTransferStore.cs
+++ b/src/Stratis.Features.FederatedPeg/TargetChain/CrossChainTransferStore.cs
@@ -931,15 +931,17 @@ namespace Stratis.Features.FederatedPeg.TargetChain
         }
 
         /// <inheritdoc />
-        [Obsolete("This doesn't lock when validating cross chain transfers. Don't use.")]
         public Task<ICrossChainTransfer[]> GetAsync(uint256[] depositIds)
         {
             return Task.Run(() =>
             {
-                this.Synchronize();
+                lock (this.lockObj)
+                {
+                    this.Synchronize();
 
-                ICrossChainTransfer[] res = this.ValidateCrossChainTransfers(this.Get(depositIds));
-                return res;
+                    ICrossChainTransfer[] res = this.ValidateCrossChainTransfers(this.Get(depositIds));
+                    return res;
+                }
             });
         }
 


### PR DESCRIPTION
It's important that we lock all calls to the CCTS. This method is still being used.