### PR TITLE
JSON wallet serializator and null values (3734)

### DIFF
--- a/src/Stratis.Bitcoin.Features.Wallet/WalletManager.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/WalletManager.cs
@@ -1329,7 +1329,7 @@ namespace Stratis.Bitcoin.Features.Wallet
 
             lock (this.lockObject)
             {
-                this.fileStorage.SaveToFile(wallet, $"{wallet.Name}.{WalletFileExtension}", false, true);
+                this.fileStorage.SaveToFile(wallet, $"{wallet.Name}.{WalletFileExtension}", new FileStorageOption { SerializeNullValues = false });
             }
         }
 

--- a/src/Stratis.Bitcoin.Features.Wallet/WalletManager.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/WalletManager.cs
@@ -1329,7 +1329,7 @@ namespace Stratis.Bitcoin.Features.Wallet
 
             lock (this.lockObject)
             {
-                this.fileStorage.SaveToFile(wallet, $"{wallet.Name}.{WalletFileExtension}");
+                this.fileStorage.SaveToFile(wallet, $"{wallet.Name}.{WalletFileExtension}", false, true);
             }
         }
 

--- a/src/Stratis.Bitcoin.Tests/Utilities/FileStorageTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Utilities/FileStorageTest.cs
@@ -234,14 +234,14 @@ namespace Stratis.Bitcoin.Tests.Utilities
             var testObject = new TestObject { Property1 = "prop1", Property2 = "prop2" };
             string dir = this.GetFolderPathForTestExecution();
             var fileStorage = new FileStorage<TestObject>(dir);
-            fileStorage.SaveToFile(testObject, "savedTestObject.json", true);
+            fileStorage.SaveToFile(testObject, "savedTestObject.json", new FileStorageOption { SaveBackupFile = true });
             testObject.Property1 = testObject.Property1 + "-changed";
-            fileStorage.SaveToFile(testObject, "savedTestObject.json", true);
+            fileStorage.SaveToFile(testObject, "savedTestObject.json", new FileStorageOption { SaveBackupFile = true });
 
             // Act
             bool isFileExists = fileStorage.Exists("savedTestObject.json");
             bool isBackupFileExists = fileStorage.Exists("savedTestObject.json.bak");
-            
+
             // Assert
             Assert.True(isFileExists);
             Assert.True(isBackupFileExists);
@@ -262,8 +262,8 @@ namespace Stratis.Bitcoin.Tests.Utilities
             var testObject = new TestObject { Property1 = "prop1", Property2 = "prop2" };
             string dir = this.GetFolderPathForTestExecution();
             var fileStorage = new FileStorage<TestObject>(dir);
-            fileStorage.SaveToFile(testObject, "savedTestObject.json", true);
-            
+            fileStorage.SaveToFile(testObject, "savedTestObject.json", new FileStorageOption { SaveBackupFile = true });
+
             // Act
             bool isFileExists = fileStorage.Exists("savedTestObject.json");
             bool isBackupFileExists = fileStorage.Exists("savedTestObject.json.bak");
@@ -288,7 +288,7 @@ namespace Stratis.Bitcoin.Tests.Utilities
             var testObject = new TestObject { Property1 = "prop1", Property2 = "prop2" };
             string dir = this.GetFolderPathForTestExecution();
             var fileStorage = new FileStorage<TestObject>(dir);
-            fileStorage.SaveToFile(testObject, "savedTestObject.json", false);
+            fileStorage.SaveToFile(testObject, "savedTestObject.json", new FileStorageOption { SaveBackupFile = false });
             testObject.Property1 = testObject.Property1 + "-changed";
             fileStorage.SaveToFile(testObject, "savedTestObject.json");
 
@@ -311,7 +311,7 @@ namespace Stratis.Bitcoin.Tests.Utilities
             var testObject = new TestObject { Property1 = "prop1", Property2 = "prop2" };
             string dir = this.GetFolderPathForTestExecution();
             var fileStorage = new FileStorage<TestObject>(dir);
-            fileStorage.SaveToFile(testObject, "savedTestObject.json", false);
+            fileStorage.SaveToFile(testObject, "savedTestObject.json", new FileStorageOption { SaveBackupFile = false });
 
             // Act
             bool isFileExists = fileStorage.Exists("savedTestObject.json");

