### PR TITLE
[FS] Fix for block and tx race condition

### DIFF
--- a/src/Stratis.Bitcoin.Features.MemoryPool/MemPoolCoinView.cs
+++ b/src/Stratis.Bitcoin.Features.MemoryPool/MemPoolCoinView.cs
@@ -84,10 +84,11 @@ namespace Stratis.Bitcoin.Features.MemoryPool
         }
 
         /// <summary>
-        /// Load the coin view for a memory pool transaction.
+        /// Load the coin view for a memory pool transaction. This should only be called
+        /// inside the memory pool lock.
         /// </summary>
         /// <param name="trx">Memory pool transaction.</param>
-        public void LoadView(Transaction trx)
+        public void LoadViewLocked(Transaction trx)
         {
             // lookup all ids (duplicate ids are ignored in case a trx spends outputs from the same parent).
             List<uint256> ids = trx.Inputs.Select(n => n.PrevOut.Hash).Distinct().Concat(new[] { trx.GetHash() }).ToList();

--- a/src/Stratis.Bitcoin.Features.MemoryPool/MemPoolCoinView.cs
+++ b/src/Stratis.Bitcoin.Features.MemoryPool/MemPoolCoinView.cs
@@ -87,16 +87,15 @@ namespace Stratis.Bitcoin.Features.MemoryPool
         /// Load the coin view for a memory pool transaction.
         /// </summary>
         /// <param name="trx">Memory pool transaction.</param>
-        public async Task LoadViewAsync(Transaction trx)
+        public void LoadView(Transaction trx)
         {
             // lookup all ids (duplicate ids are ignored in case a trx spends outputs from the same parent).
             List<uint256> ids = trx.Inputs.Select(n => n.PrevOut.Hash).Distinct().Concat(new[] { trx.GetHash() }).ToList();
             FetchCoinsResponse coins = this.Inner.FetchCoins(ids.ToArray());
+
             // find coins currently in the mempool
-            List<Transaction> mempoolcoins = await this.mempoolLock.ReadAsync(() =>
-            {
-                return this.memPool.MapTx.Values.Where(t => ids.Contains(t.TransactionHash)).Select(s => s.Transaction).ToList();
-            });
+            List<Transaction> mempoolcoins = this.memPool.MapTx.Values.Where(t => ids.Contains(t.TransactionHash)).Select(s => s.Transaction).ToList();
+
             IEnumerable<UnspentOutputs> memOutputs = mempoolcoins.Select(s => new UnspentOutputs(TxMempool.MempoolHeight, s));
             coins = new FetchCoinsResponse(coins.UnspentOutputs.Concat(memOutputs).ToArray(), coins.BlockHash);
 

--- a/src/Stratis.Bitcoin.Features.MemoryPool/MempoolManager.cs
+++ b/src/Stratis.Bitcoin.Features.MemoryPool/MempoolManager.cs
@@ -227,7 +227,7 @@ namespace Stratis.Bitcoin.Features.MemoryPool
             }
 
             var memPoolCoinView = new MempoolCoinView(this.coinView, this.memPool, this.MempoolLock, this.Validator);
-            await memPoolCoinView.LoadViewAsync(txInfo.Trx).ConfigureAwait(false);
+            memPoolCoinView.LoadView(txInfo.Trx);
             UnspentOutputs unspentOutputs = memPoolCoinView.GetCoins(trxid);
 
             return unspentOutputs;

--- a/src/Stratis.Bitcoin.Features.MemoryPool/MempoolManager.cs
+++ b/src/Stratis.Bitcoin.Features.MemoryPool/MempoolManager.cs
@@ -227,7 +227,7 @@ namespace Stratis.Bitcoin.Features.MemoryPool
             }
 
             var memPoolCoinView = new MempoolCoinView(this.coinView, this.memPool, this.MempoolLock, this.Validator);
