### PR TITLE
[FS] Dynamic fees

### DIFF
--- a/src/Stratis.Features.FederatedPeg.Tests/CrossChainTestBase.cs
+++ b/src/Stratis.Features.FederatedPeg.Tests/CrossChainTestBase.cs
@@ -100,11 +100,11 @@ namespace Stratis.Features.FederatedPeg.Tests
             this.federationGatewaySettings = Substitute.For<IFederationGatewaySettings>();
             this.ChainIndexer = new ChainIndexer(this.network);
 
-            this.federationGatewaySettings.TransactionFee(Arg.Any<int>()).ReturnsForAnyArgs((x) =>
+            this.federationGatewaySettings.GetWithdrawalTransactionFee(Arg.Any<int>()).ReturnsForAnyArgs((x) =>
             {
                 int numInputs = x.ArgAt<int>(0);
 
-                return FederationGatewaySettings.DefaultTransactionFee + FederationGatewaySettings.InputsTransactionFee * numInputs;
+                return FederationGatewaySettings.BaseTransactionFee + FederationGatewaySettings.InputsTransactionFee * numInputs;
             });
 
             // Generate the keys used by the federation members for our tests.

--- a/src/Stratis.Features.FederatedPeg.Tests/CrossChainTestBase.cs
+++ b/src/Stratis.Features.FederatedPeg.Tests/CrossChainTestBase.cs
@@ -104,7 +104,7 @@ namespace Stratis.Features.FederatedPeg.Tests
             {
                 int numInputs = x.ArgAt<int>(0);
 
-                return FederationGatewaySettings.BaseTransactionFee + FederationGatewaySettings.InputsTransactionFee * numInputs;
+                return FederationGatewaySettings.BaseTransactionFee + FederationGatewaySettings.InputTransactionFee * numInputs;
             });
 
             // Generate the keys used by the federation members for our tests.

--- a/src/Stratis.Features.FederatedPeg.Tests/CrossChainTestBase.cs
+++ b/src/Stratis.Features.FederatedPeg.Tests/CrossChainTestBase.cs
@@ -100,7 +100,12 @@ namespace Stratis.Features.FederatedPeg.Tests
             this.federationGatewaySettings = Substitute.For<IFederationGatewaySettings>();
             this.ChainIndexer = new ChainIndexer(this.network);
 
-            this.federationGatewaySettings.TransactionFee.Returns(new Money(0.01m, MoneyUnit.BTC));
+            this.federationGatewaySettings.TransactionFee(Arg.Any<int>()).ReturnsForAnyArgs((x) =>
+            {
+                int numInputs = x.ArgAt<int>(0);
+
+                return FederationGatewaySettings.DefaultTransactionFee + FederationGatewaySettings.InputsTransactionFee * numInputs;
+            });
 
             // Generate the keys used by the federation members for our tests.
             this.federationKeys = new[]
@@ -196,7 +201,7 @@ namespace Stratis.Features.FederatedPeg.Tests
             this.wallet = this.federationWalletManager.GetWallet();
 
             // TODO: The transaction builder, cross-chain store and fed wallet tx handler should be tested individually.
-            this.FederationWalletTransactionHandler = new FederationWalletTransactionHandler(this.loggerFactory, this.federationWalletManager, this.walletFeePolicy, this.network);
+            this.FederationWalletTransactionHandler = new FederationWalletTransactionHandler(this.loggerFactory, this.federationWalletManager, this.walletFeePolicy, this.network, this.federationGatewaySettings);
             this.withdrawalTransactionBuilder = new WithdrawalTransactionBuilder(this.loggerFactory, this.network, this.federationWalletManager, this.FederationWalletTransactionHandler, this.federationGatewaySettings);
 
             var storeSettings = (StoreSettings)FormatterServices.GetUninitializedObject(typeof(StoreSettings));

--- a/src/Stratis.Features.FederatedPeg.Tests/CrossChainTransferStoreTests.cs
+++ b/src/Stratis.Features.FederatedPeg.Tests/CrossChainTransferStoreTests.cs
@@ -143,11 +143,11 @@ namespace Stratis.Features.FederatedPeg.Tests
                 Assert.Equal(3, transactions[0].Outputs.Count);
 
                 // Transaction[0] output value - change.
-                Assert.Equal(new Money(10m, MoneyUnit.BTC), transactions[0].Outputs[0].Value);
+                Assert.Equal(new Money(10.01m, MoneyUnit.BTC), transactions[0].Outputs[0].Value);
                 Assert.Equal(multiSigAddress.ScriptPubKey, transactions[0].Outputs[0].ScriptPubKey);
 
-                // Transaction[0] output value - recipient 1.
-                Assert.Equal(new Money(159.99m, MoneyUnit.BTC), transactions[0].Outputs[1].Value);
+                // Transaction[0] output value - recipient 1, but minus 0.001 for the tx fee and 0.01 for sender fee.
+                Assert.Equal(new Money(159.989m, MoneyUnit.BTC), transactions[0].Outputs[1].Value);
                 Assert.Equal(address1.ScriptPubKey, transactions[0].Outputs[1].ScriptPubKey);
 
                 // Transaction[0] output value - op_return.
@@ -163,12 +163,12 @@ namespace Stratis.Features.FederatedPeg.Tests
                 // Transaction[1] outputs.
                 Assert.Equal(3, transactions[1].Outputs.Count);
 
-                // Transaction[1] output value - change.
-                Assert.Equal(new Money(10m, MoneyUnit.BTC), transactions[1].Outputs[0].Value);
+                // Transaction[1] output value - change. Includes an extra 0.01 taken from sender deposit.
+                Assert.Equal(new Money(10.01m, MoneyUnit.BTC), transactions[1].Outputs[0].Value);
                 Assert.Equal(multiSigAddress.ScriptPubKey, transactions[1].Outputs[0].ScriptPubKey);
 
-                // Transaction[1] output value - recipient 2.
-                Assert.Equal(new Money(59.99m, MoneyUnit.BTC), transactions[1].Outputs[1].Value);
+                // Transaction[1] output value - recipient 2, but minus 0.001 for the tx fee and 0.01 for sender fee.
+                Assert.Equal(new Money(59.989m, MoneyUnit.BTC), transactions[1].Outputs[1].Value);
                 Assert.Equal(address2.ScriptPubKey, transactions[1].Outputs[1].ScriptPubKey);
 
                 // Transaction[1] output value - op_return.
@@ -247,11 +247,11 @@ namespace Stratis.Features.FederatedPeg.Tests
                 Assert.Equal(3, transactions[0].Outputs.Count);
 
                 // Transaction[0] output value - change.
-                Assert.Equal(new Money(10m, MoneyUnit.BTC), transactions[0].Outputs[0].Value);
+                Assert.Equal(new Money(10.01m, MoneyUnit.BTC), transactions[0].Outputs[0].Value);
                 Assert.Equal(multiSigAddress.ScriptPubKey, transactions[0].Outputs[0].ScriptPubKey);
 
