### PR TITLE
3679 - Performance: Remove SignedMultisigTransactionBroadcaster and instead broadcast transactions once they are FullySigned.

### DIFF
--- a/src/Stratis.Features.FederatedPeg.Tests/CrossChainTestBase.cs
+++ b/src/Stratis.Features.FederatedPeg.Tests/CrossChainTestBase.cs
@@ -220,7 +220,7 @@ namespace Stratis.Features.FederatedPeg.Tests
         protected ICrossChainTransferStore CreateStore()
         {
             return new CrossChainTransferStore(this.network, this.dataFolder, this.ChainIndexer, this.federationGatewaySettings, this.dateTimeProvider,
-                this.loggerFactory, this.withdrawalExtractor, this.fullNode, this.blockRepository, this.federationWalletManager, this.withdrawalTransactionBuilder, this.dBreezeSerializer);
+                this.loggerFactory, this.withdrawalExtractor, this.fullNode, this.blockRepository, this.federationWalletManager, this.withdrawalTransactionBuilder, this.dBreezeSerializer, this.signals);
         }
 
         /// <summary>

--- a/src/Stratis.Features.FederatedPeg.Tests/SignedMultisigTransactionBroadcasterTests.cs
+++ b/src/Stratis.Features.FederatedPeg.Tests/SignedMultisigTransactionBroadcasterTests.cs
@@ -10,7 +10,9 @@ using Stratis.Bitcoin.Features.MemoryPool;
 using Stratis.Bitcoin.Features.MemoryPool.Fee;
 using Stratis.Bitcoin.Features.Wallet.Interfaces;
 using Stratis.Bitcoin.Interfaces;
+using Stratis.Bitcoin.Signals;
 using Stratis.Bitcoin.Utilities;
+using Stratis.Features.FederatedPeg.Events;
 using Stratis.Features.FederatedPeg.Interfaces;
 using Stratis.Features.FederatedPeg.TargetChain;
 using Stratis.Sidechains.Networks;
@@ -23,7 +25,6 @@ namespace Stratis.Features.FederatedPeg.Tests
         private readonly ILogger logger;
         private readonly ILoggerFactory loggerFactory;
         private readonly IDisposable leaderReceiverSubscription;
-        private readonly ICrossChainTransferStore store;
         private readonly IFederationGatewaySettings federationGatewaySettings;
         private readonly IBroadcasterManager broadcasterManager;
 
@@ -41,6 +42,7 @@ namespace Stratis.Features.FederatedPeg.Tests
 
         private readonly IInitialBlockDownloadState ibdState;
         private readonly IFederationWalletManager federationWalletManager;
+        private readonly ISignals signals;
 
         private const string PublicKey = "026ebcbf6bfe7ce1d957adbef8ab2b66c788656f35896a170257d6838bda70b95c";
 
@@ -51,7 +53,6 @@ namespace Stratis.Features.FederatedPeg.Tests
             this.federationGatewaySettings = Substitute.For<IFederationGatewaySettings>();
             this.loggerFactory.CreateLogger(null).ReturnsForAnyArgs(this.logger);
             this.leaderReceiverSubscription = Substitute.For<IDisposable>();
-            this.store = Substitute.For<ICrossChainTransferStore>();
             this.broadcasterManager = Substitute.For<IBroadcasterManager>();
             this.asyncProvider = Substitute.For<IAsyncProvider>();
             this.nodeLifetime = Substitute.For<INodeLifetime>();
@@ -59,6 +60,7 @@ namespace Stratis.Features.FederatedPeg.Tests
             this.ibdState = Substitute.For<IInitialBlockDownloadState>();
             this.federationWalletManager = Substitute.For<IFederationWalletManager>();
             this.federationWalletManager.IsFederationWalletActive().Returns(true);
+            this.signals = new Signals(this.loggerFactory, null);
 
             // Setup MempoolManager.
             this.dateTimeProvider = Substitute.For<IDateTimeProvider>();
