### PR TITLE
AddressIndexer can crash without evidence (3780)

### DIFF
--- a/src/Stratis.Bitcoin.Features.BlockStore.Tests/AddressIndexerTests.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore.Tests/AddressIndexerTests.cs
@@ -5,12 +5,14 @@ using System.Runtime.InteropServices;
 using LiteDB;
 using Moq;
 using NBitcoin;
+using Stratis.Bitcoin.AsyncWork;
 using Stratis.Bitcoin.Configuration;
 using Stratis.Bitcoin.Configuration.Logging;
 using Stratis.Bitcoin.Consensus;
 using Stratis.Bitcoin.Features.BlockStore.AddressIndexing;
 using Stratis.Bitcoin.Networks;
 using Stratis.Bitcoin.Primitives;
+using Stratis.Bitcoin.Signals;
 using Stratis.Bitcoin.Tests.Common;
 using Stratis.Bitcoin.Utilities;
 using Xunit;
@@ -23,6 +25,8 @@ namespace Stratis.Bitcoin.Features.BlockStore.Tests
         private readonly IAddressIndexer addressIndexer;
 
         private readonly Mock<IConsensusManager> consensusManagerMock;
+
+        private readonly Mock<IAsyncProvider> asyncProviderMock;
 
         private readonly Network network;
 
@@ -39,9 +43,10 @@ namespace Stratis.Bitcoin.Features.BlockStore.Tests
             var dataFolder = new DataFolder(TestBase.CreateTestDir(this));
             var stats = new Mock<INodeStats>();
             this.consensusManagerMock = new Mock<IConsensusManager>();
+            this.asyncProviderMock = new Mock<IAsyncProvider>();
 
             this.addressIndexer = new AddressIndexer(storeSettings, dataFolder, new ExtendedLoggerFactory(),
-                this.network, stats.Object, this.consensusManagerMock.Object);
+                this.network, stats.Object, this.consensusManagerMock.Object, this.asyncProviderMock.Object);
 
             this.genesisHeader = new ChainedHeader(this.network.GetGenesis().Header,
                 this.network.GetGenesis().Header.GetHash(), 0);
@@ -100,7 +105,7 @@ namespace Stratis.Bitcoin.Features.BlockStore.Tests
 
             var tx = new Transaction();
             tx.Inputs.Add(new TxIn(new OutPoint(block5.Transactions.First().GetHash(), 0)));
