### PR TITLE
[SC] Add method name to storage receipt

### DIFF
--- a/src/Stratis.Bitcoin.Features.SmartContracts/Rules/SmartContractCoinViewRuleLogic.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts/Rules/SmartContractCoinViewRuleLogic.cs
@@ -184,7 +184,8 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Rules
                 result.Return?.ToString(),
                 result.ErrorMessage,
                 deserializedCallData.Value.GasPrice,
-                txContext.TxOutValue)
+                txContext.TxOutValue,
+                deserializedCallData.Value.IsCreateContract ? null : deserializedCallData.Value.MethodName)
             {
                 BlockHash = context.ValidationContext.BlockToValidate.GetHash()
             };

--- a/src/Stratis.SmartContracts.Core.Tests/Receipts/PersistentReceiptRepositoryTests.cs
+++ b/src/Stratis.SmartContracts.Core.Tests/Receipts/PersistentReceiptRepositoryTests.cs
@@ -36,7 +36,7 @@ namespace Stratis.SmartContracts.Core.Tests.Receipts
             };
             var log2 = new Log(new uint160(12345), topics2, data2);
 
-            var receipt = new Receipt(new uint256(1234), 12345, new Log[] { log1, log2 }, new uint256(12345), new uint160(25), new uint160(24), new uint160(23), true, "SomeResult", "SomeExceptionString", 54321, 1_000_000) { BlockHash = new uint256(1234) };
+            var receipt = new Receipt(new uint256(1234), 12345, new Log[] { log1, log2 }, new uint256(12345), new uint160(25), new uint160(24), new uint160(23), true, "SomeResult", "SomeExceptionString", 54321, 1_000_000, "TestMethodName") { BlockHash = new uint256(1234) };
             this.db.Store(new Receipt[] { receipt });
             Receipt retrievedReceipt = this.db.Retrieve(receipt.TransactionHash);
             ReceiptSerializationTest.TestStorageReceiptEquality(receipt, retrievedReceipt);

--- a/src/Stratis.SmartContracts.Core.Tests/Receipts/ReceiptSerializationTest.cs
+++ b/src/Stratis.SmartContracts.Core.Tests/Receipts/ReceiptSerializationTest.cs
@@ -50,7 +50,7 @@ namespace Stratis.SmartContracts.Core.Tests.Receipts
             TestStorageSerialize(receipt);
 
             // Test cases where either the sender or contract is null - AKA CALL vs CREATE
-            receipt = new Receipt(receipt.PostState, receipt.GasUsed, receipt.Logs, new uint256(12345), new uint160(25), new uint160(24), null, true, "Test Result", "Test Error Message", 54321, 1_000_000) { BlockHash = new uint256(1234) };
+            receipt = new Receipt(receipt.PostState, receipt.GasUsed, receipt.Logs, new uint256(12345), new uint160(25), new uint160(24), null, true, "Test Result", "Test Error Message", 54321, 1_000_000, "TestMethodName") { BlockHash = new uint256(1234) };
             TestStorageSerialize(receipt);
             receipt = new Receipt(receipt.PostState, receipt.GasUsed, receipt.Logs, new uint256(12345), new uint160(25), null, new uint160(23), true, "Test Result 2", "Test Error Message 2", 54321, 1_000_000) { BlockHash = new uint256(1234) };
             TestStorageSerialize(receipt);
@@ -100,6 +100,7 @@ namespace Stratis.SmartContracts.Core.Tests.Receipts
             Assert.Equal(receipt1.NewContractAddress, receipt2.NewContractAddress);
             Assert.Equal(receipt1.Success, receipt2.Success);
             Assert.Equal(receipt1.ErrorMessage, receipt2.ErrorMessage);
+            Assert.Equal(receipt1.MethodName, receipt2.MethodName);
         }
 
         private static void TestLogsEqual(Log log1, Log log2)

--- a/src/Stratis.SmartContracts.Core.Tests/Receipts/ReceiptSerializationTest.cs
+++ b/src/Stratis.SmartContracts.Core.Tests/Receipts/ReceiptSerializationTest.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using NBitcoin;
+using Nethereum.RLP;
 using Stratis.SmartContracts.Core.Receipts;
 using Xunit;
 
