### PR TITLE
[FS] Setting transfers to Suspended required additional work

### DIFF
--- a/src/Stratis.Features.FederatedPeg.Tests/CrossChainTransferStoreTests.cs
+++ b/src/Stratis.Features.FederatedPeg.Tests/CrossChainTransferStoreTests.cs
@@ -841,7 +841,7 @@ namespace Stratis.Features.FederatedPeg.Tests
                 Assert.Equal(numDeposits, seenInBlock.Length);
 
                 // Sync our CCTS
-                // TODO: This does nothing.
+                // TODO: This does nothing. Remove?
                 recordMatureDepositResult = await crossChainTransferStore.RecordLatestMatureDepositsAsync(blockDeposits[1]);
 
                 // Lets make 10 more deposits using the change UTXOS in the block just gone.

--- a/src/Stratis.Features.FederatedPeg.Tests/CrossChainTransferStoreTests.cs
+++ b/src/Stratis.Features.FederatedPeg.Tests/CrossChainTransferStoreTests.cs
@@ -879,6 +879,9 @@ namespace Stratis.Features.FederatedPeg.Tests
                 // We do have 20 Suspended transactions now though.
                 ICrossChainTransfer[] suspended = crossChainTransferStore.GetTransfersByStatus(new CrossChainTransferStatus[] { CrossChainTransferStatus.Suspended });
                 Assert.Equal(20, suspended.Length);
+
+                // Check that the store has been rewound to re-process the suspended transfers.
+                Assert.Equal(1, crossChainTransferStore.NextMatureDepositHeight);
             }
         }
 

--- a/src/Stratis.Features.FederatedPeg.Tests/CrossChainTransferStoreTests.cs
+++ b/src/Stratis.Features.FederatedPeg.Tests/CrossChainTransferStoreTests.cs
@@ -802,7 +802,7 @@ namespace Stratis.Features.FederatedPeg.Tests
 
                 for (int i = 0; i < numDeposits; i++)
                 {
-                    deposits[i] = new Deposit((ulong) i, new Money(depositSend, MoneyUnit.BTC), address.ToString(),
+                    deposits[i] = new Deposit((ulong)i, new Money(depositSend, MoneyUnit.BTC), address.ToString(),
                         crossChainTransferStore.NextMatureDepositHeight, 1);
                 }
 
@@ -815,7 +815,9 @@ namespace Stratis.Features.FederatedPeg.Tests
 
                 (Transaction, ChainedHeader header) added = this.AddFundingTransaction(funding);
 
-                MaturedBlockDepositsModel[] blockDeposits = new[]
+                var blockDeposits = new Dictionary<int, MaturedBlockDepositsModel[]>();
+
+                blockDeposits[crossChainTransferStore.NextMatureDepositHeight] = new[]
                 {
                     new MaturedBlockDepositsModel(
                         new MaturedBlockInfoModel
@@ -826,7 +828,8 @@ namespace Stratis.Features.FederatedPeg.Tests
                         deposits)
                 };
 
-                RecordLatestMatureDepositsResult recordMatureDepositResult = await crossChainTransferStore.RecordLatestMatureDepositsAsync(blockDeposits);
+                RecordLatestMatureDepositsResult recordMatureDepositResult =
+                    await crossChainTransferStore.RecordLatestMatureDepositsAsync(blockDeposits[crossChainTransferStore.NextMatureDepositHeight]);
 
                 // Create 1 block with all 10 withdrawals inside.
                 ChainedHeader header = this.AppendBlock(recordMatureDepositResult.WithDrawalTransactions.ToArray());
@@ -838,18 +841,19 @@ namespace Stratis.Features.FederatedPeg.Tests
                 Assert.Equal(numDeposits, seenInBlock.Length);
 
                 // Sync our CCTS
-                recordMatureDepositResult = await crossChainTransferStore.RecordLatestMatureDepositsAsync(blockDeposits);
+                // TODO: This does nothing.
+                recordMatureDepositResult = await crossChainTransferStore.RecordLatestMatureDepositsAsync(blockDeposits[1]);
 
                 // Lets make 10 more deposits using the change UTXOS in the block just gone.
                 Deposit[] moreDeposits = new Deposit[numDeposits];
                 for (int i = 0; i < numDeposits; i++)
                 {
-                    ulong newId = (ulong) numDeposits + (ulong) i; // to get a unique ID.
+                    ulong newId = (ulong)numDeposits + (ulong)i; // to get a unique ID.
                     moreDeposits[i] = new Deposit(newId, new Money(depositSend, MoneyUnit.BTC), address.ToString(),
                         crossChainTransferStore.NextMatureDepositHeight, 2);
                 }
 
-                blockDeposits = new[]
+                blockDeposits[crossChainTransferStore.NextMatureDepositHeight] = new[]
                 {
                     new MaturedBlockDepositsModel(
                         new MaturedBlockInfoModel
@@ -859,11 +863,16 @@ namespace Stratis.Features.FederatedPeg.Tests
                         },
                         moreDeposits)
                 };