@@ -97,65 +99,23 @@ namespace Stratis.Features.FederatedPeg.Tests
         }
 
         [Fact]
-        public async Task Call_GetSignedTransactionsAsync_No_Signed_Transactions_Doesnt_Broadcast()
-        {
-            this.federationGatewaySettings.PublicKey.Returns(PublicKey);
-
-            var emptyTransactionPair = new CrossChainTransfer[0];
-
-            this.store.GetTransfersByStatus(new[]{CrossChainTransferStatus.FullySigned}).Returns(emptyTransactionPair);
-
-            var signedMultisigTransactionBroadcaster = new SignedMultisigTransactionBroadcaster(
-                this.asyncProvider,
-                this.loggerFactory,
-                this.store,
-                this.nodeLifetime,
-                this.mempoolManager,
-                this.broadcasterManager,
-                this.ibdState,
-                this.federationWalletManager);
-
-            await signedMultisigTransactionBroadcaster.BroadcastTransactionsAsync().ConfigureAwait(false);
-
-            this.store.Received().GetTransfersByStatus(Arg.Any<CrossChainTransferStatus[]>());
-
-            await this.broadcasterManager.DidNotReceive().BroadcastTransactionAsync(Arg.Any<Transaction>());
-
-            this.logger.Received().Log(LogLevel.Trace,
-                Arg.Any<EventId>(),
-                Arg.Is<object>(o => o.ToString() == "Signed multisig transactions do not exist in the CrossChainTransfer store."),
-                null,
-                Arg.Any<Func<object, Exception, string>>());
-        }
-
-        [Fact]
         public async Task Call_GetSignedTransactionsAsync_Signed_Transactions_Broadcasts()
         {
             this.federationGatewaySettings.PublicKey.Returns(PublicKey);
+
+            var signedMultisigTransactionBroadcaster = new SignedMultisigTransactionBroadcaster(
+                this.loggerFactory,
+                this.mempoolManager,
+                this.broadcasterManager,
+                this.ibdState,
+                this.federationWalletManager,
+                this.signals);
+
 
             var partial = new Transaction();
             var xfer = new CrossChainTransfer();
             xfer.SetPartialTransaction(partial);
 
-            var transactionPair = new CrossChainTransfer[]
-            {
-                xfer
-            };
-
-            this.store.GetTransfersByStatus(Arg.Any<CrossChainTransferStatus[]>()).Returns(transactionPair);
-
-            var signedMultisigTransactionBroadcaster = new SignedMultisigTransactionBroadcaster(
-                this.asyncProvider,
-                this.loggerFactory,
-                this.store,
-                this.nodeLifetime,
-                this.mempoolManager,
-                this.broadcasterManager,
-                this.ibdState,
-                this.federationWalletManager);
-
-            await signedMultisigTransactionBroadcaster.BroadcastTransactionsAsync().ConfigureAwait(false);
-            this.store.Received().GetTransfersByStatus(Arg.Any<CrossChainTransferStatus[]>());
             await this.broadcasterManager.Received(1).BroadcastTransactionAsync(Arg.Any<Transaction>());
         }
 
@@ -165,18 +125,20 @@ namespace Stratis.Features.FederatedPeg.Tests
             this.ibdState.IsInitialBlockDownload().Returns(true);
 
             var signedMultisigTransactionBroadcaster = new SignedMultisigTransactionBroadcaster(
-                this.asyncProvider,
-                this.loggerFactory,
-                this.store,
-                this.nodeLifetime,
-                this.mempoolManager,
-                this.broadcasterManager,
-                this.ibdState,
-                this.federationWalletManager);
+               this.loggerFactory,
+               this.mempoolManager,
+               this.broadcasterManager,
+               this.ibdState,
+               this.federationWalletManager,
+               this.signals);
 
-            await signedMultisigTransactionBroadcaster.BroadcastTransactionsAsync().ConfigureAwait(false);
+            var partial = new Transaction();
+            var xfer = new CrossChainTransfer();
+            xfer.SetPartialTransaction(partial);
 
