### PR TITLE
[FS] Lookup needs to look for height changes

### DIFF
--- a/src/Stratis.Features.FederatedPeg.Tests/Wallet/MultiSigTransactionsTests.cs
+++ b/src/Stratis.Features.FederatedPeg.Tests/Wallet/MultiSigTransactionsTests.cs
@@ -39,6 +39,38 @@ namespace Stratis.Features.FederatedPeg.Tests.Wallet
             IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
         }
 
+        [Fact]
+        public void CanChangeHeightOfSpendableTransaction()
+        {
+            var transactionData1 = new TransactionData()
+            {
+                Id = 1,
+                Index = 1,
+                BlockHeight = null,
+                SpendingDetails = null
+            };
+
+            var transactionData2 = new TransactionData()
+            {
+                Id = 2,
+                Index = 0,
+                BlockHeight = null,
+                SpendingDetails = null
+            };
+
+            var transactions = new MultiSigTransactions();
+            transactions.Add(transactionData2);
+            transactions.Add(transactionData1);
+
+            transactionData2.BlockHeight = 1;
+
+            transactions.Remove(transactionData2);
+
+            transactionData2.BlockHeight = null;
+
+            transactions.Add(transactionData2);
+        }
+
         [Theory]
         [ClassData(typeof(TestData))]
         public void TransactionDataAddedToMultiSigTransactionsExistsInExpectedLookups(bool hasBlockHeight, bool hasSpendingDetails, bool hasWithdrawalDetails, bool flipBlockHeight, bool flipSpendingDetails, bool flipWithdrawalDetails)

--- a/src/Stratis.Features.FederatedPeg/Wallet/MultiSigTransactions.cs
+++ b/src/Stratis.Features.FederatedPeg/Wallet/MultiSigTransactions.cs
@@ -184,7 +184,7 @@ namespace Stratis.Features.FederatedPeg.Wallet
         {
             lock (this.lockObject)
             {
-                if (transactionData.IsSpendable())
+                if (this.spendableTransactionList.ContainsKey(transactionData))
                     this.spendableTransactionList.Remove(transactionData);
 
                 this.RemoveSpentTransactionByHeight(transactionData);
@@ -223,6 +223,10 @@ namespace Stratis.Features.FederatedPeg.Wallet
             lock (this.lockObject)
             {
                 this.RemoveSpentTransactionByHeight(transactionData);
+
+                // This is ordered by height/id/index.
+                if (this.spendableTransactionList.ContainsKey(transactionData))
+                    this.spendableTransactionList.Remove(transactionData);
             }
         }
 
@@ -237,6 +241,10 @@ namespace Stratis.Features.FederatedPeg.Wallet
             lock (this.lockObject)
             {
                 this.AddSpentTransactionByHeight(transactionData);
+
+                // This is ordered by height/id/index.
+                if (transactionData.IsSpendable())
+                    this.spendableTransactionList.Add(transactionData, transactionData);
             }
         }
 


### PR DESCRIPTION
The `spendableTransactionList` is sorted by height/id/index and should therefore look out for changes to the `TransactionData.BlockHeight`. This PR adds code to `BeforeBlockHeightChanges` and `AfterBlockHeightChanged` to do exactly that.

The following reported issue may be related:

![image](https://user-images.githubusercontent.com/29645989/58787561-6523b500-862d-11e9-94f5-c9a761b05cbf.png)

Notice how, counter-intuitively, an error is raised on line 105 instead of line 102...

![image](https://user-images.githubusercontent.com/29645989/58787717-b92e9980-862d-11e9-8fdc-f2cc40e70025.png)