@@ -56,6 +58,17 @@ namespace Stratis.SmartContracts.Core.Tests.Receipts
             TestStorageSerialize(receipt);
         }
 
+        [Fact]
+        public void Receipt_With_No_MethodName_Deserializes_Correctly()
+        {
+            var receipt = new Receipt(new uint256(1234), 12345, new Log[]{}, new uint256(12345), new uint160(25), new uint160(24), null, true, "Test Result", "Test Error Message", 54321, 1_000_000) { BlockHash = new uint256(1234) };
+
+            byte[] serialized = ToStorageBytesRlp_NoMethodName(receipt);
+
+            Receipt deserialized = Receipt.FromStorageBytesRlp(serialized);
+            TestStorageReceiptEquality(receipt, deserialized);
+        }
+
         private void TestConsensusSerialize(Receipt receipt)
         {
             byte[] serialized = receipt.ToConsensusBytesRlp();
@@ -76,6 +89,33 @@ namespace Stratis.SmartContracts.Core.Tests.Receipts
             byte[] serialized = receipt.ToStorageBytesRlp();
             Receipt deserialized = Receipt.FromStorageBytesRlp(serialized);
             TestStorageReceiptEquality(receipt, deserialized);
+        }
+
+        /// <summary>
+        /// Serializes a receipt without including the method name. For backwards compatibility testing.
+        /// </summary>
+        /// <param name="receipt"></param>
+        /// <returns></returns>
+        public byte[] ToStorageBytesRlp_NoMethodName(Receipt receipt)
+        {
+            IList<byte[]> encodedLogs = receipt.Logs.Select(x => RLP.EncodeElement(x.ToBytesRlp())).ToList();
+
+            return RLP.EncodeList(
+                RLP.EncodeElement(receipt.PostState.ToBytes()),
+                RLP.EncodeElement(BitConverter.GetBytes(receipt.GasUsed)),
+                RLP.EncodeElement(receipt.Bloom.ToBytes()),
+                RLP.EncodeElement(RLP.EncodeList(encodedLogs.ToArray())),
+                RLP.EncodeElement(receipt.TransactionHash.ToBytes()),
+                RLP.EncodeElement(receipt.BlockHash.ToBytes()),
+                RLP.EncodeElement(receipt.From.ToBytes()),
+                RLP.EncodeElement(receipt.To?.ToBytes()),
+                RLP.EncodeElement(receipt.NewContractAddress?.ToBytes()),
+                RLP.EncodeElement(BitConverter.GetBytes(receipt.Success)),
+                RLP.EncodeElement(Encoding.UTF8.GetBytes(receipt.Result ?? "")),
+                RLP.EncodeElement(Encoding.UTF8.GetBytes(receipt.ErrorMessage ?? "")),
+                RLP.EncodeElement(BitConverter.GetBytes(receipt.GasPrice)),
+                RLP.EncodeElement(BitConverter.GetBytes(receipt.Amount))
+            );
         }
 
         /// <summary>

--- a/src/Stratis.SmartContracts.Core/Receipts/Receipt.cs
+++ b/src/Stratis.SmartContracts.Core/Receipts/Receipt.cs
@@ -70,6 +70,11 @@ namespace Stratis.SmartContracts.Core.Receipts
         public uint160 To { get; }
 
         /// <summary>
+        /// Method name sent in the CALL. Null if CREATE.
+        /// </summary>
+        public string MethodName { get; }
+
+        /// <summary>
         /// Contract address created in this CREATE. Null if CALL.
         /// </summary>
         public uint160 NewContractAddress { get; }
@@ -106,8 +111,9 @@ namespace Stratis.SmartContracts.Core.Receipts
             string result,
             string errorMessage,
             ulong gasPrice,
