### PR TITLE
Ignore OP_RETURN outputs for address indexing

### DIFF
--- a/src/Stratis.Bitcoin.Features.BlockStore/AddressIndexing/AddressIndexer.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/AddressIndexing/AddressIndexer.cs
@@ -350,6 +350,12 @@ namespace Stratis.Bitcoin.Features.BlockStore.AddressIndexing
 
         private BitcoinAddress GetAddressFromScriptPubKey(Script scriptPubKey)
         {
+            ScriptTemplate scriptTemplate = network.StandardScriptsRegistry.GetTemplateFromScriptPubKey(scriptPubKey);
+
+            // Ignore OP_RETURN outputs
+            if (scriptTemplate.Type == TxOutType.TX_NULL_DATA)
+                return null;
+
             BitcoinAddress address = scriptPubKey.GetDestinationAddress(this.network);
 
             if (address == null)

--- a/src/Stratis.Bitcoin.Features.BlockStore/AddressIndexing/AddressIndexer.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/AddressIndexing/AddressIndexer.cs
@@ -350,7 +350,7 @@ namespace Stratis.Bitcoin.Features.BlockStore.AddressIndexing
 
         private BitcoinAddress GetAddressFromScriptPubKey(Script scriptPubKey)
         {
-            ScriptTemplate scriptTemplate = network.StandardScriptsRegistry.GetTemplateFromScriptPubKey(scriptPubKey);
+            ScriptTemplate scriptTemplate = this.network.StandardScriptsRegistry.GetTemplateFromScriptPubKey(scriptPubKey);
 
             // Ignore OP_RETURN outputs
             if (scriptTemplate.Type == TxOutType.TX_NULL_DATA)


### PR DESCRIPTION
If they are not ignored, `GetDestinationAddress` doesn't know what to do with them and treats them as segwit addresses. This throws an exception on networks that have no bech32 encoders defined.