-            await this.MempoolLock.WriteAsync(() => { memPoolCoinView.LoadViewLocked(txInfo.Trx); });
+            await this.MempoolLock.ReadAsync(() => { memPoolCoinView.LoadViewLocked(txInfo.Trx); });
             UnspentOutputs unspentOutputs = memPoolCoinView.GetCoins(trxid);
 
             return unspentOutputs;

--- a/src/Stratis.Bitcoin.Features.MemoryPool/MempoolManager.cs
+++ b/src/Stratis.Bitcoin.Features.MemoryPool/MempoolManager.cs
@@ -227,7 +227,7 @@ namespace Stratis.Bitcoin.Features.MemoryPool
             }
 
             var memPoolCoinView = new MempoolCoinView(this.coinView, this.memPool, this.MempoolLock, this.Validator);
-            memPoolCoinView.LoadView(txInfo.Trx);
+            await this.MempoolLock.WriteAsync(() => { memPoolCoinView.LoadViewLocked(txInfo.Trx); });
             UnspentOutputs unspentOutputs = memPoolCoinView.GetCoins(trxid);
 
             return unspentOutputs;

--- a/src/Stratis.Bitcoin.Features.MemoryPool/MempoolValidator.cs
+++ b/src/Stratis.Bitcoin.Features.MemoryPool/MempoolValidator.cs
@@ -404,6 +404,7 @@ namespace Stratis.Bitcoin.Features.MemoryPool
                 if (nTxSize > offset)
                     nTxSize -= (int)offset;
             }
+
             return nTxSize;
         }
 
