### PR TITLE
[SC] Return type name with API response

### DIFF
--- a/src/Stratis.Bitcoin.Features.SmartContracts/Models/GetCodeResponse.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts/Models/GetCodeResponse.cs
@@ -4,6 +4,9 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Models
 {
     public sealed class GetCodeResponse
     {
+        [JsonProperty(PropertyName = "type")]
+        public string Type { get; set; }
+
         [JsonProperty(PropertyName = "bytecode")]
         public string Bytecode { get; set; }
 

--- a/src/Stratis.Bitcoin.Features.SmartContracts/ReflectionExecutor/Controllers/SmartContractsController.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts/ReflectionExecutor/Controllers/SmartContractsController.cs
@@ -95,6 +95,7 @@ namespace Stratis.Bitcoin.Features.SmartContracts.ReflectionExecutor.Controllers
         {
             uint160 addressNumeric = address.ToUint160(this.network);
             byte[] contractCode = this.stateRoot.GetCode(addressNumeric);
+            string typeName = this.stateRoot.GetContractType(addressNumeric);
 
             if (contractCode == null || !contractCode.Any())
             {
@@ -110,6 +111,7 @@ namespace Stratis.Bitcoin.Features.SmartContracts.ReflectionExecutor.Controllers
             {
                 Message = string.Format("Contract execution code retrieved at {0}", address),
                 Bytecode = contractCode.ToHexString(),
+                Type = typeName,
                 CSharp = sourceResult.IsSuccess ? sourceResult.Value : sourceResult.Error // Show the source, or the reason why the source couldn't be retrieved.
             });
         }

--- a/src/Stratis.Bitcoin.Features.SmartContracts/ReflectionExecutor/Controllers/SmartContractsController.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts/ReflectionExecutor/Controllers/SmartContractsController.cs
@@ -95,7 +95,6 @@ namespace Stratis.Bitcoin.Features.SmartContracts.ReflectionExecutor.Controllers
         {
             uint160 addressNumeric = address.ToUint160(this.network);
             byte[] contractCode = this.stateRoot.GetCode(addressNumeric);
-            string typeName = this.stateRoot.GetContractType(addressNumeric);
 
             if (contractCode == null || !contractCode.Any())
             {
@@ -104,6 +103,8 @@ namespace Stratis.Bitcoin.Features.SmartContracts.ReflectionExecutor.Controllers
                     Message = string.Format("No contract execution code exists at {0}", address)
                 });
             }
+
+            string typeName = this.stateRoot.GetContractType(addressNumeric);
 
             Result<string> sourceResult = this.contractDecompiler.GetSource(contractCode);
 


### PR DESCRIPTION
Related to 3887. We _do_ return code for all types in the module, but it's not obvious which Type is the contract type. This PR adds the return Type name.