### PR TITLE
[FN] Peer discovery

### DIFF
--- a/src/NBitcoin/DNSSeedData.cs
+++ b/src/NBitcoin/DNSSeedData.cs
@@ -32,7 +32,7 @@ namespace NBitcoin
         /// <summary>
         /// Gets the IP addresses of nodes associated with the host.
         /// </summary>
-        /// /// <param name="forceRefresh">Normally the DNS lookups get cached after the first resolution. This indicates that the results should be discarded and overwritten.</param>
+        /// <param name="forceRefresh">Normally the DNS lookups get cached after the first resolution. This indicates that the results should be discarded and overwritten.</param>
         /// <returns>A list of IP addresses.</returns>
         public IPAddress[] GetAddressNodes(bool forceRefresh = false)
         {

--- a/src/NBitcoin/DNSSeedData.cs
+++ b/src/NBitcoin/DNSSeedData.cs
@@ -32,10 +32,11 @@ namespace NBitcoin
         /// <summary>
         /// Gets the IP addresses of nodes associated with the host.
         /// </summary>
+        /// /// <param name="forceRefresh">Normally the DNS lookups get cached after the first resolution. This indicates that the results should be discarded and overwritten.</param>
         /// <returns>A list of IP addresses.</returns>
-        public IPAddress[] GetAddressNodes()
+        public IPAddress[] GetAddressNodes(bool forceRefresh = false)
         {
-            if (this.addresses != null)
+            if (this.addresses != null && !forceRefresh)
             {
                 return this.addresses;
             }

--- a/src/Stratis.Bitcoin/P2P/PeerDiscoveryLoop.cs
+++ b/src/Stratis.Bitcoin/P2P/PeerDiscoveryLoop.cs
@@ -131,7 +131,7 @@ namespace Stratis.Bitcoin.P2P
             // We need DNS discovery to happen in two main cases:
             // 1. We have no other peers.
             // 2. Periodically (but infrequently) so that we will have fresh alternatives to connect to if our current peers disconnect.
-            if (this.peerAddressManager.Peers.Count == 0 || (this.seedAndDnsAttempted - DateTime.Now).TotalSeconds > RetrySeedsThresholdSeconds)
+            if (this.peerAddressManager.Peers.Count == 0 || (DateTime.Now - this.seedAndDnsAttempted).TotalSeconds > RetrySeedsThresholdSeconds)
             {
                 this.AddDNSSeedNodes(peersToDiscover);
                 this.AddSeedNodes(peersToDiscover);

--- a/src/Stratis.Bitcoin/P2P/PeerDiscoveryLoop.cs
+++ b/src/Stratis.Bitcoin/P2P/PeerDiscoveryLoop.cs
@@ -30,8 +30,11 @@ namespace Stratis.Bitcoin.P2P
     /// <summary>Async loop that discovers new peers to connect to.</summary>
     public sealed class PeerDiscovery : IPeerDiscovery
     {
-        /// <summary>The async loop we need to wait upon before we can shut down this connector.</summary>
+        /// <summary>The async loop for performing discovery on actual peers. We need to wait upon it before we can shut down this connector.</summary>
         private IAsyncLoop asyncLoop;
+
+        /// <summary>The async loop for discovering from DNS seeds & seed nodes. We need to wait upon it before we can shut down this connector.</summary>
+        private IAsyncLoop dnsAsyncLoop;
 
         /// <summary>Factory for creating background async loop tasks.</summary>
         private readonly IAsyncProvider asyncProvider;
@@ -60,10 +63,13 @@ namespace Stratis.Bitcoin.P2P
         /// <summary>Factory for creating P2P network peers.</summary>
         private readonly INetworkPeerFactory networkPeerFactory;
 
-        /// <summary>Indicates the dns and seed nodes were attempted.</summary>
-        private bool isSeedAndDnsAttempted;
+        /// <summary>Indicates the last time DNS and seed nodes were attempted.</summary>
+        private DateTime seedAndDnsAttempted;
 
         private const int TargetAmountOfPeersToDiscover = 2000;
+
+        // Only retry DNS seeds and seed nodes after an entire day has elapsed under normal circumstances.
+        private const int RetrySeedsThresholdSeconds = 86400;
 
         public PeerDiscovery(
             IAsyncProvider asyncProvider,
@@ -94,7 +100,17 @@ namespace Stratis.Bitcoin.P2P
             if (!connectionManager.Parameters.PeerAddressManagerBehaviour().Mode.HasFlag(PeerAddressManagerBehaviourMode.Discover))
                 return;
 
+            this.seedAndDnsAttempted = DateTime.Now;
+
             this.currentParameters = connectionManager.Parameters.Clone(); // TODO we shouldn't add all the behaviors, only those that we need.
+
+            this.dnsAsyncLoop = this.asyncProvider.CreateAndRunAsyncLoop(nameof(this.DiscoverDNSSeedsAsync), async token =>
+                {
+                    if (this.peerAddressManager.Peers.Count < TargetAmountOfPeersToDiscover)
+                        await this.DiscoverDNSSeedsAsync();
+                },
+                this.nodeLifetime.ApplicationStopping,
+                TimeSpans.TenSeconds);
 
             this.asyncLoop = this.asyncProvider.CreateAndRunAsyncLoop(nameof(this.DiscoverPeersAsync), async token =>
             {
@@ -106,47 +122,63 @@ namespace Stratis.Bitcoin.P2P
         }
 
         /// <summary>
-        /// See <see cref="DiscoverPeers"/>.
+        /// See <see cref="DiscoverPeers"/>. This loop deals with discovery from DNS seeds and seed nodes as opposed to peers.
+        /// </summary>
+        private async Task DiscoverDNSSeedsAsync()
+        {
+            var peersToDiscover = new List<IPEndPoint>();
+
+            // We need DNS discovery to happen in two main cases:
+            // 1. We have no other peers.
+            // 2. Periodically (but infrequently) so that we will have fresh alternatives to connect to if our current peers disconnect.
+            if (this.peerAddressManager.Peers.Count == 0 || (this.seedAndDnsAttempted - DateTime.Now).TotalSeconds > RetrySeedsThresholdSeconds)
+            {
+                this.AddDNSSeedNodes(peersToDiscover);
+                this.AddSeedNodes(peersToDiscover);
+                this.seedAndDnsAttempted = DateTime.Now;
+
+                // TODO: We should possibly also consider the case where all the peers we know about are Attempted and we haven't successfully Handshaked with any.
+            }
+            else
+            {
+                this.logger.LogTrace("(-)[NOTHING_TO_DO]");
+                return;
+            }
+
+            if (peersToDiscover.Count == 0)
+            {
+                this.logger.LogTrace("(-)[NO_DNS_SEED_ADDRESSES]");
+                return;
+            }
+
+            // Randomise the order prior to attempting connections.
+            peersToDiscover = peersToDiscover.OrderBy(a => RandomUtils.GetInt32()).ToList();
+
+            await this.ConnectToDiscoveryCandidatesAsync(peersToDiscover).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// See <see cref="DiscoverPeers"/>. This loop deals with discovery from peers as opposed to DNS seeds and seed nodes.
         /// </summary>
         private async Task DiscoverPeersAsync()
         {
             var peersToDiscover = new List<IPEndPoint>();
+
+            // The peer selector returns a quantity of peers for discovery already in random order.
             List<PeerAddress> foundPeers = this.peerAddressManager.PeerSelector.SelectPeersForDiscovery(1000).ToList();
             peersToDiscover.AddRange(foundPeers.Select(p => p.Endpoint));
 
             if (peersToDiscover.Count == 0)
             {
-                // On normal circumstances the dns seeds are attempted only once per node lifetime.
-                if (this.isSeedAndDnsAttempted)
-                {
-                    this.logger.LogTrace("(-)[DNS_ATTEMPTED]");
-                    return;
-                }
-
-                this.AddDNSSeedNodes(peersToDiscover);
-                this.AddSeedNodes(peersToDiscover);
-                this.isSeedAndDnsAttempted = true;
-
-                if (peersToDiscover.Count == 0)
-                {
-                    this.logger.LogTrace("(-)[NO_ADDRESSES]");
-                    return;
-                }
-
-                peersToDiscover = peersToDiscover.OrderBy(a => RandomUtils.GetInt32()).ToList();
-            }
-            else
-            {
-                // If all attempts have failed then attempt the dns seeds again.
-                if (foundPeers.All(peer => peer.Attempted))
-                {
-                    peersToDiscover.Clear();
-                    this.AddDNSSeedNodes(peersToDiscover);
-                    this.AddSeedNodes(peersToDiscover);
-                    this.isSeedAndDnsAttempted = true;
-                }
+                this.logger.LogTrace("(-)[NO_ADDRESSES]");
+                return;
             }
 
+            await this.ConnectToDiscoveryCandidatesAsync(peersToDiscover).ConfigureAwait(false);
+        }
+
+        private async Task ConnectToDiscoveryCandidatesAsync(List<IPEndPoint> peersToDiscover)
+        {
             await peersToDiscover.ForEachAsync(5, this.nodeLifetime.ApplicationStopping, async (endPoint, cancellation) =>
             {
                 using (CancellationTokenSource connectTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellation))
@@ -189,7 +221,7 @@ namespace Stratis.Bitcoin.P2P
         }
 
         /// <summary>
-        /// Add peers to the address manager from the network DNS's seed nodes.
+        /// Add peers to the address manager from the network's DNS seed nodes.
         /// </summary>
         private void AddDNSSeedNodes(List<IPEndPoint> endPoints)
         {
@@ -197,7 +229,8 @@ namespace Stratis.Bitcoin.P2P
             {
                 try
                 {
-                    IPAddress[] ipAddresses = seed.GetAddressNodes();
+                    // We want to try to ensure we get a fresh set of results from the seeder each time we query it.
+                    IPAddress[] ipAddresses = seed.GetAddressNodes(true);
                     endPoints.AddRange(ipAddresses.Select(ip => new IPEndPoint(ip, this.network.DefaultPort)));
                 }
                 catch (Exception)
@@ -219,6 +252,7 @@ namespace Stratis.Bitcoin.P2P
         public void Dispose()
         {
             this.asyncLoop?.Dispose();
+            this.dnsAsyncLoop?.Dispose();
         }
     }
 }

--- a/src/Stratis.Bitcoin/P2P/PeerDiscoveryLoop.cs
+++ b/src/Stratis.Bitcoin/P2P/PeerDiscoveryLoop.cs
@@ -138,7 +138,7 @@ namespace Stratis.Bitcoin.P2P
             else
             {
                 // If all attempts have failed then attempt the dns seeds again.
-                if (!this.isSeedAndDnsAttempted && foundPeers.All(peer => peer.Attempted))
+                if (foundPeers.All(peer => peer.Attempted))
                 {
                     peersToDiscover.Clear();
                     this.AddDNSSeedNodes(peersToDiscover);


### PR DESCRIPTION
This looks like a bug, as it seems to me you could land up in a scenario where all peers retrieved from the seeds were non-responsive, and you would never ask the seeds again for more potential peers.