### PR TITLE
[POA] Handle the CollateralChecker not initialized exception

### DIFF
--- a/src/Stratis.Bitcoin.Features.PoA/PoAConsensusErrors.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/PoAConsensusErrors.cs
@@ -19,6 +19,8 @@ namespace Stratis.Bitcoin.Features.PoA
         public static ConsensusError VotingDataInvalidFormat => new ConsensusError("invalid-voting-data-format", "voting data format is invalid");
 
         // Collateral related errors.
+        public static ConsensusError CollateralCheckerNotReady => new ConsensusError("collateral-checker-not-ready", "collateral checker is not ready");
+
         public static ConsensusError InvalidCollateralAmount => new ConsensusError("invalid-collateral-amount", "collateral requirement is not fulfilled");
     }
 }

--- a/src/Stratis.Features.FederatedPeg.Tests/CheckCollateralFullValidationRuleTests.cs
+++ b/src/Stratis.Features.FederatedPeg.Tests/CheckCollateralFullValidationRuleTests.cs
@@ -56,7 +56,7 @@ namespace Stratis.Features.FederatedPeg.Tests
         [Fact]
         public async Task PassesIfCollateralIsOkAsync()
         {
-            this.collateralCheckerMock.Setup(x => x.CheckCollateral(It.IsAny<IFederationMember>())).Returns(true);
+            this.collateralCheckerMock.Setup(x => x.CheckCollateral(It.IsAny<IFederationMember>())).Returns(CheckCollateralResult.Passed());
 
             await this.rule.RunAsync(this.ruleContext);
         }
@@ -64,7 +64,7 @@ namespace Stratis.Features.FederatedPeg.Tests
         [Fact]
         public async Task ThrowsIfCollateralCheckFailsAsync()
         {
-            this.collateralCheckerMock.Setup(x => x.CheckCollateral(It.IsAny<IFederationMember>())).Returns(false);
+            this.collateralCheckerMock.Setup(x => x.CheckCollateral(It.IsAny<IFederationMember>())).Returns(CheckCollateralResult.Failed());
 
             await Assert.ThrowsAsync<ConsensusErrorException>(() => this.rule.RunAsync(this.ruleContext));
         }

--- a/src/Stratis.Features.FederatedPeg.Tests/CollateralCheckerTests.cs
+++ b/src/Stratis.Features.FederatedPeg.Tests/CollateralCheckerTests.cs
@@ -92,9 +92,9 @@ namespace Stratis.Features.FederatedPeg.Tests
 
             await this.collateralChecker.InitializeAsync();
 
-            Assert.True(this.collateralChecker.CheckCollateral(this.collateralFederationMembers[0]));
-            Assert.True(this.collateralChecker.CheckCollateral(this.collateralFederationMembers[1]));
-            Assert.False(this.collateralChecker.CheckCollateral(this.collateralFederationMembers[2]));
+            Assert.True(this.collateralChecker.CheckCollateral(this.collateralFederationMembers[0]).Succeeded);
+            Assert.True(this.collateralChecker.CheckCollateral(this.collateralFederationMembers[1]).Succeeded);
+            Assert.False(this.collateralChecker.CheckCollateral(this.collateralFederationMembers[2]).Succeeded);
 
             // Now change what the client returns and make sure collateral check fails after update.
             AddressBalanceModel updated = collateralData.Balances.First(b => b.Address == this.collateralFederationMembers[0].CollateralMainchainAddress);
@@ -103,7 +103,7 @@ namespace Stratis.Features.FederatedPeg.Tests
             // Wait CollateralUpdateIntervalSeconds + 1 seconds
 
             await Task.Delay(21_000);
-            Assert.False(this.collateralChecker.CheckCollateral(this.collateralFederationMembers[0]));
+            Assert.False(this.collateralChecker.CheckCollateral(this.collateralFederationMembers[0]).Succeeded);
 
             this.collateralChecker.Dispose();
         }

--- a/src/Stratis.Features.FederatedPeg/Collateral/CheckCollateralFullValidationRule.cs
+++ b/src/Stratis.Features.FederatedPeg/Collateral/CheckCollateralFullValidationRule.cs
@@ -41,10 +41,16 @@ namespace Stratis.Features.FederatedPeg.Collateral
 
             IFederationMember federationMember = this.slotsManager.GetFederationMemberForTimestamp(context.ValidationContext.BlockToValidate.Header.Time);
 
-            if (!this.collateralChecker.CheckCollateral(federationMember))
+            CheckCollateralResult result = this.collateralChecker.CheckCollateral(federationMember);
+
+            if (!result.IsInitialized)
+            {
+                PoAConsensusErrors.CollateralCheckerNotReady.Throw();
+            }
+
+            if (!result.Succeeded)
             {
                 context.ValidationContext.RejectUntil = this.dateTime.GetUtcNow() + TimeSpan.FromMinutes(CollateralCheckBanDurationMinutes);
-
                 this.Logger.LogTrace("(-)[BAD_COLLATERAL]");
                 PoAConsensusErrors.InvalidCollateralAmount.Throw();
             }

--- a/src/Stratis.Features.FederatedPeg/Collateral/CheckCollateralResult.cs
+++ b/src/Stratis.Features.FederatedPeg/Collateral/CheckCollateralResult.cs
@@ -1,0 +1,34 @@
+﻿namespace Stratis.Features.FederatedPeg.Collateral
+{
+    /// <summary>
+    /// Returns information with regards to checking a particular federation member's collateral.
+    /// </summary>
+    public sealed class CheckCollateralResult
+    {
+        private CheckCollateralResult() { }
+
+        /// <summary>A flag indicating the <see cref="CollateralChecker"/>'s initialization status.</summary>
+        public bool IsInitialized { get; private set; }
+
+        /// <summary><c>True</c> if the federation member's collateral amount is valid.</summary>
+        public bool Succeeded { get; private set; }
+
+        /// <summary>Indicates that the the collateral amount of the federation member is not valid.</summary>
+        public static CheckCollateralResult Failed()
+        {
+            return new CheckCollateralResult() { IsInitialized = true };
+        }
+
+        /// <summary>Indicates that the collateral checker is not yet initialized.</summary>
+        public static CheckCollateralResult NotInitialized()
+        {
+            return new CheckCollateralResult();
+        }
+
+        /// <summary>Indicates that the collateral checker is initialized and that the federation member's collateral amount is valid.</summary>
+        public static CheckCollateralResult Passed()
+        {
+            return new CheckCollateralResult() { IsInitialized = true, Succeeded = true };
+        }
+    }
+}

--- a/src/Stratis.Features.FederatedPeg/Collateral/CollateralChecker.cs
+++ b/src/Stratis.Features.FederatedPeg/Collateral/CollateralChecker.cs
@@ -24,7 +24,7 @@ namespace Stratis.Features.FederatedPeg.Collateral
         /// <summary>Checks if given federation member fulfills the collateral requirement.</summary>
         /// <param name="federationMember">The federation member to check.</param>
         /// <returns>
-        /// A result class indicating whether or not the collateral check was able to be done due to the it's initialization status
+        /// A result class indicating whether or not the collateral check was able to be done due to it's initialization status
         /// and if the check succeeded (i.e. the federation member has enough collateral).
         /// </returns>
         CheckCollateralResult CheckCollateral(IFederationMember federationMember);


### PR DESCRIPTION
This is an alternative to:

https://stratisplatformuk.visualstudio.com/StratisBitcoinFullNode/_workitems/edit/3782

It is better to work with a result class and then throw from the rule if the collateral checker is not yet fully initialized before trying to validate a block.