### PR TITLE
[FN] Don't add already confirmed transactions to mempool

### DIFF
--- a/src/Stratis.Bitcoin.Features.MemoryPool/MempoolErrors.cs
+++ b/src/Stratis.Bitcoin.Features.MemoryPool/MempoolErrors.cs
@@ -124,6 +124,9 @@ namespace Stratis.Bitcoin.Features.MemoryPool
         /// <summary>'non-final' error returns a <see cref="RejectNonstandard"/> reject code.</summary>
         public static MempoolError NonFinal = new MempoolError(RejectNonstandard, "non-final");
 
+        /// <summary>'txn-already-confirmed' error returns a <see cref="RejectAlreadyKnown"/> reject code.</summary>
+        public static MempoolError AlreadyConfirmed = new MempoolError(RejectAlreadyKnown, "txn-already-confirmed");
+
         /// <summary>'txn-already-in-mempool' error returns a <see cref="RejectAlreadyKnown"/> reject code.</summary>
         public static MempoolError InPool = new MempoolError(RejectAlreadyKnown, "txn-already-in-mempool");
 


### PR DESCRIPTION
This PR attempt to prevent transactions from appearing in both the mempool and the consensus chain by ensuring that the following rules are applied:
1. When a transaction is added to the consensus chain remove it from the mempool.
2. **Don't add transactions to the mempool if they occur on the consensus chain.**

**Thereby enforcing mutual exclusivity.**

The mutual exclusivity ensures that "All mined transactions should be removed from mempool".

This PR only addresses **item 2** as it seems that item 1 is already implemented.

See https://stratisplatformuk.visualstudio.com/StratisBitcoinFullNode/_workitems/edit/3674.