-                // Transaction[0] output value - recipient 1, but minus 0.01 for the tx fee.
-                Assert.Equal(new Money(159.99m, MoneyUnit.BTC), transactions[0].Outputs[1].Value);
+                // Transaction[0] output value - recipient 1, but minus 0.001 for the tx fee and 0.01 for sender fee.
+                Assert.Equal(new Money(159.989m, MoneyUnit.BTC), transactions[0].Outputs[1].Value);
                 Assert.Equal(address1.ScriptPubKey, transactions[0].Outputs[1].ScriptPubKey);
 
                 // Transaction[0] output value - op_return.
@@ -284,12 +284,12 @@ namespace Stratis.Features.FederatedPeg.Tests
                 // Transaction[1] outputs.
                 Assert.Equal(3, transactions[1].Outputs.Count);
 
-                // Transaction[1] output value - change.
-                Assert.Equal(new Money(970m, MoneyUnit.BTC), transactions[1].Outputs[0].Value);
+                // Transaction[1] output value - change. Includes an extra 0.01 taken from sender deposit.
+                Assert.Equal(new Money(970.01m, MoneyUnit.BTC), transactions[1].Outputs[0].Value);
                 Assert.Equal(multiSigAddress.ScriptPubKey, transactions[1].Outputs[0].ScriptPubKey);
 
-                // Transaction[1] output value - recipient 2, but minus 0.01 for the tx fee.
-                Assert.Equal(new Money(99.99m, MoneyUnit.BTC), transactions[1].Outputs[1].Value);
+                // Transaction[1] output value - recipient 2, but minus 0.001 for the tx fee and 0.01 for sender fee.
+                Assert.Equal(new Money(99.989m, MoneyUnit.BTC), transactions[1].Outputs[1].Value);
                 Assert.Equal(address2.ScriptPubKey, transactions[1].Outputs[1].ScriptPubKey);
 
                 // Transaction[1] output value - op_return.
@@ -304,7 +304,8 @@ namespace Stratis.Features.FederatedPeg.Tests
 
                 (Money confirmed, Money unconfirmed) spendable = this.federationWalletManager.GetSpendableAmount();
 
-                Assert.Equal(new Money(980m, MoneyUnit.BTC), spendable.unconfirmed);
+                // Includes 0.02 taken from deposit amounts.
+                Assert.Equal(new Money(980.02m, MoneyUnit.BTC), spendable.unconfirmed);
             }
         }
 
@@ -763,7 +764,7 @@ namespace Stratis.Features.FederatedPeg.Tests
                 transfer2 = crossChainTransferStore.GetAsync(new[] { deposit2.Id }).GetAwaiter().GetResult().FirstOrDefault();
                 Assert.Equal(CrossChainTransferStatus.Partial, transfer2?.Status);
 
-                Assert.Equal(2, this.wallet.MultiSigAddress.Transactions.Count);
+                Assert.Equal(4, this.wallet.MultiSigAddress.Transactions.Count);
             }
         }
 

--- a/src/Stratis.Features.FederatedPeg.Tests/CrossChainTransferStoreTests.cs
+++ b/src/Stratis.Features.FederatedPeg.Tests/CrossChainTransferStoreTests.cs
@@ -143,11 +143,11 @@ namespace Stratis.Features.FederatedPeg.Tests
                 Assert.Equal(3, transactions[0].Outputs.Count);
 
                 // Transaction[0] output value - change.
-                Assert.Equal(new Money(10.01m, MoneyUnit.BTC), transactions[0].Outputs[0].Value);
+                Assert.Equal(new Money(10.0006m, MoneyUnit.BTC), transactions[0].Outputs[0].Value);
                 Assert.Equal(multiSigAddress.ScriptPubKey, transactions[0].Outputs[0].ScriptPubKey);
 
                 // Transaction[0] output value - recipient 1, but minus 0.001 for the tx fee and 0.01 for sender fee.
-                Assert.Equal(new Money(159.989m, MoneyUnit.BTC), transactions[0].Outputs[1].Value);
+                Assert.Equal(new Money(159.999m, MoneyUnit.BTC), transactions[0].Outputs[1].Value);
                 Assert.Equal(address1.ScriptPubKey, transactions[0].Outputs[1].ScriptPubKey);
 
                 // Transaction[0] output value - op_return.
@@ -164,11 +164,11 @@ namespace Stratis.Features.FederatedPeg.Tests
                 Assert.Equal(3, transactions[1].Outputs.Count);
 
                 // Transaction[1] output value - change. Includes an extra 0.01 taken from sender deposit.
-                Assert.Equal(new Money(10.01m, MoneyUnit.BTC), transactions[1].Outputs[0].Value);
+                Assert.Equal(new Money(10.0007m, MoneyUnit.BTC), transactions[1].Outputs[0].Value);
                 Assert.Equal(multiSigAddress.ScriptPubKey, transactions[1].Outputs[0].ScriptPubKey);
 
                 // Transaction[1] output value - recipient 2, but minus 0.001 for the tx fee and 0.01 for sender fee.
-                Assert.Equal(new Money(59.989m, MoneyUnit.BTC), transactions[1].Outputs[1].Value);
+                Assert.Equal(new Money(59.999m, MoneyUnit.BTC), transactions[1].Outputs[1].Value);
                 Assert.Equal(address2.ScriptPubKey, transactions[1].Outputs[1].ScriptPubKey);
 
                 // Transaction[1] output value - op_return.
@@ -246,12 +246,12 @@ namespace Stratis.Features.FederatedPeg.Tests
                 // Transaction[0] outputs.
                 Assert.Equal(3, transactions[0].Outputs.Count);
 
-                // Transaction[0] output value - change.
-                Assert.Equal(new Money(10.01m, MoneyUnit.BTC), transactions[0].Outputs[0].Value);
+                // Transaction[0] output value - Change + small profit. 2 UTXOS used as inputs.
+                Assert.Equal(new Money(10.0006m, MoneyUnit.BTC), transactions[0].Outputs[0].Value);
                 Assert.Equal(multiSigAddress.ScriptPubKey, transactions[0].Outputs[0].ScriptPubKey);
 
-                // Transaction[0] output value - recipient 1, but minus 0.001 for the tx fee and 0.01 for sender fee.
-                Assert.Equal(new Money(159.989m, MoneyUnit.BTC), transactions[0].Outputs[1].Value);
+                // Transaction[0] output value - recipient 1, but minus 0.001 for the constant tx fee.
+                Assert.Equal(new Money(159.999m, MoneyUnit.BTC), transactions[0].Outputs[1].Value);
                 Assert.Equal(address1.ScriptPubKey, transactions[0].Outputs[1].ScriptPubKey);
 
                 // Transaction[0] output value - op_return.
@@ -284,12 +284,12 @@ namespace Stratis.Features.FederatedPeg.Tests
                 // Transaction[1] outputs.
                 Assert.Equal(3, transactions[1].Outputs.Count);
 
