### PR TITLE
3629-Errors not logged in Node.txt

### DIFF
--- a/src/Stratis.Bitcoin/Configuration/Logging/LoggingConfiguration.cs
+++ b/src/Stratis.Bitcoin/Configuration/Logging/LoggingConfiguration.cs
@@ -173,7 +173,7 @@ namespace Stratis.Bitcoin.Configuration.Logging
             LogManager.Configuration.AddTarget(mainTarget);
 
             // Default logging level is Info for all components.
-            var defaultRule = new LoggingRule($"{nameof(Stratis)}.{nameof(Bitcoin)}.*", settings.LogLevel, mainTarget);
+            var defaultRule = new LoggingRule($"{nameof(Stratis)}.*", settings.LogLevel, mainTarget);
 
             if (settings.DebugArgs.Any() && settings.DebugArgs[0] != "1")
             {

--- a/src/Stratis.Features.FederatedPeg/CollateralChecker.cs
+++ b/src/Stratis.Features.FederatedPeg/CollateralChecker.cs
@@ -84,11 +84,11 @@ namespace Stratis.Features.FederatedPeg
             {
                 bool success = await this.UpdateCollateralInfoAsync(this.cancellationSource.Token).ConfigureAwait(false);
 
-                this.logger.LogWarning("Failed to update collateral. Ensure that mainnet gateway node is running and API is enabled. " +
-                                       "Node will not continue initialization before another gateway node responds.");
-
                 if (!success)
                 {
+                    this.logger.LogWarning("Failed to update collateral. Ensure that mainnet gateway node is running and API is enabled. " +
+                                       "Node will not continue initialization before another gateway node responds.");
+
                     try
                     {
                         await Task.Delay(CollateralInitializationUpdateIntervalSeconds * 1000, this.cancellationSource.Token).ConfigureAwait(false);


### PR DESCRIPTION
fixes https://dev.azure.com/Stratisplatformuk/StratisBitcoinFullNode/_workitems/edit/3629/ issue

I've relaxed the rule to include all entry generated in any `Stratis.*` namespace and not only for `Stratis.Bitcoin.*`