### PR TITLE
[WIP] [FN] Address indexer performance

### DIFF
--- a/src/Stratis.Bitcoin.Features.BlockStore.Tests/AddressIndexerTests.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore.Tests/AddressIndexerTests.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Threading;
 using Moq;
 using NBitcoin;
+using Stratis.Bitcoin.AsyncWork;
 using Stratis.Bitcoin.Configuration;
 using Stratis.Bitcoin.Configuration.Logging;
 using Stratis.Bitcoin.Consensus;
@@ -10,6 +11,7 @@ using Stratis.Bitcoin.Features.BlockStore.AddressIndexing;
 using Stratis.Bitcoin.Interfaces;
 using Stratis.Bitcoin.Networks;
 using Stratis.Bitcoin.Primitives;
+using Stratis.Bitcoin.Signals;
 using Stratis.Bitcoin.Tests.Common;
 using Stratis.Bitcoin.Utilities;
 using Xunit;
@@ -23,6 +25,10 @@ namespace Stratis.Bitcoin.Features.BlockStore.Tests
         private readonly Mock<IBlockStore> blockStoreMock;
 
         private readonly Mock<IConsensusManager> consensusManagerMock;
+
+        private readonly Mock<IAsyncProvider> asyncProviderMock;
+
+        private readonly Mock<ISignals> signals;
 
         private readonly Network network;
 
@@ -40,9 +46,11 @@ namespace Stratis.Bitcoin.Features.BlockStore.Tests
             this.blockStoreMock = new Mock<IBlockStore>();
             var stats = new Mock<INodeStats>();
             this.consensusManagerMock = new Mock<IConsensusManager>();
+            this.asyncProviderMock = new Mock<IAsyncProvider>();
+            this.signals = new Mock<ISignals>();
 
             this.addressIndexer = new AddressIndexer(storeSettings, dataFolder, new ExtendedLoggerFactory(), this.network, this.blockStoreMock.Object,
-                stats.Object, this.consensusManagerMock.Object);
+                stats.Object, this.consensusManagerMock.Object, this.asyncProviderMock.Object, this.signals.Object);
 
             this.genesisHeader = new ChainedHeader(this.network.GetGenesis().Header, this.network.GetGenesis().Header.GetHash(), 0);
         }

--- a/src/Stratis.Bitcoin.Features.BlockStore.Tests/AddressIndexerTests.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore.Tests/AddressIndexerTests.cs
@@ -132,7 +132,7 @@ namespace Stratis.Bitcoin.Features.BlockStore.Tests
 
             TestBase.WaitLoop(() => this.addressIndexer.IndexerTip == headers.Last());
 
-            Dictionary<string, List<AddressBalanceChange>> index = this.addressIndexer.GetAddressIndexCopy();
+            Dictionary<string, AddressIndexData> index = this.addressIndexer.GetAddressIndexCopy();
             Assert.Equal(2, index.Keys.Count);
 
             Assert.Equal(60_000, this.addressIndexer.GetAddressBalance(address1).Satoshi);

--- a/src/Stratis.Bitcoin.Features.BlockStore/AddressIndexing/AddressIndexer.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/AddressIndexing/AddressIndexer.cs
@@ -63,6 +63,8 @@ namespace Stratis.Bitcoin.Features.BlockStore.AddressIndexing
 
         private const string DbKey = "AddrData";
 
+        private const string DbTipDataKey = "AddrTipData";
+
         /// <summary>
         /// Time to wait before attempting to index the next block.
         /// Waiting happens after a failure to get next block to index.
@@ -123,7 +125,7 @@ namespace Stratis.Bitcoin.Features.BlockStore.AddressIndexing
 
             this.logger.LogDebug("TxIndexing is enabled.");
 
-            this.tipDataStore = this.db.GetCollection<AddressIndexTipData>("AddrTipData");
+            this.tipDataStore = this.db.GetCollection<AddressIndexTipData>(DbTipDataKey);
 
             this.dataStore = this.db.GetCollection<AddressIndexData>(DbKey);
 
@@ -136,6 +138,8 @@ namespace Stratis.Bitcoin.Features.BlockStore.AddressIndexing
 
                 foreach (AddressIndexData data in this.dataStore.FindAll())
                     this.addressesIndex[data.Address] = data;
