### PR TITLE
[FS] Remove "Hex" field from Federation Wallet

### DIFF
--- a/src/Stratis.Features.FederatedPeg.Tests/ControllersTests/FederationGatewayControllerTests.cs
+++ b/src/Stratis.Features.FederatedPeg.Tests/ControllersTests/FederationGatewayControllerTests.cs
@@ -109,6 +109,10 @@ namespace Stratis.Features.FederatedPeg.Tests.ControllersTests
 
             this.consensusManager.Tip.Returns(tip);
 
+            this.consensusManager.GetBlockData(Arg.Any<uint256>()).ReturnsForAnyArgs((x) => {
+                return new ChainedHeaderBlock(new Block(), tip);
+            });
+
             IActionResult result = await controller.GetMaturedBlockDepositsAsync(new MaturedBlockRequestModel(1, 1000)).ConfigureAwait(false);
 
             result.Should().BeOfType<ErrorResult>();
@@ -182,6 +186,10 @@ namespace Stratis.Features.FederatedPeg.Tests.ControllersTests
             this.depositExtractor.When(x => x.ExtractBlockDeposits(Arg.Any<ChainedHeaderBlock>())).Do(info =>
             {
                 depositExtractorCallCount++;
+            });
+
+            this.consensusManager.GetBlockData(Arg.Any<uint256>()).ReturnsForAnyArgs((x) => {
+                return new ChainedHeaderBlock(new Block(), earlierBlock);
             });
 
             IActionResult result = await controller.GetMaturedBlockDepositsAsync(new MaturedBlockRequestModel(earlierBlock.Height, 1000)).ConfigureAwait(false);

--- a/src/Stratis.Features.FederatedPeg.Tests/CrossChainTestBase.cs
+++ b/src/Stratis.Features.FederatedPeg.Tests/CrossChainTestBase.cs
@@ -133,6 +133,18 @@ namespace Stratis.Features.FederatedPeg.Tests
 
                 return blocks;
             });
+
+            this.blockRepository.GetBlock(Arg.Any<uint256>()).ReturnsForAnyArgs((x) =>
+            {
+                uint256 hash = x.ArgAt<uint256>(0);
+                this.blockDict.TryGetValue(hash, out Block block);
+
+                return block;
+            });
+
+            this.blockRepository.TipHashAndHeight.Returns((x) => {
+                return new HashHeightPair(this.blockDict.Last().Value.GetHash(), this.blockDict.Count - 1);
+            });
         }
 
         /// <summary>

--- a/src/Stratis.Features.FederatedPeg.Tests/CrossChainTestBase.cs
+++ b/src/Stratis.Features.FederatedPeg.Tests/CrossChainTestBase.cs
@@ -194,7 +194,8 @@ namespace Stratis.Features.FederatedPeg.Tests
                 new NodeLifetime(),
                 this.dateTimeProvider,
                 this.federatedPegSettings,
-                this.withdrawalExtractor);
+                this.withdrawalExtractor,
+                this.blockRepository);
 
             // Starts and creates the wallet.
             this.federationWalletManager.Start();

--- a/src/Stratis.Features.FederatedPeg/SourceChain/MaturedBlocksProvider.cs
+++ b/src/Stratis.Features.FederatedPeg/SourceChain/MaturedBlocksProvider.cs
@@ -66,6 +66,13 @@ namespace Stratis.Features.FederatedPeg.SourceChain
 
                 ChainedHeaderBlock block = this.consensusManager.GetBlockData(currentHeader.HashBlock);
 
+                if (block?.Block?.Transactions == null)
+                {
+                    // Report unexpected results from consenus manager.
+                    this.logger.LogWarning("Stop matured blocks collection due to consensus manager integrity failure. Send what we've collected.");
+                    break;
+                }
+
                 MaturedBlockDepositsModel maturedBlockDeposits = this.depositExtractor.ExtractBlockDeposits(block);
 
                 if (maturedBlockDeposits == null)