+
                 recordMatureDepositResult =
-                    await crossChainTransferStore.RecordLatestMatureDepositsAsync(blockDeposits);
+                    await crossChainTransferStore.RecordLatestMatureDepositsAsync(blockDeposits[crossChainTransferStore.NextMatureDepositHeight]);
 
                 // We built more transctions with the UTXOs included in a block...
                 Assert.True(recordMatureDepositResult.WithDrawalTransactions.Count > 0);
+
+                int expectedPartials = crossChainTransferStore.GetTransfersByStatus(new CrossChainTransferStatus[] { CrossChainTransferStatus.Partial }).Length;
+                int expectedSuspends = crossChainTransferStore.GetTransfersByStatus(new CrossChainTransferStatus[] { CrossChainTransferStatus.Suspended }).Length;
+                int expectedSeenInBlocks = crossChainTransferStore.GetTransfersByStatus(new CrossChainTransferStatus[] { CrossChainTransferStatus.SeenInBlock }).Length;
 
                 // Now lets rewind.
                 this.ChainIndexer.SetTip(added.header);
@@ -871,7 +880,7 @@ namespace Stratis.Features.FederatedPeg.Tests
                 TestBase.WaitLoop(() => this.federationWalletManager.WalletTipHash == this.ChainIndexer.Tip.HashBlock);
 
                 // If we were able to keep FullySigned transactions then we would have FullySigned after this rewind.
-                ICrossChainTransfer[] fullySigned = crossChainTransferStore.GetTransfersByStatus(new CrossChainTransferStatus[] {CrossChainTransferStatus.FullySigned});
+                ICrossChainTransfer[] fullySigned = crossChainTransferStore.GetTransfersByStatus(new CrossChainTransferStatus[] { CrossChainTransferStatus.FullySigned });
 
                 // However we have none.
                 Assert.Empty(fullySigned);
@@ -880,8 +889,23 @@ namespace Stratis.Features.FederatedPeg.Tests
                 ICrossChainTransfer[] suspended = crossChainTransferStore.GetTransfersByStatus(new CrossChainTransferStatus[] { CrossChainTransferStatus.Suspended });
                 Assert.Equal(20, suspended.Length);
 
-                // Check that the store has been rewound to re-process the suspended transfers.
-                Assert.Equal(1, crossChainTransferStore.NextMatureDepositHeight);
+                // See if we will recover to the point where the reorg occurred.
+                while (crossChainTransferStore.NextMatureDepositHeight <= blockDeposits.Max(kv => kv.Key))
+                {
+                    recordMatureDepositResult = await crossChainTransferStore.RecordLatestMatureDepositsAsync(
+                        blockDeposits[crossChainTransferStore.NextMatureDepositHeight]);
+
+                    if (!recordMatureDepositResult.MatureDepositRecorded)
+                        break;
+
+                    // Makes the withdrawals seen and makes their UTXOs spendable.
+                    this.AppendBlock(recordMatureDepositResult.WithDrawalTransactions.ToArray());
+                }
+
+                // Verify our expectations.
+                Assert.Equal(expectedPartials, crossChainTransferStore.GetTransfersByStatus(new CrossChainTransferStatus[] { CrossChainTransferStatus.Partial }).Length);
+                Assert.Equal(expectedSuspends, crossChainTransferStore.GetTransfersByStatus(new CrossChainTransferStatus[] { CrossChainTransferStatus.Suspended }).Length);
+                Assert.Equal(expectedSeenInBlocks, crossChainTransferStore.GetTransfersByStatus(new CrossChainTransferStatus[] { CrossChainTransferStatus.SeenInBlock }).Length);
             }
         }
 