-            this.store.Received(0).GetTransfersByStatus(Arg.Any<CrossChainTransferStatus[]>());
+            this.signals.Publish(new CrossChainTransferTransactionFullySigned(xfer));
+
+            await this.broadcasterManager.Received(0).BroadcastTransactionAsync(Arg.Any<Transaction>());
         }
 
         [Fact]
@@ -184,19 +146,23 @@ namespace Stratis.Features.FederatedPeg.Tests
         {
             this.federationWalletManager.IsFederationWalletActive().Returns(false);
 
+            this.ibdState.IsInitialBlockDownload().Returns(true);
+
             var signedMultisigTransactionBroadcaster = new SignedMultisigTransactionBroadcaster(
-                this.asyncProvider,
-                this.loggerFactory,
-                this.store,
-                this.nodeLifetime,
-                this.mempoolManager,
-                this.broadcasterManager,
-                this.ibdState,
-                this.federationWalletManager);
+               this.loggerFactory,
+               this.mempoolManager,
+               this.broadcasterManager,
+               this.ibdState,
+               this.federationWalletManager,
+               this.signals);
 
-            await signedMultisigTransactionBroadcaster.BroadcastTransactionsAsync().ConfigureAwait(false);
+            var partial = new Transaction();
+            var xfer = new CrossChainTransfer();
+            xfer.SetPartialTransaction(partial);
 
-            this.store.Received(0).GetTransfersByStatus(Arg.Any<CrossChainTransferStatus[]>());
+            this.signals.Publish(new CrossChainTransferTransactionFullySigned(xfer));
+
+            await this.broadcasterManager.Received(0).BroadcastTransactionAsync(Arg.Any<Transaction>());
         }
 
         public void Dispose()

--- a/src/Stratis.Features.FederatedPeg.Tests/SignedMultisigTransactionBroadcasterTests.cs
+++ b/src/Stratis.Features.FederatedPeg.Tests/SignedMultisigTransactionBroadcasterTests.cs
@@ -118,6 +118,7 @@ namespace Stratis.Features.FederatedPeg.Tests
                 xfer.SetPartialTransaction(partial);
 
                 this.signals.Publish(new CrossChainTransferTransactionFullySigned(xfer));
+                await Task.Delay(100); //the event subscriber handles the event asynchronously so let's wait a bit to give it the time to complete.
 
                 await this.broadcasterManager.Received(1).BroadcastTransactionAsync(Arg.Any<Transaction>());
             }
@@ -143,6 +144,7 @@ namespace Stratis.Features.FederatedPeg.Tests
                 xfer.SetPartialTransaction(partial);
 
                 this.signals.Publish(new CrossChainTransferTransactionFullySigned(xfer));
+                await Task.Delay(100); //the event subscriber handles the event asynchronously so let's wait a bit to give it the time to complete.
 
                 await this.broadcasterManager.Received(0).BroadcastTransactionAsync(Arg.Any<Transaction>());
             }
@@ -170,6 +172,7 @@ namespace Stratis.Features.FederatedPeg.Tests
                 xfer.SetPartialTransaction(partial);
 
                 this.signals.Publish(new CrossChainTransferTransactionFullySigned(xfer));
+                await Task.Delay(100); //the event subscriber handles the event asynchronously so let's wait a bit to give it the time to complete.
 
                 await this.broadcasterManager.Received(0).BroadcastTransactionAsync(Arg.Any<Transaction>());
             }

