### PR TITLE
[FN] Make address indexer use script address reader

### DIFF
--- a/src/Stratis.Bitcoin.Features.BlockStore/AddressIndexing/AddressIndexer.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/AddressIndexing/AddressIndexer.cs
@@ -307,7 +307,7 @@ namespace Stratis.Bitcoin.Features.BlockStore.AddressIndexing
 
                     string address = this.scriptAddressReader.GetAddressFromScriptPubKey(this.network, txOut.ScriptPubKey);
 
-                    if (address == string.Empty)
+                    if (string.IsNullOrEmpty(address))
                     {
                         // This condition need not be logged, as the address reader should be aware of all
                         // possible address formats already.
@@ -330,7 +330,7 @@ namespace Stratis.Bitcoin.Features.BlockStore.AddressIndexing
 
                         string address = this.scriptAddressReader.GetAddressFromScriptPubKey(this.network, txOut.ScriptPubKey);
 
-                        if (address == string.Empty)
+                        if (string.IsNullOrEmpty(address))
                         {
                             // This condition need not be logged, as the address reader should be aware of all
                             // possible address formats already.

--- a/src/Stratis.Bitcoin.Features.BlockStore/AddressIndexing/AddressIndexer.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/AddressIndexing/AddressIndexer.cs
@@ -57,6 +57,8 @@ namespace Stratis.Bitcoin.Features.BlockStore.AddressIndexing
 
         private readonly IConsensusManager consensusManager;
 
+        private readonly IScriptAddressReader scriptAddressReader;
+
         private readonly TimeSpan flushChangesInterval;
 
         private const string DbKey = "AddrData";
@@ -89,6 +91,7 @@ namespace Stratis.Bitcoin.Features.BlockStore.AddressIndexing
             this.nodeStats = nodeStats;
             this.dataFolder = dataFolder;
             this.consensusManager = consensusManager;
+            this.scriptAddressReader = new ScriptAddressReader();
 
             this.lockObject = new object();
             this.flushChangesInterval = TimeSpan.FromMinutes(5);
@@ -263,7 +266,7 @@ namespace Stratis.Bitcoin.Features.BlockStore.AddressIndexing
         /// <returns><c>true</c> if block was processed. <c>false</c> if reorg detected and we failed to process a block.</returns>
         private bool ProcessBlock(Block block, ChainedHeader header)
         {
-            // Process inputs
+            // Process inputs.
             var inputs = new List<TxIn>();
 
             // Collect all inputs excluding coinbases.
@@ -298,23 +301,20 @@ namespace Stratis.Bitcoin.Features.BlockStore.AddressIndexing
 
                     Money amountSpent = txOut.Value;
 
-                    BitcoinAddress address = this.GetAddressFromScriptPubKey(txOut.ScriptPubKey);
+                    // Transactions that don't actually change the balance just bloat the database.
+                    if (amountSpent == 0)
+                        continue;
 
-                    if (address == null)
+                    string address = this.scriptAddressReader.GetAddressFromScriptPubKey(this.network, txOut.ScriptPubKey);
+
+                    if (address == string.Empty)
                     {
-                        this.logger.LogDebug("Failed to extract an address from '{0}' while parsing inputs.", txOut.ScriptPubKey);
+                        // This condition need not be logged, as the address reader should be aware of all
+                        // possible address formats already.
                         continue;
                     }
 
-                    List<AddressBalanceChange> changes = this.GetOrCreateAddressChangesCollectionLocked(address.ToString());
-
-                    // Record money being spent.
-                    changes.Add(new AddressBalanceChange()
-                    {
-                        BalanceChangedHeight = header.Height,
-                        Satoshi = amountSpent.Satoshi,
-                        Deposited = false
-                    });
+                    this.ProcessBalanceChange(header.Height, address, amountSpent, false);
                 }
 
                 // Process outputs.
@@ -324,23 +324,20 @@ namespace Stratis.Bitcoin.Features.BlockStore.AddressIndexing
                     {
                         Money amountReceived = txOut.Value;
 
-                        BitcoinAddress address = this.GetAddressFromScriptPubKey(txOut.ScriptPubKey);
+                        // Transactions that don't actually change the balance just bloat the database.
+                        if (amountReceived == 0)
+                            continue;
 
-                        if (address == null)
+                        string address = this.scriptAddressReader.GetAddressFromScriptPubKey(this.network, txOut.ScriptPubKey);
+
+                        if (address == string.Empty)
                         {
-                            this.logger.LogDebug("Failed to extract an address from '{0}' while parsing outputs.", txOut.ScriptPubKey);
+                            // This condition need not be logged, as the address reader should be aware of all
+                            // possible address formats already.
                             continue;
                         }
 
-                        List<AddressBalanceChange> changes = this.GetOrCreateAddressChangesCollectionLocked(address.ToString());
-
-                        // Record money being sent.
-                        changes.Add(new AddressBalanceChange()
-                        {
-                            BalanceChangedHeight = header.Height,
-                            Satoshi = amountReceived.Satoshi,
-                            Deposited = true
-                        });
+                        this.ProcessBalanceChange(header.Height, address, amountReceived, true);
                     }
                 }
             }
@@ -348,26 +345,17 @@ namespace Stratis.Bitcoin.Features.BlockStore.AddressIndexing
             return true;
         }
 