-                // Transaction[1] output value - change. Includes an extra 0.01 taken from sender deposit.
-                Assert.Equal(new Money(970.01m, MoneyUnit.BTC), transactions[1].Outputs[0].Value);
+                // Transaction[1] output value - change.
+                Assert.Equal(new Money(970.0006m, MoneyUnit.BTC), transactions[1].Outputs[0].Value);
                 Assert.Equal(multiSigAddress.ScriptPubKey, transactions[1].Outputs[0].ScriptPubKey);
 
                 // Transaction[1] output value - recipient 2, but minus 0.001 for the tx fee and 0.01 for sender fee.
-                Assert.Equal(new Money(99.989m, MoneyUnit.BTC), transactions[1].Outputs[1].Value);
+                Assert.Equal(new Money(99.999m, MoneyUnit.BTC), transactions[1].Outputs[1].Value);
                 Assert.Equal(address2.ScriptPubKey, transactions[1].Outputs[1].ScriptPubKey);
 
                 // Transaction[1] output value - op_return.
@@ -304,8 +304,8 @@ namespace Stratis.Features.FederatedPeg.Tests
 
                 (Money confirmed, Money unconfirmed) spendable = this.federationWalletManager.GetSpendableAmount();
 
-                // Includes 0.02 taken from deposit amounts.
-                Assert.Equal(new Money(980.02m, MoneyUnit.BTC), spendable.unconfirmed);
+                // Includes 0.0012 taken from deposit amounts - our profit.
+                Assert.Equal(new Money(980.0012m, MoneyUnit.BTC), spendable.unconfirmed);
             }
         }
 

--- a/src/Stratis.Features.FederatedPeg.Tests/DepositExtractorTests.cs
+++ b/src/Stratis.Features.FederatedPeg.Tests/DepositExtractorTests.cs
@@ -46,11 +46,11 @@ namespace Stratis.Features.FederatedPeg.Tests
             this.addressHelper = new MultisigAddressHelper(this.network, this.counterChainNetwork);
 
             this.settings.MultiSigRedeemScript.Returns(this.addressHelper.PayToMultiSig);
-            this.settings.TransactionFee(Arg.Any<int>()).ReturnsForAnyArgs((x) =>
+            this.settings.GetWithdrawalTransactionFee(Arg.Any<int>()).ReturnsForAnyArgs((x) =>
             {
                 int numInputs = x.ArgAt<int>(0);
 
-                return FederationGatewaySettings.DefaultTransactionFee + FederationGatewaySettings.InputsTransactionFee * numInputs;
+                return FederationGatewaySettings.BaseTransactionFee + FederationGatewaySettings.InputsTransactionFee * numInputs;
             });
 
             this.opReturnDataReader.TryGetTargetAddress(null, out string address).Returns(callInfo => { callInfo[1] = null; return false; });
@@ -170,21 +170,21 @@ namespace Stratis.Features.FederatedPeg.Tests
             byte[] opReturnBytes = Encoding.UTF8.GetBytes(targetAddress.ToString());
 
             // Set amount to be less than withdrawal fee
-            long depositAmount = FederationGatewaySettings.DefaultTransactionFee - 1;
+            long depositAmount = FederationGatewaySettings.BaseTransactionFee - 1;
             Transaction depositTransaction = this.transactionBuilder.BuildOpReturnTransaction(
                 this.addressHelper.SourceChainMultisigAddress, opReturnBytes, depositAmount);
             block.AddTransaction(depositTransaction);
             this.opReturnDataReader.TryGetTargetAddress(depositTransaction, out string unused1).Returns(callInfo => { callInfo[1] = targetAddress.ToString(); return true; });
 
             // Set amount to be exactly withdrawal fee
-            long secondDepositAmount = FederationGatewaySettings.DefaultTransactionFee;
+            long secondDepositAmount = FederationGatewaySettings.BaseTransactionFee;
             Transaction secondDepositTransaction = this.transactionBuilder.BuildOpReturnTransaction(
                 this.addressHelper.SourceChainMultisigAddress, opReturnBytes, secondDepositAmount);
             block.AddTransaction(secondDepositTransaction);
             this.opReturnDataReader.TryGetTargetAddress(secondDepositTransaction, out string unused2).Returns(callInfo => { callInfo[1] = targetAddress.ToString(); return true; });
 
             // Set amount to be greater than withdrawal fee (just)
-            long thirdDepositAmount = FederationGatewaySettings.DefaultTransactionFee + 1;
+            long thirdDepositAmount = FederationGatewaySettings.BaseTransactionFee + 1;
             Transaction thirdDepositTransaction = this.transactionBuilder.BuildOpReturnTransaction(
                 this.addressHelper.SourceChainMultisigAddress, opReturnBytes, thirdDepositAmount);
             block.AddTransaction(thirdDepositTransaction);
@@ -194,7 +194,7 @@ namespace Stratis.Features.FederatedPeg.Tests
 
             // Should only be one, with the value just over the withdrawal fee.
             extractedDeposits.Count.Should().Be(1);
-            extractedDeposits.First().Amount.Should().Be(FederationGatewaySettings.DefaultTransactionFee + 1);
+            extractedDeposits.First().Amount.Should().Be(FederationGatewaySettings.BaseTransactionFee + 1);
         }
     }
 }

--- a/src/Stratis.Features.FederatedPeg.Tests/DepositExtractorTests.cs
+++ b/src/Stratis.Features.FederatedPeg.Tests/DepositExtractorTests.cs
@@ -50,7 +50,7 @@ namespace Stratis.Features.FederatedPeg.Tests
             {
                 int numInputs = x.ArgAt<int>(0);
 
-                return FederationGatewaySettings.BaseTransactionFee + FederationGatewaySettings.InputsTransactionFee * numInputs;
+                return FederationGatewaySettings.BaseTransactionFee + FederationGatewaySettings.InputTransactionFee * numInputs;
             });
 
             this.opReturnDataReader.TryGetTargetAddress(null, out string address).Returns(callInfo => { callInfo[1] = null; return false; });

--- a/src/Stratis.Features.FederatedPeg.Tests/DepositExtractorTests.cs
+++ b/src/Stratis.Features.FederatedPeg.Tests/DepositExtractorTests.cs
@@ -46,7 +46,13 @@ namespace Stratis.Features.FederatedPeg.Tests
             this.addressHelper = new MultisigAddressHelper(this.network, this.counterChainNetwork);
 
             this.settings.MultiSigRedeemScript.Returns(this.addressHelper.PayToMultiSig);
-            this.settings.TransactionFee.Returns(FederationGatewaySettings.DefaultTransactionFee);
+            this.settings.TransactionFee(Arg.Any<int>()).ReturnsForAnyArgs((x) =>
+            {
+                int numInputs = x.ArgAt<int>(0);
+
+                return FederationGatewaySettings.DefaultTransactionFee + FederationGatewaySettings.InputsTransactionFee * numInputs;
+            });
+
             this.opReturnDataReader.TryGetTargetAddress(null, out string address).Returns(callInfo => { callInfo[1] = null; return false; });
 
             this.transactionBuilder = new TestTransactionBuilder();

