### PR TITLE
[FS] Remove redundant validation and methods in CCTS

### DIFF
--- a/src/Stratis.Features.FederatedPeg/Interfaces/ICrossChainTransferStore.cs
+++ b/src/Stratis.Features.FederatedPeg/Interfaces/ICrossChainTransferStore.cs
@@ -95,11 +95,6 @@ namespace Stratis.Features.FederatedPeg.Interfaces
         /// <returns>The counter of the cross chain transfer for each <see cref="CrossChainTransferStatus"/> status</returns>
         Dictionary<CrossChainTransferStatus, int> GetCrossChainTransferStatusCounter();
 
-        /// <summary>
-        /// Get transfers by status without validating or locking. Useful for retrieving console data.
-        /// </summary>
-        ICrossChainTransfer[] QueryTransfersByStatus(CrossChainTransferStatus[] statuses);
-
 
         /// <summary>
         /// Get transfers by ID without validating or locking. Useful for retrieving console data.

--- a/src/Stratis.Features.FederatedPeg/TargetChain/CrossChainTransferStore.cs
+++ b/src/Stratis.Features.FederatedPeg/TargetChain/CrossChainTransferStore.cs
@@ -7,7 +7,6 @@ using System.Threading.Tasks;
 using DBreeze;
 using DBreeze.DataTypes;
 using DBreeze.Utils;
-using Microsoft.AspNetCore.CookiePolicy;
 using Microsoft.Extensions.Logging;
 using NBitcoin;
 using Stratis.Bitcoin;
@@ -1100,36 +1099,6 @@ namespace Stratis.Features.FederatedPeg.TargetChain
             return transaction.Inputs.Select(i => i.PrevOut).OrderBy(t => t, comparer).FirstOrDefault();
         }
 
-        private ICrossChainTransfer[] GetTransfersByStatusInternalLocked(CrossChainTransferStatus[] statuses, bool sort = false, bool validate = true)
-        {
-            var depositIds = new HashSet<uint256>();
-            foreach (CrossChainTransferStatus status in statuses)
-                depositIds.UnionWith(this.depositsIdsByStatus[status]);
-
-            uint256[] partialTransferHashes = depositIds.ToArray();
-            ICrossChainTransfer[] partialTransfers = this.Get(partialTransferHashes).Where(t => t != null).ToArray();
-
-            if (validate)
-            {
-                this.ValidateCrossChainTransfers(partialTransfers);
-                partialTransfers = partialTransfers.Where(t => statuses.Contains(t.Status)).ToArray();
-            }
-
-            if (!sort)
-            {
-                return partialTransfers;
-            }
-
-            // When sorting, Suspended transactions will have null PartialTransactions. Always put them last in the order they're in.
-            IEnumerable<ICrossChainTransfer> unsortable = partialTransfers.Where(x => x.Status == CrossChainTransferStatus.Suspended || x.Status == CrossChainTransferStatus.Rejected);
-            IEnumerable<ICrossChainTransfer> sortable = partialTransfers.Where(x => x.Status != CrossChainTransferStatus.Suspended && x.Status != CrossChainTransferStatus.Rejected);
-
-            return sortable.OrderBy(t => this.EarliestOutput(t.PartialTransaction), Comparer<OutPoint>.Create((x, y) =>
-                    ((FederationWalletManager)this.federationWalletManager).CompareOutpoints(x, y)))
-                .Concat(unsortable)
-                .ToArray();
-        }
-
         /// <inheritdoc />
         public ICrossChainTransfer[] GetTransfersByStatus(CrossChainTransferStatus[] statuses, bool sort = false)
         {
@@ -1137,23 +1106,29 @@ namespace Stratis.Features.FederatedPeg.TargetChain
             {
                 return this.federationWalletManager.Synchronous(() =>
                 {
+                    // Always make sure we're up to date before retrieving.
                     Guard.Assert(this.Synchronize());
 
-                    return this.GetTransfersByStatusInternalLocked(statuses, sort);
-                });
-            }
-        }
+                    var depositIds = new HashSet<uint256>();
+                    foreach (CrossChainTransferStatus status in statuses)
+                        depositIds.UnionWith(this.depositsIdsByStatus[status]);
 
-        /// <inheritdoc />
-        public ICrossChainTransfer[] QueryTransfersByStatus(CrossChainTransferStatus[] statuses)
-        {
-            lock (this.lockObj)
-            {
-                return this.federationWalletManager.Synchronous(() =>
-                {
-                    Guard.Assert(this.Synchronize());
+                    uint256[] partialTransferHashes = depositIds.ToArray();
+                    ICrossChainTransfer[] partialTransfers = this.Get(partialTransferHashes).Where(t => t != null).ToArray();
 
-                    return this.GetTransfersByStatusInternalLocked(statuses, true, false);
+                    if (!sort)
+                    {
+                        return partialTransfers;
+                    }
+
+                    // When sorting, Suspended transactions will have null PartialTransactions. Always put them last in the order they're in.
+                    IEnumerable<ICrossChainTransfer> unsortable = partialTransfers.Where(x => x.Status == CrossChainTransferStatus.Suspended || x.Status == CrossChainTransferStatus.Rejected);
+                    IEnumerable<ICrossChainTransfer> sortable = partialTransfers.Where(x => x.Status != CrossChainTransferStatus.Suspended && x.Status != CrossChainTransferStatus.Rejected);
+
+                    return sortable.OrderBy(t => this.EarliestOutput(t.PartialTransaction), Comparer<OutPoint>.Create((x, y) =>
+                            ((FederationWalletManager)this.federationWalletManager).CompareOutpoints(x, y)))
+                        .Concat(unsortable)
+                        .ToArray();
                 });
             }
         }

--- a/src/Stratis.Features.FederatedPeg/TargetChain/CrossChainTransferStore.cs
+++ b/src/Stratis.Features.FederatedPeg/TargetChain/CrossChainTransferStore.cs
@@ -1046,8 +1046,7 @@ namespace Stratis.Features.FederatedPeg.TargetChain
                     {
                         Guard.Assert(this.Synchronize());
 
-                        ICrossChainTransfer[] res = this.ValidateCrossChainTransfers(this.Get(depositIds));
-                        return res;
+                        return this.Get(depositIds);
                     });
                 }
             });

--- a/src/Stratis.Features.FederatedPeg/TargetChain/WithdrawalHistoryProvider.cs
+++ b/src/Stratis.Features.FederatedPeg/TargetChain/WithdrawalHistoryProvider.cs
@@ -89,7 +89,7 @@ namespace Stratis.Features.FederatedPeg.TargetChain
             var result = new List<WithdrawalModel>();
 
             // Get all Suspended, all Partial, and all FullySigned transfers.
-            ICrossChainTransfer[] inProgressTransfers = this.crossChainTransferStore.QueryTransfersByStatus(new CrossChainTransferStatus[]
+            ICrossChainTransfer[] inProgressTransfers = this.crossChainTransferStore.GetTransfersByStatus(new CrossChainTransferStatus[]
             {
                 CrossChainTransferStatus.Suspended,
                 CrossChainTransferStatus.Partial,


### PR DESCRIPTION
- Remove `QueryTransfersByStatus` which was redundant. Virtually same code as `GetTransfersByStatus`.
- Remove `validate` parameter which was redundant. The methods using it had already locked the wallet and called `Synchronize()` which does the validation beforehand, so the validation that was happening due to `validate` was never doing anything.

For https://stratisplatformuk.visualstudio.com/StratisBitcoinFullNode/_workitems/edit/3767