### PR TITLE
[POA] Handle the CollateralChecker not initialized exception, round #2

### DIFF
--- a/src/Stratis.Bitcoin.Features.PoA/FederationMember.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/FederationMember.cs
@@ -77,7 +77,6 @@ namespace Stratis.Bitcoin.Features.PoA
         /// <summary>Mainchain address that should have the collateral.</summary>
         public string CollateralMainchainAddress { get; set; }
 
-
         /// <inheritdoc />
         public override bool Equals(object obj)
         {

--- a/src/Stratis.Features.FederatedPeg/Collateral/CollateralChecker.cs
+++ b/src/Stratis.Features.FederatedPeg/Collateral/CollateralChecker.cs
@@ -93,7 +93,7 @@ namespace Stratis.Features.FederatedPeg.Collateral
             {
                 await this.UpdateCollateralInfoAsync(this.cancellationSource.Token).ConfigureAwait(false);
 
-                await this.DelayCollateralCheckAsync();
+                await this.DelayCollateralCheckAsync().ConfigureAwait(false);
             }
 
             this.updateCollateralContinuouslyTask = this.UpdateCollateralInfoContinuouslyAsync();
@@ -108,10 +108,13 @@ namespace Stratis.Features.FederatedPeg.Collateral
 
                 this.logger.LogWarning("Node initialization will not continue until the gateway node responds.");
 
-                await this.DelayCollateralCheckAsync();
+                await this.DelayCollateralCheckAsync().ConfigureAwait(false);
             }
         }
 
+        /// <summary>
+        /// Delay checking the federation member's collateral with <see cref="CollateralUpdateIntervalSeconds"/> seconds.
+        /// </summary>
         private async Task DelayCollateralCheckAsync()
         {
             try

--- a/src/Stratis.Features.FederatedPeg/Collateral/CollateralChecker.cs
+++ b/src/Stratis.Features.FederatedPeg/Collateral/CollateralChecker.cs
@@ -93,6 +93,8 @@ namespace Stratis.Features.FederatedPeg.Collateral
             {
                 await this.UpdateCollateralInfoAsync(this.cancellationSource.Token).ConfigureAwait(false);
 
+                this.logger.LogWarning("Node initialization will not continue until the gateway node responds.");
+
                 await this.DelayCollateralCheckAsync().ConfigureAwait(false);
             }
 
@@ -105,8 +107,6 @@ namespace Stratis.Features.FederatedPeg.Collateral
             while (!this.cancellationSource.IsCancellationRequested)
             {
                 await this.UpdateCollateralInfoAsync(this.cancellationSource.Token).ConfigureAwait(false);
-
-                this.logger.LogWarning("Node initialization will not continue until the gateway node responds.");
 
                 await this.DelayCollateralCheckAsync().ConfigureAwait(false);
             }

--- a/src/Stratis.Features.FederatedPeg/Collateral/CollateralChecker.cs
+++ b/src/Stratis.Features.FederatedPeg/Collateral/CollateralChecker.cs
@@ -22,6 +22,7 @@ namespace Stratis.Features.FederatedPeg.Collateral
         Task InitializeAsync();
 
         /// <summary>Checks if given federation member fulfills the collateral requirement.</summary>
+        /// <param name="federationMember">The federation member whose collateral will be checked.</param>
         bool CheckCollateral(IFederationMember federationMember);
     }
 
@@ -42,6 +43,8 @@ namespace Stratis.Features.FederatedPeg.Collateral
 
         private SubscriptionToken memberAddedToken, memberKickedToken;
 
+        private const string CollateralCheckFailedMessage = "Failed to update collateral, please ensure that the mainnet gateway node is running and it's API feature is enabled.";
+
         /// <summary>Amount of confirmations required for collateral.</summary>
         private const int RequiredConfirmations = 1;
 
@@ -58,7 +61,7 @@ namespace Stratis.Features.FederatedPeg.Collateral
 
         private Task updateCollateralContinuouslyTask;
 
