### PR TITLE
[FS] Removed dedupe code as it filters out legit transactions

### DIFF
--- a/src/Stratis.Bitcoin.Features.Wallet/Controllers/WalletController.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Controllers/WalletController.cs
@@ -486,7 +486,8 @@ namespace Stratis.Bitcoin.Features.Wallet.Controllers
                                     Id = transaction.SpendingDetails.TransactionId,
                                     Timestamp = transaction.SpendingDetails.CreationTime,
                                     ConfirmedInBlock = transaction.SpendingDetails.BlockHeight,
-                                    BlockIndex = transaction.SpendingDetails.BlockIndex
+                                    BlockIndex = transaction.SpendingDetails.BlockIndex,
+                                    OutputIndex = transaction.Index
                                 };
 
                                 transactionItems.Add(stakingItem);
@@ -512,7 +513,8 @@ namespace Stratis.Bitcoin.Features.Wallet.Controllers
                                 Timestamp = transaction.SpendingDetails.CreationTime,
                                 ConfirmedInBlock = transaction.SpendingDetails.BlockHeight,
                                 BlockIndex = transaction.SpendingDetails.BlockIndex,
-                                Amount = Money.Zero
+                                Amount = Money.Zero,
+                                OutputIndex = transaction.Index
                             };
 
                             // If this 'send' transaction has made some external payments, i.e the funds were not sent to another address in the wallet.
@@ -568,13 +570,16 @@ namespace Stratis.Bitcoin.Features.Wallet.Controllers
                                 Id = transaction.Id,
                                 Timestamp = transaction.CreationTime,
                                 ConfirmedInBlock = transaction.BlockHeight,
-                                BlockIndex = transaction.BlockIndex
+                                BlockIndex = transaction.BlockIndex,
+                                OutputIndex = transaction.Index
                             };
 
                             transactionItems.Add(receivedItem);
                             itemsCount++;
                         }
                     }
+
+                    transactionItems = transactionItems.Distinct(new SentTransactionItemModelComparer()).Select(e => e).ToList();
 
                     // Sort and filter the history items.
                     List<TransactionItemModel> itemsToInclude = transactionItems.OrderByDescending(t => t.Timestamp)

--- a/src/Stratis.Bitcoin.Features.Wallet/Controllers/WalletController.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Controllers/WalletController.cs
@@ -486,8 +486,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Controllers
                                     Id = transaction.SpendingDetails.TransactionId,
                                     Timestamp = transaction.SpendingDetails.CreationTime,
                                     ConfirmedInBlock = transaction.SpendingDetails.BlockHeight,
-                                    BlockIndex = transaction.SpendingDetails.BlockIndex,
-                                    OutputIndex = 0 // set index output to 0 so that it can be later on deduped
+                                    BlockIndex = transaction.SpendingDetails.BlockIndex
                                 };
 
                                 transactionItems.Add(stakingItem);

--- a/src/Stratis.Bitcoin.Features.Wallet/Controllers/WalletController.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Controllers/WalletController.cs
@@ -1390,8 +1390,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Controllers
         {
             TransactionItemModel existingTransaction = items.FirstOrDefault(i => i.Id == transaction.Id &&
                                                                                  i.Type == TransactionItemType.Received &&
-                                                                                 i.ConfirmedInBlock == transaction.BlockHeight &&
-                                                                                 i.Amount == transaction.Amount);
+                                                                                 i.ConfirmedInBlock == transaction.BlockHeight);
             return existingTransaction;
         }
     }

--- a/src/Stratis.Bitcoin.Features.Wallet/Controllers/WalletController.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Controllers/WalletController.cs
@@ -487,7 +487,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Controllers
                                     Timestamp = transaction.SpendingDetails.CreationTime,
                                     ConfirmedInBlock = transaction.SpendingDetails.BlockHeight,
                                     BlockIndex = transaction.SpendingDetails.BlockIndex,
-                                    OutputIndex = transaction.Index
+                                    OutputIndex = 0 // set index output to 0 so that it can be later on deduped
                                 };
 
                                 transactionItems.Add(stakingItem);

--- a/src/Stratis.Bitcoin.Features.Wallet/Controllers/WalletController.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Controllers/WalletController.cs
@@ -576,8 +576,6 @@ namespace Stratis.Bitcoin.Features.Wallet.Controllers
                         }
                     }
 
-                    transactionItems = transactionItems.Distinct(new SentTransactionItemModelComparer()).Select(e => e).ToList();
-
                     // Sort and filter the history items.
                     List<TransactionItemModel> itemsToInclude = transactionItems.OrderByDescending(t => t.Timestamp)
                         .Where(x => string.IsNullOrEmpty(request.SearchQuery) || (x.Id.ToString() == request.SearchQuery || x.ToAddress == request.SearchQuery || x.Payments.Any(p => p.DestinationAddress == request.SearchQuery)))

--- a/src/Stratis.Bitcoin.Features.Wallet/Helpers/SentTransactionItemModelComparer.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Helpers/SentTransactionItemModelComparer.cs
@@ -33,8 +33,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Helpers
                 x.ConfirmedInBlock == y.ConfirmedInBlock &&
                 x.Type == y.Type && 
                 x.Amount == y.Amount && 
-                x.Payments.Count == y.Payments.Count &&
-                x.OutputIndex == y.OutputIndex);
+                x.Payments.Count == y.Payments.Count);
 
             if (!propertiesAreEqual)
             {

--- a/src/Stratis.Bitcoin.Features.Wallet/Helpers/SentTransactionItemModelComparer.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Helpers/SentTransactionItemModelComparer.cs
@@ -31,7 +31,10 @@ namespace Stratis.Bitcoin.Features.Wallet.Helpers
 
             bool propertiesAreEqual = (x.Id == y.Id &&
                 x.ConfirmedInBlock == y.ConfirmedInBlock &&
-                x.Type == y.Type && x.Amount == y.Amount && x.Payments.Count == y.Payments.Count);
+                x.Type == y.Type && 
+                x.Amount == y.Amount && 
+                x.Payments.Count == y.Payments.Count &&
+                x.OutputIndex == y.OutputIndex);
 
             if (!propertiesAreEqual)
             {

--- a/src/Stratis.Bitcoin.Features.Wallet/Models/WalletHistoryModel.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Models/WalletHistoryModel.cs
@@ -86,6 +86,9 @@ namespace Stratis.Bitcoin.Features.Wallet.Models
         /// </summary>
         [JsonProperty(PropertyName = "blockIndex", NullValueHandling = NullValueHandling.Ignore)]
         public int? BlockIndex { get; set; }
+
+        [JsonIgnore]
+        public int? OutputIndex { get; set; }
     }
 
     public class PaymentDetailModel

--- a/src/Stratis.Bitcoin.Features.Wallet/Models/WalletHistoryModel.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Models/WalletHistoryModel.cs
@@ -86,9 +86,6 @@ namespace Stratis.Bitcoin.Features.Wallet.Models
         /// </summary>
         [JsonProperty(PropertyName = "blockIndex", NullValueHandling = NullValueHandling.Ignore)]
         public int? BlockIndex { get; set; }
-
-        [JsonIgnore]
-        public int? OutputIndex { get; set; }
     }
 
     public class PaymentDetailModel


### PR DESCRIPTION
Found an original PR that added `Distinct()` to dedupe transactions: https://github.com/stratisproject/StratisBitcoinFullNode/pull/3362. Not sure why it was needed. Investigating why it was needed.