-            var block10 = new Block() {Transactions = new List<Transaction>() {tx}};
+            var block10 = new Block() { Transactions = new List<Transaction>() { tx } };
 
             this.consensusManagerMock.Setup(x => x.GetBlockData(It.IsAny<uint256>())).Returns((uint256 hash) =>
             {
@@ -180,7 +185,7 @@ namespace Stratis.Bitcoin.Features.BlockStore.Tests
 
             var outPoint = new OutPoint(uint256.Parse("0000af9ab2c8660481328d0444cf167dfd31f24ca2dbba8e5e963a2434cffa93"), 0);
 
-            var data = new OutPointData() { Outpoint = outPoint.ToString(), ScriptPubKeyBytes = new byte[] {0, 0, 0, 0}, Money = Money.Coins(1) };
+            var data = new OutPointData() { Outpoint = outPoint.ToString(), ScriptPubKeyBytes = new byte[] { 0, 0, 0, 0 }, Money = Money.Coins(1) };
 
             cache.AddOutPointData(data);
 
@@ -272,7 +277,7 @@ namespace Stratis.Bitcoin.Features.BlockStore.Tests
 
             balanceChanges.Add(new AddressBalanceChange() { BalanceChangedHeight = 1, Deposited = true, Satoshi = 1 });
 
-            var data = new AddressIndexerData() { Address = address, BalanceChanges = balanceChanges};
+            var data = new AddressIndexerData() { Address = address, BalanceChanges = balanceChanges };
 
             cache.AddOrUpdate(data.Address, data, data.BalanceChanges.Count + 1);
 

--- a/src/Stratis.Bitcoin.Features.BlockStore/AddressIndexing/AddressIndexer.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/AddressIndexing/AddressIndexer.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using LiteDB;
 using Microsoft.Extensions.Logging;
 using NBitcoin;
+using Stratis.Bitcoin.AsyncWork;
 using Stratis.Bitcoin.Configuration;
 using Stratis.Bitcoin.Consensus;
 using Stratis.Bitcoin.Interfaces;
@@ -50,6 +51,8 @@ namespace Stratis.Bitcoin.Features.BlockStore.AddressIndexing
         private readonly DataFolder dataFolder;
 
         private readonly IConsensusManager consensusManager;
+
+        private readonly IAsyncProvider asyncProvider;
 
         private readonly IScriptAddressReader scriptAddressReader;
 
@@ -94,13 +97,14 @@ namespace Stratis.Bitcoin.Features.BlockStore.AddressIndexing
 
         private readonly AverageCalculator averageTimePerBlock;
 
-        public AddressIndexer(StoreSettings storeSettings, DataFolder dataFolder, ILoggerFactory loggerFactory, Network network, INodeStats nodeStats, IConsensusManager consensusManager)
+        public AddressIndexer(StoreSettings storeSettings, DataFolder dataFolder, ILoggerFactory loggerFactory, Network network, INodeStats nodeStats, IConsensusManager consensusManager, IAsyncProvider asyncProvider)
         {
             this.storeSettings = storeSettings;
             this.network = network;
             this.nodeStats = nodeStats;
             this.dataFolder = dataFolder;
             this.consensusManager = consensusManager;
+            this.asyncProvider = asyncProvider;
             this.loggerFactory = loggerFactory;
             this.scriptAddressReader = new ScriptAddressReader();
 
@@ -124,7 +128,7 @@ namespace Stratis.Bitcoin.Features.BlockStore.AddressIndexing
             string dbPath = Path.Combine(this.dataFolder.RootPath, AddressIndexerDatabaseFilename);
 
             FileMode fileMode = RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? FileMode.Exclusive : FileMode.Shared;
-            this.db = new LiteDatabase(new ConnectionString() {Filename = dbPath, Mode = fileMode });
+            this.db = new LiteDatabase(new ConnectionString() { Filename = dbPath, Mode = fileMode });
 
             this.addressIndexRepository = new AddressIndexRepository(this.db, this.loggerFactory);
 
@@ -154,143 +158,138 @@ namespace Stratis.Bitcoin.Features.BlockStore.AddressIndexing
 
             this.indexingTask = Task.Run(async () => await this.IndexAddressesContinuouslyAsync().ConfigureAwait(false));
 
+            this.asyncProvider.RegisterTask($"{nameof(AddressIndexer)}.{nameof(this.indexingTask)}", this.indexingTask);
+
             this.nodeStats.RegisterStats(this.AddInlineStats, StatsType.Inline, 400);
         }
 
         private async Task IndexAddressesContinuouslyAsync()
         {
-            try
+            Stopwatch watch = Stopwatch.StartNew();
+
+            while (!this.cancellation.IsCancellationRequested)
             {
-                Stopwatch watch = Stopwatch.StartNew();
-
-                while (!this.cancellation.IsCancellationRequested)
+                if (DateTime.Now - this.lastFlushTime > this.flushChangesInterval)
                 {
-                    if (DateTime.Now - this.lastFlushTime > this.flushChangesInterval)
+                    this.logger.LogDebug("Flushing changes.");
+
+                    lock (this.lockObject)
                     {
-                        this.logger.LogDebug("Flushing changes.");
-
-                        lock (this.lockObject)
-                        {
-                            this.addressIndexRepository.SaveAllItems();
-                            this.outpointsRepository.SaveAllItems();
-                            this.tipDataStore.Update(this.tipData);
-                        }
-
-                        this.lastFlushTime = DateTime.Now;
-
-                        this.logger.LogDebug("Flush completed.");
+                        this.addressIndexRepository.SaveAllItems();
+                        this.outpointsRepository.SaveAllItems();
+                        this.tipDataStore.Update(this.tipData);
                     }
 
-                    if (this.cancellation.IsCancellationRequested)
-                        break;
+                    this.lastFlushTime = DateTime.Now;
 
-                    ChainedHeader nextHeader = this.consensusManager.Tip.GetAncestor(this.IndexerTip.Height + 1);
+                    this.logger.LogDebug("Flush completed.");
+                }
 
-                    if (nextHeader == null)
+                if (this.cancellation.IsCancellationRequested)
+                    break;
+
+                ChainedHeader nextHeader = this.consensusManager.Tip.GetAncestor(this.IndexerTip.Height + 1);
+
+                if (nextHeader == null)
+                {
+                    this.logger.LogDebug("Next header wasn't found. Waiting.");
+
+                    try
                     {
-                        this.logger.LogDebug("Next header wasn't found. Waiting.");
-
-                        try
-                        {
-                            await Task.Delay(DelayTimeMs, this.cancellation.Token).ConfigureAwait(false);
-                        }
-                        catch (OperationCanceledException)
-                        {
-                        }
-
-                        continue;
+                        await Task.Delay(DelayTimeMs, this.cancellation.Token).ConfigureAwait(false);
+                    }
+                    catch (OperationCanceledException)
+                    {
                     }
 
-                    if (nextHeader.Previous.HashBlock != this.IndexerTip.HashBlock)
+                    continue;
+                }
+
+                if (nextHeader.Previous.HashBlock != this.IndexerTip.HashBlock)
+                {
+                    ChainedHeader lastCommonHeader = nextHeader.FindFork(this.IndexerTip);
+
+                    this.logger.LogDebug("Reorganization detected. Rewinding till '{0}'.", lastCommonHeader);
+
+                    lock (this.lockObject)
                     {
-                        ChainedHeader lastCommonHeader = nextHeader.FindFork(this.IndexerTip);
+                        // The cache doesn't really lend itself to handling a reorg very well.
+                        // Therefore, we leverage LiteDb's indexing capabilities to tell us
+                        // which records are for the affected blocks.
+                        // TODO: May also be efficient to run ProcessBlocks with inverted deposit flags instead, depending on size of reorg
 
-                        this.logger.LogDebug("Reorganization detected. Rewinding till '{0}'.", lastCommonHeader);
+                        List<string> affectedAddresses = this.addressIndexRepository.GetAddressesHigherThanHeight(lastCommonHeader.Height);
 
-                        lock (this.lockObject)
+                        foreach (string address in affectedAddresses)
                         {
-                            // The cache doesn't really lend itself to handling a reorg very well.
-                            // Therefore, we leverage LiteDb's indexing capabilities to tell us
-                            // which records are for the affected blocks.
-                            // TODO: May also be efficient to run ProcessBlocks with inverted deposit flags instead, depending on size of reorg
-
-                            List<string> affectedAddresses = this.addressIndexRepository.GetAddressesHigherThanHeight(lastCommonHeader.Height);
-
-                            foreach (string address in affectedAddresses)
-                            {
-                                AddressIndexerData indexData = this.addressIndexRepository.GetOrCreateAddress(address);
-                                indexData.BalanceChanges.RemoveAll(x => x.BalanceChangedHeight > lastCommonHeader.Height);
-                            }
+                            AddressIndexerData indexData = this.addressIndexRepository.GetOrCreateAddress(address);
+                            indexData.BalanceChanges.RemoveAll(x => x.BalanceChangedHeight > lastCommonHeader.Height);
                         }
-
-                        this.IndexerTip = lastCommonHeader;
-
-                        lock (this.lockObject)
-                        {
-                            this.tipData.TipHashBytes = this.IndexerTip.HashBlock.ToBytes();
-                        }
-
-                        continue;
                     }
 
-                    // Get next header block and process it.
-                    Block blockToProcess = this.consensusManager.GetBlockData(nextHeader.HashBlock).Block;
-
-                    if (blockToProcess == null)
-                    {
-                        this.logger.LogDebug("Next block wasn't found. Waiting.");
-
-                        try
-                        {
-                            await Task.Delay(DelayTimeMs, this.cancellation.Token).ConfigureAwait(false);
-                        }
-                        catch (OperationCanceledException)
-                        {
-                        }
-
-                        continue;
-                    }
-
-                    watch.Restart();
-
-                    bool success = this.ProcessBlock(blockToProcess, nextHeader);
-
-                    watch.Stop();
-                    this.averageTimePerBlock.AddSample(watch.Elapsed.TotalMilliseconds);
-
-                    if (!success)
-                    {
-                        this.logger.LogDebug("Failed to process next block. Waiting.");
-
-                        try
-                        {
-                            await Task.Delay(DelayTimeMs, this.cancellation.Token).ConfigureAwait(false);
-                        }
-                        catch (OperationCanceledException)
-                        {
-                        }
-
-                        continue;
-                    }
-
-                    this.IndexerTip = nextHeader;
+                    this.IndexerTip = lastCommonHeader;
 
                     lock (this.lockObject)
                     {
                         this.tipData.TipHashBytes = this.IndexerTip.HashBlock.ToBytes();
                     }
+
+                    continue;
                 }
+
+                // Get next header block and process it.
+                Block blockToProcess = this.consensusManager.GetBlockData(nextHeader.HashBlock).Block;
+
+                if (blockToProcess == null)
+                {
+                    this.logger.LogDebug("Next block wasn't found. Waiting.");
+
+                    try
+                    {
+                        await Task.Delay(DelayTimeMs, this.cancellation.Token).ConfigureAwait(false);
+                    }
+                    catch (OperationCanceledException)
+                    {
+                    }
+
+                    continue;
+                }
+
+                watch.Restart();
+
+                bool success = this.ProcessBlock(blockToProcess, nextHeader);
+
+                watch.Stop();
+                this.averageTimePerBlock.AddSample(watch.Elapsed.TotalMilliseconds);
+
+                if (!success)
+                {
+                    this.logger.LogDebug("Failed to process next block. Waiting.");
+
+                    try
+                    {
+                        await Task.Delay(DelayTimeMs, this.cancellation.Token).ConfigureAwait(false);
+                    }
+                    catch (OperationCanceledException)
+                    {
+                    }
+
+                    continue;
+                }
+
+                this.IndexerTip = nextHeader;
 
                 lock (this.lockObject)
                 {
-                    this.addressIndexRepository.SaveAllItems();
-                    this.outpointsRepository.SaveAllItems();
-                    this.tipDataStore.Update(this.tipData);
+                    this.tipData.TipHashBytes = this.IndexerTip.HashBlock.ToBytes();
                 }
             }
-            catch (Exception e)
+
+            lock (this.lockObject)
             {
-                this.logger.LogCritical(e.ToString());
+                this.addressIndexRepository.SaveAllItems();
+                this.outpointsRepository.SaveAllItems();
+                this.tipDataStore.Update(this.tipData);
             }
         }
 

--- a/src/Stratis.Bitcoin/AsyncWork/AsyncProvider.InnerClasses.cs
+++ b/src/Stratis.Bitcoin/AsyncWork/AsyncProvider.InnerClasses.cs
@@ -21,6 +21,18 @@ namespace Stratis.Bitcoin.AsyncWork
         /// <seealso cref="Stratis.Bitcoin.AsyncWork.AsyncProvider.IAsyncTaskInfoSetter" />
         internal class AsyncTaskInfo : IAsyncTaskInfoSetter
         {
+            internal enum AsyncTaskType
+            {
+                /// <summary> Refers to an <see cref="IAsyncLoop"/>.</summary>
+                Loop,
+
+                /// <summary> Refers to an <see cref="IAsyncDelegateDequeuer{T}"/>.</summary>
+                Dequeuer,
+
+                /// <summary> Refers to a registered <see cref="Task"/>.</summary>
+                RegisteredTask
+            }
+
             public string FriendlyName { get; }
 
             /// <summary>
@@ -35,14 +47,9 @@ namespace Stratis.Bitcoin.AsyncWork
             Exception IAsyncTaskInfoSetter.Exception { set => this.Exception = value; }
 
             /// <summary>
-            /// Gets a value indicating whether this instance contains an <see cref="IAsyncLoop"/> information.
+            /// Specifies which type of async worker this instance contains information about.
             /// </summary>
-            public bool IsLoop { get; }
-
-            /// <summary>
-            /// Gets a value indicating whether this instance contains an <see cref="IAsyncDelegateDequeuer{T}"/> information.
-            /// </summary>
-            public bool IsDelegateWorker { get; }
+            public AsyncTaskType Type { get; }
 
             public bool IsRunning => this.Status != TaskStatus.Faulted;
 
@@ -51,11 +58,10 @@ namespace Stratis.Bitcoin.AsyncWork
             /// </summary>
             /// <param name="friendlyName">Friendly name of the async delegate.</param>
             /// <param name="isDelegateWorker">if set to <c>true</c> the information represents an <see cref="IAsyncDelegateDequeuer"/>, otherwise an <see cref="IAsyncLoop"/>.</param>
-            public AsyncTaskInfo(string friendlyName, bool isDelegateWorker)
+            public AsyncTaskInfo(string friendlyName, AsyncTaskType type)
             {
                 this.FriendlyName = friendlyName;
-                this.IsDelegateWorker = isDelegateWorker;
-                this.IsLoop = !isDelegateWorker;
+                this.Type = type;
             }
         }
     }

--- a/src/Stratis.Bitcoin/AsyncWork/AsyncProvider.cs
+++ b/src/Stratis.Bitcoin/AsyncWork/AsyncProvider.cs
@@ -187,7 +187,7 @@ namespace Stratis.Bitcoin.AsyncWork
                 TaskScheduler.Default
                 );
 
