### PR TITLE
3728 - Cannot load transaction history in Stratis Core

### DIFF
--- a/src/Stratis.Bitcoin.Features.Wallet/Helpers/SentTransactionItemModelComparer.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Helpers/SentTransactionItemModelComparer.cs
@@ -68,7 +68,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Helpers
 
             foreach (PaymentDetailModel payment in obj.Payments)
             {
-                hashValue = hashValue ^ payment.Amount.GetHashCode() ^ payment.DestinationAddress.GetHashCode();
+                hashValue = hashValue ^ payment.Amount.GetHashCode() ^ (payment.DestinationAddress ?? string.Empty).GetHashCode();
             }
 
             return hashValue;


### PR DESCRIPTION
fixed the issue. Payment DestinationAddress default value was set from String.Empty to null and it was causing a nullexception when SentTransactionItemModelComparer was used (e.g. wallet/history API)