--- a/src/Stratis.Bitcoin/Utilities/FileStorage.cs
+++ b/src/Stratis.Bitcoin/Utilities/FileStorage.cs
@@ -53,7 +53,7 @@ namespace Stratis.Bitcoin.Utilities
         internal JsonSerializerSettings GetSerializationSettings()
         {
             // get default Json serializer settings
-            JsonSerializerSettings settings = JsonConvert.DefaultSettings?.Invoke() ?? new JsonSerializerSettings();
+            var settings = new JsonSerializerSettings();
 
             settings.NullValueHandling = this.SerializeNullValues ? NullValueHandling.Include : NullValueHandling.Ignore;
 

--- a/src/Stratis.Bitcoin/Utilities/FileStorage.cs
+++ b/src/Stratis.Bitcoin/Utilities/FileStorage.cs
@@ -6,6 +6,61 @@ using Newtonsoft.Json;
 
 namespace Stratis.Bitcoin.Utilities
 {
+    public class FileStorageOption
+    {
+        internal static FileStorageOption Default { get; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the output file content should be indented. Default value is false.
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if output file content is indented; otherwise, <c>false</c>.
+        /// </value>
+        public bool Indent { get; set; }
+
+        /// <summary>
+        /// A value indicating whether to save a backup of the file. Default value is false.
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> to save a backup file; otherwise, <c>false</c>.
+        /// </value>
+        public bool SaveBackupFile { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether a null value should be serialized in the output file. Default value is true.
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if null values are serialized; otherwise, <c>false</c>.
+        /// </value>
+        public bool SerializeNullValues { get; set; }
+
+        public FileStorageOption()
+        {
+            this.SaveBackupFile = false;
+            this.Indent = false;
+            this.SerializeNullValues = true;
+        }
+
+        static FileStorageOption()
+        {
+            Default = new FileStorageOption();
+        }
+
+        /// <summary>
+        /// Gets the serialization settings based on current options.
+        /// </summary>
+        /// <returns></returns>
+        internal JsonSerializerSettings GetSerializationSettings()
+        {
+            // get default Json serializer settings
+            JsonSerializerSettings settings = JsonConvert.DefaultSettings?.Invoke() ?? new JsonSerializerSettings();
+
+            settings.NullValueHandling = this.SerializeNullValues ? NullValueHandling.Include : NullValueHandling.Ignore;
+
+            return settings;
+        }
+    }
+
     /// <summary>
     /// Class providing methods to save objects as files on the file system.
     /// </summary>
@@ -34,33 +89,28 @@ namespace Stratis.Bitcoin.Utilities
         /// </summary>
         /// <param name="toSave">Object to save as a file.</param>
         /// <param name="fileName">Name of the file to be saved.</param>
-        /// <param name="saveBackupFile">A value indicating whether to save a backup of the file.</param>
-        /// <param name="minimalSize">Specifies if the output file should be optimized for minimizing disk usage. If <c>true</c> the output isn't indented and null values aren't stored.</param>
-        public void SaveToFile(T toSave, string fileName, bool saveBackupFile = false, bool minimalSize = false)
+        /// <param name="options">The serialization options.</param>
+        public void SaveToFile(T toSave, string fileName, FileStorageOption options = null)
         {
             Guard.NotEmpty(fileName, nameof(fileName));
             Guard.NotNull(toSave, nameof(toSave));
+
+            if (options == null)
+                options = FileStorageOption.Default;
 
             string filePath = Path.Combine(this.FolderPath, fileName);
             long uniqueId = DateTime.UtcNow.Ticks;
             string newFilePath = $"{filePath}.{uniqueId}.new";
             string tempFilePath = $"{filePath}.{uniqueId}.temp";
 
-            if (minimalSize)
-            {
-                File.WriteAllText(newFilePath, JsonConvert.SerializeObject(toSave, Formatting.None, new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore }));
-            }
-            else
-            {
-                File.WriteAllText(newFilePath, JsonConvert.SerializeObject(toSave, Formatting.Indented));
-            }
+            File.WriteAllText(newFilePath, JsonConvert.SerializeObject(toSave, options.Indent ? Formatting.Indented : Formatting.None, options.GetSerializationSettings()));
 
             // If the file does not exist yet, create it.
             if (!File.Exists(filePath))
             {
                 File.Move(newFilePath, filePath);
 
-                if (saveBackupFile)
+                if (options.SaveBackupFile)
                 {
                     File.Copy(filePath, $"{filePath}.bak", true);
                 }
@@ -68,7 +118,7 @@ namespace Stratis.Bitcoin.Utilities
                 return;
             }
 
-            if (saveBackupFile)
+            if (options.SaveBackupFile)
             {
                 File.Copy(filePath, $"{filePath}.bak", true);
             }

--- a/src/Stratis.Bitcoin/Utilities/FileStorage.cs
+++ b/src/Stratis.Bitcoin/Utilities/FileStorage.cs
@@ -35,7 +35,8 @@ namespace Stratis.Bitcoin.Utilities
         /// <param name="toSave">Object to save as a file.</param>
         /// <param name="fileName">Name of the file to be saved.</param>
         /// <param name="saveBackupFile">A value indicating whether to save a backup of the file.</param>
-        public void SaveToFile(T toSave, string fileName, bool saveBackupFile = false)
+        /// <param name="minimalSize">Specifies if the output file should be optimized for minimizing disk usage. If <c>true</c> the output isn't indented and null values aren't stored.</param>
+        public void SaveToFile(T toSave, string fileName, bool saveBackupFile = false, bool minimalSize = false)
         {
             Guard.NotEmpty(fileName, nameof(fileName));
             Guard.NotNull(toSave, nameof(toSave));
@@ -45,7 +46,14 @@ namespace Stratis.Bitcoin.Utilities
             string newFilePath = $"{filePath}.{uniqueId}.new";
             string tempFilePath = $"{filePath}.{uniqueId}.temp";
 
-            File.WriteAllText(newFilePath, JsonConvert.SerializeObject(toSave, Formatting.Indented));
+            if (minimalSize)
+            {
+                File.WriteAllText(newFilePath, JsonConvert.SerializeObject(toSave, Formatting.None, new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore }));
+            }
+            else
+            {
+                File.WriteAllText(newFilePath, JsonConvert.SerializeObject(toSave, Formatting.Indented));
+            }
 
             // If the file does not exist yet, create it.
             if (!File.Exists(filePath))


### PR DESCRIPTION
refers to the issue https://dev.azure.com/Stratisplatformuk/StratisBitcoinFullNode/_workitems/edit/3734/

Save space on wallet serialization and allow to do the same for other users of FileStorage.SaveFile

In this commit I did apply this optimization only for standard Wallet (`WalletManager.SaveWallet`),  we could do the same for any serialization and is as simple as passing a parameter to `FileStorage.SaveToFile` with `minimalSize` set to true

Actually that class is used by FederationWalletManager, PeerAddressManager, AddressBookManager, WatchOnlyWalletManager

I haven't done by purpose because it's out of scope about the issue itself, but it's very trivial do to 