-        private bool isInitialized;
+        private bool collateralUpdated;
 
         public CollateralChecker(ILoggerFactory loggerFactory,
             IHttpClientFactory httpClientFactory,
@@ -74,7 +77,6 @@ namespace Stratis.Features.FederatedPeg.Collateral
             this.depositsByAddress = new Dictionary<string, Money>();
             this.logger = loggerFactory.CreateLogger(this.GetType().FullName);
             this.blockStoreClient = new BlockStoreClient(loggerFactory, httpClientFactory, $"http://{settings.CounterChainApiHost}", settings.CounterChainApiPort);
-            this.isInitialized = false;
         }
 
         public async Task InitializeAsync()
@@ -82,47 +84,39 @@ namespace Stratis.Features.FederatedPeg.Collateral
             this.memberAddedToken = this.signals.Subscribe<FedMemberAdded>(this.OnFedMemberAdded);
             this.memberKickedToken = this.signals.Subscribe<FedMemberKicked>(this.OnFedMemberKicked);
 
-            foreach (CollateralFederationMember federationMember in this.federationManager.GetFederationMembers()
-                .Cast<CollateralFederationMember>().Where(x => x.CollateralAmount != null && x.CollateralAmount > 0))
+            foreach (CollateralFederationMember federationMember in this.federationManager.GetFederationMembers().Cast<CollateralFederationMember>().Where(x => x.CollateralAmount != null && x.CollateralAmount > 0))
             {
                 this.logger.LogDebug("Initializing federation member {0} with amount {1}.", federationMember.CollateralMainchainAddress, federationMember.CollateralAmount);
-
-                this.depositsByAddress.Add(federationMember.CollateralMainchainAddress, 0);
+                this.depositsByAddress.Add(federationMember.CollateralMainchainAddress, federationMember.CollateralAmount);
             }
 
-            while (true)
+            while (!this.cancellationSource.IsCancellationRequested && !this.collateralUpdated)
             {
-                bool success = await this.UpdateCollateralInfoAsync(this.cancellationSource.Token).ConfigureAwait(false);
-
-                if (!success)
-                {
-                    this.logger.LogWarning("Failed to update collateral. Ensure that mainnet gateway node is running and API is enabled. " +
-                                       "Node will not continue initialization before another gateway node responds.");
-
-                    try
-                    {
-                        await Task.Delay(CollateralInitializationUpdateIntervalSeconds * 1000, this.cancellationSource.Token).ConfigureAwait(false);
-                    }
-                    catch (OperationCanceledException)
-                    {
-                        this.logger.LogTrace("(-)[CANCELLED]");
-                        return;
-                    }
-                }
-                else
-                {
+                this.collateralUpdated = await this.UpdateCollateralInfoAsync(this.cancellationSource.Token).ConfigureAwait(false);
+                if (this.collateralUpdated)
                     break;
+
+                this.logger.LogWarning(CollateralCheckFailedMessage);
+                this.logger.LogWarning("Node initialization will not continue until the gateway node responds.");
+
+                try
+                {
+                    await Task.Delay(CollateralInitializationUpdateIntervalSeconds * 1000, this.cancellationSource.Token).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException)
+                {
+                    this.logger.LogTrace("(-)[CANCELLED]");
+                    return;
                 }
             }
 
             this.updateCollateralContinuouslyTask = this.UpdateCollateralInfoContinuouslyAsync();
-            this.isInitialized = true;
         }
 
         /// <summary>Continuously updates info about money deposited to fed member's addresses.</summary>
         private async Task UpdateCollateralInfoContinuouslyAsync()
         {
-            while (!this.cancellationSource.Token.IsCancellationRequested)
+            while (!this.cancellationSource.IsCancellationRequested)
             {
                 try
                 {
@@ -134,14 +128,13 @@ namespace Stratis.Features.FederatedPeg.Collateral
                     return;
                 }
 
-                bool success = await this.UpdateCollateralInfoAsync(this.cancellationSource.Token).ConfigureAwait(false);
-
-                if (!success)
-                    this.logger.LogWarning("Failed to update collateral. Ensure that mainnet gateway node is running and API is enabled.");
+                bool collateralUpdated = await this.UpdateCollateralInfoAsync(this.cancellationSource.Token).ConfigureAwait(false);
+                if (!collateralUpdated)
+                    this.logger.LogWarning(CollateralCheckFailedMessage);
             }
         }
 
