### PR TITLE
[DNS] Make DNS response authoritative

### DIFF
--- a/src/Stratis.Bitcoin.Features.Dns/DnsSeedServer.cs
+++ b/src/Stratis.Bitcoin.Features.Dns/DnsSeedServer.cs
@@ -350,6 +350,8 @@ namespace Stratis.Bitcoin.Features.Dns
                 }
             }
 
+            response.AuthorativeServer = true;
+
             // Set new start index.
             Interlocked.Increment(ref this.startIndex);
 


### PR DESCRIPTION
This sets the appropriate bit (`AA`) in the response header.