+
+                // TODO: Investigate EnsureIndex - can it index block heights to speed up reorg processing?
 
                 if (this.tipData == null)
                 {

--- a/src/Stratis.Bitcoin.Features.BlockStore/AddressIndexing/AddressIndexer.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/AddressIndexing/AddressIndexer.cs
@@ -446,6 +446,7 @@ namespace Stratis.Bitcoin.Features.BlockStore.AddressIndexing
             };
 
             this.addressesIndex[address] = indexData;
+            this.dirtyAddresses.Add(address);
 
             return indexData.BalanceChanges;
         }

--- a/src/Stratis.Bitcoin.Features.BlockStore/AddressIndexing/AddressIndexer.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/AddressIndexing/AddressIndexer.cs
@@ -383,7 +383,7 @@ namespace Stratis.Bitcoin.Features.BlockStore.AddressIndexing
                         continue;
                     }
 
-                    this.dirtyAddresses.Add(address.ToString());
+                    this.dirtyAddresses.Add(address);
 
                     this.ProcessBalanceChange(header.Height, address, amountSpent, false);
                 }

--- a/src/Stratis.Bitcoin.Features.BlockStore/AddressIndexing/AddressIndexer.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/AddressIndexing/AddressIndexer.cs
@@ -395,28 +395,6 @@ namespace Stratis.Bitcoin.Features.BlockStore.AddressIndexing
             });
         }
 
-        private BitcoinAddress GetAddressFromScriptPubKey(Script scriptPubKey)
-        {
-            ScriptTemplate scriptTemplate = this.network.StandardScriptsRegistry.GetTemplateFromScriptPubKey(scriptPubKey);
-
-            // Ignore OP_RETURN outputs
-            if (scriptTemplate.Type == TxOutType.TX_NULL_DATA)
-                return null;
-
-            BitcoinAddress address = scriptPubKey.GetDestinationAddress(this.network);
-
-            if (address == null)
-            {
-                // Handle P2PK
-                PubKey[] destinationKeys = scriptPubKey.GetDestinationPublicKeys(this.network);
-
-                if (destinationKeys.Length == 1)
-                    address = destinationKeys[0].GetAddress(this.network);
-            }
-
-            return address;
-        }
-
         /// <remarks>Should be protected by <see cref="lockObject"/>.</remarks>
         private List<AddressBalanceChange> GetOrCreateAddressChangesCollectionLocked(string address)
         {

--- a/src/Stratis.Bitcoin.Features.BlockStore/AddressIndexing/AddressIndexerTypes.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/AddressIndexing/AddressIndexerTypes.cs
@@ -1,16 +1,22 @@
 ﻿using System.Collections.Generic;
+using LiteDB;
 
 namespace Stratis.Bitcoin.Features.BlockStore.AddressIndexing
 {
-    public class AddressIndexerData
+    public class AddressIndexTipData
     {
         /// <summary>Id required for litedb.</summary>
         public int Id { get; set; }
 
         public byte[] TipHashBytes { get; set; }
+    }
 
-        /// <summary>Address changes by address.</summary>
-        public Dictionary<string, List<AddressBalanceChange>> AddressChanges { get; set; }
+    public class AddressIndexData
+    {
+        [BsonId]
+        public string Address { get; set; }
+
+        public List<AddressBalanceChange> BalanceChanges { get; set; }
     }
 
     public class AddressBalanceChange


### PR DESCRIPTION
This changes the address indexer from operating under a single-document data model, to a document-per-address model. It is hypothesised that this will be more efficient than flushing the entire data structure periodically, as only a subset of the address index is likely to be changed in any flush interval. This is achieved via caching the 'dirty' addresses so that updates can be performed on only these documents.

Benchmarking of LiteDB also indicates that performance for updates is significantly improved via batching, so this has been introduced as well (it wasn't necessary before with the entire index contained in a single document).

This needs proper benchmark testing before merging, but serves as an interim proof of concept. The handling of reorgs can also still be improved in efficiency.

Memory usage still needs to be addressed. Possibly introducing some form of LRU cache bounded in size will be an acceptable approach for this.