-        private async Task<bool> UpdateCollateralInfoAsync(CancellationToken cancellation = default(CancellationToken))
+        private async Task<bool> UpdateCollateralInfoAsync(CancellationToken cancellation)
         {
             List<string> addressesToCheck;
 
@@ -152,34 +145,34 @@ namespace Stratis.Features.FederatedPeg.Collateral
 
             if (addressesToCheck.Count == 0)
             {
+                this.logger.LogInformation("None of the federation members has a valid collateral amount to check.");
                 this.logger.LogTrace("(-)[NOTHING_TO_CHECK]:true");
                 return true;
             }
 
             this.logger.LogDebug("Addresses to check {0}.", addressesToCheck.Count);
 
-            AddressBalancesModel collateral = await this.blockStoreClient.GetAddressBalancesAsync(addressesToCheck, RequiredConfirmations, cancellation).ConfigureAwait(false);
+            AddressBalancesModel collateralBalances = await this.blockStoreClient.GetAddressBalancesAsync(addressesToCheck, RequiredConfirmations, cancellation).ConfigureAwait(false);
 
-            if (collateral == null)
+            if (collateralBalances == null)
             {
-                this.logger.LogWarning("Failed to fetch address balances from counter chain node!");
-                this.logger.LogTrace("(-)[FAILED]:false");
+                this.logger.LogWarning("Failed to fetch collateral balances from the counter chain node.");
+                this.logger.LogTrace("(-)[CALL_RETURNED_NULL_RESULT]:false");
                 return false;
             }
 
-            this.logger.LogDebug("Addresses received {0}.", collateral.Balances.Count);
+            this.logger.LogDebug("Addresses received {0}.", collateralBalances.Balances.Count);
 
-            if (collateral.Balances.Count != addressesToCheck.Count)
+            if (collateralBalances.Balances.Count != addressesToCheck.Count)
             {
-                this.logger.LogDebug("Expected {0} data entries but received {1}.", addressesToCheck.Count, collateral.Balances.Count);
-
-                this.logger.LogTrace("(-)[INCONSISTENT_DATA]:false");
+                this.logger.LogDebug("Expected {0} data entries but received {1}.", addressesToCheck.Count, collateralBalances.Balances.Count);
+                this.logger.LogTrace("(-)[CALL_RETURNED_INCONSISTENT_DATA]:false");
                 return false;
             }
 
             lock (this.locker)
             {
-                foreach (AddressBalanceModel addressMoney in collateral.Balances)
+                foreach (AddressBalanceModel addressMoney in collateralBalances.Balances)
                 {
                     this.logger.LogDebug("Updating federated member {0} with amount {1}.", addressMoney.Address, addressMoney.Balance);
                     this.depositsByAddress[addressMoney.Address] = addressMoney.Balance;
@@ -191,7 +184,7 @@ namespace Stratis.Features.FederatedPeg.Collateral
 
         public bool CheckCollateral(IFederationMember federationMember)
         {
-            if (!this.isInitialized)
+            if (!this.collateralUpdated)
             {
                 this.logger.LogTrace("(-)[NOT_INITIALIZED]");
                 throw new Exception("Component is not initialized!");


### PR DESCRIPTION
So here we block node initialization until the call to check collateral has completed. If there are no deposits to check the checker will assume that the checker initialized properly.