### PR TITLE
[FS] Handle collateral checker not initialized

### DIFF
--- a/src/Stratis.Bitcoin.Features.PoA/PoAConsensusErrors.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/PoAConsensusErrors.cs
@@ -20,5 +20,7 @@ namespace Stratis.Bitcoin.Features.PoA
 
         // Collateral related errors.
         public static ConsensusError InvalidCollateralAmount => new ConsensusError("invalid-collateral-amount", "collateral requirement is not fulfilled");
+
+        public static ConsensusError CollateralCheckerNotReady => new ConsensusError("collateral-checker-not-ready", "collateral checker is not ready");
     }
 }

--- a/src/Stratis.Bitcoin.Features.PoA/PoAMiner.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/PoAMiner.cs
@@ -157,7 +157,7 @@ namespace Stratis.Bitcoin.Features.PoA
                     builder.AppendLine("<<==============================================================>>");
                     this.logger.LogInformation(builder.ToString());
                 }
-                catch (ConsensusException err) when (err.Message == "collateral checker is not ready")
+                catch (ConsensusException err) when (err.Message == PoAConsensusErrors.CollateralCheckerNotReady.Message)
                 {
                     // Retry.
                 }

--- a/src/Stratis.Bitcoin.Features.PoA/PoAMiner.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/PoAMiner.cs
@@ -157,6 +157,10 @@ namespace Stratis.Bitcoin.Features.PoA
                     builder.AppendLine("<<==============================================================>>");
                     this.logger.LogInformation(builder.ToString());
                 }
+                catch (ConsensusException err) when (err.Message == "collateral checker is not ready")
+                {
+                    // Retry.
+                }
                 catch (OperationCanceledException)
                 {
                 }

--- a/src/Stratis.Features.FederatedPeg/Collateral/CollateralChecker.cs
+++ b/src/Stratis.Features.FederatedPeg/Collateral/CollateralChecker.cs
@@ -194,7 +194,7 @@ namespace Stratis.Features.FederatedPeg.Collateral
             if (!this.isInitialized)
             {
                 this.logger.LogTrace("(-)[NOT_INITIALIZED]");
-                throw new Exception("Component is not initialized!");
+                PoAConsensusErrors.CollateralCheckerNotReady.Throw();
             }
 
             var member = federationMember as CollateralFederationMember;


### PR DESCRIPTION
The collateral checker throws an error due to not being initialized. This happens when the mining loop causes the collateral checker to be called. The solution is to handle the error in the mining loop to prevent the loop from exiting.

See https://stratisplatformuk.visualstudio.com/StratisBitcoinFullNode/_workitems/edit/3782,