### PR TITLE
Set Swagger API response cache control header

### DIFF
--- a/src/Stratis.Bitcoin.Features.Api/NoCacheMiddleware.cs
+++ b/src/Stratis.Bitcoin.Features.Api/NoCacheMiddleware.cs
@@ -8,18 +8,18 @@ namespace Stratis.Bitcoin.Features.Api
     /// </summary>
     public class NoCacheMiddleware
     {
-        private readonly RequestDelegate _next;
+        private readonly RequestDelegate next;
 
         public NoCacheMiddleware(RequestDelegate next)
         {
-            this._next = next;
+            this.next = next;
         }
 
         public async Task InvokeAsync(HttpContext context)
         {
             context.Response.Headers["Cache-Control"] = "no-cache";
 
-            await this._next(context);
+            await this.next(context);
         }
     }
 }

--- a/src/Stratis.Bitcoin.Features.Api/NoCacheMiddleware.cs
+++ b/src/Stratis.Bitcoin.Features.Api/NoCacheMiddleware.cs
@@ -1,0 +1,25 @@
+﻿using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+
+namespace Stratis.Bitcoin.Features.Api
+{
+    /// <summary>
+    /// Middleware to set the response Cache-Control to no-cache.
+    /// </summary>
+    public class NoCacheMiddleware
+    {
+        private readonly RequestDelegate _next;
+
+        public NoCacheMiddleware(RequestDelegate next)
+        {
+            this._next = next;
+        }
+
+        public async Task InvokeAsync(HttpContext context)
+        {
+            context.Response.Headers["Cache-Control"] = "no-cache";
+
+            await this._next(context);
+        }
+    }
+}

--- a/src/Stratis.Bitcoin.Features.Api/Startup.cs
+++ b/src/Stratis.Bitcoin.Features.Api/Startup.cs
@@ -97,6 +97,9 @@ namespace Stratis.Bitcoin.Features.Api
 
             app.UseCors("CorsPolicy");
 
+            // Register this before MVC and Swagger.
+            app.Map("/api", a => a.UseMiddleware<NoCacheMiddleware>());
+
             app.UseMvc();
 
             // Enable middleware to serve generated Swagger as a JSON endpoint.

--- a/src/Stratis.Bitcoin.Features.Api/Startup.cs
+++ b/src/Stratis.Bitcoin.Features.Api/Startup.cs
@@ -98,7 +98,7 @@ namespace Stratis.Bitcoin.Features.Api
             app.UseCors("CorsPolicy");
 
             // Register this before MVC and Swagger.
-            app.Map("/api", a => a.UseMiddleware<NoCacheMiddleware>());
+            app.UseMiddleware<NoCacheMiddleware>();
 
             app.UseMvc();
 


### PR DESCRIPTION
API responses currently don't set a caching policy. This causes weird behaviour in some browsers where they return a cached response which is different from expected. See VSTS #3971 which was a result of this.

I don't think there's ever a scenario where we want the browser to cache these values, so we should be able to set the `Cache-Control` header to `no-cache` to prevent this happening.