### PR TITLE
Api clients error handling

### DIFF
--- a/src/Stratis.Bitcoin.Features.BlockStore/Controllers/BlockStoreClient.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/Controllers/BlockStoreClient.cs
@@ -9,7 +9,7 @@ using Stratis.Bitcoin.Controllers.Models;
 namespace Stratis.Bitcoin.Features.BlockStore.Controllers
 {
     /// <summary>Rest client for <see cref="BlockStoreController"/>.</summary>
-    public interface IBlockStoreClient
+    public interface IBlockStoreClient : IRestApiClientBase
     {
         /// <summary><see cref="BlockStoreController.GetAddressesBalances"/></summary>
         Task<AddressBalancesResult> GetAddressBalancesAsync(IEnumerable<string> addresses, int minConfirmations, CancellationToken cancellation = default(CancellationToken));

--- a/src/Stratis.Bitcoin/Controllers/RestApiClientBase.cs
+++ b/src/Stratis.Bitcoin/Controllers/RestApiClientBase.cs
@@ -95,8 +95,8 @@ namespace Stratis.Bitcoin.Controllers
                 }
                 catch (HttpRequestException ex)
                 {
-                    this.logger.LogError("Target node is not ready to receive API calls at this time ({0})", publicationUri);
-                    this.logger.LogError("Failed to send a message. Exception: '{0}'.", ex);
+                    this.logger.LogError("Target node is not ready to receive API calls at this time on {0}. Reason: {1}.", publicationUri, ex.Message);
+                    this.logger.LogDebug("Failed to send a message. Exception: '{0}'.", ex);
                     return new HttpResponseMessage() { ReasonPhrase = ex.Message, StatusCode = HttpStatusCode.InternalServerError };
                 }
             }
@@ -204,7 +204,7 @@ namespace Stratis.Bitcoin.Controllers
 
         protected virtual void OnRetry(Exception exception, TimeSpan delay)
         {
-            this.logger.LogWarning("Exception while calling API method: {0}. Retrying...", exception.ToString());
+            this.logger.LogDebug("Exception while calling API method: {0}. Retrying...", exception.ToString());
         }
     }
 

--- a/src/Stratis.Bitcoin/Controllers/RestApiClientBase.cs
+++ b/src/Stratis.Bitcoin/Controllers/RestApiClientBase.cs
@@ -13,8 +13,14 @@ using Stratis.Bitcoin.Utilities;
 
 namespace Stratis.Bitcoin.Controllers
 {
+    public interface IRestApiClientBase
+    {
+        /// <summary>Api endpoint URL that client uses to make calls.</summary>
+        string EndpointUrl { get; }
+    }
+
     /// <summary>Client for making API calls for methods provided by controllers.</summary>
-    public abstract class RestApiClientBase
+    public abstract class RestApiClientBase : IRestApiClientBase
     {
         private readonly IHttpClientFactory httpClientFactory;
 
@@ -31,6 +37,9 @@ namespace Stratis.Bitcoin.Controllers
         public const int TimeoutMs = 60_000;
 
         private readonly RetryPolicy policy;
+
+        /// <inheritdoc />
+        public string EndpointUrl => this.endpointUrl;
 
         public RestApiClientBase(ILoggerFactory loggerFactory, IHttpClientFactory httpClientFactory, int port, string controllerName, string url)
         {

--- a/src/Stratis.Bitcoin/Controllers/RestApiClientBase.cs
+++ b/src/Stratis.Bitcoin/Controllers/RestApiClientBase.cs
@@ -95,7 +95,7 @@ namespace Stratis.Bitcoin.Controllers
                 }
                 catch (HttpRequestException ex)
                 {
-                    this.logger.LogError("Target node is not ready to receive API calls at this time on {0}. Reason: {1}.", publicationUri, ex.Message);
+                    this.logger.LogError("Target node is not ready to receive API calls at this time on {0}. Reason: {1}.", this.EndpointUrl, ex.Message);
                     this.logger.LogDebug("Failed to send a message. Exception: '{0}'.", ex);
                     return new HttpResponseMessage() { ReasonPhrase = ex.Message, StatusCode = HttpStatusCode.InternalServerError };
                 }
@@ -192,8 +192,8 @@ namespace Stratis.Bitcoin.Controllers
                 }
                 catch (HttpRequestException ex)
                 {
-                    this.logger.LogError("Target node is not ready to receive API calls at this time ({0})", url);
-                    this.logger.LogError("Failed to send a message. Exception: '{0}'.", ex);
+                    this.logger.LogError("Target node is not ready to receive API calls at this time ({0})", this.EndpointUrl);
+                    this.logger.LogDebug("Failed to send a message to '{0}'. Exception: '{1}'.", url, ex);
                     return new HttpResponseMessage() { ReasonPhrase = ex.Message, StatusCode = HttpStatusCode.InternalServerError };
                 }
             }

--- a/src/Stratis.Features.FederatedPeg/Controllers/FederationGatewayClient.cs
+++ b/src/Stratis.Features.FederatedPeg/Controllers/FederationGatewayClient.cs
@@ -10,7 +10,7 @@ using Stratis.Features.FederatedPeg.Models;
 namespace Stratis.Features.FederatedPeg.Controllers
 {
     /// <summary>Rest client for <see cref="FederationGatewayController"/>.</summary>
-    public interface IFederationGatewayClient
+    public interface IFederationGatewayClient : IRestApiClientBase
     {
         /// <summary><see cref="FederationGatewayController.GetMaturedBlockDepositsAsync"/></summary>
         Task<List<MaturedBlockDepositsModel>> GetMaturedBlockDepositsAsync(MaturedBlockRequestModel model, CancellationToken cancellation = default(CancellationToken));

--- a/src/Stratis.Features.FederatedPeg/TargetChain/MaturedBlocksSyncManager.cs
+++ b/src/Stratis.Features.FederatedPeg/TargetChain/MaturedBlocksSyncManager.cs
@@ -144,7 +144,7 @@ namespace Stratis.Features.FederatedPeg.TargetChain
                 }
             }
             else
-                this.logger.LogWarning("Failed to fetch matured block deposits from counter chain node! {0} doesn't respond!", this.federationGatewayClient.EndpointUrl);
+                this.logger.LogDebug("Failed to fetch matured block deposits from counter chain node! {0} doesn't respond!", this.federationGatewayClient.EndpointUrl);
 
             return delayRequired;
         }

--- a/src/Stratis.Features.FederatedPeg/TargetChain/MaturedBlocksSyncManager.cs
+++ b/src/Stratis.Features.FederatedPeg/TargetChain/MaturedBlocksSyncManager.cs
@@ -144,7 +144,7 @@ namespace Stratis.Features.FederatedPeg.TargetChain
                 }
             }
             else
-                this.logger.LogWarning("Failed to fetch matured block deposits from counter chain node!");
+                this.logger.LogWarning("Failed to fetch matured block deposits from counter chain node! {0} doesn't respond!", this.federationGatewayClient.EndpointUrl);
 
             return delayRequired;
         }


### PR DESCRIPTION
Removed duplicated messages, reduced amount of data shown when api endpoint is down (no need to see stack trace there on console's logging level)