--- a/src/Stratis.Features.FederatedPeg.Tests/DepositExtractorTests.cs
+++ b/src/Stratis.Features.FederatedPeg.Tests/DepositExtractorTests.cs
@@ -170,21 +170,21 @@ namespace Stratis.Features.FederatedPeg.Tests
             byte[] opReturnBytes = Encoding.UTF8.GetBytes(targetAddress.ToString());
 
             // Set amount to be less than withdrawal fee
-            long depositAmount = FederationGatewaySettings.BaseTransactionFee - 1;
+            long depositAmount = FederationGatewaySettings.CrossChainTransferFee - 1;
             Transaction depositTransaction = this.transactionBuilder.BuildOpReturnTransaction(
                 this.addressHelper.SourceChainMultisigAddress, opReturnBytes, depositAmount);
             block.AddTransaction(depositTransaction);
             this.opReturnDataReader.TryGetTargetAddress(depositTransaction, out string unused1).Returns(callInfo => { callInfo[1] = targetAddress.ToString(); return true; });
 
             // Set amount to be exactly withdrawal fee
-            long secondDepositAmount = FederationGatewaySettings.BaseTransactionFee;
+            long secondDepositAmount = FederationGatewaySettings.CrossChainTransferFee;
             Transaction secondDepositTransaction = this.transactionBuilder.BuildOpReturnTransaction(
                 this.addressHelper.SourceChainMultisigAddress, opReturnBytes, secondDepositAmount);
             block.AddTransaction(secondDepositTransaction);
             this.opReturnDataReader.TryGetTargetAddress(secondDepositTransaction, out string unused2).Returns(callInfo => { callInfo[1] = targetAddress.ToString(); return true; });
 
             // Set amount to be greater than withdrawal fee (just)
-            long thirdDepositAmount = FederationGatewaySettings.BaseTransactionFee + 1;
+            long thirdDepositAmount = FederationGatewaySettings.CrossChainTransferFee + 1;
             Transaction thirdDepositTransaction = this.transactionBuilder.BuildOpReturnTransaction(
                 this.addressHelper.SourceChainMultisigAddress, opReturnBytes, thirdDepositAmount);
             block.AddTransaction(thirdDepositTransaction);
@@ -194,7 +194,7 @@ namespace Stratis.Features.FederatedPeg.Tests
 
             // Should only be one, with the value just over the withdrawal fee.
             extractedDeposits.Count.Should().Be(1);
-            extractedDeposits.First().Amount.Should().Be(FederationGatewaySettings.BaseTransactionFee + 1);
+            extractedDeposits.First().Amount.Should().Be(FederationGatewaySettings.CrossChainTransferFee + 1);
         }
     }
 }

--- a/src/Stratis.Features.FederatedPeg.Tests/WithdrawalTransactionBuilderTests.cs
+++ b/src/Stratis.Features.FederatedPeg.Tests/WithdrawalTransactionBuilderTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Extensions.Logging;
 using Moq;
@@ -11,6 +12,7 @@ using Stratis.Sidechains.Networks;
 using Xunit;
 using Recipient = Stratis.Features.FederatedPeg.Wallet.Recipient;
 using TransactionBuildContext = Stratis.Features.FederatedPeg.Wallet.TransactionBuildContext;
+using UnspentOutputReference = Stratis.Features.FederatedPeg.Wallet.UnspentOutputReference;
 
 namespace Stratis.Features.FederatedPeg.Tests
 {
@@ -49,6 +51,31 @@ namespace Stratis.Features.FederatedPeg.Tests
         [Fact]
         public void FeeIsTakenFromRecipient()
         {
+            Script redeemScript = PayToMultiSigTemplate.Instance.GenerateScriptPubKey(2, new[] {new Key().PubKey, new Key().PubKey});
+
+            this.federationWalletManager.Setup(x => x.GetSpendableTransactionsInWallet(It.IsAny<int>()))
+                .Returns(new List<UnspentOutputReference>
+                {
+                    new UnspentOutputReference
+                    {
+                        Transaction = new FederatedPeg.Wallet.TransactionData
+                        {
+                            Amount = Money.Coins(105),
+                            Id = uint256.One,
+                            ScriptPubKey = redeemScript.Hash.ScriptPubKey
+                        }
+                    }
+                });
+
+            this.federationWalletManager.Setup(x => x.GetWallet())
+                .Returns(new FederationWallet
+                {
+                    MultiSigAddress = new MultiSigAddress
+                    {
+                        RedeemScript = redeemScript
+                    }
+                });
+
             var txBuilder = new WithdrawalTransactionBuilder(
                 this.loggerFactory.Object,
                 this.network,
@@ -67,9 +94,13 @@ namespace Stratis.Features.FederatedPeg.Tests
 
             Assert.NotNull(ret);
 
-            Money expectedAmountAfterFee = recipient.Amount - this.federationGatewaySettings.Object.GetWithdrawalTransactionFee(ret.Inputs.Count);
-
+            // Fee taken from amount should be the total fee. 
+            Money expectedAmountAfterFee = recipient.Amount - FederationGatewaySettings.CrossChainTransferFee;
             this.federationWalletTransactionHandler.Verify(x => x.BuildTransaction(It.Is<TransactionBuildContext>(y => y.Recipients.First().Amount == expectedAmountAfterFee)));
+
+            // Fee used to send transaction should be a smaller amount.
+            Money expectedTxFee = FederationGatewaySettings.BaseTransactionFee + 1 * FederationGatewaySettings.InputsTransactionFee;
+            this.federationWalletTransactionHandler.Verify(x => x.BuildTransaction(It.Is<TransactionBuildContext>(y => y.TransactionFee == expectedTxFee)));
         }
 
         [Fact]

--- a/src/Stratis.Features.FederatedPeg.Tests/WithdrawalTransactionBuilderTests.cs
+++ b/src/Stratis.Features.FederatedPeg.Tests/WithdrawalTransactionBuilderTests.cs
@@ -34,9 +34,9 @@ namespace Stratis.Features.FederatedPeg.Tests
             this.logger = new Mock<ILogger>();
             this.loggerFactory.Setup(x => x.CreateLogger(It.IsAny<string>()))
                 .Returns(this.logger.Object);
-            this.federationGatewaySettings.Setup<Money>(x => x.TransactionFee(It.IsAny<int>()))
+            this.federationGatewaySettings.Setup<Money>(x => x.GetWithdrawalTransactionFee(It.IsAny<int>()))
                 .Returns<int>((numInputs) => {
-                    return FederationGatewaySettings.DefaultTransactionFee + FederationGatewaySettings.InputsTransactionFee * numInputs;
+                    return FederationGatewaySettings.BaseTransactionFee + FederationGatewaySettings.InputsTransactionFee * numInputs;
                 });
 
             this.federationWalletManager.Setup(x => x.Secret)
@@ -67,7 +67,7 @@ namespace Stratis.Features.FederatedPeg.Tests
 
             Assert.NotNull(ret);
 
-            Money expectedAmountAfterFee = recipient.Amount - this.federationGatewaySettings.Object.TransactionFee(ret.Inputs.Count);
+            Money expectedAmountAfterFee = recipient.Amount - this.federationGatewaySettings.Object.GetWithdrawalTransactionFee(ret.Inputs.Count);
 
             this.federationWalletTransactionHandler.Verify(x => x.BuildTransaction(It.Is<TransactionBuildContext>(y => y.Recipients.First().Amount == expectedAmountAfterFee)));
         }

--- a/src/Stratis.Features.FederatedPeg.Tests/WithdrawalTransactionBuilderTests.cs
+++ b/src/Stratis.Features.FederatedPeg.Tests/WithdrawalTransactionBuilderTests.cs
@@ -34,9 +34,10 @@ namespace Stratis.Features.FederatedPeg.Tests
             this.logger = new Mock<ILogger>();
             this.loggerFactory.Setup(x => x.CreateLogger(It.IsAny<string>()))
                 .Returns(this.logger.Object);
-
-            this.federationGatewaySettings.Setup(x => x.TransactionFee)
-                .Returns(FederationGatewaySettings.DefaultTransactionFee);
+            this.federationGatewaySettings.Setup<Money>(x => x.TransactionFee(It.IsAny<int>()))
+                .Returns<int>((numInputs) => {
+                    return FederationGatewaySettings.DefaultTransactionFee + FederationGatewaySettings.InputsTransactionFee * numInputs;
+                });
 
             this.federationWalletManager.Setup(x => x.Secret)
                 .Returns(new WalletSecret());
@@ -66,7 +67,7 @@ namespace Stratis.Features.FederatedPeg.Tests
 
             Assert.NotNull(ret);
 
-            Money expectedAmountAfterFee = recipient.Amount - this.federationGatewaySettings.Object.TransactionFee;
+            Money expectedAmountAfterFee = recipient.Amount - this.federationGatewaySettings.Object.TransactionFee(ret.Inputs.Count);
 
             this.federationWalletTransactionHandler.Verify(x => x.BuildTransaction(It.Is<TransactionBuildContext>(y => y.Recipients.First().Amount == expectedAmountAfterFee)));
         }

