### PR TITLE
Stop node initialization in case data folder is being used by another instance of the application

### DIFF
--- a/src/Stratis.Bitcoin/FullNode.cs
+++ b/src/Stratis.Bitcoin/FullNode.cs
@@ -165,14 +165,6 @@ namespace Stratis.Bitcoin
             this.logger = this.Services.ServiceProvider.GetService<ILoggerFactory>().CreateLogger(this.GetType().FullName);
             this.DataFolder = this.Services.ServiceProvider.GetService<DataFolder>();
 
-            this.nodeRunningLock = new NodeRunningLock(this.DataFolder);
-
-            if (!this.nodeRunningLock.TryLockNodeFolder())
-            {
-                this.logger.LogCritical("Node folder is being used by another instance of the application!");
-                throw new Exception("Node folder is being used!");
-            }
-
             this.DateTimeProvider = this.Services.ServiceProvider.GetService<IDateTimeProvider>();
             this.Network = this.Services.ServiceProvider.GetService<Network>();
             this.Settings = this.Services.ServiceProvider.GetService<NodeSettings>();
@@ -202,6 +194,14 @@ namespace Stratis.Bitcoin
 
             if (this.State == FullNodeState.Disposing || this.State == FullNodeState.Disposed)
                 throw new ObjectDisposedException(nameof(FullNode));
+
+            this.nodeRunningLock = new NodeRunningLock(this.DataFolder);
+
+            if (!this.nodeRunningLock.TryLockNodeFolder())
+            {
+                this.logger.LogCritical("Node folder is being used by another instance of the application!");
+                throw new Exception("Node folder is being used!");
+            }
 
             this.nodeLifetime = this.Services.ServiceProvider.GetRequiredService<INodeLifetime>() as NodeLifetime;
             this.fullNodeFeatureExecutor = this.Services.ServiceProvider.GetRequiredService<FullNodeFeatureExecutor>();

--- a/src/Stratis.Bitcoin/FullNode.cs
+++ b/src/Stratis.Bitcoin/FullNode.cs
@@ -80,6 +80,8 @@ namespace Stratis.Bitcoin
 
         private IAsyncLoop periodicBenchmarkLoop;
 
+        private NodeRunningLock nodeRunningLock;
+
         /// <inheritdoc />
         public INodeLifetime NodeLifetime
         {
@@ -160,10 +162,17 @@ namespace Stratis.Bitcoin
             Guard.NotNull(serviceProvider, nameof(serviceProvider));
 
             this.Services = serviceProvider;
-
             this.logger = this.Services.ServiceProvider.GetService<ILoggerFactory>().CreateLogger(this.GetType().FullName);
-
             this.DataFolder = this.Services.ServiceProvider.GetService<DataFolder>();
+
+            this.nodeRunningLock = new NodeRunningLock(this.DataFolder);
+
+            if (!this.nodeRunningLock.TryLockNodeFolder())
+            {
+                this.logger.LogCritical("Node folder is being used by another instance of the application!");
+                throw new Exception("Node folder is being used!");
+            }
+
             this.DateTimeProvider = this.Services.ServiceProvider.GetService<IDateTimeProvider>();
             this.Network = this.Services.ServiceProvider.GetService<Network>();
             this.Settings = this.Services.ServiceProvider.GetService<NodeSettings>();
@@ -291,6 +300,8 @@ namespace Stratis.Bitcoin
             // Fire INodeLifetime.Stopped.
             this.logger.LogInformation("Notify application has stopped.");
             this.nodeLifetime.NotifyStopped();
+
+            this.nodeRunningLock.UnlockNodeFolder();
 
             this.State = FullNodeState.Disposed;
         }

--- a/src/Stratis.Bitcoin/Utilities/NodeRunningLock.cs
+++ b/src/Stratis.Bitcoin/Utilities/NodeRunningLock.cs
@@ -1,0 +1,40 @@
+﻿using System.IO;
+using Stratis.Bitcoin.Configuration;
+
+namespace Stratis.Bitcoin.Utilities
+{
+    /// <summary>
+    /// Class that prevents another instance of the node to run in the same data folder
+    /// and allows external applications to see if the node is running.
+    /// </summary>
+    public class NodeRunningLock
+    {
+        private readonly string lockFileName;
+
+        private FileStream fileStream;
+
+        public NodeRunningLock(DataFolder dataFolder)
+        {
+            this.lockFileName = Path.Combine(dataFolder.RootPath, "lockfile");
+        }
+
+        public bool TryLockNodeFolder()
+        {
+            try
+            {
+                this.fileStream = new FileStream(this.lockFileName, FileMode.Create, FileAccess.ReadWrite, FileShare.None);
+                return true;
+            }
+            catch (IOException)
+            {
+                return false;
+            }
+        }
+
+        public void UnlockNodeFolder()
+        {
+            this.fileStream.Close();
+            File.Delete(this.lockFileName);
+        }
+    }
+}


### PR DESCRIPTION
This allows us to stop node initialization before we initialize any component that uses dbreeze which will fail inevitably. 