### PR TITLE
Remove usages of network name

### DIFF
--- a/src/NBitcoin/ConsensusOptions.cs
+++ b/src/NBitcoin/ConsensusOptions.cs
@@ -181,7 +181,7 @@
         /// <param name="network">The network.</param>
         public virtual int GetStakeMinConfirmations(int height, Network network)
         {
-            if (network.Name.ToLowerInvariant().Contains("test")) // TODO: When rules are moved to network, we can use the extension method IsTest() from Stratis.Bitcoin.
+            if (network.NetworkType == NetworkType.Testnet || network.NetworkType == NetworkType.Regtest)
                 return height < CoinstakeMinConfirmationActivationHeightTestnet ? 10 : 20;
 
             return height < CoinstakeMinConfirmationActivationHeightMainnet ? 50 : 500;

--- a/src/NBitcoin/OpenAsset/CoinprismColoredTransactionRepository.cs
+++ b/src/NBitcoin/OpenAsset/CoinprismColoredTransactionRepository.cs
@@ -67,7 +67,7 @@ namespace NBitcoin.OpenAsset
                 var result = new ColoredTransaction();
 
                 string url = string.Empty;
-                if (this.network.Name.ToLowerInvariant().Contains("test"))
+                if (this.network.NetworkType == NetworkType.Testnet || this.network.NetworkType == NetworkType.Regtest)
                     url = string.Format("https://testnet.api.coinprism.com/v1/transactions/{0}", txId);
                 else
                     url = string.Format("https://api.coinprism.com/v1/transactions/{0}", txId);
@@ -154,7 +154,7 @@ namespace NBitcoin.OpenAsset
                 throw new ArgumentNullException(nameof(transaction));
 
             string url = string.Empty;
-            if (this.network.Name.ToLowerInvariant().Contains("test"))
+            if (this.network.NetworkType == NetworkType.Testnet || this.network.NetworkType == NetworkType.Regtest)
                 url = "https://testnet.api.coinprism.com/v1/sendrawtransaction";
             else
                 url = "https://api.coinprism.com/v1/transactions/v1/sendrawtransaction";

--- a/src/NBitcoin/QBitNinjaTransactionRepository.cs
+++ b/src/NBitcoin/QBitNinjaTransactionRepository.cs
@@ -16,7 +16,10 @@ namespace NBitcoin
         public QBitNinjaTransactionRepository(Network network)
         {
             this.network = network ?? throw new ArgumentNullException("network");
-            this.BaseUri = new Uri("http://" + (network.Name.ToLowerInvariant().Contains("test") ? "t" : string.Empty) + "api.qbit.ninja/");
+
+            bool isTest = this.network.NetworkType == NetworkType.Testnet || this.network.NetworkType == NetworkType.Regtest;
+
+            this.BaseUri = new Uri("http://" + (isTest ? "t" : string.Empty) + "api.qbit.ninja/");
         }
 
         public QBitNinjaTransactionRepository(Uri baseUri)

--- a/src/Stratis.Bitcoin/Utilities/NetworkExtensions.cs
+++ b/src/Stratis.Bitcoin/Utilities/NetworkExtensions.cs
@@ -14,17 +14,17 @@ namespace Stratis.Bitcoin.Utilities
         /// Determines whether this network is a test network.
         /// </summary>
         /// <param name="network">The network.</param>
-        /// <returns><c>true</c> if the specified network is test, <c>false</c> otherwise.</returns>
+        /// <returns><c>true</c> if the specified network is a test network, <c>false</c> otherwise.</returns>
         public static bool IsTest(this Network network)
         {
-            return network.NetworkType == NetworkType.Testnet;
+            return network.NetworkType == NetworkType.Testnet || network.NetworkType == NetworkType.Regtest;
         }
 
         /// <summary>
         /// Determines whether this network is a regtest network.
         /// </summary>
         /// <param name="network">The network.</param>
-        /// <returns><c>true</c> if the specified network is test, <c>false</c> otherwise.</returns>
+        /// <returns><c>true</c> if the specified network is a regtest network, <c>false</c> otherwise.</returns>
         public static bool IsRegTest(this Network network)
         {
             return network.NetworkType == NetworkType.Regtest;

--- a/src/Stratis.Bitcoin/Utilities/NetworkExtensions.cs
+++ b/src/Stratis.Bitcoin/Utilities/NetworkExtensions.cs
@@ -17,7 +17,7 @@ namespace Stratis.Bitcoin.Utilities
         /// <returns><c>true</c> if the specified network is test, <c>false</c> otherwise.</returns>
         public static bool IsTest(this Network network)
         {
-            return network.Name.ToLowerInvariant().Contains("test");
+            return network.NetworkType == NetworkType.Testnet;
         }
 
         /// <summary>
@@ -27,7 +27,7 @@ namespace Stratis.Bitcoin.Utilities
         /// <returns><c>true</c> if the specified network is test, <c>false</c> otherwise.</returns>
         public static bool IsRegTest(this Network network)
         {
-            return network.Name.ToLowerInvariant().Contains("regtest");
+            return network.NetworkType == NetworkType.Regtest;
         }
 
         /// <summary>
@@ -37,6 +37,7 @@ namespace Stratis.Bitcoin.Utilities
         /// <returns><c>true</c> if the specified network is bitcoin, <c>false</c> otherwise.</returns>
         public static bool IsBitcoin(this Network network)
         {
+            // TODO: Need a more elegant way of determining this
             return !network.Name.ToLowerInvariant().Contains("stratis");
         }
     }


### PR DESCRIPTION
Determining network type by string comparisons is quite horrible.