-        private BitcoinAddress GetAddressFromScriptPubKey(Script scriptPubKey)
+        private void ProcessBalanceChange(int height, string address, Money amount, bool deposited)
         {
-            ScriptTemplate scriptTemplate = this.network.StandardScriptsRegistry.GetTemplateFromScriptPubKey(scriptPubKey);
+            List<AddressBalanceChange> changes = this.GetOrCreateAddressChangesCollectionLocked(address);
 
-            // Ignore OP_RETURN outputs
-            if (scriptTemplate.Type == TxOutType.TX_NULL_DATA)
-                return null;
-
-            BitcoinAddress address = scriptPubKey.GetDestinationAddress(this.network);
-
-            if (address == null)
+            // Record balance change.
+            changes.Add(new AddressBalanceChange()
             {
-                // Handle P2PK
-                PubKey[] destinationKeys = scriptPubKey.GetDestinationPublicKeys(this.network);
-
-                if (destinationKeys.Length == 1)
-                    address = destinationKeys[0].GetAddress(this.network);
-            }
-
-            return address;
+                BalanceChangedHeight = height,
+                Satoshi = amount.Satoshi,
+                Deposited = deposited
+            });
         }
 
         /// <remarks>Should be protected by <see cref="lockObject"/>.</remarks>

--- a/src/Stratis.Bitcoin.Features.Wallet/WalletManager.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/WalletManager.cs
@@ -1175,7 +1175,7 @@ namespace Stratis.Bitcoin.Features.Wallet
                 {
                     // Figure out how to retrieve the destination address.
                     string destinationAddress = this.scriptAddressReader.GetAddressFromScriptPubKey(this.network, paidToOutput.ScriptPubKey);
-                    if (destinationAddress == string.Empty)
+                    if (string.IsNullOrEmpty(destinationAddress))
                         if (this.scriptToAddressLookup.TryGetValue(paidToOutput.ScriptPubKey, out HdAddress destination))
                             destinationAddress = destination.Address;
 

--- a/src/Stratis.Bitcoin.Features.Wallet/WalletRPCController.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/WalletRPCController.cs
@@ -422,7 +422,7 @@ namespace Stratis.Bitcoin.Features.Wallet
                         var prevTransactionScriptPubkey = prevTransaction.Outputs[txIn.PrevOut.N].ScriptPubKey;
 
                         var addressBase58 = this.scriptAddressReader.GetAddressFromScriptPubKey(this.Network, prevTransactionScriptPubkey);
-                        if (addressBase58 == null)
+                        if (string.IsNullOrEmpty(addressBase58))
                             continue;
 
                         addressGroupBase58.Add(addressBase58);
@@ -436,7 +436,7 @@ namespace Stratis.Bitcoin.Features.Wallet
                             if (IsChange(internalAddresses, txOut.ScriptPubKey))
                             {
                                 var txOutAddressBase58 = this.scriptAddressReader.GetAddressFromScriptPubKey(this.Network, txOut.ScriptPubKey);
-                                if (txOutAddressBase58 != null)
+                                if (!string.IsNullOrEmpty(txOutAddressBase58))
                                     addressGroupBase58.Add(txOutAddressBase58);
                             }
                         }
@@ -452,8 +452,8 @@ namespace Stratis.Bitcoin.Features.Wallet
                     {
                         var grouping = new List<string>();
 
-                        var addressBase58 = this.scriptAddressReader.GetAddressFromScriptPubKey(this.Network, txOut.ScriptPubKey);
-                        if (addressBase58 == null)
+                        string addressBase58 = this.scriptAddressReader.GetAddressFromScriptPubKey(this.Network, txOut.ScriptPubKey);
+                        if (string.IsNullOrEmpty(addressBase58))
                             continue;
 
                         grouping.Add(addressBase58);

--- a/src/Stratis.Bitcoin/Consensus/ScriptAddressReader.cs
+++ b/src/Stratis.Bitcoin/Consensus/ScriptAddressReader.cs
@@ -9,9 +9,9 @@ namespace Stratis.Bitcoin.Consensus
         /// <inheritdoc cref="IScriptAddressReader.GetAddressFromScriptPubKey"/>
         public string GetAddressFromScriptPubKey(Network network, Script script)
         {
-            var scriptTemplate = network.StandardScriptsRegistry.GetTemplateFromScriptPubKey(script);
+            ScriptTemplate scriptTemplate = network.StandardScriptsRegistry.GetTemplateFromScriptPubKey(script);
 
-            var destinationAddress = string.Empty;
+            string destinationAddress = null;
 
             switch (scriptTemplate?.Type)
             {

--- a/src/Stratis.Bitcoin/Consensus/ScriptAddressReader.cs
+++ b/src/Stratis.Bitcoin/Consensus/ScriptAddressReader.cs
@@ -13,7 +13,7 @@ namespace Stratis.Bitcoin.Consensus
 
             var destinationAddress = string.Empty;
 
-            switch (scriptTemplate.Type)
+            switch (scriptTemplate?.Type)
             {
                 // Pay to PubKey can be found in outputs of staking transactions.
                 case TxOutType.TX_PUBKEY:


### PR DESCRIPTION
#3613 is insufficient, this is a more future-proof way of handling extraction of addresses from scripts.

WIP because the reader should be injected into the indexer. Currently hardcoded to use `ScriptAddressReader`, this should currently only incorrectly handle smart contract & possibly cold-staking transactions.