### PR TITLE
Fix rewind data index

### DIFF
--- a/src/Stratis.Bitcoin.Features.Consensus/CoinViews/CachedCoinView.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/CoinViews/CachedCoinView.cs
@@ -427,7 +427,7 @@ namespace Stratis.Bitcoin.Features.Consensus.CoinViews
                             for (int i = 0; i < unspent.Outputs.Length; i++)
                             {
                                 // Only push to rewind data index UTXOs that are spent.
-                                if (unspent.Outputs[i] != clone.Outputs[i])
+                                if (unspent.Outputs[i] == null && clone.Outputs[i] != null)
                                 {
                                     var key = new OutPoint(unspent.TransactionId, i);
                                     indexItems[key] = this.blockHeight;

--- a/src/Stratis.Bitcoin.Features.Consensus/CoinViews/CachedCoinView.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/CoinViews/CachedCoinView.cs
@@ -421,6 +421,19 @@ namespace Stratis.Bitcoin.Features.Consensus.CoinViews
                         cacheItem.UnspentOutputs.Spend(unspent);
 
                         this.logger.LogTrace("Cache item after spend {0}:'{1}'.", nameof(cacheItem.UnspentOutputs), cacheItem.UnspentOutputs);
+
+                        if (this.rewindDataIndexCache != null)
+                        {
+                            for (int i = 0; i < unspent.Outputs.Length; i++)
+                            {
+                                // Only push to rewind data index UTXOs that are spent.
+                                if (unspent.Outputs[i] != clone.Outputs[i])
+                                {
+                                    var key = new OutPoint(unspent.TransactionId, i);
+                                    indexItems[key] = this.blockHeight;
+                                }
+                            }
+                        }
                     }
                     else
                     {
@@ -434,15 +447,6 @@ namespace Stratis.Bitcoin.Features.Consensus.CoinViews
                     }
 
                     cacheItem.IsDirty = true;
-
-                    if (this.rewindDataIndexCache != null)
-                    {
-                        for (int i = 0; i < unspent.Outputs.Length; i++)
-                        {
-                            var key = new OutPoint(unspent.TransactionId, i);
-                            indexItems[key] = this.blockHeight;
-                        }
-                    }
 
                     // Inner does not need to know pruned unspent that it never saw.
                     if (cacheItem.UnspentOutputs.IsPrunable && !cacheItem.ExistInInner)

--- a/src/Stratis.Bitcoin.Features.Wallet/Controllers/WalletController.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Controllers/WalletController.cs
@@ -1346,7 +1346,8 @@ namespace Stratis.Bitcoin.Features.Wallet.Controllers
                     MinConfirmations = 1,
                     Shuffle = true,
                     WalletPassword = request.WalletPassword,
-                    Recipients = recipients
+                    Recipients = recipients,
+                    Time = (uint)this.dateTimeProvider.GetAdjustedTimeAsUnixTimestamp()
                 };
 
                 Transaction transactionResult = this.walletTransactionHandler.BuildTransaction(context);

--- a/src/Stratis.Bitcoin.Features.Wallet/WalletTransactionHandler.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/WalletTransactionHandler.cs
@@ -193,6 +193,9 @@ namespace Stratis.Bitcoin.Features.Wallet
             this.AddSecrets(context);
             this.FindChangeAddress(context);
             this.AddFee(context);
+
+            if (context.Time.HasValue)
+                context.TransactionBuilder.SetTimeStamp(context.Time.Value);
         }
 
         /// <summary>
@@ -498,5 +501,10 @@ namespace Stratis.Bitcoin.Features.Wallet
         /// Whether the secret should be cached for 5 mins after it is used or not.
         /// </summary>
         public bool CacheSecret { get; set; }
+
+        /// <summary>
+        /// The timestamp to set on the transaction.
+        /// </summary>
+        public uint? Time { get; set; }
     }
 }

--- a/src/Stratis.Bitcoin.IntegrationTests.Common/EnvironmentMockUpHelpers/CoreNode.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests.Common/EnvironmentMockUpHelpers/CoreNode.cs
@@ -62,6 +62,9 @@ namespace Stratis.Bitcoin.IntegrationTests.Common.EnvironmentMockUpHelpers
 
         public Mnemonic Mnemonic { get; set; }
 
+        public string WalletName => this.builderWalletName;
+        public string WalletPassword => this.builderWalletPassword;
+
         private bool builderAlwaysFlushBlocks;
         private bool builderEnablePeerDiscovery;
         private bool builderNoValidation;


### PR DESCRIPTION
Rewind Data Index was indexing too much (new UTXO as well as spent UTXO) and it was overwriting UTXO that where not spend but still pulled from disk (this is due to the nature of how coinview works where all the UTXOs of a trx are loaded even though not all inputs are spent n the block)