--- a/src/Stratis.Features.FederatedPeg/TargetChain/CrossChainTransferStore.cs
+++ b/src/Stratis.Features.FederatedPeg/TargetChain/CrossChainTransferStore.cs
@@ -157,11 +157,7 @@ namespace Stratis.Features.FederatedPeg.TargetChain
             lock (this.lockObj)
             {
                 this.federationWalletManager.Synchronous(() =>
-                {
-                    // Remove all unconfirmed transaction data from the wallet to be re-added when blocks are processed.
-                    if (this.federationWalletManager.RemoveUnconfirmedTransactionData())
-                        this.federationWalletManager.SaveWallet();
-
+                {                    
                     Guard.Assert(this.Synchronize());
                 });
             }

--- a/src/Stratis.Features.FederatedPeg/Wallet/FederationWalletManager.cs
+++ b/src/Stratis.Features.FederatedPeg/Wallet/FederationWalletManager.cs
@@ -223,7 +223,7 @@ namespace Stratis.Features.FederatedPeg.Wallet
                     {
                         // The spending transaction could not be found in the consensus chain.
                         // Set the firstMissingTransactionHeight to the block of the spending transaction.
-                        SpendingDetails spendingDetails = spentOutputs.Where(td => td.BlockHeight != null).Select(td => td.SpendingDetails).FirstOrDefault();
+                        SpendingDetails spendingDetails = spentOutputs.Select(td => td.SpendingDetails).Where(s => s.BlockHeight != null).FirstOrDefault();
 
                         Guard.Assert(spendingDetails != null);
 

--- a/src/Stratis.Features.FederatedPeg/Wallet/FederationWalletManager.cs
+++ b/src/Stratis.Features.FederatedPeg/Wallet/FederationWalletManager.cs
@@ -164,7 +164,7 @@ namespace Stratis.Features.FederatedPeg.Wallet
             {
                 SpendingDetails spendingDetail = transactionData.SpendingDetails;
 
-                if (spendingDetail?.TransactionId == null || !string.IsNullOrEmpty(spendingDetail.Hex))
+                if (spendingDetail?.TransactionId == null || spendingDetail.Transaction != null)
                     continue;
 
                 // Some SpendingDetail.BlockHash values may bet set to (uint256)0, so fix that too.
@@ -205,10 +205,8 @@ namespace Stratis.Features.FederatedPeg.Wallet
 
                     if (spendTransaction != null)
                     {
-                        string hex = spendTransaction.ToHex();
-
                         foreach (TransactionData transactionData in spentOutputs)
-                            transactionData.SpendingDetails.Hex = hex;
+                            transactionData.SpendingDetails.Transaction = spendTransaction;
                     }
                     else
                     {
@@ -810,7 +808,7 @@ namespace Stratis.Features.FederatedPeg.Wallet
                 CreationTime = DateTimeOffset.FromUnixTimeSeconds(block?.Header.Time ?? transaction.Time),
                 BlockHeight = blockHeight,
                 BlockHash = blockHash,
-                Hex = transaction.ToHex(),
+                Transaction = transaction,
                 IsCoinStake = transaction.IsCoinStake == false ? (bool?)null : true
             };
 
@@ -927,7 +925,7 @@ namespace Stratis.Features.FederatedPeg.Wallet
                             spendingDetail.BlockHeight ?? 0,
                             spendingDetail.BlockHash);
 
-                        Transaction transaction = this.network.CreateTransaction(spendingDetail.Hex);
+                        Transaction transaction = spendingDetail.Transaction;
 
                         withdrawals.Add((transaction, withdrawal));
                     }

--- a/src/Stratis.Features.FederatedPeg/Wallet/FederationWalletManager.cs
+++ b/src/Stratis.Features.FederatedPeg/Wallet/FederationWalletManager.cs
@@ -175,7 +175,7 @@ namespace Stratis.Features.FederatedPeg.Wallet
 
                 if (spendingDetail?.TransactionId == null || spendingDetail.Transaction != null)
                 {
-                    res.Add(transactionData, spendingDetail.Transaction);
+                    res.Add(transactionData, spendingDetail?.Transaction);
                     continue;
                 }
 

--- a/src/Stratis.Features.FederatedPeg/Wallet/FederationWalletManager.cs
+++ b/src/Stratis.Features.FederatedPeg/Wallet/FederationWalletManager.cs
@@ -222,16 +222,13 @@ namespace Stratis.Features.FederatedPeg.Wallet
                     else
                     {
                         // The spending transaction could not be found in the consensus chain.
-                        // Set the maxValidHeight to the block before where the spending transaction occurred.
-                        foreach (TransactionData transactionData in spentOutputs)
-                        {
-                            SpendingDetails spendingDetails = transactionData.SpendingDetails;
+                        // Set the firstMissingTransactionHeight to the block of the spending transaction.
+                        SpendingDetails spendingDetails = spentOutputs.Where(td => td.BlockHeight != null).Select(td => td.SpendingDetails).FirstOrDefault();
 
-                            Guard.Assert(spendingDetails.BlockHeight != null);
+                        Guard.Assert(spendingDetails != null);
 
-                            if (spendingDetails.BlockHeight < firstMissingTransactionHeight)
-                                firstMissingTransactionHeight = (int)spendingDetails.BlockHeight;
-                        }
+                        if (spendingDetails.BlockHeight < firstMissingTransactionHeight)
+                            firstMissingTransactionHeight = (int)spendingDetails.BlockHeight;
                     }
                 }
             }

