### PR TITLE
Fix CM's ShouldDisconnect IP address matching

### DIFF
--- a/src/Stratis.Bitcoin/Connection/ConnectionManager.cs
+++ b/src/Stratis.Bitcoin/Connection/ConnectionManager.cs
@@ -404,17 +404,7 @@ namespace Stratis.Bitcoin.Connection
             }
 
             // Don't disconnect if this peer is in -addnode or -connect.
-            bool isAddNodeOrConnect = false;
-            foreach (IPEndPoint addNodeEndPoint in this.ConnectionSettings.AddNode.Union(this.ConnectionSettings.Connect))
-            {
-                if (peer.PeerEndPoint.MatchIpOnly(addNodeEndPoint))
-                {
-                    isAddNodeOrConnect = true;
-                    break;
-                }
-            }
-
-            if (isAddNodeOrConnect)
+            if (this.ConnectionSettings.AddNode.Union(this.ConnectionSettings.Connect).Any(ep => peer.PeerEndPoint.MatchIpOnly(ep)))
             {
                 this.logger.LogTrace("(-)[ADD_NODE_OR_CONNECT]:false");
                 return false;

--- a/src/Stratis.Bitcoin/Connection/ConnectionManager.cs
+++ b/src/Stratis.Bitcoin/Connection/ConnectionManager.cs
@@ -407,7 +407,7 @@ namespace Stratis.Bitcoin.Connection
             bool isAddNodeOrConnect = false;
             foreach (IPEndPoint addNodeEndPoint in this.ConnectionSettings.AddNode.Union(this.ConnectionSettings.Connect))
             {
-                if (peer.PeerEndPoint.Address.Equals(addNodeEndPoint.Address))
+                if (peer.PeerEndPoint.MatchIpOnly(addNodeEndPoint))
                 {
                     isAddNodeOrConnect = true;
                     break;


### PR DESCRIPTION
This PR fixes the IP address matching in the CM's `ShouldDisconnect` method to take into account that IP addresses can be either V4 or V6.

This may be related to https://stratisplatformuk.visualstudio.com/StratisBitcoinFullNode/_workitems/edit/3934.