### PR TITLE
[FS] Fix FindWithdrawalTransactions

### DIFF
--- a/src/Stratis.Features.FederatedPeg.Tests/CrossChainTransferStoreTests.cs
+++ b/src/Stratis.Features.FederatedPeg.Tests/CrossChainTransferStoreTests.cs
@@ -358,7 +358,7 @@ namespace Stratis.Features.FederatedPeg.Tests
 
                 // Lets break the first transaction
                 this.federationWalletManager.RemoveTransientTransactions(deposit1.Id);
-                
+
                 // Transactions after will be broken
                 transfers = crossChainTransferStore.GetAsync(new uint256[] { txId1, txId2, txId3 }).GetAwaiter().GetResult().ToArray();
                 Assert.Equal(CrossChainTransferStatus.Suspended, transfers[0].Status);
@@ -706,7 +706,7 @@ namespace Stratis.Features.FederatedPeg.Tests
                 BitcoinAddress address2 = (new Key()).PubKey.Hash.GetAddress(this.network);
 
                 // First deposit.
-                var deposit1 = new Deposit(1, new Money(99m, MoneyUnit.BTC), address1.ToString(), crossChainTransferStore.NextMatureDepositHeight, 1);
+                var deposit1 = new Deposit(1, new Money(100m, MoneyUnit.BTC), address1.ToString(), crossChainTransferStore.NextMatureDepositHeight, 1);
 
                 MaturedBlockDepositsModel[] blockDeposit1 = new[] { new MaturedBlockDepositsModel(
                     new MaturedBlockInfoModel() {
@@ -721,7 +721,7 @@ namespace Stratis.Features.FederatedPeg.Tests
                 Assert.Equal(CrossChainTransferStatus.Partial, transfer1?.Status);
 
                 // Second deposit.
-                var deposit2 = new Deposit(2, new Money(99m, MoneyUnit.BTC), address2.ToString(), crossChainTransferStore.NextMatureDepositHeight, 2);
+                var deposit2 = new Deposit(2, new Money(100m, MoneyUnit.BTC), address2.ToString(), crossChainTransferStore.NextMatureDepositHeight, 2);
 
                 MaturedBlockDepositsModel[] blockDeposit2 = new[] { new MaturedBlockDepositsModel(
                     new MaturedBlockInfoModel() {
@@ -760,7 +760,7 @@ namespace Stratis.Features.FederatedPeg.Tests
                 transfer2 = crossChainTransferStore.GetAsync(new[] { deposit2.Id }).GetAwaiter().GetResult().FirstOrDefault();
                 Assert.Equal(CrossChainTransferStatus.Partial, transfer2?.Status);
 
-                Assert.Equal(4, this.wallet.MultiSigAddress.Transactions.Count);
+                Assert.Equal(2, this.wallet.MultiSigAddress.Transactions.Count);
             }
         }
 

--- a/src/Stratis.Features.FederatedPeg/Interfaces/IFederationWalletManager.cs
+++ b/src/Stratis.Features.FederatedPeg/Interfaces/IFederationWalletManager.cs
@@ -99,9 +99,8 @@ namespace Stratis.Features.FederatedPeg.Interfaces
         /// Finds all withdrawal transactions with optional filtering by deposit id or transaction id.
         /// </summary>
         /// <param name="depositId">Filters by this deposit id if not <c>null</c>.</param>
-        /// <param name="transactionId">Filters by this transaction id if not <c>null</c>.</param>
         /// <returns>The transaction data containing the withdrawal transaction.</returns>
-        List<(Transaction, TransactionData, IWithdrawal)> FindWithdrawalTransactions(uint256 depositId = null);
+        List<(Transaction, IWithdrawal)> FindWithdrawalTransactions(uint256 depositId = null);
 
         /// <summary>
         /// Removes the transient transactions associated with the corresponding deposit ids.

--- a/src/Stratis.Features.FederatedPeg/Interfaces/IFederationWalletManager.cs
+++ b/src/Stratis.Features.FederatedPeg/Interfaces/IFederationWalletManager.cs
@@ -55,10 +55,10 @@ namespace Stratis.Features.FederatedPeg.Interfaces
         /// </summary>
         /// <param name="transaction">The transaction.</param>
         /// <param name="blockHeight">The height of the block this transaction came from. Null if it was not a transaction included in a block.</param>
+        /// <param name="blockHash">The hash of the block this transaction came from. Null if it was not a transaction included in a block.</param>
         /// <param name="block">The block in which this transaction was included.</param>
-        /// <param name="isPropagated">Transaction propagation state.</param>
         /// <returns>A value indicating whether this transaction affects the wallet.</returns>
-        bool ProcessTransaction(Transaction transaction, int? blockHeight = null, Block block = null);
+        bool ProcessTransaction(Transaction transaction, int? blockHeight = null, uint256 blockHash = null, Block block = null);
 
         /// <summary>
         /// Verifies that the transaction's input UTXO's have been reserved by the wallet.

--- a/src/Stratis.Features.FederatedPeg/TargetChain/CrossChainTransferStore.cs
+++ b/src/Stratis.Features.FederatedPeg/TargetChain/CrossChainTransferStore.cs
@@ -168,13 +168,10 @@ namespace Stratis.Features.FederatedPeg.TargetChain
                 ICrossChainTransfer[] transfers = this.GetTransfersByStatusInternal(new[] { CrossChainTransferStatus.SeenInBlock }, true, false).ToArray();
                 foreach (ICrossChainTransfer transfer in transfers)
                 {
-                    (Transaction tran, TransactionData tranData, _) = this.federationWalletManager.FindWithdrawalTransactions(transfer.DepositTransactionId).FirstOrDefault();
+                    (Transaction tran, _) = this.federationWalletManager.FindWithdrawalTransactions(transfer.DepositTransactionId).FirstOrDefault();
                     if (tran == null && wallet.LastBlockSyncedHeight >= transfer.BlockHeight)
                     {
-                        this.federationWalletManager.ProcessTransaction(transfer.PartialTransaction);
-                        (tran, tranData, _) = this.federationWalletManager.FindWithdrawalTransactions(transfer.DepositTransactionId).FirstOrDefault();
-                        tranData.BlockHeight = transfer.BlockHeight;
-                        tranData.BlockHash = transfer.BlockHash;
+                        this.federationWalletManager.ProcessTransaction(transfer.PartialTransaction, transfer.BlockHeight);
                     }
                 }
             }
@@ -231,7 +228,7 @@ namespace Stratis.Features.FederatedPeg.TargetChain
                 if (partialTransfer.Status != CrossChainTransferStatus.Partial && partialTransfer.Status != CrossChainTransferStatus.FullySigned)
                     continue;
 
-                List<(Transaction, TransactionData, IWithdrawal)> walletData = this.federationWalletManager.FindWithdrawalTransactions(partialTransfer.DepositTransactionId);
+                List<(Transaction, IWithdrawal)> walletData = this.federationWalletManager.FindWithdrawalTransactions(partialTransfer.DepositTransactionId);
                 if (walletData.Count == 1 && this.ValidateTransaction(walletData[0].Item1))
                 {
                     Transaction walletTran = walletData[0].Item1;
@@ -242,8 +239,8 @@ namespace Stratis.Features.FederatedPeg.TargetChain
                     {
                         partialTransfer.SetPartialTransaction(walletTran);
 
-                        if (walletData[0].Item2.BlockHeight != null)
-                            tracker.SetTransferStatus(partialTransfer, CrossChainTransferStatus.SeenInBlock, walletData[0].Item2.BlockHash, (int)walletData[0].Item2.BlockHeight);
+                        if (walletData[0].Item2.BlockNumber != 0)
+                            tracker.SetTransferStatus(partialTransfer, CrossChainTransferStatus.SeenInBlock, walletData[0].Item2.BlockHash, (int)walletData[0].Item2.BlockNumber);
                         else if (this.ValidateTransaction(walletTran, true))
                             tracker.SetTransferStatus(partialTransfer, CrossChainTransferStatus.FullySigned);
                         else
@@ -254,7 +251,7 @@ namespace Stratis.Features.FederatedPeg.TargetChain
                 }
 
                 // Remove any invalid withdrawal transactions.
-                foreach (IWithdrawal withdrawal in walletData.Select(d => d.Item3))
+                foreach (IWithdrawal withdrawal in walletData.Select(d => d.Item2))
                     this.federationWalletManager.RemoveTransientTransactions(withdrawal.DepositId);
 
                 // The chain may have been rewound so that this transaction or its UTXO's have been lost.
@@ -298,11 +295,11 @@ namespace Stratis.Features.FederatedPeg.TargetChain
                     }
 
                     // Remove transient transactions after the next mature deposit height.
-                    foreach ((Transaction, TransactionData, IWithdrawal) t in this.federationWalletManager.FindWithdrawalTransactions())
+                    foreach ((Transaction, IWithdrawal) t in this.federationWalletManager.FindWithdrawalTransactions())
                     {
-                        if (t.Item3.BlockNumber >= newChainATip)
+                        if (t.Item2.BlockNumber >= newChainATip)
                         {
-                            this.federationWalletManager.RemoveTransientTransactions(t.Item3.DepositId);
+                            this.federationWalletManager.RemoveTransientTransactions(t.Item2.DepositId);
                         }
                     }
 

--- a/src/Stratis.Features.FederatedPeg/TargetChain/CrossChainTransferStore.cs
+++ b/src/Stratis.Features.FederatedPeg/TargetChain/CrossChainTransferStore.cs
@@ -171,7 +171,7 @@ namespace Stratis.Features.FederatedPeg.TargetChain
                     (Transaction tran, _) = this.federationWalletManager.FindWithdrawalTransactions(transfer.DepositTransactionId).FirstOrDefault();
                     if (tran == null && wallet.LastBlockSyncedHeight >= transfer.BlockHeight)
                     {
-                        this.federationWalletManager.ProcessTransaction(transfer.PartialTransaction, transfer.BlockHeight);
+                        this.federationWalletManager.ProcessTransaction(transfer.PartialTransaction, transfer.BlockHeight, transfer.BlockHash);
                     }
                 }
             }
@@ -679,7 +679,7 @@ namespace Stratis.Features.FederatedPeg.TargetChain
                             Transaction transaction = block.Transactions.Single(t => t.GetHash() == withdrawal.Id);
 
                             // Ensure that the wallet is in step.
-                            this.federationWalletManager.ProcessTransaction(transaction, withdrawal.BlockNumber, block);
+                            this.federationWalletManager.ProcessTransaction(transaction, withdrawal.BlockNumber, withdrawal.BlockHash, block);
 
                             if (crossChainTransfers[i] == null)
                             {

--- a/src/Stratis.Features.FederatedPeg/Wallet/FederationWalletManager.cs
+++ b/src/Stratis.Features.FederatedPeg/Wallet/FederationWalletManager.cs
@@ -371,7 +371,7 @@ namespace Stratis.Features.FederatedPeg.Wallet
                         continue;
                     }
 
-                    // If we're trying to spend an input that is already spent, and it's not coming in a new block, don't reserve the transaction. 
+                    // If we're trying to spend an input that is already spent, and it's not coming in a new block, don't reserve the transaction.
                     // This would be the case when blocks are synced in between CrossChainTransferStore calling
                     // FederationWalletTransactionHandler.BuildTransaction and FederationWalletManager.ProcessTransaction.
                     if (blockHeight == null && tTx.SpendingDetails?.BlockHeight != null)
@@ -385,8 +385,8 @@ namespace Stratis.Features.FederatedPeg.Wallet
                 if (withdrawal != null)
                 {
                     // Exit if already present and included in a block.
-                    List<(Transaction, TransactionData, IWithdrawal)> walletData = this.FindWithdrawalTransactions(withdrawal.DepositId);
-                    if ((walletData.Count == 1) && (walletData[0].Item2.BlockHeight != null))
+                    List<(Transaction, IWithdrawal)> walletData = this.FindWithdrawalTransactions(withdrawal.DepositId);
+                    if ((walletData.Count == 1) && (walletData[0].Item2.BlockNumber != 0))
                     {
                         this.logger.LogTrace("Deposit {0} Already included in block.", withdrawal.DepositId);
                         return false;
@@ -783,10 +783,9 @@ namespace Stratis.Features.FederatedPeg.Wallet
                 // Remove transient transactions not seen in a block yet.
                 bool walletUpdated = false;
 
-                foreach ((Transaction transaction, TransactionData transactionData, _) in this.FindWithdrawalTransactions(depositId)
-                    .Where(w => w.Item2.BlockHash == null))
+                foreach ((Transaction transaction, _) in this.FindWithdrawalTransactions(depositId)
+                    .Where(w => w.Item2.BlockNumber == 0))
                 {
-                    Guard.Assert(transactionData.SpendingDetails == null);
                     walletUpdated |= this.RemoveTransaction(transaction);
                 }
 
@@ -809,23 +808,34 @@ namespace Stratis.Features.FederatedPeg.Wallet
         }
 
         /// <inheritdoc />
-        public List<(Transaction, TransactionData, IWithdrawal)> FindWithdrawalTransactions(uint256 depositId = null)
+        public List<(Transaction, IWithdrawal)> FindWithdrawalTransactions(uint256 depositId = null)
         {
+            // A withdrawal is a transaction that spends funds from the multisig wallet.
             lock (this.lockObject)
             {
-                List<(Transaction, TransactionData, IWithdrawal)> withdrawals = new List<(Transaction, TransactionData, IWithdrawal)>();
+                var withdrawals = new List<(Transaction, IWithdrawal)>();
 
                 foreach (TransactionData transactionData in this.Wallet.MultiSigAddress.Transactions)
                 {
-                    Transaction walletTran = transactionData.GetFullTransaction(this.network);
-                    IWithdrawal withdrawal = this.withdrawalExtractor.ExtractWithdrawalFromTransaction(walletTran, transactionData.BlockHash, transactionData.BlockHeight ?? 0);
+                    if (transactionData.SpendingDetails == null)
+                        continue;
+
+                    Transaction walletTran = this.network.CreateTransaction(transactionData.SpendingDetails.Hex);
+
+                    if (withdrawals.Any(w => w.Item1.GetHash() == walletTran.GetHash()))
+                        continue;
+
+                    int? blockHeight = transactionData.SpendingDetails.BlockHeight;
+                    uint256 blockHash = (blockHeight == null) ? null : this.chainIndexer.GetHeader((int)blockHeight).HashBlock;
+
+                    IWithdrawal withdrawal = this.withdrawalExtractor.ExtractWithdrawalFromTransaction(walletTran, blockHash, blockHeight ?? 0);
                     if (withdrawal == null)
                         continue;
 
                     if (depositId != null && withdrawal.DepositId != depositId)
                         continue;
 
-                    withdrawals.Add((walletTran, transactionData, withdrawal));
+                    withdrawals.Add((walletTran, withdrawal));
                 }
 
                 return withdrawals;

--- a/src/Stratis.Features.FederatedPeg/Wallet/SpendingDetails.cs
+++ b/src/Stratis.Features.FederatedPeg/Wallet/SpendingDetails.cs
@@ -33,6 +33,12 @@ namespace Stratis.Features.FederatedPeg.Wallet
         public int? BlockHeight { get; set; }
 
         /// <summary>
+        /// The hash of the block including this transaction.
+        /// </summary>
+        [JsonProperty(PropertyName = "blockHash", NullValueHandling = NullValueHandling.Ignore)]
+        public uint256 BlockHash { get; set; }
+
+        /// <summary>
         /// A value indicating whether this is a coin stake transaction or not.
         /// </summary>
         [JsonProperty(PropertyName = "isCoinStake", NullValueHandling = NullValueHandling.Ignore)]


### PR DESCRIPTION
This PR re-introduces #3568 which was rewound in #3573 due to the wallet containing spending transactions with block heights that could not be mapped to block hashes.

The PR will now be improved by adding a BlockHash to SpendingDetails to compliment the existing BlockHeight field.