--- a/src/Stratis.Features.FederatedPeg.Tests/WithdrawalTransactionBuilderTests.cs
+++ b/src/Stratis.Features.FederatedPeg.Tests/WithdrawalTransactionBuilderTests.cs
@@ -38,7 +38,7 @@ namespace Stratis.Features.FederatedPeg.Tests
                 .Returns(this.logger.Object);
             this.federationGatewaySettings.Setup<Money>(x => x.GetWithdrawalTransactionFee(It.IsAny<int>()))
                 .Returns<int>((numInputs) => {
-                    return FederationGatewaySettings.BaseTransactionFee + FederationGatewaySettings.InputsTransactionFee * numInputs;
+                    return FederationGatewaySettings.BaseTransactionFee + FederationGatewaySettings.InputTransactionFee * numInputs;
                 });
 
             this.federationWalletManager.Setup(x => x.Secret)
@@ -99,7 +99,7 @@ namespace Stratis.Features.FederatedPeg.Tests
             this.federationWalletTransactionHandler.Verify(x => x.BuildTransaction(It.Is<TransactionBuildContext>(y => y.Recipients.First().Amount == expectedAmountAfterFee)));
 
             // Fee used to send transaction should be a smaller amount.
-            Money expectedTxFee = FederationGatewaySettings.BaseTransactionFee + 1 * FederationGatewaySettings.InputsTransactionFee;
+            Money expectedTxFee = FederationGatewaySettings.BaseTransactionFee + 1 * FederationGatewaySettings.InputTransactionFee;
             this.federationWalletTransactionHandler.Verify(x => x.BuildTransaction(It.Is<TransactionBuildContext>(y => y.TransactionFee == expectedTxFee)));
         }
 

--- a/src/Stratis.Features.FederatedPeg/FederationGatewaySettings.cs
+++ b/src/Stratis.Features.FederatedPeg/FederationGatewaySettings.cs
@@ -28,17 +28,25 @@ namespace Stratis.Features.FederatedPeg
         private const string MinimumDepositConfirmationsParam = "mindepositconfirmations";
 
         /// <summary>
-        /// The transaction fee used by the federation to build withdrawal transactions.
+        /// The fee taken by the federation to build withdrawal transactions. The federation will keep most of this.
         /// </summary>
-        /// <remarks>
-        /// Changing <see cref="TransactionFee"/> affects both the deposit threshold on this chain and the withdrawal transaction fee on this chain.
+        /// Changing <see cref="CrossChainTransferFee"/> affects both the deposit threshold on this chain and the withdrawal transaction fee on this chain.
         /// This value shouldn't be different for the 2 pegged chain nodes or deposits could be extracted that don't have the amount required to
         /// cover the withdrawal fee on the other chain.
         ///
         /// TODO: This should be configurable on the Network level in the future, but individual nodes shouldn't be tweaking it.
         /// </remarks>
-        public static readonly Money DefaultTransactionFee = Money.Coins(0.001m);
-        public static readonly Money InputsTransactionFee = Money.Coins(0.0m);
+        public static readonly Money CrossChainTransferFee = Money.Coins(0.001m);
+
+        /// <summary>
+        /// The fee always given to a withdrawal transaction.
+        /// </summary>
+        public static readonly Money BaseTransactionFee = Money.Coins(0.0002m);
+
+        /// <summary>
+        /// The extra fee given to a withdrawal transaction per input it spends. This number should be high enough such that the built transactions are always valid, yet low enough such that the federation can turn a profit.
+        /// </summary>
+        public static readonly Money InputsTransactionFee = Money.Coins(0.0001m);
 
         /// <summary>
         /// Sidechains to STRAT don't need to check for deposits for the whole main chain. Only from when they begun.
@@ -117,9 +125,9 @@ namespace Stratis.Features.FederatedPeg
         public int MultiSigN { get; }
 
         /// <inheritdoc/>
-        public Money TransactionFee(int numInputs)
+        public Money GetWithdrawalTransactionFee(int numInputs)
         {
-            return DefaultTransactionFee + numInputs * InputsTransactionFee;
+            return BaseTransactionFee + numInputs * InputsTransactionFee;
         }
 
         /// <inheritdoc/>

--- a/src/Stratis.Features.FederatedPeg/FederationGatewaySettings.cs
+++ b/src/Stratis.Features.FederatedPeg/FederationGatewaySettings.cs
@@ -38,6 +38,7 @@ namespace Stratis.Features.FederatedPeg
         /// TODO: This should be configurable on the Network level in the future, but individual nodes shouldn't be tweaking it.
         /// </remarks>
         public static readonly Money DefaultTransactionFee = Money.Coins(0.001m);
