### PR TITLE
[Wallet] Fix for transaction sorting

### DIFF
--- a/src/Stratis.Bitcoin.Features.Wallet/Controllers/WalletController.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Controllers/WalletController.cs
@@ -442,7 +442,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Controllers
 
                     // Sorting the history items by descending dates. That includes received and sent dates.
                     List<FlatHistory> items = accountHistory.History
-                                                            .OrderBy(o => (o.Transaction.SpendingDetails?.IsSpentConfirmed() ?? false) ? 1 : 0)
+                                                            .OrderBy(o => (o.Transaction.SpendingDetails?.IsSpentConfirmed() ?? true) ? 1 : 0)
                                                             .ThenByDescending(o => o.Transaction.SpendingDetails?.CreationTime ?? o.Transaction.CreationTime)
                                                             .ToList();
 

--- a/src/Stratis.Bitcoin.Features.Wallet/Controllers/WalletController.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Controllers/WalletController.cs
@@ -442,7 +442,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Controllers
 
                     // Sorting the history items by descending dates. That includes received and sent dates.
                     List<FlatHistory> items = accountHistory.History
-                                                            .OrderBy(o => (o.Transaction.SpendingDetails?.IsSpentConfirmed() ?? true) ? 1 : 0)
+                                                            .OrderBy(o => o.Transaction.IsConfirmed() ? 1 : 0)
                                                             .ThenByDescending(o => o.Transaction.SpendingDetails?.CreationTime ?? o.Transaction.CreationTime)
                                                             .ToList();
 

--- a/src/Stratis.Bitcoin.Features.Wallet/Controllers/WalletController.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Controllers/WalletController.cs
@@ -441,7 +441,10 @@ namespace Stratis.Bitcoin.Features.Wallet.Controllers
                     var transactionItems = new List<TransactionItemModel>();
 
                     // Sorting the history items by descending dates. That includes received and sent dates.
-                    List<FlatHistory> items = accountHistory.History.OrderByDescending(o => o.Transaction.SpendingDetails?.CreationTime ?? o.Transaction.CreationTime).ToList();
+                    List<FlatHistory> items = accountHistory.History
+                                                            .OrderBy(o => (o.Transaction.SpendingDetails?.IsSpentConfirmed() ?? false) ? 1 : 0)
+                                                            .ThenByDescending(o => o.Transaction.SpendingDetails?.CreationTime ?? o.Transaction.CreationTime)
+                                                            .ToList();
 
                     // Represents a sublist containing only the transactions that have already been spent.
                     List<FlatHistory> spendingDetails = items.Where(t => t.Transaction.SpendingDetails != null).ToList();


### PR DESCRIPTION
A fix to place unconfirmed transactions first in the transaction history