### PR TITLE
[API] Add block store endpoint to return the address indexer's height.

### DIFF
--- a/src/Stratis.Bitcoin.Features.BlockStore/Controllers/BlockStoreController.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/Controllers/BlockStoreController.cs
@@ -17,10 +17,11 @@ namespace Stratis.Bitcoin.Features.BlockStore.Controllers
 {
     public static class BlockStoreRouteEndPoint
     {
-        public const string GetBlock = "block";
-        public const string GetBlockCount = "GetBlockCount";
         public const string GetAddressBalance = "getaddressbalance";
         public const string GetAddressesBalances = "getaddressesbalances";
+        public const string GetAddressIndexerTip = "addressindexertip";
+        public const string GetBlock = "block";
+        public const string GetBlockCount = "GetBlockCount";
         public const string GetReceivedByAddress = "getreceivedbyaddress";
     }
 
@@ -28,6 +29,8 @@ namespace Stratis.Bitcoin.Features.BlockStore.Controllers
     [Route("api/[controller]")]
     public class BlockStoreController : Controller
     {
+        private readonly IAddressIndexer addressIndexer;
+
         /// <see cref="IBlockStore"/>
         private readonly IBlockStore blockStore;
 
@@ -42,8 +45,6 @@ namespace Stratis.Bitcoin.Features.BlockStore.Controllers
 
         /// <summary>Current network for the active controller instance.</summary>
         private readonly Network network;
-
-        private readonly IAddressIndexer addressIndexer;
 
         public BlockStoreController(
             Network network,
@@ -64,6 +65,26 @@ namespace Stratis.Bitcoin.Features.BlockStore.Controllers
             this.chainState = chainState;
             this.chainIndexer = chainIndexer;
             this.logger = loggerFactory.CreateLogger(this.GetType().FullName);
+        }
+
+        /// <summary>
+        /// Retrieves the tip height of the <see cref="addressIndexer"/>.
+        /// </summary>
+        /// <returns>If the <see cref="addressIndexer"/> is not null this will return the tip's height.</returns>
+        [Route(BlockStoreRouteEndPoint.GetAddressIndexerTip)]
+        [HttpGet]
+        public IActionResult GetAddressIndexerTip()
+        {
+            try
+            {
+                ChainedHeader addressIndexerTip = this.addressIndexer.IndexerTip;
+                return this.Json(new AddressIndexerTipModel() { TipHash = addressIndexerTip?.HashBlock, TipHeight = addressIndexerTip?.Height });
+            }
+            catch (Exception e)
+            {
+                this.logger.LogError("Exception occurred: {0}", e.ToString());
+                return ErrorHelpers.BuildErrorResponse(HttpStatusCode.BadRequest, e.Message, e.ToString());
+            }
         }
 
         /// <summary>

--- a/src/Stratis.Bitcoin.Features.BlockStore/Controllers/BlockStoreController.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/Controllers/BlockStoreController.cs
@@ -68,9 +68,9 @@ namespace Stratis.Bitcoin.Features.BlockStore.Controllers
         }
 
         /// <summary>
-        /// Retrieves the tip height of the <see cref="addressIndexer"/>.
+        /// Retrieves the <see cref="addressIndexer"/>'s tip.
         /// </summary>
-        /// <returns>If the <see cref="addressIndexer"/> is not null this will return the tip's height.</returns>
+        /// <returns>An instance of <see cref="AddressIndexerTipModel"/> containing the tip's hash and height.</returns>
         [Route(BlockStoreRouteEndPoint.GetAddressIndexerTip)]
         [HttpGet]
         public IActionResult GetAddressIndexerTip()

--- a/src/Stratis.Bitcoin.Features.BlockStore/Models/AddressIndexerTipModel.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/Models/AddressIndexerTipModel.cs
@@ -1,0 +1,10 @@
+﻿using NBitcoin;
+
+namespace Stratis.Bitcoin.Features.BlockStore.Models
+{
+    public sealed class AddressIndexerTipModel
+    {
+        public uint256 TipHash { get; set; }
+        public int? TipHeight { get; set; }
+    }
+}


### PR DESCRIPTION
http://localhost:37221/api/blockstore/addressindexertip

returns:

{"tipHash":"a6087a042129c58edf421ea5684a8931ab7a1e388924437ecc6ec0b602ef7316","tipHeight":19583}