+        public static readonly Money InputsTransactionFee = Money.Coins(0.0m);
 
         /// <summary>
         /// Sidechains to STRAT don't need to check for deposits for the whole main chain. Only from when they begun.
@@ -69,8 +70,6 @@ namespace Stratis.Features.FederatedPeg
             this.FederationPublicKeys = payToMultisigScriptParams.PubKeys;
 
             this.PublicKey = configReader.GetOrDefault<string>(PublicKeyParam, null);
-
-            this.TransactionFee = DefaultTransactionFee;
 
             if (this.FederationPublicKeys.All(p => p != new PubKey(this.PublicKey)))
             {
@@ -118,7 +117,10 @@ namespace Stratis.Features.FederatedPeg
         public int MultiSigN { get; }
 
         /// <inheritdoc/>
-        public Money TransactionFee { get; }
+        public Money TransactionFee(int numInputs)
+        {
+            return DefaultTransactionFee + numInputs * InputsTransactionFee;
+        }
 
         /// <inheritdoc/>
         public int CounterChainDepositStartBlock { get; }

--- a/src/Stratis.Features.FederatedPeg/FederationGatewaySettings.cs
+++ b/src/Stratis.Features.FederatedPeg/FederationGatewaySettings.cs
@@ -30,6 +30,7 @@ namespace Stratis.Features.FederatedPeg
         /// <summary>
         /// The fee taken by the federation to build withdrawal transactions. The federation will keep most of this.
         /// </summary>
+        /// <remarks>
         /// Changing <see cref="CrossChainTransferFee"/> affects both the deposit threshold on this chain and the withdrawal transaction fee on this chain.
         /// This value shouldn't be different for the 2 pegged chain nodes or deposits could be extracted that don't have the amount required to
         /// cover the withdrawal fee on the other chain.
@@ -46,7 +47,7 @@ namespace Stratis.Features.FederatedPeg
         /// <summary>
         /// The extra fee given to a withdrawal transaction per input it spends. This number should be high enough such that the built transactions are always valid, yet low enough such that the federation can turn a profit.
         /// </summary>
-        public static readonly Money InputsTransactionFee = Money.Coins(0.0001m);
+        public static readonly Money InputTransactionFee = Money.Coins(0.0001m);
 
         /// <summary>
         /// Sidechains to STRAT don't need to check for deposits for the whole main chain. Only from when they begun.
@@ -127,7 +128,7 @@ namespace Stratis.Features.FederatedPeg
         /// <inheritdoc/>
         public Money GetWithdrawalTransactionFee(int numInputs)
         {
-            return BaseTransactionFee + numInputs * InputsTransactionFee;
+            return BaseTransactionFee + numInputs * InputTransactionFee;
         }
 
         /// <inheritdoc/>

--- a/src/Stratis.Features.FederatedPeg/Interfaces/IFederationGatewaySettings.cs
+++ b/src/Stratis.Features.FederatedPeg/Interfaces/IFederationGatewaySettings.cs
@@ -52,7 +52,7 @@ namespace Stratis.Features.FederatedPeg.Interfaces
         /// <summary>
         /// The transaction fee required for withdrawals.
         /// </summary>
-        Money TransactionFee(int numInputs);
+        Money GetWithdrawalTransactionFee(int numInputs);
 
         /// <summary>
         /// The block number on the other chain to start retrieving deposits from.

--- a/src/Stratis.Features.FederatedPeg/Interfaces/IFederationGatewaySettings.cs
+++ b/src/Stratis.Features.FederatedPeg/Interfaces/IFederationGatewaySettings.cs
@@ -52,7 +52,7 @@ namespace Stratis.Features.FederatedPeg.Interfaces
         /// <summary>
         /// The transaction fee required for withdrawals.
         /// </summary>
-        Money TransactionFee { get; }
+        Money TransactionFee(int numInputs);
 
         /// <summary>
         /// The block number on the other chain to start retrieving deposits from.

--- a/src/Stratis.Features.FederatedPeg/SourceChain/DepositExtractor.cs
+++ b/src/Stratis.Features.FederatedPeg/SourceChain/DepositExtractor.cs
@@ -79,13 +79,13 @@ namespace Stratis.Features.FederatedPeg.SourceChain
                 return null;
 
             // Deposits have a certain structure.
-            if (transaction.Outputs.Count != ExpectedNumberOfOutputsNoChange 
+            if (transaction.Outputs.Count != ExpectedNumberOfOutputsNoChange
                 && transaction.Outputs.Count != ExpectedNumberOfOutputsChange)
                 return null;
 
             List<TxOut> depositsToMultisig = transaction.Outputs.Where(output =>
                 output.ScriptPubKey == this.depositScript
-                && output.Value > this.settings.TransactionFee).ToList();
+                && output.Value > this.settings.TransactionFee(transaction.Inputs.Count)).ToList();
 
             if (!depositsToMultisig.Any())
                 return null;

--- a/src/Stratis.Features.FederatedPeg/SourceChain/DepositExtractor.cs
+++ b/src/Stratis.Features.FederatedPeg/SourceChain/DepositExtractor.cs
@@ -85,7 +85,7 @@ namespace Stratis.Features.FederatedPeg.SourceChain
 
             List<TxOut> depositsToMultisig = transaction.Outputs.Where(output =>
                 output.ScriptPubKey == this.depositScript
-                && output.Value > this.settings.TransactionFee(transaction.Inputs.Count)).ToList();
+                && output.Value > FederationGatewaySettings.CrossChainTransferFee).ToList();
 
             if (!depositsToMultisig.Any())
                 return null;

--- a/src/Stratis.Features.FederatedPeg/TargetChain/CrossChainTransferStore.cs
+++ b/src/Stratis.Features.FederatedPeg/TargetChain/CrossChainTransferStore.cs
@@ -30,6 +30,9 @@ namespace Stratis.Features.FederatedPeg.TargetChain
         // <summary>Block batch size for synchronization</summary>
         private const int synchronizationBatchSize = 1000;
 
+        /// <summary>Amount withheld from the deposit amount when creating the withdrawal transaction.</summary>
+        private const decimal fixedTransferCost = 0.01m;
+
         /// <summary>This contains deposits ids indexed by block hash of the corresponding transaction.</summary>
         private readonly Dictionary<uint256, HashSet<uint256>> depositIdsByBlockHash = new Dictionary<uint256, HashSet<uint256>>();
 
@@ -435,13 +438,13 @@ namespace Stratis.Features.FederatedPeg.TargetChain
                                 CrossChainTransferStatus status = CrossChainTransferStatus.Suspended;
                                 Script scriptPubKey = BitcoinAddress.Create(deposit.TargetAddress, this.network).ScriptPubKey;
 