-            // task will continue with onAsyncDelegateCompleted if @delegate completed or was canceled
+            // task will continue with OnRegisteredTaskCompleted if @delegate completed or was canceled
             taskToRegister.ContinueWith(
                 this.OnRegisteredTaskCompleted,
                 CancellationToken.None,

--- a/src/Stratis.Bitcoin/AsyncWork/AsyncProvider.cs
+++ b/src/Stratis.Bitcoin/AsyncWork/AsyncProvider.cs
@@ -238,7 +238,7 @@ namespace Stratis.Bitcoin.AsyncWork
         {
             lock (this.lockRegisteredTasks)
             {
-                // task in the dictionaries are either running or faulted so we just look for a dequeuer with the given name and status not faulted.
+                // task in the dictionaries are either running or faulted so we just look for a registered task with the given name and status not faulted.
                 return this.registeredTasks.Values.Any(@delegate => @delegate.FriendlyName == name && @delegate.Status != TaskStatus.Faulted && @delegate.Type == AsyncTaskInfo.AsyncTaskType.RegisteredTask);
             }
         }

--- a/src/Stratis.Bitcoin/AsyncWork/AsyncProvider.cs
+++ b/src/Stratis.Bitcoin/AsyncWork/AsyncProvider.cs
@@ -28,7 +28,7 @@ namespace Stratis.Bitcoin.AsyncWork
         private Dictionary<IAsyncDelegate, AsyncTaskInfo> asyncDelegates;
 
         /// <summary>
-        /// Holds a list of currently registered tasks with their healthy status.
+        /// Holds a list of currently registered tasks with their health status.
         /// Protected by <see cref="lockRegisteredTasks"/> lock
         /// </summary>
         private Dictionary<Task, AsyncTaskInfo> registeredTasks;

--- a/src/Stratis.Bitcoin/AsyncWork/AsyncProvider.cs
+++ b/src/Stratis.Bitcoin/AsyncWork/AsyncProvider.cs
@@ -234,7 +234,7 @@ namespace Stratis.Bitcoin.AsyncWork
         }
 
         /// <inheritdoc />
