### PR TITLE
Correct PoA console output

### DIFF
--- a/src/Stratis.Bitcoin.Features.PoA/PoAMiner.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/PoAMiner.cs
@@ -317,7 +317,7 @@ namespace Stratis.Bitcoin.Features.PoA
             for (int i = tip.Height; (i > 0) && (i > tip.Height - maxDepth); i--)
             {
                 // Add stats for current header.
-                string pubKeyRepresentation = this.slotsManager.GetFederationMemberForTimestamp(currentTime).ToString().Substring(0, pubKeyTakeCharacters);
+                string pubKeyRepresentation = this.slotsManager.GetFederationMemberForTimestamp(currentTime).PubKey.ToString().Substring(0, pubKeyTakeCharacters);
 
                 log.Append("[" + pubKeyRepresentation + "]-");
                 depthReached++;


### PR DESCRIPTION
The output was in this form instead of the desired truncated pubkey format:

```
======PoA Miner======
Mining information for the last 20 blocks.
MISS means that miner didn't produce a block at the timestamp he was supposed to.
[PubK]-MISS-[PubK]-[PubK]-[PubK]-[PubK]-MISS-[PubK]-MISS-[PubK]-[PubK]-[PubK]-[PubK]-MISS-[PubK]-MISS-[PubK]-[PubK]-[PubK]-[PubK]-MISS-...
```