--- a/src/Stratis.Features.FederatedPeg/TargetChain/CrossChainTransferStore.cs
+++ b/src/Stratis.Features.FederatedPeg/TargetChain/CrossChainTransferStore.cs
@@ -282,7 +282,7 @@ namespace Stratis.Features.FederatedPeg.TargetChain
                     // Remove any remnants of suspended transactions from the wallet.
                     foreach (KeyValuePair<ICrossChainTransfer, CrossChainTransferStatus?> kv in tracker)
                     {
-                        if (kv.Value == CrossChainTransferStatus.Suspended)
+                        if (kv.Key.Status == CrossChainTransferStatus.Suspended)
                         {
                             this.federationWalletManager.RemoveWithdrawalTransactions(kv.Key.DepositTransactionId);
                         }

--- a/src/Stratis.Features.FederatedPeg/TargetChain/CrossChainTransferStore.cs
+++ b/src/Stratis.Features.FederatedPeg/TargetChain/CrossChainTransferStore.cs
@@ -439,13 +439,13 @@ namespace Stratis.Features.FederatedPeg.TargetChain
                                 CrossChainTransferStatus status = CrossChainTransferStatus.Suspended;
                                 Script scriptPubKey = BitcoinAddress.Create(deposit.TargetAddress, this.network).ScriptPubKey;
 
-                            if (!haveSuspendedTransfers)
-                            {
-                                var recipient = new Recipient
+                                if (!haveSuspendedTransfers)
                                 {
-                                    Amount = deposit.Amount,
-                                    ScriptPubKey = scriptPubKey
-                                };
+                                    var recipient = new Recipient
+                                    {
+                                        Amount = deposit.Amount,
+                                        ScriptPubKey = scriptPubKey
+                                    };
 
                                     uint blockTime = maturedDeposit.BlockInfo.BlockTime;
 
@@ -797,18 +797,38 @@ namespace Stratis.Features.FederatedPeg.TargetChain
                     dbreezeTransaction.ValuesLazyLoadingIsOn = false;
 
                     ChainedHeader prevTip = this.TipHashAndHeight;
+                    int prevDepositHeight = this.NextMatureDepositHeight;
 
                     try
                     {
                         StatusChangeTracker tracker = this.OnDeleteBlocks(dbreezeTransaction, fork.Height);
+
+                        int newDepositHeight = Math.Min(prevDepositHeight, tracker
+                            .Select(kv => kv.Key)
+                            .Where(transfer => transfer.Status == CrossChainTransferStatus.Suspended)
+                            .Min(transfer => transfer.DepositHeight) ?? int.MaxValue);
+
+                        this.SaveNextMatureHeight(dbreezeTransaction, newDepositHeight);
                         this.SaveTipHashAndHeight(dbreezeTransaction, fork);
+
                         dbreezeTransaction.Commit();
+
+                        // Remove any remnants of suspended transactions from the wallet.
+                        bool walletUpdated = false;
+                        foreach (KeyValuePair<ICrossChainTransfer, CrossChainTransferStatus?> kv in tracker)
+                            if (kv.Key.Status == CrossChainTransferStatus.Suspended)
+                                walletUpdated |= this.federationWalletManager.RemoveWithdrawalTransactions(kv.Key.DepositTransactionId);
+
+                        if (walletUpdated)
+                            this.federationWalletManager.SaveWallet();
+
                         this.UndoLookups(tracker);
                     }
                     catch (Exception err)
                     {
                         // Restore expected store state in case the calling code retries / continues using the store.
                         this.TipHashAndHeight = prevTip;
+                        this.NextMatureDepositHeight = prevDepositHeight;
                         this.RollbackAndThrowTransactionError(dbreezeTransaction, err, "REWIND_ERROR");
                     }
                 }


### PR DESCRIPTION
When setting transfers to suspended (as per #3643) the `NextMatureDepositHeight` also needs to be updated to ensure that the transfers are retried.

It may be causing this bug:

![image](https://user-images.githubusercontent.com/29645989/58747009-6d061c80-84a8-11e9-802d-c9209229ac25.png)