--- a/src/Stratis.Features.FederatedPeg.Tests/SignedMultisigTransactionBroadcasterTests.cs
+++ b/src/Stratis.Features.FederatedPeg.Tests/SignedMultisigTransactionBroadcasterTests.cs
@@ -103,20 +103,24 @@ namespace Stratis.Features.FederatedPeg.Tests
         {
             this.federationGatewaySettings.PublicKey.Returns(PublicKey);
 
-            var signedMultisigTransactionBroadcaster = new SignedMultisigTransactionBroadcaster(
-                this.loggerFactory,
-                this.mempoolManager,
-                this.broadcasterManager,
-                this.ibdState,
-                this.federationWalletManager,
-                this.signals);
+            using (var signedMultisigTransactionBroadcaster = new SignedMultisigTransactionBroadcaster(
+               this.loggerFactory,
+               this.mempoolManager,
+               this.broadcasterManager,
+               this.ibdState,
+               this.federationWalletManager,
+               this.signals))
+            {
+                signedMultisigTransactionBroadcaster.Start();
 
+                var partial = new Transaction();
+                var xfer = new CrossChainTransfer();
+                xfer.SetPartialTransaction(partial);
 
-            var partial = new Transaction();
-            var xfer = new CrossChainTransfer();
-            xfer.SetPartialTransaction(partial);
+                this.signals.Publish(new CrossChainTransferTransactionFullySigned(xfer));
 
-            await this.broadcasterManager.Received(1).BroadcastTransactionAsync(Arg.Any<Transaction>());
+                await this.broadcasterManager.Received(1).BroadcastTransactionAsync(Arg.Any<Transaction>());
+            }
         }
 
         [Fact]
@@ -124,21 +128,24 @@ namespace Stratis.Features.FederatedPeg.Tests
         {
             this.ibdState.IsInitialBlockDownload().Returns(true);
 
-            var signedMultisigTransactionBroadcaster = new SignedMultisigTransactionBroadcaster(
+            using (var signedMultisigTransactionBroadcaster = new SignedMultisigTransactionBroadcaster(
                this.loggerFactory,
                this.mempoolManager,
                this.broadcasterManager,
                this.ibdState,
                this.federationWalletManager,
-               this.signals);
+               this.signals))
+            {
+                signedMultisigTransactionBroadcaster.Start();
 
-            var partial = new Transaction();
-            var xfer = new CrossChainTransfer();
-            xfer.SetPartialTransaction(partial);
+                var partial = new Transaction();
+                var xfer = new CrossChainTransfer();
+                xfer.SetPartialTransaction(partial);
 
-            this.signals.Publish(new CrossChainTransferTransactionFullySigned(xfer));
+                this.signals.Publish(new CrossChainTransferTransactionFullySigned(xfer));
 
-            await this.broadcasterManager.Received(0).BroadcastTransactionAsync(Arg.Any<Transaction>());
+                await this.broadcasterManager.Received(0).BroadcastTransactionAsync(Arg.Any<Transaction>());
+            }
         }
 
         [Fact]
@@ -148,21 +155,24 @@ namespace Stratis.Features.FederatedPeg.Tests
 
             this.ibdState.IsInitialBlockDownload().Returns(true);
 
-            var signedMultisigTransactionBroadcaster = new SignedMultisigTransactionBroadcaster(
+            using (var signedMultisigTransactionBroadcaster = new SignedMultisigTransactionBroadcaster(
                this.loggerFactory,
                this.mempoolManager,
                this.broadcasterManager,
                this.ibdState,
                this.federationWalletManager,
-               this.signals);
+               this.signals))
+            {
+                signedMultisigTransactionBroadcaster.Start();
 
-            var partial = new Transaction();
-            var xfer = new CrossChainTransfer();
-            xfer.SetPartialTransaction(partial);
+                var partial = new Transaction();
+                var xfer = new CrossChainTransfer();
+                xfer.SetPartialTransaction(partial);
 
-            this.signals.Publish(new CrossChainTransferTransactionFullySigned(xfer));
+                this.signals.Publish(new CrossChainTransferTransactionFullySigned(xfer));
 
-            await this.broadcasterManager.Received(0).BroadcastTransactionAsync(Arg.Any<Transaction>());
+                await this.broadcasterManager.Received(0).BroadcastTransactionAsync(Arg.Any<Transaction>());
+            }
         }
 
         public void Dispose()