@@ -426,7 +427,7 @@ namespace Stratis.Bitcoin.Features.MemoryPool
             // use the sequential scheduler for that.
             await this.mempoolLock.WriteAsync(() =>
             {
-                context.View.LoadView(context.Transaction);
+                context.View.LoadViewLocked(context.Transaction);
 
                 // If the transaction already exists in the mempool,
                 // we only record the state but do not throw an exception.

--- a/src/Stratis.Bitcoin.Features.MemoryPool/MempoolValidator.cs
+++ b/src/Stratis.Bitcoin.Features.MemoryPool/MempoolValidator.cs
@@ -421,12 +421,13 @@ namespace Stratis.Bitcoin.Features.MemoryPool
 
             // create the MemPoolCoinView and load relevant utxoset
             context.View = new MempoolCoinView(this.coinView, this.memPool, this.mempoolLock, this);
-            await context.View.LoadViewAsync(context.Transaction).ConfigureAwait(false);
 
             // adding to the mem pool can only be done sequentially
             // use the sequential scheduler for that.
             await this.mempoolLock.WriteAsync(() =>
             {
+                context.View.LoadView(context.Transaction);
+
                 // If the transaction already exists in the mempool,
                 // we only record the state but do not throw an exception.
                 // This is because the caller will check if the state is invalid

--- a/src/Stratis.Bitcoin.IntegrationTests/MinerTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/MinerTests.cs
@@ -97,7 +97,7 @@ namespace Stratis.Bitcoin.IntegrationTests
         {
             var context = new MempoolValidationContext(tx, new MempoolValidationState(false));
             context.View = new MempoolCoinView(testContext.cachedCoinView, testContext.mempool, testContext.mempoolLock, null);
-            context.View.LoadView(tx);
+            context.View.LoadViewLocked(tx);
             return MempoolValidator.CheckSequenceLocks(testContext.network, chainedHeader, context, flags, uselock, false);
         }
 

--- a/src/Stratis.Bitcoin.IntegrationTests/MinerTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/MinerTests.cs
@@ -97,7 +97,7 @@ namespace Stratis.Bitcoin.IntegrationTests
         {
             var context = new MempoolValidationContext(tx, new MempoolValidationState(false));
             context.View = new MempoolCoinView(testContext.cachedCoinView, testContext.mempool, testContext.mempoolLock, null);
-            context.View.LoadViewLocked(tx);
+            testContext.mempoolLock.WriteAsync(() => context.View.LoadViewLocked(tx)).GetAwaiter().GetResult();
             return MempoolValidator.CheckSequenceLocks(testContext.network, chainedHeader, context, flags, uselock, false);
         }
 

--- a/src/Stratis.Bitcoin.IntegrationTests/MinerTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/MinerTests.cs
@@ -97,7 +97,7 @@ namespace Stratis.Bitcoin.IntegrationTests
         {
             var context = new MempoolValidationContext(tx, new MempoolValidationState(false));
             context.View = new MempoolCoinView(testContext.cachedCoinView, testContext.mempool, testContext.mempoolLock, null);
-            testContext.mempoolLock.WriteAsync(() => context.View.LoadViewLocked(tx)).GetAwaiter().GetResult();
+            testContext.mempoolLock.ReadAsync(() => context.View.LoadViewLocked(tx)).GetAwaiter().GetResult();
             return MempoolValidator.CheckSequenceLocks(testContext.network, chainedHeader, context, flags, uselock, false);
         }
 

--- a/src/Stratis.Bitcoin.IntegrationTests/MinerTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/MinerTests.cs
@@ -97,7 +97,7 @@ namespace Stratis.Bitcoin.IntegrationTests
         {
             var context = new MempoolValidationContext(tx, new MempoolValidationState(false));
             context.View = new MempoolCoinView(testContext.cachedCoinView, testContext.mempool, testContext.mempoolLock, null);
-            context.View.LoadViewAsync(tx).GetAwaiter().GetResult();
+            context.View.LoadView(tx);
             return MempoolValidator.CheckSequenceLocks(testContext.network, chainedHeader, context, flags, uselock, false);
         }
 

--- a/src/Stratis.SmartContracts.IntegrationTests/PoW/SmartContractMinerTests.cs
+++ b/src/Stratis.SmartContracts.IntegrationTests/PoW/SmartContractMinerTests.cs
@@ -112,7 +112,7 @@ namespace Stratis.SmartContracts.IntegrationTests.PoW
                 View = new MempoolCoinView(testContext.cachedCoinView, testContext.mempool, testContext.mempoolLock, null)
             };
 
-            context.View.LoadViewAsync(tx).GetAwaiter().GetResult();
+            context.View.LoadView(tx);
 
             return MempoolValidator.CheckSequenceLocks(testContext.network, chainedBlock, context, flags, uselock, false);
         }

--- a/src/Stratis.SmartContracts.IntegrationTests/PoW/SmartContractMinerTests.cs
+++ b/src/Stratis.SmartContracts.IntegrationTests/PoW/SmartContractMinerTests.cs
@@ -112,7 +112,7 @@ namespace Stratis.SmartContracts.IntegrationTests.PoW
                 View = new MempoolCoinView(testContext.cachedCoinView, testContext.mempool, testContext.mempoolLock, null)
             };
 
-            context.View.LoadViewLocked(tx);
+            testContext.mempoolLock.ReadAsync(() => context.View.LoadViewLocked(tx)).GetAwaiter().GetResult();
 
             return MempoolValidator.CheckSequenceLocks(testContext.network, chainedBlock, context, flags, uselock, false);
         }

--- a/src/Stratis.SmartContracts.IntegrationTests/PoW/SmartContractMinerTests.cs
+++ b/src/Stratis.SmartContracts.IntegrationTests/PoW/SmartContractMinerTests.cs
@@ -112,7 +112,7 @@ namespace Stratis.SmartContracts.IntegrationTests.PoW
                 View = new MempoolCoinView(testContext.cachedCoinView, testContext.mempool, testContext.mempoolLock, null)
             };
 
-            context.View.LoadView(tx);
+            context.View.LoadViewLocked(tx);
 
             return MempoolValidator.CheckSequenceLocks(testContext.network, chainedBlock, context, flags, uselock, false);
         }


### PR DESCRIPTION
This should fix a condition where transaction is about to be placed into a memory pool while a block with the same transaction in it arrives.