### PR TITLE
Please add the ability to inject a custom PoW hash.

### DIFF
--- a/src/NBitcoin/BlockStake.cs
+++ b/src/NBitcoin/BlockStake.cs
@@ -254,6 +254,11 @@ namespace NBitcoin
     public class PosBlockHeader : BlockHeader
 #pragma warning restore 618
     {
+        /// <summary>
+        /// Optional injectable custom PoW hash function.
+        /// </summary>
+        public static Func<byte[], uint256> CustomPoWHash;
+
         /// <inheritdoc />
         public override int CurrentVersion => 7;
 
@@ -294,11 +299,14 @@ namespace NBitcoin
         /// <inheritdoc />
         public override uint256 GetPoWHash()
         {
+            byte[] serialized;
+
             using (var ms = new MemoryStream())
             {
                 this.ReadWriteHashingStream(new BitcoinStream(ms, true));
-                return HashX13.Instance.Hash(ms.ToArray());
+                serialized = ms.ToArray();
             }
+            return CustomPoWHash == null ? HashX13.Instance.Hash(serialized) : CustomPoWHash(serialized);
         }
     }
 


### PR DESCRIPTION
A hash is essentially a function that takes a byte array and returns a byte array.

PoSBlockHeader has an unnecessary dependency on HashX13 (which could also be moved from NBitcoin into a separate library if needed).

I propose adding this hook for a delegate:
public static Func<byte[], uint256> CustomPoWHash;

If you look at the calling mechanism you see that it's possible to add this without any breaking changes.