-            ulong amount) 
-            : this(postState, gasUsed, logs, BuildBloom(logs), transactionHash, null, @from, to, newContractAddress, success, result, errorMessage, gasPrice, amount)
+            ulong amount,
+            string methodName = null) 
+            : this(postState, gasUsed, logs, BuildBloom(logs), transactionHash, null, @from, to, newContractAddress, success, result, errorMessage, gasPrice, amount, methodName)
         { }
 
         /// <summary>
@@ -116,7 +122,7 @@ namespace Stratis.SmartContracts.Core.Receipts
         public Receipt(uint256 postState,
             ulong gasUsed,
             Log[] logs)
-            : this(postState, gasUsed, logs, BuildBloom(logs), null, null, null, null, null, false, null, null, 0, 0)
+            : this(postState, gasUsed, logs, BuildBloom(logs), null, null, null, null, null, false, null, null, 0, 0, null)
         { }
 
         /// <summary>
@@ -127,7 +133,7 @@ namespace Stratis.SmartContracts.Core.Receipts
             ulong gasUsed,
             Log[] logs,
             Bloom bloom) 
-            : this(postState, gasUsed, logs, bloom, null, null, null, null, null, false, null, null, 0, 0)
+            : this(postState, gasUsed, logs, bloom, null, null, null, null, null, false, null, null, 0, 0, null)
         { }
 
         private Receipt(uint256 postState,
@@ -136,14 +142,15 @@ namespace Stratis.SmartContracts.Core.Receipts
             Bloom bloom,
             uint256 transactionHash,
             uint256 blockHash,
-            uint160 from,
+            uint160 @from,
             uint160 to,
             uint160 newContractAddress,
             bool success,
             string result,
             string errorMessage,
             ulong gasPrice,
-            ulong amount)
+            ulong amount,
+            string methodName)
         {
             this.PostState = postState;
             this.GasPrice = gasPrice;
@@ -159,6 +166,7 @@ namespace Stratis.SmartContracts.Core.Receipts
             this.Result = result;
             this.ErrorMessage = errorMessage;
             this.Amount = amount;
+            this.MethodName = methodName;
         }
 
         /// <summary>
@@ -235,6 +243,9 @@ namespace Stratis.SmartContracts.Core.Receipts
             RLPCollection innerLogList = (RLPCollection)logList[0];
             Log[] logs = innerLogList.Select(x => Log.FromBytesRlp(x.RLPData)).ToArray();
 
+            // Method name is the 15th item to be added. Existing receipts without this data will throw exceptions without this check.
+            var hasMethodName = innerList.Count > 14;
+
             var receipt = new Receipt(
                 new uint256(innerList[0].RLPData),
                 BitConverter.ToUInt64(innerList[1].RLPData),
@@ -249,7 +260,8 @@ namespace Stratis.SmartContracts.Core.Receipts
                 innerList[10].RLPData != null ? Encoding.UTF8.GetString(innerList[10].RLPData) : null,
                 innerList[11].RLPData != null ? Encoding.UTF8.GetString(innerList[11].RLPData) : null,
                 BitConverter.ToUInt64(innerList[12].RLPData),
-                BitConverter.ToUInt64(innerList[13].RLPData));
+                BitConverter.ToUInt64(innerList[13].RLPData),
+                hasMethodName && innerList[14].RLPData != null ? Encoding.UTF8.GetString(innerList[14].RLPData) : null);
 
             return receipt;
         }
@@ -275,7 +287,8 @@ namespace Stratis.SmartContracts.Core.Receipts
                 RLP.EncodeElement(Encoding.UTF8.GetBytes(this.Result ?? "")),
                 RLP.EncodeElement(Encoding.UTF8.GetBytes(this.ErrorMessage ?? "")),
                 RLP.EncodeElement(BitConverter.GetBytes(this.GasPrice)),
-                RLP.EncodeElement(BitConverter.GetBytes(this.Amount))
+                RLP.EncodeElement(BitConverter.GetBytes(this.Amount)),
+                RLP.EncodeElement(Encoding.UTF8.GetBytes(this.MethodName ?? ""))
             );
         }
 


### PR DESCRIPTION
Adds the MethodName to CALL receipts. This is not backwards compatible for existing receipts, so we add a check for this field when retrieving the receipt from storage.