### PR TITLE
[FS] Ensure proper behavior when there is no collateral requirement configured

### DIFF
--- a/src/Stratis.Bitcoin.Features.BlockStore/AddressIndexing/AddressIndexer.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/AddressIndexing/AddressIndexer.cs
@@ -37,7 +37,7 @@ namespace Stratis.Bitcoin.Features.BlockStore.AddressIndexing
 
         /// <summary>Returns verbose balances data.</summary>
         /// <param name="addresses">The set of addresses that will be queried.</param>
-        VerboseAddressBalancesResult GetVerboseAddressBalancesData(string[] addresses);
+        VerboseAddressBalancesResult GetAddressIndexerState(string[] addresses);
     }
 
     public class AddressIndexer : IAddressIndexer
@@ -579,12 +579,9 @@ namespace Stratis.Bitcoin.Features.BlockStore.AddressIndexing
         }
 
         /// <inheritdoc />
-        public VerboseAddressBalancesResult GetVerboseAddressBalancesData(string[] addresses)
+        public VerboseAddressBalancesResult GetAddressIndexerState(string[] addresses)
         {
-            var result = new VerboseAddressBalancesResult()
-            {
-                ConsensusTipHeight = this.consensusManager.Tip.Height
-            };
+            var result = new VerboseAddressBalancesResult(this.consensusManager.Tip.Height);
 
             if (addresses.Length == 0)
                 return result;

--- a/src/Stratis.Bitcoin.Features.BlockStore/AddressIndexing/AddressIndexer.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/AddressIndexing/AddressIndexer.cs
@@ -581,12 +581,18 @@ namespace Stratis.Bitcoin.Features.BlockStore.AddressIndexing
         /// <inheritdoc />
         public VerboseAddressBalancesResult GetVerboseAddressBalancesData(string[] addresses)
         {
+            var result = new VerboseAddressBalancesResult()
+            {
+                ConsensusTipHeight = this.consensusManager.Tip.Height
+            };
+
+            if (addresses.Length == 0)
+                return result;
+
             (bool isQueryable, string reason) = this.IsQueryable();
 
             if (!isQueryable)
                 return VerboseAddressBalancesResult.RequestFailed(reason);
-
-            var result = new VerboseAddressBalancesResult();
 
             lock (this.lockObject)
             {
@@ -603,8 +609,6 @@ namespace Stratis.Bitcoin.Features.BlockStore.AddressIndexing
                     result.BalancesData.Add(copy);
                 }
             }
-
-            result.ConsensusTipHeight = this.consensusManager.Tip.Height;
 
             return result;
         }

--- a/src/Stratis.Bitcoin.Features.BlockStore/Controllers/BlockStoreController.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/Controllers/BlockStoreController.cs
@@ -181,7 +181,7 @@ namespace Stratis.Bitcoin.Features.BlockStore.Controllers
         {
             try
             {
-                string[] addressesArray = addresses.Split(',');
+                string[] addressesArray = addresses?.Split(',') ?? new string[] { };
 
                 this.logger.LogDebug("Asking data for {0} addresses.", addressesArray.Length);
 

--- a/src/Stratis.Bitcoin.Features.BlockStore/Controllers/BlockStoreController.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/Controllers/BlockStoreController.cs
@@ -185,7 +185,7 @@ namespace Stratis.Bitcoin.Features.BlockStore.Controllers
 
                 this.logger.LogDebug("Asking data for {0} addresses.", addressesArray.Length);
 
-                VerboseAddressBalancesResult result = this.addressIndexer.GetVerboseAddressBalancesData(addressesArray);
+                VerboseAddressBalancesResult result = this.addressIndexer.GetAddressIndexerState(addressesArray);
 
                 return this.Json(result);
             }

--- a/src/Stratis.Bitcoin.IntegrationTests.Common/EnvironmentMockUpHelpers/CoreNode.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests.Common/EnvironmentMockUpHelpers/CoreNode.cs
@@ -274,7 +274,7 @@ namespace Stratis.Bitcoin.IntegrationTests.Common.EnvironmentMockUpHelpers
                 return this.runner.FullNode.NodeService<IAsyncProvider>();
         }
 
