### PR TITLE
[FS] Fix destination of mined fees

### DIFF
--- a/src/Stratis.Features.FederatedPeg/FederatedPegBlockDefinition.cs
+++ b/src/Stratis.Features.FederatedPeg/FederatedPegBlockDefinition.cs
@@ -48,7 +48,6 @@ namespace Stratis.Features.FederatedPeg
             : base(blockBufferGenerator, coinView, consensusManager, dateTimeProvider, executorFactory, loggerFactory, mempool, mempoolLock, network, senderRetriever, stateRoot, minerSettings)
         {
             this.payToMultisigScript = federatedPegSettings.MultiSigAddress.ScriptPubKey;
-            this.payToMemberScript = PayToPubkeyTemplate.Instance.GenerateScriptPubKey(new PubKey(federatedPegSettings.PublicKey));
 
             this.premineSplitter = premineSplitter;
         }
@@ -57,7 +56,8 @@ namespace Stratis.Features.FederatedPeg
         {
             bool miningPremine = (chainTip.Height + 1) == this.Network.Consensus.PremineHeight;
 
-            Script rewardScript = miningPremine ? this.payToMultisigScript : this.payToMemberScript;
+            // If we are not mining the premine, then the reward should fall back to what was selected by the caller.
+            Script rewardScript = miningPremine ? this.payToMultisigScript : scriptPubKey;
 
             BlockTemplate built = base.Build(chainTip, rewardScript);
 


### PR DESCRIPTION
https://dev.azure.com/Stratisplatformuk/StratisBitcoinFullNode/_workitems/edit/3823

If we're not mining the premine then it should be `PoAMiner`'s responsibility to determine the destination. In this case the member's public key has nothing to do with their wallet, so sending the reward there results in the fees not appearing in the wallet.