--- a/src/Stratis.Features.FederatedPeg/Events/CrossChainTransferTransactionFullySigned.cs
+++ b/src/Stratis.Features.FederatedPeg/Events/CrossChainTransferTransactionFullySigned.cs
@@ -1,0 +1,20 @@
+﻿using NBitcoin;
+using Stratis.Bitcoin.EventBus;
+using Stratis.Features.FederatedPeg.Interfaces;
+
+namespace Stratis.Features.FederatedPeg.Events
+{
+    /// <summary>
+    /// Raised when the partial crosschain transactions of a deposit are merged together and the final transaction is fully signed.
+    /// </summary>
+    /// <seealso cref="Stratis.Bitcoin.EventBus.EventBase" />
+    public class CrossChainTransferTransactionFullySigned : EventBase
+    {
+        public ICrossChainTransfer Transfer { get; }
+
+        public CrossChainTransferTransactionFullySigned(ICrossChainTransfer transfer)
+        {
+            this.Transfer = transfer;
+        }
+    }
+}

--- a/src/Stratis.Features.FederatedPeg/TargetChain/CrossChainTransferStore.cs
+++ b/src/Stratis.Features.FederatedPeg/TargetChain/CrossChainTransferStore.cs
@@ -12,7 +12,9 @@ using NBitcoin;
 using Stratis.Bitcoin;
 using Stratis.Bitcoin.Configuration;
 using Stratis.Bitcoin.Features.BlockStore;
+using Stratis.Bitcoin.Signals;
 using Stratis.Bitcoin.Utilities;
+using Stratis.Features.FederatedPeg.Events;
 using Stratis.Features.FederatedPeg.Interfaces;
 using Stratis.Features.FederatedPeg.Models;
 using Stratis.Features.FederatedPeg.Wallet;
@@ -66,13 +68,14 @@ namespace Stratis.Features.FederatedPeg.TargetChain
         private readonly IFederationWalletManager federationWalletManager;
         private readonly IWithdrawalTransactionBuilder withdrawalTransactionBuilder;
         private readonly IFederationGatewaySettings settings;
