### PR TITLE
[FS] Limit pending tx withdrawal history

### DIFF
--- a/src/Stratis.Features.FederatedPeg/FederatedPegFeature.cs
+++ b/src/Stratis.Features.FederatedPeg/FederatedPegFeature.cs
@@ -49,6 +49,9 @@ namespace Stratis.Features.FederatedPeg
         /// </summary>
         private const int TransfersToDisplay = 10;
 
+        /// <summary>
+        /// The maximum number of pending transactions to display in the console logging.
+        /// </summary>
         private const int PendingToDisplay = 25;
 
         public const string FederationGatewayFeatureNamespace = "federationgateway";

--- a/src/Stratis.Features.FederatedPeg/FederatedPegFeature.cs
+++ b/src/Stratis.Features.FederatedPeg/FederatedPegFeature.cs
@@ -49,6 +49,8 @@ namespace Stratis.Features.FederatedPeg
         /// </summary>
         private const int TransfersToDisplay = 10;
 
+        private const int PendingToDisplay = 25;
+
         public const string FederationGatewayFeatureNamespace = "federationgateway";
 
         private readonly IConnectionManager connectionManager;
@@ -223,8 +225,12 @@ namespace Stratis.Features.FederatedPeg
             if (pendingWithdrawals.Count > 0)
             {
                 benchLog.AppendLine("--- Pending Withdrawals ---");
-                foreach (WithdrawalModel withdrawal in pendingWithdrawals)
+                foreach (WithdrawalModel withdrawal in pendingWithdrawals.Take(PendingToDisplay))
                     benchLog.AppendLine(withdrawal.ToString());
+
+                if (pendingWithdrawals.Count > PendingToDisplay)
+                    benchLog.AppendLine($"And {pendingWithdrawals.Count - PendingToDisplay} more...");
+
                 benchLog.AppendLine();
             }
 

--- a/src/Stratis.Features.FederatedPeg/TargetChain/CrossChainTransferStore.cs
+++ b/src/Stratis.Features.FederatedPeg/TargetChain/CrossChainTransferStore.cs
@@ -1073,19 +1073,7 @@ namespace Stratis.Features.FederatedPeg.TargetChain
         /// <inheritdoc />
         public ICrossChainTransfer[] QueryTransfersByStatus(CrossChainTransferStatus[] statuses)
         {
-            lock (this.lockObj)
-            {
-                var depositIds = new HashSet<uint256>();
-
-                foreach (CrossChainTransferStatus status in statuses)
-                    depositIds.UnionWith(this.depositsIdsByStatus[status]);
-
-                uint256[] partialTransferHashes = depositIds.ToArray();
-                ICrossChainTransfer[] partialTransfers = this.Get(partialTransferHashes).Where(t => t != null).ToArray();
-
-                return partialTransfers.OrderBy(t => this.EarliestOutput(t.PartialTransaction), Comparer<OutPoint>.Create((x, y) =>
-                ((FederationWalletManager)this.federationWalletManager).CompareOutpoints(x, y))).ToArray();
-            }
+            return this.GetTransfersByStatusInternalLocked(statuses, true, false);
         }
 
         /// <inheritdoc />

--- a/src/Stratis.Features.FederatedPeg/TargetChain/CrossChainTransferStore.cs
+++ b/src/Stratis.Features.FederatedPeg/TargetChain/CrossChainTransferStore.cs
@@ -1083,7 +1083,8 @@ namespace Stratis.Features.FederatedPeg.TargetChain
                 uint256[] partialTransferHashes = depositIds.ToArray();
                 ICrossChainTransfer[] partialTransfers = this.Get(partialTransferHashes).Where(t => t != null).ToArray();
 
-                return partialTransfers;
+                return partialTransfers.OrderBy(t => this.EarliestOutput(t.PartialTransaction), Comparer<OutPoint>.Create((x, y) =>
+                ((FederationWalletManager)this.federationWalletManager).CompareOutpoints(x, y))).ToArray();
             }
         }
 

--- a/src/Stratis.Features.FederatedPeg/TargetChain/CrossChainTransferStore.cs
+++ b/src/Stratis.Features.FederatedPeg/TargetChain/CrossChainTransferStore.cs
@@ -1073,7 +1073,15 @@ namespace Stratis.Features.FederatedPeg.TargetChain
         /// <inheritdoc />
         public ICrossChainTransfer[] QueryTransfersByStatus(CrossChainTransferStatus[] statuses)
         {
-            return this.GetTransfersByStatusInternalLocked(statuses, true, false);
+            lock (this.lockObj)
+            {
+                return this.federationWalletManager.Synchronous(() =>
+                {
+                    Guard.Assert(this.Synchronize());
+
+                    return this.GetTransfersByStatusInternalLocked(statuses, true, false);
+                });
+            }
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
Limits the pending transaction withdrawal history to 25 entries. Uses the same ordering as `PartialTransactionRequester`.