### PR TITLE
[FS] Fix for null connection when peer is disconnected

### DIFF
--- a/src/Stratis.Bitcoin/Connection/ConnectionManagerBehavior.cs
+++ b/src/Stratis.Bitcoin/Connection/ConnectionManagerBehavior.cs
@@ -99,7 +99,9 @@ namespace Stratis.Bitcoin.Connection
         protected override void DetachCore()
         {
             this.AttachedPeer.StateChanged.Unregister(this.OnStateChangedAsync);
-            this.connectionManager.PeerDisconnected(this.AttachedPeer.Connection.Id);
+
+            if (this.AttachedPeer.Connection != null)
+                this.connectionManager.PeerDisconnected(this.AttachedPeer.Connection.Id);
         }
     }
 }


### PR DESCRIPTION
Looks like Connection is getting a null in some cases. Checked `AttachedPeer` and it is already locked and checked for null as part of the `NetworkPeerBehavior.Detach`.