### PR TITLE
Fix "getblock" to correctly default verbosity to 1

### DIFF
--- a/src/Stratis.Bitcoin.Features.RPC/Controllers/FullNodeController.cs
+++ b/src/Stratis.Bitcoin.Features.RPC/Controllers/FullNodeController.cs
@@ -358,15 +358,15 @@ namespace Stratis.Bitcoin.Features.RPC.Controllers
         /// <summary>
         /// RPC method for returning a block.
         /// <para>
-        /// Supports Json format by default, and optionally raw (hex) format by supplying <c>false</c> to <see cref="isJsonFormat"/>.
+        /// Supports Json format by default, and optionally raw (hex) format by supplying <c>0</c> to <see cref="verbosity"/>.
         /// </para>
         /// </summary>
         /// <param name="blockHash">Hash of block to find.</param>
-        /// <param name="verbosity">0 for hex encoded data, 1 for a json object, and 2 for json object with transaction data.</param>
+        /// <param name="verbosity">Defaults to 1. 0 for hex encoded data, 1 for a json object, and 2 for json object with transaction data.</param>
         /// <returns>The block according to format specified in <see cref="verbosity"/></returns>
         [ActionName("getblock")]
         [ActionDescription("Returns the block in hex, given a block hash.")]
-        public async Task<object> GetBlockAsync(string blockHash, int verbosity = 0)
+        public async Task<object> GetBlockAsync(string blockHash, int verbosity = 1)
         {
             Block block = this.blockStore != null ? this.blockStore.GetBlock(uint256.Parse(blockHash)) : null;
 


### PR DESCRIPTION
- The Bitcoin documentation defaults verbosity to 1, and returns JSON, not HEX. Recent changes to this RPC method changed the previous default boolean from true, to false.