### PR TITLE
[FS] Fix spentTransactionsByHeightDict

### DIFF
--- a/src/Stratis.Features.FederatedPeg.Tests/Wallet/MultiSigTransactionsTests.cs
+++ b/src/Stratis.Features.FederatedPeg.Tests/Wallet/MultiSigTransactionsTests.cs
@@ -57,6 +57,7 @@ namespace Stratis.Features.FederatedPeg.Tests.Wallet
                     WithdrawalDetails = hasWithdrawalDetails ? new WithdrawalDetails() {
                          MatchingDepositId = spendingDepositId
                     } : null,
+                    BlockHeight = spendingBlockHeight(),
                     TransactionId = spendingTransactionId
                 };
             }
@@ -64,6 +65,11 @@ namespace Stratis.Features.FederatedPeg.Tests.Wallet
             int? blockHeight()
             {
                 return hasBlockHeight ? 3 : (int?)null;
+            }
+
+            int? spendingBlockHeight()
+            {
+                return hasBlockHeight ? 4 : (int?)null;
             }
 
             var transactionData = new TransactionData()
@@ -82,7 +88,7 @@ namespace Stratis.Features.FederatedPeg.Tests.Wallet
             void Validate()
             {
                 if (hasBlockHeight && hasSpendingDetails)
-                    Assert.Single(transactions.SpentTransactionsBeforeHeight(int.MaxValue), x => x.Item1 == blockHeight());
+                    Assert.Single(transactions.SpentTransactionsBeforeHeight(int.MaxValue), x => x.Item1 == spendingBlockHeight());
                 else
                     Assert.Empty(transactions.SpentTransactionsBeforeHeight(int.MaxValue));
 

--- a/src/Stratis.Features.FederatedPeg/Wallet/MultiSigTransactions.cs
+++ b/src/Stratis.Features.FederatedPeg/Wallet/MultiSigTransactions.cs
@@ -64,13 +64,13 @@ namespace Stratis.Features.FederatedPeg.Wallet
 
         private void AddSpentTransactionByHeight(TransactionData transactionData)
         {
-            if (transactionData.IsSpendable() || transactionData.BlockHeight == null)
+            if (transactionData.IsSpendable() || transactionData.SpendingDetails.BlockHeight == null)
                 return;
 
-            if (!this.spentTransactionsByHeightDict.TryGetValue((int)transactionData.BlockHeight, out List<TransactionData> txList))
+            if (!this.spentTransactionsByHeightDict.TryGetValue((int)transactionData.SpendingDetails.BlockHeight, out List<TransactionData> txList))
             {
                 txList = new List<TransactionData>();
-                this.spentTransactionsByHeightDict.Add((int)transactionData.BlockHeight, txList);
+                this.spentTransactionsByHeightDict.Add((int)transactionData.SpendingDetails.BlockHeight, txList);
             }
 
             txList.Add(transactionData);
@@ -78,15 +78,15 @@ namespace Stratis.Features.FederatedPeg.Wallet
 
         private void RemoveSpentTransactionByHeight(TransactionData transactionData)
         {
-            if (transactionData.BlockHeight == null)
+            if (transactionData.SpendingDetails?.BlockHeight == null)
                 return;
 
-            if (this.spentTransactionsByHeightDict.TryGetValue((int)transactionData.BlockHeight, out List<TransactionData> txList))
+            if (this.spentTransactionsByHeightDict.TryGetValue((int)transactionData.SpendingDetails.BlockHeight, out List<TransactionData> txList))
             {
                 txList.Remove(transactionData);
 
                 if (txList.Count == 0)
-                    this.spentTransactionsByHeightDict.Remove((int)transactionData.BlockHeight);
+                    this.spentTransactionsByHeightDict.Remove((int)transactionData.SpendingDetails.BlockHeight);
             }
         }
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/29645989/58691888-a66b5900-83d0-11e9-8ca4-22588e33a928.png)

The code is looking at the `BlockHeight` on `TransactionData` instead of `SpendingDetails.BlockHeight` so we may end up with missing outpoints for transactions that still need them.

Fixes an error in #3666.