-        public bool IsRegisteredTask(string name)
+        public bool IsRegisteredTaskRunning(string name)
         {
             lock (this.lockRegisteredTasks)
             {

--- a/src/Stratis.Bitcoin/AsyncWork/AsyncProvider.cs
+++ b/src/Stratis.Bitcoin/AsyncWork/AsyncProvider.cs
@@ -179,7 +179,7 @@ namespace Stratis.Bitcoin.AsyncWork
                 this.registeredTasks.Add(taskToRegister, new AsyncTaskInfo(name, AsyncTaskInfo.AsyncTaskType.RegisteredTask));
             }
 
-            // task will continue with onAsyncDelegateUnhandledException if @delegate had unhandled exceptions
+            // task will continue with OnRegisteredTaskUnhandledException if @delegate had unhandled exceptions
             taskToRegister.ContinueWith(
                 this.OnRegisteredTaskUnhandledException,
                 CancellationToken.None,

--- a/src/Stratis.Bitcoin/AsyncWork/AsyncProvider.cs
+++ b/src/Stratis.Bitcoin/AsyncWork/AsyncProvider.cs
@@ -19,12 +19,19 @@ namespace Stratis.Bitcoin.AsyncWork
         private const int DefaultLoopRepeatInterval = 1000;
 
         private object lockAsyncDelegates;
+        private object lockRegisteredTasks;
 
         /// <summary>
         /// Holds a list of currently running async delegates or delegates that stopped because of unhandled exceptions.
         /// Protected by <see cref="lockAsyncDelegates"/> lock
         /// </summary>
         private Dictionary<IAsyncDelegate, AsyncTaskInfo> asyncDelegates;
+
+        /// <summary>
+        /// Holds a list of currently registered tasks with their healthy status.
+        /// Protected by <see cref="lockRegisteredTasks"/> lock
+        /// </summary>
+        private Dictionary<Task, AsyncTaskInfo> registeredTasks;
 
         private ILoggerFactory loggerFactory;
         private ILogger logger;
@@ -41,8 +48,10 @@ namespace Stratis.Bitcoin.AsyncWork
         public AsyncProvider(ILoggerFactory loggerFactory, ISignals signals, INodeLifetime nodeLifetime)
         {
             this.lockAsyncDelegates = new object();
+            this.lockRegisteredTasks = new object();
 
             this.asyncDelegates = new Dictionary<IAsyncDelegate, AsyncTaskInfo>();
+            this.registeredTasks = new Dictionary<Task, AsyncTaskInfo>();
 
             this.loggerFactory = Guard.NotNull(loggerFactory, nameof(loggerFactory));
             this.logger = this.loggerFactory.CreateLogger(this.GetType().FullName);
@@ -60,12 +69,12 @@ namespace Stratis.Bitcoin.AsyncWork
             {
                 newDelegate = new AsyncQueue<T>(new AsyncQueue<T>.OnEnqueueAsync(@delegate));
 
-                this.asyncDelegates.Add(newDelegate, new AsyncTaskInfo(friendlyName, true));
+                this.asyncDelegates.Add(newDelegate, new AsyncTaskInfo(friendlyName, AsyncTaskInfo.AsyncTaskType.Dequeuer));
             }
 
             // task will continue with onAsyncDelegateUnhandledException if @delegate had unhandled exceptions
             newDelegate.ConsumerTask.ContinueWith(
-                this.onAsyncDelegateUnhandledException,
+                this.OnAsyncDelegateUnhandledException,
                 newDelegate,
                 CancellationToken.None,
                 TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
@@ -74,7 +83,7 @@ namespace Stratis.Bitcoin.AsyncWork
 
             // task will continue with onAsyncDelegateCompleted if @delegate completed or was canceled
             newDelegate.ConsumerTask.ContinueWith(
-                this.onAsyncDelegateCompleted,
+                this.OnAsyncDelegateCompleted,
                 newDelegate,
                 CancellationToken.None,
                 TaskContinuationOptions.NotOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
@@ -97,14 +106,14 @@ namespace Stratis.Bitcoin.AsyncWork
             Task loopTask;
             lock (this.asyncDelegates)
             {
-                this.asyncDelegates.Add(loopInstance, new AsyncTaskInfo(name, false));
+                this.asyncDelegates.Add(loopInstance, new AsyncTaskInfo(name, AsyncTaskInfo.AsyncTaskType.Loop));
             }
 
             loopTask = loopInstance.Run(cancellation, repeatEvery ?? TimeSpan.FromMilliseconds(DefaultLoopRepeatInterval), startAfter).RunningTask;
 
             // task will continue with onAsyncDelegateUnhandledException if @delegate had unhandled exceptions
             loopTask.ContinueWith(
-                this.onAsyncDelegateUnhandledException,
+                this.OnAsyncDelegateUnhandledException,
                 loopInstance,
                 CancellationToken.None,
                 TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
@@ -113,7 +122,7 @@ namespace Stratis.Bitcoin.AsyncWork
 
             // task will continue with onAsyncDelegateCompleted if @delegate completed or was canceled
             loopTask.ContinueWith(
-                this.onAsyncDelegateCompleted,
+                this.OnAsyncDelegateCompleted,
                 loopInstance,
                 CancellationToken.None,
                 TaskContinuationOptions.NotOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
@@ -158,6 +167,38 @@ namespace Stratis.Bitcoin.AsyncWork
         }
 
         /// <inheritdoc />
+        public Task RegisterTask(string name, Task taskToRegister)
+        {
+            Guard.NotEmpty(name, nameof(name));
+            Guard.NotNull(taskToRegister, nameof(taskToRegister));
+
+            // instantiate the loop
+
+            lock (this.lockRegisteredTasks)
+            {
+                this.registeredTasks.Add(taskToRegister, new AsyncTaskInfo(name, AsyncTaskInfo.AsyncTaskType.RegisteredTask));
+            }
+
+            // task will continue with onAsyncDelegateUnhandledException if @delegate had unhandled exceptions
+            taskToRegister.ContinueWith(
+                this.OnRegisteredTaskUnhandledException,
+                CancellationToken.None,
+                TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+                TaskScheduler.Default
+                );
+
+            // task will continue with onAsyncDelegateCompleted if @delegate completed or was canceled
+            taskToRegister.ContinueWith(
+                this.OnRegisteredTaskCompleted,
+                CancellationToken.None,
+                TaskContinuationOptions.NotOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+                TaskScheduler.Default
+                );
+
+            return taskToRegister;
+        }
+
+        /// <inheritdoc />
         public bool IsAsyncDelegateDequeuerRunning(IAsyncDelegate asyncDelegate)
         {
             lock (this.lockAsyncDelegates)
@@ -178,7 +219,7 @@ namespace Stratis.Bitcoin.AsyncWork
             lock (this.lockAsyncDelegates)
             {
                 // task in the dictionaries are either running or faulted so we just look for an IAsyncDelegate with the given name and status not faulted.
-                return this.asyncDelegates.Values.Any(@delegate => @delegate.FriendlyName == name && @delegate.Status != TaskStatus.Faulted && @delegate.IsDelegateWorker == true);
+                return this.asyncDelegates.Values.Any(@delegate => @delegate.FriendlyName == name && @delegate.Status != TaskStatus.Faulted && @delegate.Type == AsyncTaskInfo.AsyncTaskType.Dequeuer);
             }
         }
 
@@ -188,7 +229,17 @@ namespace Stratis.Bitcoin.AsyncWork
             lock (this.lockAsyncDelegates)
             {
                 // task in the dictionaries are either running or faulted so we just look for a dequeuer with the given name and status not faulted.
-                return this.asyncDelegates.Values.Any(@delegate => @delegate.FriendlyName == name && @delegate.Status != TaskStatus.Faulted && @delegate.IsLoop == true);
+                return this.asyncDelegates.Values.Any(@delegate => @delegate.FriendlyName == name && @delegate.Status != TaskStatus.Faulted && @delegate.Type == AsyncTaskInfo.AsyncTaskType.Loop);
+            }
+        }
+
+        /// <inheritdoc />
+        public bool IsRegisteredTask(string name)
+        {
+            lock (this.lockRegisteredTasks)
+            {
+                // task in the dictionaries are either running or faulted so we just look for a dequeuer with the given name and status not faulted.
+                return this.registeredTasks.Values.Any(@delegate => @delegate.FriendlyName == name && @delegate.Status != TaskStatus.Faulted && @delegate.Type == AsyncTaskInfo.AsyncTaskType.RegisteredTask);
             }
         }
 
@@ -196,15 +247,19 @@ namespace Stratis.Bitcoin.AsyncWork
         [NoTrace]
         public string GetStatistics(bool faultyOnly)
         {
-            List<KeyValuePair<IAsyncDelegate, AsyncTaskInfo>> taskInformationsDump;
+            var taskInformations = new List<AsyncTaskInfo>();
             lock (this.lockAsyncDelegates)
             {
-                // takes a snapshot of the informations.
-                taskInformationsDump = this.asyncDelegates.ToList();
+                taskInformations.AddRange(this.asyncDelegates.Values);
             }
 
-            int running = taskInformationsDump.Where(info => info.Value.IsRunning).Count();
-            int faulted = taskInformationsDump.Where(info => !info.Value.IsRunning).Count();
+            lock (this.lockRegisteredTasks)
+            {
+                taskInformations.AddRange(this.registeredTasks.Values);
+            }
+
+            int running = taskInformations.Where(info => info.IsRunning).Count();
+            int faulted = taskInformations.Where(info => !info.IsRunning).Count();
 
             var sb = new StringBuilder();
             sb.AppendLine();
@@ -214,15 +269,14 @@ namespace Stratis.Bitcoin.AsyncWork
                 return sb.ToString(); // If there are no faulty tasks and faultOnly is set to true, return just the header.
 
             var data =
-                from item in taskInformationsDump
-                let info = item.Value
+                from info in taskInformations
                 orderby info.FriendlyName
                 select new
                 {
                     Columns = new string[]
                     {
                         info.FriendlyName,
-                        (info.IsLoop ? "Loop" : "Dequeuer"),
+                        (info.Type.ToString()),
                         (info.IsRunning ? "Running" : "Faulted")
                     },
                     Exception = info.Exception?.Message
@@ -262,13 +316,64 @@ namespace Stratis.Bitcoin.AsyncWork
             return sb.ToString();
         }
 
+        private void OnRegisteredTaskCompleted(Task task)
+        {
+            AsyncTaskInfo itemToRemove;
+            lock (this.lockRegisteredTasks)
+            {
+                if (this.registeredTasks.TryGetValue(task, out itemToRemove))
+                {
+                    this.registeredTasks.Remove(task);
+                }
+            }
+
+            if (itemToRemove != null)
+            {
+                this.logger.LogTrace("Registered task '{0}' Removed. Id: {1}.", itemToRemove.FriendlyName, task.Id);
+            }
+            else
+            {
+                // Should never happen.
+                this.logger.LogError("Cannot find the registered task with Id {0}.", task.Id);
+            }
+        }
+
+        /// <summary>
+        ///  This method is called when a registered Task throws an unhandled exception.
+        /// </summary>
+        /// <param name="task">The task causing the exception.</param>
+        /// <param name="state">not used</param>
+        private void OnRegisteredTaskUnhandledException(Task task)
+        {
+            AsyncTaskInfo delegateInfo;
+            lock (this.lockRegisteredTasks)
+            {
+                if (this.registeredTasks.TryGetValue(task, out delegateInfo))
+                {
+                    // casted to IAsyncTaskInfoSetter to be able to set properties
+                    IAsyncTaskInfoSetter infoSetter = delegateInfo;
+
+                    infoSetter.Exception = task.Exception.GetBaseException();
+                    infoSetter.Status = task.Status;
+                }
+                else
+                {
+                    // Should never happen.
+                    this.logger.LogError("Cannot find the registered task with Id {0}.", task.Id);
+                    return;
+                }
+
+                this.logger.LogError(task.Exception.GetBaseException(), "Unhandled exception for registered task {0}.", delegateInfo.FriendlyName);
+            }
+        }
+
         /// <summary>
         ///  This method is called when a Task running an <see cref="IAsyncDelegate"/> captured an unhandled exception.
         /// </summary>
         /// <param name="task">The delegate task.</param>
         /// <param name="state">The <see cref="IAsyncDelegate"/> that's run by the delegateTask</param>
         /// <remarks>state can be either of type <see cref="IAsyncDelegateDequeuer{T}"/> or <see cref="IAsyncLoop"/></remarks>
-        private void onAsyncDelegateUnhandledException(Task task, object state)
+        private void OnAsyncDelegateUnhandledException(Task task, object state)
         {
             AsyncTaskInfo delegateInfo;
             lock (this.lockAsyncDelegates)
@@ -298,7 +403,7 @@ namespace Stratis.Bitcoin.AsyncWork
         /// </summary>
         /// <param name="task">The delegate task.</param>
         /// <param name="state">The <see cref="IAsyncDelegate"/> that's run by the delegateTask</param>
-        private void onAsyncDelegateCompleted(Task task, object state)
+        private void OnAsyncDelegateCompleted(Task task, object state)
         {
             AsyncTaskInfo itemToRemove;
             lock (this.lockAsyncDelegates)

--- a/src/Stratis.Bitcoin/AsyncWork/IAsyncProvider.cs
+++ b/src/Stratis.Bitcoin/AsyncWork/IAsyncProvider.cs
@@ -92,7 +92,7 @@ namespace Stratis.Bitcoin.AsyncWork
         ///   <c>true</c> if the specified <see cref="IAsyncDelegate" /> is currently running, otherwise, <c>false</c>.
         /// </returns>
         /// <remarks>
-        /// Names are not granted to be unique, consider adding prefixes to names when loops are transient and does not act like singletons.
+        /// Names are not guaranteed to be unique, consider adding prefixes to names when loops are transient and does not act like singletons.
         /// This method is mostly used for tests.
         /// state can be either of type <see cref="IAsyncDelegateDequeuer{T}" /> or <see cref="IAsyncLoop" />
         /// </remarks>
@@ -106,7 +106,7 @@ namespace Stratis.Bitcoin.AsyncWork
         ///   <c>true</c> if a <see cref="Task" /> with the specified name is currently running, otherwise, <c>false</c>.
         /// </returns>
         /// <remarks>
-        /// Names are not granted to be unique, consider adding prefixes to names when <see cref="IAsyncLoop" /> are transient and does not act like singletons. This method is mostly used for tests.
+        /// Names are not guaranteed to be unique, consider adding prefixes to names when <see cref="IAsyncLoop" /> are transient and does not act like singletons. This method is mostly used for tests.
         /// </remarks>
         bool IsRegisteredTask(string name);
 

--- a/src/Stratis.Bitcoin/AsyncWork/IAsyncProvider.cs
+++ b/src/Stratis.Bitcoin/AsyncWork/IAsyncProvider.cs
@@ -52,6 +52,15 @@ namespace Stratis.Bitcoin.AsyncWork
         IAsyncLoop CreateAndRunAsyncLoopUntil(string name, CancellationToken cancellation, Func<bool> condition, Action action, Action<Exception> onException, TimeSpan? repeatEvery = null, TimeSpan? startAfter = null);
 
         /// <summary>
+        /// Registers the passed task to be able to monitor it's healthy status.
+        /// It doesn't perform any schedule on the task, it's all up to the caller to handle the task life-cycle.
+        /// </summary>
+        /// <param name="name">The name assigned to the task.</param>
+        /// <param name="taskToRegister">The task to register.</param>
+        /// <returns>The same task passed as argument</returns>
+        Task RegisterTask(string name, Task taskToRegister);
+
+        /// <summary>
         /// Determines whether an <see cref="IAsyncDelegateDequeuer{T}" /> with the specified name is running.
         /// </summary>
         /// <param name="name">The name.</param>
@@ -71,7 +80,7 @@ namespace Stratis.Bitcoin.AsyncWork
         ///   <c>true</c> if an <see cref="IAsyncLoop" /> with the specified name is currently running, otherwise, <c>false</c>.
         /// </returns>
         /// <remarks>
-        /// Names are not unique, consider adding prefixes to names when <see cref="IAsyncLoop" /> are transient and does not act like singletons. This method is mostly used for tests.
+        /// Names are not granted to be unique, consider adding prefixes to names when <see cref="IAsyncLoop" /> are transient and does not act like singletons. This method is mostly used for tests.
         /// </remarks>
         bool IsAsyncLoopRunning(string name);
 
@@ -83,11 +92,23 @@ namespace Stratis.Bitcoin.AsyncWork
         ///   <c>true</c> if the specified <see cref="IAsyncDelegate" /> is currently running, otherwise, <c>false</c>.
         /// </returns>
         /// <remarks>
-        /// Names are not unique, consider adding prefixes to names when loops are transient and does not act like singletons.
+        /// Names are not granted to be unique, consider adding prefixes to names when loops are transient and does not act like singletons.
         /// This method is mostly used for tests.
         /// state can be either of type <see cref="IAsyncDelegateDequeuer{T}" /> or <see cref="IAsyncLoop" />
         /// </remarks>
         bool IsAsyncDelegateDequeuerRunning(IAsyncDelegate asyncDelegate);
+
+        /// <summary>
+        /// Determines whether a registered <see cref="Task" /> with the specified name is running.
+        /// </summary>
+        /// <param name="name">The friendly name of the task.</param>
+        /// <returns>
+        ///   <c>true</c> if a <see cref="Task" /> with the specified name is currently running, otherwise, <c>false</c>.
+        /// </returns>
+        /// <remarks>
+        /// Names are not granted to be unique, consider adding prefixes to names when <see cref="IAsyncLoop" /> are transient and does not act like singletons. This method is mostly used for tests.
+        /// </remarks>
+        bool IsRegisteredTask(string name);
 
         /// <summary>
         /// returns statistics about running or faulted async loops.

--- a/src/Stratis.Bitcoin/AsyncWork/IAsyncProvider.cs
+++ b/src/Stratis.Bitcoin/AsyncWork/IAsyncProvider.cs
@@ -52,7 +52,7 @@ namespace Stratis.Bitcoin.AsyncWork
         IAsyncLoop CreateAndRunAsyncLoopUntil(string name, CancellationToken cancellation, Func<bool> condition, Action action, Action<Exception> onException, TimeSpan? repeatEvery = null, TimeSpan? startAfter = null);
 
         /// <summary>
-        /// Registers the passed task to be able to monitor it's healthy status.
+        /// Registers the passed task to be able to monitor it's health status.
         /// It doesn't perform any schedule on the task, it's all up to the caller to handle the task life-cycle.
         /// </summary>
         /// <param name="name">The name assigned to the task.</param>
@@ -80,7 +80,7 @@ namespace Stratis.Bitcoin.AsyncWork
         ///   <c>true</c> if an <see cref="IAsyncLoop" /> with the specified name is currently running, otherwise, <c>false</c>.
         /// </returns>
         /// <remarks>
-        /// Names are not granted to be unique, consider adding prefixes to names when <see cref="IAsyncLoop" /> are transient and does not act like singletons. This method is mostly used for tests.
+        /// Names are not guaranteed to be unique, consider adding prefixes to names when <see cref="IAsyncLoop" /> are transient and does not act like singletons. This method is mostly used for tests.
         /// </remarks>
         bool IsAsyncLoopRunning(string name);
 

--- a/src/Stratis.Bitcoin/AsyncWork/IAsyncProvider.cs
+++ b/src/Stratis.Bitcoin/AsyncWork/IAsyncProvider.cs
@@ -108,7 +108,7 @@ namespace Stratis.Bitcoin.AsyncWork
         /// <remarks>
         /// Names are not guaranteed to be unique, consider adding prefixes to names when <see cref="IAsyncLoop" /> are transient and does not act like singletons. This method is mostly used for tests.
         /// </remarks>
-        bool IsRegisteredTask(string name);
+        bool IsRegisteredTaskRunning(string name);
 
         /// <summary>
         /// returns statistics about running or faulted async loops.


### PR DESCRIPTION
Implemented an AsyncProvider method to register simple task and handle their healthy status and used such method (AsyncProvider.RegisterTask) to register AddressIndexer indexing Task.

This way if it fails we have evidence in the AsyncProvider statistic output