-                                if (!haveSuspendedTransfers)
+                            if (!haveSuspendedTransfers)
+                            {
+                                var recipient = new Recipient
                                 {
-                                    var recipient = new Recipient
-                                    {
-                                        Amount = deposit.Amount,
-                                        ScriptPubKey = scriptPubKey
-                                    };
+                                    Amount = deposit.Amount - new Money(fixedTransferCost, MoneyUnit.BTC),
+                                    ScriptPubKey = scriptPubKey
+                                };
 
                                     uint blockTime = maturedDeposit.BlockInfo.BlockTime;
 

--- a/src/Stratis.Features.FederatedPeg/TargetChain/CrossChainTransferStore.cs
+++ b/src/Stratis.Features.FederatedPeg/TargetChain/CrossChainTransferStore.cs
@@ -30,9 +30,6 @@ namespace Stratis.Features.FederatedPeg.TargetChain
         // <summary>Block batch size for synchronization</summary>
         private const int synchronizationBatchSize = 1000;
 
-        /// <summary>Amount withheld from the deposit amount when creating the withdrawal transaction.</summary>
-        private const decimal fixedTransferCost = 0.01m;
-
         /// <summary>This contains deposits ids indexed by block hash of the corresponding transaction.</summary>
         private readonly Dictionary<uint256, HashSet<uint256>> depositIdsByBlockHash = new Dictionary<uint256, HashSet<uint256>>();
 
@@ -442,7 +439,7 @@ namespace Stratis.Features.FederatedPeg.TargetChain
                             {
                                 var recipient = new Recipient
                                 {
-                                    Amount = deposit.Amount - new Money(fixedTransferCost, MoneyUnit.BTC),
+                                    Amount = deposit.Amount,
                                     ScriptPubKey = scriptPubKey
                                 };
 

--- a/src/Stratis.Features.FederatedPeg/TargetChain/WithdrawalTransactionBuilder.cs
+++ b/src/Stratis.Features.FederatedPeg/TargetChain/WithdrawalTransactionBuilder.cs
@@ -65,7 +65,7 @@ namespace Stratis.Features.FederatedPeg.TargetChain
                 (List<Coin> coins, List<Wallet.UnspentOutputReference> unspentOutputs) =
                     FederationWalletTransactionHandler.DetermineCoins(this.federationWalletManager, this.network, multiSigContext, this.federationGatewaySettings);
 
-                Money transactionFee = this.federationGatewaySettings.TransactionFee(coins.Count);
+                Money transactionFee = this.federationGatewaySettings.GetWithdrawalTransactionFee(coins.Count);
 
                 multiSigContext.Recipients = new[] { recipient.WithPaymentReducedByFee(transactionFee) }.ToList();
                 multiSigContext.TransactionFee = transactionFee;

--- a/src/Stratis.Features.FederatedPeg/TargetChain/WithdrawalTransactionBuilder.cs
+++ b/src/Stratis.Features.FederatedPeg/TargetChain/WithdrawalTransactionBuilder.cs
@@ -59,10 +59,10 @@ namespace Stratis.Features.FederatedPeg.TargetChain
                     IgnoreVerify = true,
                     WalletPassword = walletPassword,
                     Sign = sign,
-                    Time = this.network.Consensus.IsProofOfStake ? blockTime : (uint?) null,
+                    Time = this.network.Consensus.IsProofOfStake ? blockTime : (uint?) null
                 };
 
-                multiSigContext.Recipients = new[] { recipient.WithPaymentReducedByFee(FederationGatewaySettings.CrossChainTransferFee) }.ToList(); // The fee known to the user is taken.
+                multiSigContext.Recipients = new List<Recipient> { recipient.WithPaymentReducedByFee(FederationGatewaySettings.CrossChainTransferFee) }; // The fee known to the user is taken.
 
                 // TODO: Amend this so we're not picking coins twice.
                 (List<Coin> coins, List<Wallet.UnspentOutputReference> unspentOutputs) = FederationWalletTransactionHandler.DetermineCoins(this.federationWalletManager, this.network, multiSigContext, this.federationGatewaySettings);

--- a/src/Stratis.Features.FederatedPeg/Wallet/DeterministicCoinOrdering.cs
+++ b/src/Stratis.Features.FederatedPeg/Wallet/DeterministicCoinOrdering.cs
@@ -11,11 +11,11 @@ namespace Stratis.Features.FederatedPeg.Wallet
         /// <summary>
         /// Returns the unspent outputs in the preferred order of consumption.
         /// </summary>
-        /// <param name="context">The context associated with the current transaction being built.</param>
+        /// <param name="unspentOutputs">The unspent outputs to order.</param>
         /// <returns>The unspent outputs in the preferred order of consumption.</returns>
-        public static IOrderedEnumerable<UnspentOutputReference> GetOrderedUnspentOutputs(TransactionBuildContext context)
+        public static IOrderedEnumerable<UnspentOutputReference> GetOrderedUnspentOutputs(List<UnspentOutputReference> unspentOutputs)
         {
-            return context.UnspentOutputs.OrderBy(a => a, Comparer<UnspentOutputReference>.Create(CompareUnspentOutputReferences));
+            return unspentOutputs.OrderBy(a => a, Comparer<UnspentOutputReference>.Create(CompareUnspentOutputReferences));
         }
 
         /// <summary>

--- a/src/Stratis.Features.FederatedPeg/Wallet/FederationWalletManager.cs
+++ b/src/Stratis.Features.FederatedPeg/Wallet/FederationWalletManager.cs
@@ -952,7 +952,7 @@ namespace Stratis.Features.FederatedPeg.Wallet
                 if (checkSignature)
                 {
                     TransactionBuilder builder = new TransactionBuilder(this.Wallet.Network).AddCoins(coins);
-                    if (!builder.Verify(transaction, this.federationGatewaySettings.TransactionFee, out TransactionPolicyError[] errors))
+                    if (!builder.Verify(transaction, this.federationGatewaySettings.TransactionFee(coins.Count), out TransactionPolicyError[] errors))
                     {
                         // Trace the reason validation failed. Note that failure here doesn't mean an error necessarily. Just that the transaction is not fully signed.
                         foreach (TransactionPolicyError transactionPolicyError in errors)

--- a/src/Stratis.Features.FederatedPeg/Wallet/FederationWalletManager.cs
+++ b/src/Stratis.Features.FederatedPeg/Wallet/FederationWalletManager.cs
@@ -952,7 +952,7 @@ namespace Stratis.Features.FederatedPeg.Wallet
                 if (checkSignature)
                 {
                     TransactionBuilder builder = new TransactionBuilder(this.Wallet.Network).AddCoins(coins);
-                    if (!builder.Verify(transaction, this.federationGatewaySettings.TransactionFee(coins.Count), out TransactionPolicyError[] errors))
+                    if (!builder.Verify(transaction, this.federationGatewaySettings.GetWithdrawalTransactionFee(coins.Count), out TransactionPolicyError[] errors))
                     {
                         // Trace the reason validation failed. Note that failure here doesn't mean an error necessarily. Just that the transaction is not fully signed.
                         foreach (TransactionPolicyError transactionPolicyError in errors)

--- a/src/Stratis.Features.FederatedPeg/Wallet/FederationWalletTransactionHandler.cs
+++ b/src/Stratis.Features.FederatedPeg/Wallet/FederationWalletTransactionHandler.cs
@@ -251,7 +251,7 @@ namespace Stratis.Features.FederatedPeg.Wallet
                 count++;
 
                 // Sufficient UTXOs are selected to cover the value of the outputs + fee.
-                if (sum >= (totalToSend + settings.TransactionFee(count)))
+                if (sum >= (totalToSend + settings.GetWithdrawalTransactionFee(count)))
                     break;
             }
 

--- a/src/Stratis.Features.FederatedPeg/Wallet/FederationWalletTransactionHandler.cs
+++ b/src/Stratis.Features.FederatedPeg/Wallet/FederationWalletTransactionHandler.cs
@@ -56,20 +56,26 @@ namespace Stratis.Features.FederatedPeg.Wallet
 
         private readonly MemoryCache privateKeyCache;
 
+        private readonly IFederationGatewaySettings settings;
+
         public FederationWalletTransactionHandler(
             ILoggerFactory loggerFactory,
             IFederationWalletManager walletManager,
             IWalletFeePolicy walletFeePolicy,
-            Network network)
+            Network network,
+            IFederationGatewaySettings settings)
         {
             Guard.NotNull(loggerFactory, nameof(loggerFactory));
             Guard.NotNull(walletManager, nameof(walletManager));
             Guard.NotNull(walletFeePolicy, nameof(walletFeePolicy));
             Guard.NotNull(network, nameof(network));
+            Guard.NotNull(settings, nameof(settings));
 
             this.walletManager = walletManager;
             this.walletFeePolicy = walletFeePolicy;
             this.network = network;
+            this.settings = settings;
+
             this.logger = loggerFactory.CreateLogger(this.GetType().FullName);
             this.privateKeyCache = new MemoryCache(new MemoryCacheOptions() { ExpirationScanFrequency = new TimeSpan(0, 1, 0) });
         }
@@ -181,15 +187,31 @@ namespace Stratis.Features.FederatedPeg.Wallet
         /// <param name="context">The context associated with the current transaction being built.</param>
         private void AddCoins(TransactionBuilder transactionBuilder, TransactionBuildContext context)
         {
-            context.UnspentOutputs = this.walletManager.GetSpendableTransactionsInWallet(context.MinConfirmations).ToList();
+            (List<Coin> coins, List<UnspentOutputReference> unspentOutputs) = DetermineCoins(this.walletManager, this.network, context, this.settings);
 
-            if (context.UnspentOutputs.Count == 0)
+            context.UnspentOutputs = unspentOutputs;
+
+            if (unspentOutputs.Count == 0)
             {
                 throw new WalletException(NoSpendableTransactionsMessage);
             }
 
+            transactionBuilder.AddCoins(coins);
+        }
+
+        /// <summary>
+        /// Determines the inputs/coins that will be used for the transaction.
+        /// </summary>
+        /// <param name="walletManager">The federation wallet manager.</param>
+        /// <param name="network">The network.</param>
+        /// <param name="context">The transacion build context.</param>
+        /// <returns>The coins and unspent outputs that will be used.</returns>
+        public static (List<Coin>, List<UnspentOutputReference>) DetermineCoins(IFederationWalletManager walletManager, Network network, TransactionBuildContext context, IFederationGatewaySettings settings)
+        {
+            List<UnspentOutputReference> unspentOutputs = walletManager.GetSpendableTransactionsInWallet(context.MinConfirmations).ToList();
+
             // Get total spendable balance in the account.
-            long balance = context.UnspentOutputs.Sum(t => t.Transaction.Amount);
+            long balance = unspentOutputs.Sum(t => t.Transaction.Amount);
             long totalToSend = context.Recipients.Sum(s => s.Amount);
             if (balance < totalToSend)
                 throw new WalletException(NotEnoughFundsMessage);
@@ -201,7 +223,7 @@ namespace Stratis.Features.FederatedPeg.Wallet
                 // input is part of the UTXO set and filter out UTXOs that are not
                 // in the initial list if 'context.AllowOtherInputs' is false.
 
-                Dictionary<OutPoint, UnspentOutputReference> availableHashList = context.UnspentOutputs.ToDictionary(item => item.ToOutPoint(), item => item);
+                Dictionary<OutPoint, UnspentOutputReference> availableHashList = unspentOutputs.ToDictionary(item => item.ToOutPoint(), item => item);
 
                 if (!context.SelectedInputs.All(input => availableHashList.ContainsKey(input)))
                     throw new WalletException("Not all the selected inputs were found on the wallet.");
@@ -210,28 +232,30 @@ namespace Stratis.Features.FederatedPeg.Wallet
                 {
                     foreach (KeyValuePair<OutPoint, UnspentOutputReference> unspentOutputsItem in availableHashList)
                         if (!context.SelectedInputs.Contains(unspentOutputsItem.Key))
-                            context.UnspentOutputs.Remove(unspentOutputsItem.Value);
+                            unspentOutputs.Remove(unspentOutputsItem.Value);
                 }
             }
 
             long sum = 0;
+            int count = 0;
             var coins = new List<Coin>();
 
             // We order the potential inputs now because we order them by information that the coin selector won't have access to.
-            IEnumerable<UnspentOutputReference> orderedUnspentOutputs = DeterministicCoinOrdering.GetOrderedUnspentOutputs(context);
+            IEnumerable<UnspentOutputReference> orderedUnspentOutputs = DeterministicCoinOrdering.GetOrderedUnspentOutputs(unspentOutputs);
 
             foreach (UnspentOutputReference item in orderedUnspentOutputs)
             {
-                coins.Add(ScriptCoin.Create(this.network, item.Transaction.Id, (uint)item.Transaction.Index, item.Transaction.Amount, item.Transaction.ScriptPubKey, this.walletManager.GetWallet().MultiSigAddress.RedeemScript));
+                coins.Add(ScriptCoin.Create(network, item.Transaction.Id, (uint)item.Transaction.Index, item.Transaction.Amount, item.Transaction.ScriptPubKey, walletManager.GetWallet().MultiSigAddress.RedeemScript));
                 sum += item.Transaction.Amount;
 
-                // Sufficient UTXOs are selected to cover the value of the outputs + fee.
-                if (sum >= (totalToSend + context.TransactionFee))
-                    break;
+                count++;
 
+                // Sufficient UTXOs are selected to cover the value of the outputs + fee.
+                if (sum >= (totalToSend + settings.TransactionFee(count)))
+                    break;
             }
 
-            transactionBuilder.AddCoins(coins);
+            return (coins, unspentOutputs);
         }
 
         /// <summary>


### PR DESCRIPTION
- Everyone pays 0.001 to transfer coins across.
- Withdrawal transactions will be assigned 0.0002 in fees, plus 0.0001 for every input it uses.
- Given that the wallet has to receive a UTXO to be able to spend it, the average gain for the federation wallet is 0.0007 per 1-way deposit.