--- a/src/Stratis.Features.FederatedPeg/Wallet/FederationWalletManager.cs
+++ b/src/Stratis.Features.FederatedPeg/Wallet/FederationWalletManager.cs
@@ -156,6 +156,13 @@ namespace Stratis.Features.FederatedPeg.Wallet
             this.blockStore = blockStore;
         }
 
+        /// <summary>
+        /// The purpose of this method is to retrieve <see cref="Transaction"/> objects for each <see cref="SpendingDetails.TransactionId"/>.
+        /// If any transaction can't be resolved the wallet is rewound to remove the corrupt <see cref="TransactionData"/> record containing
+        /// the <see cref="SpendingDetails"/>.
+        /// </summary>
+        /// <param name="transactions">The <see cref="TransactionData"/> records for which to retrieve the transactions.</param>
+        /// <returns>Retrieved <see cref="Transaction"/> objects for each <see cref="SpendingDetails.TransactionId"/></returns>
         private Dictionary<TransactionData, Transaction> GetSpendingTransactions(IEnumerable<TransactionData> transactions)
         {
             var res = new Dictionary<TransactionData, Transaction>();

--- a/src/Stratis.Features.FederatedPeg/Wallet/SpendingDetails.cs
+++ b/src/Stratis.Features.FederatedPeg/Wallet/SpendingDetails.cs
@@ -52,10 +52,10 @@ namespace Stratis.Features.FederatedPeg.Wallet
         public DateTimeOffset CreationTime { get; set; }
 
         /// <summary>
-        /// Hexadecimal representation of this spending transaction.
+        /// Spending transaction.
         /// </summary>
         [JsonIgnore]
-        public string Hex { get; set; }
+        public Transaction Transaction { get; set; }
 
         /// <summary>
         /// If this spending transaction is a withdrawal, this contains its details.

--- a/src/Stratis.Features.FederatedPeg/Wallet/SpendingDetails.cs
+++ b/src/Stratis.Features.FederatedPeg/Wallet/SpendingDetails.cs
@@ -54,7 +54,7 @@ namespace Stratis.Features.FederatedPeg.Wallet
         /// <summary>
         /// Hexadecimal representation of this spending transaction.
         /// </summary>
-        [JsonProperty(PropertyName = "hex", NullValueHandling = NullValueHandling.Ignore)]
+        [JsonIgnore]
         public string Hex { get; set; }
 
         /// <summary>

--- a/src/Stratis.Features.FederatedPeg/Wallet/TransactionData.cs
+++ b/src/Stratis.Features.FederatedPeg/Wallet/TransactionData.cs
@@ -94,12 +94,6 @@ namespace Stratis.Features.FederatedPeg.Wallet
         [JsonConverter(typeof(ScriptJsonConverter))]
         public Script ScriptPubKey { get; set; }
 
-        /// <summary>
-        /// Hexadecimal representation of this transaction.
-        /// </summary>
-        [JsonProperty(PropertyName = "hex", NullValueHandling = NullValueHandling.Ignore)]
-        public string Hex { get; set; }
-
         [JsonIgnore]
         public OutPoint Key => new OutPoint(this.Id, this.Index);
 
@@ -134,12 +128,6 @@ namespace Stratis.Features.FederatedPeg.Wallet
         public bool IsConfirmed()
         {
             return this.BlockHeight != null;
-        }
-
-        [NoTrace]
-        public Transaction GetFullTransaction(Network network)
-        {
-            return network.CreateTransaction(this.Hex);
         }
 
         public bool IsSpendable()


### PR DESCRIPTION
The transaction hex currently stored in the wallet can be retrieved from the block store.