### PR TITLE
[FN] Handshaking improvement

### DIFF
--- a/src/Stratis.Bitcoin/P2P/Peer/NetworkPeer.cs
+++ b/src/Stratis.Bitcoin/P2P/Peer/NetworkPeer.cs
@@ -708,6 +708,8 @@ namespace Stratis.Bitcoin.P2P.Peer
         /// <inheritdoc/>
         public async Task VersionHandshakeAsync(NetworkPeerRequirement requirements, CancellationToken cancellationToken)
         {
+            // In stratisX, the equivalent functionality is contained in main.cpp, method ProcessMessage()
+
             requirements = requirements ?? new NetworkPeerRequirement();
             using (var listener = new NetworkPeerListener(this, this.asyncProvider))
             {
@@ -777,11 +779,8 @@ namespace Stratis.Bitcoin.P2P.Peer
                     await this.SendMessageAsync(addrPayload, cancellationToken).ConfigureAwait(false);
                 }
 
-                // We treat outbound peers as slightly more trusted, so we ask them for the peers they're aware of to aid our own discovery.
-                if (!this.Inbound)
-                {
-                    await this.SendMessageAsync(new GetAddrPayload(), cancellationToken).ConfigureAwait(false);
-                }
+                // Ask the just-handshaked peer for the peers they know about to aid in our own peer discovery.
+                await this.SendMessageAsync(new GetAddrPayload(), cancellationToken).ConfigureAwait(false);
             }
         }
 

--- a/src/Stratis.Bitcoin/P2P/Peer/NetworkPeer.cs
+++ b/src/Stratis.Bitcoin/P2P/Peer/NetworkPeer.cs
@@ -776,6 +776,12 @@ namespace Stratis.Bitcoin.P2P.Peer
 
                     await this.SendMessageAsync(addrPayload, cancellationToken).ConfigureAwait(false);
                 }
+
+                // We treat outbound peers as slightly more trusted, so we ask them for the peers they're aware of to aid our own discovery.
+                if (!this.Inbound)
+                {
+                    await this.SendMessageAsync(new GetAddrPayload(), cancellationToken).ConfigureAwait(false);
+                }
             }
         }
 

--- a/src/Stratis.Bitcoin/P2P/PeerAddressManagerBehaviour.cs
+++ b/src/Stratis.Bitcoin/P2P/PeerAddressManagerBehaviour.cs
@@ -123,7 +123,7 @@ namespace Stratis.Bitcoin.P2P
                         if (addr.Addresses.Length > MaxAddressesPerAddrPayload)
                         {
                             // Not respecting the protocol.
-                            this.peerBanning.BanAndDisconnectPeer(peer.PeerEndPoint, "Protocol violation: addr payload size is limited by 1000 entries.");
+                            this.peerBanning.BanAndDisconnectPeer(peer.PeerEndPoint, $"Protocol violation: addr payload size is limited by {MaxAddressesPerAddrPayload} entries.");
 
                             this.logger.LogTrace("(-)[PROTOCOL_VIOLATION]");
                             return;

--- a/src/Stratis.Bitcoin/P2P/PeerDiscoveryLoop.cs
+++ b/src/Stratis.Bitcoin/P2P/PeerDiscoveryLoop.cs
@@ -168,7 +168,6 @@ namespace Stratis.Bitcoin.P2P
 
                         networkPeer = await this.networkPeerFactory.CreateConnectedNetworkPeerAsync(endPoint, clonedParameters).ConfigureAwait(false);
                         await networkPeer.VersionHandshakeAsync(connectTokenSource.Token).ConfigureAwait(false);
-                        await networkPeer.SendMessageAsync(new GetAddrPayload(), connectTokenSource.Token).ConfigureAwait(false);
 
                         this.peerAddressManager.PeerDiscoveredFrom(endPoint, DateTimeProvider.Default.GetUtcNow());
 


### PR DESCRIPTION
As far as I can determine, during the normal handshaking process we were never sending a `getaddr` request. So `getaddr` is only ever sent as part of the discovery loop executed every 10 seconds. But a peer we have just handshaked & connected with will most likely not accept a second connection from us due to IP range filtering, so we never find out its known peers.

https://github.com/stratisproject/stratisX/blob/master/src/main.cpp#L2947-L2953