### PR TITLE
[FS] [PoA] Add an "info" call to CirrusMinerD

### DIFF
--- a/src/Stratis.Bitcoin.Features.PoA/Models/PoAInfoModel.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/Models/PoAInfoModel.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Newtonsoft.Json;
+
+namespace Stratis.Bitcoin.Features.PoA.Models
+{
+    public class PoAInfoModel
+    {
+        [JsonProperty(PropertyName = "miningPubKey", NullValueHandling = NullValueHandling.Ignore)]
+        public string MiningPublicKey { get; set; }
+
+        [JsonProperty(PropertyName = "federationMiningPubKeys", NullValueHandling = NullValueHandling.Ignore)]
+        public IEnumerable<string> FederationMiningPubKeys { get; set; }
+    }
+}

--- a/src/Stratis.Bitcoin.Features.PoA/Voting/DefaultVotingController.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/Voting/DefaultVotingController.cs
@@ -5,6 +5,7 @@ using System.Net;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using NBitcoin;
+using Stratis.Bitcoin.Features.PoA.Models;
 using Stratis.Bitcoin.Features.Wallet.Models;
 using Stratis.Bitcoin.Utilities;
 using Stratis.Bitcoin.Utilities.JsonErrors;
@@ -33,6 +34,30 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
             this.network = network;
 
             this.logger = loggerFactory.CreateLogger(this.GetType().FullName);
+        }
+
+        /// <summary>
+        /// For simplicity have put this here. It's currently the only place to get information about the current mining key on CirrusMinerD.
+        /// </summary>
+        [Route("info")]
+        [HttpGet]
+        public IActionResult GetInfo()
+        {
+            try
+            {
+                var model = new PoAInfoModel
+                {
+                    MiningPublicKey = this.fedManager.CurrentFederationKey?.PubKey.ToString(),
+                    FederationMiningPubKeys = this.fedManager.GetFederationMembers().Select(k => k.ToString()),
+                };
+
+                return this.Json(model);
+            }
+            catch (Exception e)
+            {
+                this.logger.LogError("Exception occurred: {0}", e.ToString());
+                return ErrorHelpers.BuildErrorResponse(HttpStatusCode.BadRequest, e.Message, e.ToString());
+            }
         }
 
         [Route("fedmembers")]


### PR DESCRIPTION
https://stratisplatformuk.visualstudio.com/StratisBitcoinFullNode/_workitems/edit/3839

The FederationGateway controller provides a couple of useful properties via its `Info` API call that aren't available on CirrusMinerD because CirrusMinerD doesn't have the FederationGateway code.

This just moves a couple of the useful properties over to be queried via the poa controller as well.

I understand this means there is some duplication of methods returning things. For now I just want to fix the issue with minimal code and we need to do some serious API design in the future