+        private readonly ISignals signals;
 
         /// <summary>Provider of time functions.</summary>
         private readonly object lockObj;
 
         public CrossChainTransferStore(Network network, DataFolder dataFolder, ChainIndexer chainIndexer, IFederationGatewaySettings settings, IDateTimeProvider dateTimeProvider,
             ILoggerFactory loggerFactory, IWithdrawalExtractor withdrawalExtractor, IFullNode fullNode, IBlockRepository blockRepository,
-            IFederationWalletManager federationWalletManager, IWithdrawalTransactionBuilder withdrawalTransactionBuilder, DBreezeSerializer dBreezeSerializer)
+            IFederationWalletManager federationWalletManager, IWithdrawalTransactionBuilder withdrawalTransactionBuilder, DBreezeSerializer dBreezeSerializer, ISignals signals)
         {
             Guard.NotNull(network, nameof(network));
             Guard.NotNull(dataFolder, nameof(dataFolder));
@@ -99,6 +102,7 @@ namespace Stratis.Features.FederatedPeg.TargetChain
             this.NextMatureDepositHeight = 1;
             this.cancellation = new CancellationTokenSource();
             this.settings = settings;
+            this.signals = signals;
 
             // Future-proof store name.
             string depositStoreName = "federatedTransfers" + settings.MultiSigAddress.ToString();
@@ -602,6 +606,7 @@ namespace Stratis.Features.FederatedPeg.TargetChain
                                 {
                                     this.logger.LogInformation("Deposit: {0} collected enough signatures and is FullySigned", transfer.DepositTransactionId);
                                     transfer.SetStatus(CrossChainTransferStatus.FullySigned);
+                                    this.signals.Publish(new CrossChainTransferTransactionFullySigned(transfer));
                                 }
 
                                 this.PutTransfer(dbreezeTransaction, transfer);

--- a/src/Stratis.Features.FederatedPeg/TargetChain/SignedMultisigTransactionBroadcaster.cs
+++ b/src/Stratis.Features.FederatedPeg/TargetChain/SignedMultisigTransactionBroadcaster.cs
@@ -1,12 +1,13 @@
 ﻿using System;
-using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
-using Stratis.Bitcoin.AsyncWork;
+using Stratis.Bitcoin.EventBus;
 using Stratis.Bitcoin.Features.MemoryPool;
 using Stratis.Bitcoin.Features.Wallet.Interfaces;
 using Stratis.Bitcoin.Interfaces;
+using Stratis.Bitcoin.Signals;
 using Stratis.Bitcoin.Utilities;
+using Stratis.Features.FederatedPeg.Events;
 using Stratis.Features.FederatedPeg.Interfaces;
 
 namespace Stratis.Features.FederatedPeg.TargetChain
@@ -17,14 +18,6 @@ namespace Stratis.Features.FederatedPeg.TargetChain
     /// </summary>
     public interface ISignedMultisigTransactionBroadcaster
     {
-        /// <summary>
-        /// Broadcast signed transactions that are not in the mempool.
-        /// </summary>
-        /// <remarks>
-        /// The current federated leader equal the <see cref="IFederationGatewaySettings.PublicKey"/> before it can broadcast the transactions.
-        /// </remarks>
-        Task BroadcastTransactionsAsync();
-
         /// <summary>
         /// Starts the broadcasting of fully signed transactions every N seconds.
         /// </summary>
@@ -42,60 +35,34 @@ namespace Stratis.Features.FederatedPeg.TargetChain
         /// How often to trigger the query for and broadcasting of new transactions.
         /// </summary>
         private static readonly TimeSpan TimeBetweenQueries = TimeSpans.TenSeconds;
-
         private readonly ILogger logger;
-        private readonly ICrossChainTransferStore store;
         private readonly MempoolManager mempoolManager;
         private readonly IBroadcasterManager broadcasterManager;
-        private readonly INodeLifetime nodeLifetime;
-        private readonly IAsyncProvider asyncProvider;
+        private readonly ISignals signals;
 
         private readonly IInitialBlockDownloadState ibdState;
         private readonly IFederationWalletManager federationWalletManager;
-
-        private IAsyncLoop asyncLoop;
+        private SubscriptionToken onCrossChainTransactionFullySignedSubscription;
 
         public SignedMultisigTransactionBroadcaster(
-            IAsyncProvider asyncProvider,
             ILoggerFactory loggerFactory,
-            ICrossChainTransferStore store,
-            INodeLifetime nodeLifetime,
             MempoolManager mempoolManager,
             IBroadcasterManager broadcasterManager,
             IInitialBlockDownloadState ibdState,
-            IFederationWalletManager federationWalletManager)
+            IFederationWalletManager federationWalletManager,
+            ISignals signals)
         {
             Guard.NotNull(loggerFactory, nameof(loggerFactory));
-            Guard.NotNull(store, nameof(store));
-            Guard.NotNull(mempoolManager, nameof(mempoolManager));
-            Guard.NotNull(broadcasterManager, nameof(broadcasterManager));
+            this.mempoolManager = Guard.NotNull(mempoolManager, nameof(mempoolManager));
+            this.broadcasterManager = Guard.NotNull(broadcasterManager, nameof(broadcasterManager));
+            this.ibdState = Guard.NotNull(ibdState, nameof(ibdState));
+            this.federationWalletManager = Guard.NotNull(federationWalletManager, nameof(federationWalletManager));
+            this.signals = Guard.NotNull(signals, nameof(signals));
 
-
-            this.asyncProvider = asyncProvider;
             this.logger = loggerFactory.CreateLogger(this.GetType().FullName);
-            this.store = store;
-            this.nodeLifetime = nodeLifetime;
-            this.mempoolManager = mempoolManager;
-            this.broadcasterManager = broadcasterManager;
-
-            this.ibdState = ibdState;
-            this.federationWalletManager = federationWalletManager;
         }
 
-        /// <inheritdoc />
-        public void Start()
-        {
-            this.asyncLoop = this.asyncProvider.CreateAndRunAsyncLoop(nameof(PartialTransactionRequester), _ =>
-                {
-                    this.BroadcastTransactionsAsync().GetAwaiter().GetResult();
-                    return Task.CompletedTask;
-                },
-                this.nodeLifetime.ApplicationStopping,
-                TimeBetweenQueries);
-        }
-
-        /// <inheritdoc />
-        public async Task BroadcastTransactionsAsync()
+        private async Task OnCrossChainTransactionFullySigned(CrossChainTransferTransactionFullySigned @event)
         {
             if (this.ibdState.IsInitialBlockDownload() || !this.federationWalletManager.IsFederationWalletActive())
             {
@@ -103,43 +70,35 @@ namespace Stratis.Features.FederatedPeg.TargetChain
                 return;
             }
 
-            ICrossChainTransfer[] transfers = this.store.GetTransfersByStatus(new CrossChainTransferStatus[]{CrossChainTransferStatus.FullySigned});
-
-            if (!transfers.Any())
+            TxMempoolInfo txInfo = await this.mempoolManager.InfoAsync(@event.Transfer.PartialTransaction.GetHash()).ConfigureAwait(false);
+            if (txInfo != null)
             {
-                this.logger.LogTrace("Signed multisig transactions do not exist in the CrossChainTransfer store.");
+                this.logger.LogTrace("Deposit ID '{0}' already in the mempool.", @event.Transfer.DepositTransactionId);
                 return;
             }
 
-            foreach (ICrossChainTransfer transfer in transfers)
-            {
-                TxMempoolInfo txInfo = await this.mempoolManager.InfoAsync(transfer.PartialTransaction.GetHash()).ConfigureAwait(false);
+            this.logger.LogInformation("Broadcasting deposit-id={0} a signed multisig transaction {1} to the network.", @event.Transfer.DepositTransactionId, @event.Transfer.PartialTransaction.GetHash());
 
-                if (txInfo != null)
-                {
-                    this.logger.LogTrace("Deposit ID '{0}' already in the mempool.", transfer.DepositTransactionId);
-                    continue;
-                }
+            await this.broadcasterManager.BroadcastTransactionAsync(@event.Transfer.PartialTransaction).ConfigureAwait(false);
+        }
 
-                this.logger.LogInformation("Broadcasting deposit-id={0} a signed multisig transaction {1} to the network.", transfer.DepositTransactionId, transfer.PartialTransaction.GetHash());
-
-                await this.broadcasterManager.BroadcastTransactionAsync(transfer.PartialTransaction).ConfigureAwait(false);
-            }
+        /// <inheritdoc />
+        public void Start()
+        {
+            this.onCrossChainTransactionFullySignedSubscription = this.signals.Subscribe<CrossChainTransferTransactionFullySigned>(async (tx) => await this.OnCrossChainTransactionFullySigned(tx).ConfigureAwait(false));
         }
 
         public void Dispose()
         {
             this.Stop();
-            this.store?.Dispose();
         }
 
         /// <inheritdoc />
         public void Stop()
         {
-            if (this.asyncLoop != null)
+            if (this.onCrossChainTransactionFullySignedSubscription != null)
             {
-                this.asyncLoop.Dispose();
-                this.asyncLoop = null;
+                this.signals.Unsubscribe(this.onCrossChainTransactionFullySignedSubscription);
             }
         }
     }


### PR DESCRIPTION
I've used the eventbus to publish a `CrossChainTransferTransactionFullySigned` event that SignedMultisigTransactionBroadcaster subscribes to, in order to broadcast a transaction as soon as it's marked as fullysigned.

Implemented some tests too