-        public CoreNode Start()
+        public CoreNode Start(Action startAction = null)
         {
             lock (this.lockObject)
             {
@@ -283,6 +283,7 @@ namespace Stratis.Bitcoin.IntegrationTests.Common.EnvironmentMockUpHelpers
                 this.runner.OverrideDateTimeProvider = this.builderOverrideDateTimeProvider;
 
                 this.runner.BuildNode();
+                startAction?.Invoke();
                 this.runner.Start();
                 this.State = CoreNodeState.Starting;
             }

--- a/src/Stratis.Bitcoin/Controllers/Models/AddressBalancesResult.cs
+++ b/src/Stratis.Bitcoin/Controllers/Models/AddressBalancesResult.cs
@@ -57,9 +57,14 @@ namespace Stratis.Bitcoin.Controllers.Models
     /// </summary>
     public sealed class VerboseAddressBalancesResult
     {
-        public VerboseAddressBalancesResult()
+        private VerboseAddressBalancesResult()
         {
             this.BalancesData = new List<AddressIndexerData>();
+        }
+
+        public VerboseAddressBalancesResult(int consensusTipHeight) : this()
+        {
+            this.ConsensusTipHeight = consensusTipHeight;
         }
 
         public List<AddressIndexerData> BalancesData { get; set; }

--- a/src/Stratis.Features.FederatedPeg.IntegrationTests/NodeInitialisationTests.cs
+++ b/src/Stratis.Features.FederatedPeg.IntegrationTests/NodeInitialisationTests.cs
@@ -77,7 +77,7 @@ namespace Stratis.Features.FederatedPeg.IntegrationTests
         {
             var mockClient = new Mock<IBlockStoreClient>();
             mockClient.Setup(x => x.GetVerboseAddressesBalancesDataAsync(It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new Bitcoin.Controllers.Models.VerboseAddressBalancesResult() { ConsensusTipHeight = 100000 });
+                .ReturnsAsync(new Bitcoin.Controllers.Models.VerboseAddressBalancesResult(100000));
 
             node.Start(() => {
                 ICollateralChecker collateralChecker = node.FullNode.NodeService<ICollateralChecker>();

--- a/src/Stratis.Features.FederatedPeg.IntegrationTests/NodeInitialisationTests.cs
+++ b/src/Stratis.Features.FederatedPeg.IntegrationTests/NodeInitialisationTests.cs
@@ -1,10 +1,14 @@
-﻿using System.Linq;
+﻿using System.Collections.Generic;
+using System.Linq;
 using System.Net;
+using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Flurl;
 using Flurl.Http;
+using Moq;
 using NBitcoin;
+using Stratis.Bitcoin.Features.BlockStore.Controllers;
 using Stratis.Bitcoin.Features.PoA;
 using Stratis.Bitcoin.IntegrationTests.Common;
 using Stratis.Bitcoin.IntegrationTests.Common.EnvironmentMockUpHelpers;
@@ -63,10 +67,22 @@ namespace Stratis.Features.FederatedPeg.IntegrationTests
 
                 CoreNode miner = nodeBuilder.CreateSidechainMinerNode(this.sidechainNetwork, this.mainNetwork, federationKey);
 
-                miner.Start();
+                this.StartNodeWithMockCounterNodeAPI(miner);
 
                 Assert.Equal(CoreNodeState.Running, miner.State);
             }
+        }
+
+        private void StartNodeWithMockCounterNodeAPI(CoreNode node)
+        {
+            var mockClient = new Mock<IBlockStoreClient>();
+            mockClient.Setup(x => x.GetVerboseAddressesBalancesDataAsync(It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new Bitcoin.Controllers.Models.VerboseAddressBalancesResult() { ConsensusTipHeight = 100000 });
+
+            node.Start(() => {
+                ICollateralChecker collateralChecker = node.FullNode.NodeService<ICollateralChecker>();
+                collateralChecker.SetPrivateVariableValue("blockStoreClient", mockClient.Object);
+            });
         }
 
         [Fact]
@@ -82,7 +98,7 @@ namespace Stratis.Features.FederatedPeg.IntegrationTests
                 gateway.AppendToConfig($"publickey={this.sidechainNetwork.FederationMnemonics[0].DeriveExtKey().PrivateKey.PubKey}");
                 gateway.AppendToConfig("federationips=0.0.0.0,0.0.0.1"); // Placeholders
 
-                gateway.Start();
+                this.StartNodeWithMockCounterNodeAPI(gateway);
 
                 Assert.Equal(CoreNodeState.Running, gateway.State);
             }
@@ -160,8 +176,8 @@ namespace Stratis.Features.FederatedPeg.IntegrationTests
                 side.AppendToConfig($"counterchainapiport={main.ApiPort}");
                 main.AppendToConfig($"counterchainapiport={side.ApiPort}");
 
-                side.Start();
                 main.Start();
+                side.Start();
 
                 Assert.Equal(CoreNodeState.Running, main.State);
                 Assert.Equal(CoreNodeState.Running, side.State);

--- a/src/Stratis.Features.FederatedPeg.Tests/CollateralCheckerTests.cs
+++ b/src/Stratis.Features.FederatedPeg.Tests/CollateralCheckerTests.cs
@@ -80,9 +80,8 @@ namespace Stratis.Features.FederatedPeg.Tests
         {
             var blockStoreClientMock = new Mock<IBlockStoreClient>();
 
-            var collateralData = new VerboseAddressBalancesResult()
+            var collateralData = new VerboseAddressBalancesResult(this.collateralCheckHeight + 1000)
             {
-                ConsensusTipHeight = this.collateralCheckHeight + 1000,
                 BalancesData = new List<AddressIndexerData>()
                 {
                     new AddressIndexerData()

--- a/src/Stratis.Features.FederatedPeg/Collateral/CollateralChecker.cs
+++ b/src/Stratis.Features.FederatedPeg/Collateral/CollateralChecker.cs
@@ -158,11 +158,7 @@ namespace Stratis.Features.FederatedPeg.Collateral
 
             if (addressesToCheck.Count == 0)
             {
-                this.collateralUpdated = true;
-
                 this.logger.LogInformation("None of the federation members has a collateral requirement configured.");
-                this.logger.LogTrace("(-)[NOTHING_TO_CHECK]:true");
-                return;
             }
 
             this.logger.LogDebug("Addresses to check {0}.", addressesToCheck.Count);


### PR DESCRIPTION
Currently the `ConsensusTipHeight` is not being returned when there is no collateral requirement configured. This PR avoids the resultant strange behavior, such as the side chain tip not advancing.

See https://stratisplatformuk.visualstudio.com/StratisBitcoinFullNode/_workitems/edit/3998.