### PR TITLE
[FS] Fix CheckCollateralFullValidationRule

### DIFF
--- a/src/Stratis.Features.FederatedPeg.Tests/CheckCollateralFullValidationRuleTests.cs
+++ b/src/Stratis.Features.FederatedPeg.Tests/CheckCollateralFullValidationRuleTests.cs
@@ -9,6 +9,7 @@ using Stratis.Bitcoin.Features.PoA;
 using Stratis.Bitcoin.Interfaces;
 using Stratis.Bitcoin.Utilities;
 using Stratis.Features.FederatedPeg.Collateral;
+using Stratis.Features.FederatedPeg.CounterChain;
 using Xunit;
 
 namespace Stratis.Features.FederatedPeg.Tests
@@ -23,6 +24,8 @@ namespace Stratis.Features.FederatedPeg.Tests
 
         private readonly Mock<ISlotsManager> slotsManagerMock;
 
+        private readonly Mock<CounterChainNetworkWrapper> counterChainNetworkWrapperMock;
+
         private readonly RuleContext ruleContext;
 
         public CheckCollateralFullValidationRuleTests()
@@ -30,6 +33,7 @@ namespace Stratis.Features.FederatedPeg.Tests
             this.ibdMock = new Mock<IInitialBlockDownloadState>();
             this.collateralCheckerMock = new Mock<ICollateralChecker>();
             this.slotsManagerMock = new Mock<ISlotsManager>();
+            this.counterChainNetworkWrapperMock = new Mock<CounterChainNetworkWrapper>();
 
 
             this.ibdMock.Setup(x => x.IsInitialBlockDownload()).Returns(false);
@@ -50,7 +54,7 @@ namespace Stratis.Features.FederatedPeg.Tests
             var votingOutputScript = new Script(OpcodeType.OP_RETURN, Op.GetPushOp(encodedHeight));
             block.Transactions[0].AddOutput(Money.Zero, votingOutputScript);
 
-            this.rule = new CheckCollateralFullValidationRule(this.ibdMock.Object, this.collateralCheckerMock.Object, this.slotsManagerMock.Object, new Mock<IDateTimeProvider>().Object, new PoANetwork());
+            this.rule = new CheckCollateralFullValidationRule(this.ibdMock.Object, this.collateralCheckerMock.Object, this.slotsManagerMock.Object, new Mock<IDateTimeProvider>().Object, new PoANetwork(), this.counterChainNetworkWrapperMock.Object);
             this.rule.Logger = new ExtendedLoggerFactory().CreateLogger(this.rule.GetType().FullName);
             this.rule.Initialize();
         }

--- a/src/Stratis.Features.FederatedPeg.Tests/CheckCollateralFullValidationRuleTests.cs
+++ b/src/Stratis.Features.FederatedPeg.Tests/CheckCollateralFullValidationRuleTests.cs
@@ -7,6 +7,7 @@ using Stratis.Bitcoin.Consensus;
 using Stratis.Bitcoin.Consensus.Rules;
 using Stratis.Bitcoin.Features.PoA;
 using Stratis.Bitcoin.Interfaces;
+using Stratis.Bitcoin.Networks;
 using Stratis.Bitcoin.Utilities;
 using Stratis.Features.FederatedPeg.Collateral;
 using Stratis.Features.FederatedPeg.CounterChain;
@@ -24,7 +25,7 @@ namespace Stratis.Features.FederatedPeg.Tests
 
         private readonly Mock<ISlotsManager> slotsManagerMock;
 
-        private readonly Mock<CounterChainNetworkWrapper> counterChainNetworkWrapperMock;
+        private readonly CounterChainNetworkWrapper counterChainNetworkWrapper;
 
         private readonly RuleContext ruleContext;
 
@@ -33,8 +34,7 @@ namespace Stratis.Features.FederatedPeg.Tests
             this.ibdMock = new Mock<IInitialBlockDownloadState>();
             this.collateralCheckerMock = new Mock<ICollateralChecker>();
             this.slotsManagerMock = new Mock<ISlotsManager>();
-            this.counterChainNetworkWrapperMock = new Mock<CounterChainNetworkWrapper>();
-
+            this.counterChainNetworkWrapper = new CounterChainNetworkWrapper(Networks.Stratis.Mainnet());
 
             this.ibdMock.Setup(x => x.IsInitialBlockDownload()).Returns(false);
             this.slotsManagerMock
@@ -54,7 +54,7 @@ namespace Stratis.Features.FederatedPeg.Tests
             var votingOutputScript = new Script(OpcodeType.OP_RETURN, Op.GetPushOp(encodedHeight));
             block.Transactions[0].AddOutput(Money.Zero, votingOutputScript);
 
-            this.rule = new CheckCollateralFullValidationRule(this.ibdMock.Object, this.collateralCheckerMock.Object, this.slotsManagerMock.Object, new Mock<IDateTimeProvider>().Object, new PoANetwork(), this.counterChainNetworkWrapperMock.Object);
+            this.rule = new CheckCollateralFullValidationRule(this.ibdMock.Object, this.collateralCheckerMock.Object, this.slotsManagerMock.Object, new Mock<IDateTimeProvider>().Object, new PoANetwork(), this.counterChainNetworkWrapper);
             this.rule.Logger = new ExtendedLoggerFactory().CreateLogger(this.rule.GetType().FullName);
             this.rule.Initialize();
         }

--- a/src/Stratis.Features.FederatedPeg.Tests/CollateralCheckerTests.cs
+++ b/src/Stratis.Features.FederatedPeg.Tests/CollateralCheckerTests.cs
@@ -52,7 +52,7 @@ namespace Stratis.Features.FederatedPeg.Tests
 
             FederatedPegSettings fedPegSettings = FedPegTestsHelper.CreateSettings(network, out NodeSettings nodeSettings);
 
-            CounterChainSettings settings = new CounterChainSettings(nodeSettings, Networks.Stratis.Regtest());
+            CounterChainSettings settings = new CounterChainSettings(nodeSettings, new CounterChainNetworkWrapper(Networks.Stratis.Regtest()));
             var asyncMock = new Mock<IAsyncProvider>();
             asyncMock.Setup(a => a.RegisterTask(It.IsAny<string>(), It.IsAny<Task>()));
 

--- a/src/Stratis.Features.FederatedPeg.Tests/RestClientsTests/FederationGatewayClientTests.cs
+++ b/src/Stratis.Features.FederatedPeg.Tests/RestClientsTests/FederationGatewayClientTests.cs
@@ -23,7 +23,7 @@ namespace Stratis.Features.FederatedPeg.Tests.RestClientsTests
 
             var nodeSettings = new NodeSettings(Sidechains.Networks.CirrusNetwork.NetworksSelector.Regtest(), NBitcoin.Protocol.ProtocolVersion.ALT_PROTOCOL_VERSION, args: args);
 
-            this.client = new FederationGatewayClient(new ExtendedLoggerFactory(), new CounterChainSettings(nodeSettings, Networks.Stratis.Regtest()), new HttpClientFactory());
+            this.client = new FederationGatewayClient(new ExtendedLoggerFactory(), new CounterChainSettings(nodeSettings, new CounterChainNetworkWrapper(Networks.Stratis.Regtest())), new HttpClientFactory());
         }
 
         [Fact]

--- a/src/Stratis.Features.FederatedPeg/Collateral/CheckCollateralFullValidationRule.cs
+++ b/src/Stratis.Features.FederatedPeg/Collateral/CheckCollateralFullValidationRule.cs
@@ -8,6 +8,7 @@ using Stratis.Bitcoin.Features.BlockStore.AddressIndexing;
 using Stratis.Bitcoin.Features.PoA;
 using Stratis.Bitcoin.Interfaces;
 using Stratis.Bitcoin.Utilities;
+using Stratis.Features.FederatedPeg.CounterChain;
 
 namespace Stratis.Features.FederatedPeg.Collateral
 {
@@ -27,13 +28,16 @@ namespace Stratis.Features.FederatedPeg.Collateral
 
         private readonly Network network;
 
+        private readonly Network counterChainNetwork;
+
         /// <summary>For how many seconds the block should be banned in case collateral check failed.</summary>
         private readonly int collateralCheckBanDurationSeconds;
 
         public CheckCollateralFullValidationRule(IInitialBlockDownloadState ibdState, ICollateralChecker collateralChecker,
-            ISlotsManager slotsManager, IDateTimeProvider dateTime, Network network)
+            ISlotsManager slotsManager, IDateTimeProvider dateTime, Network network, CounterChainNetworkWrapper counterChainNetwork)
         {
             this.network = network;
+            this.counterChainNetwork = counterChainNetwork.CounterChainNetwork;
             this.encoder = new CollateralHeightCommitmentEncoder();
             this.ibdState = ibdState;
             this.collateralChecker = collateralChecker;
@@ -67,7 +71,7 @@ namespace Stratis.Features.FederatedPeg.Collateral
             this.Logger.LogDebug("Commitment is: {0}.", commitmentHeight);
 
             int counterChainHeight = this.collateralChecker.GetCounterChainConsensusHeight();
-            int maxReorgLength = AddressIndexer.GetMaxReorgOrFallbackMaxReorg(this.network);
+            int maxReorgLength = AddressIndexer.GetMaxReorgOrFallbackMaxReorg(this.counterChainNetwork);
 
             // Check if commitment height is less than `mainchain consensus tip height - MaxReorg`.
             if (commitmentHeight > counterChainHeight - maxReorgLength)

--- a/src/Stratis.Features.FederatedPeg/Collateral/CheckCollateralFullValidationRule.cs
+++ b/src/Stratis.Features.FederatedPeg/Collateral/CheckCollateralFullValidationRule.cs
@@ -28,23 +28,20 @@ namespace Stratis.Features.FederatedPeg.Collateral
 
         private readonly Network network;
 
-        private readonly Network counterChainNetwork;
-
         /// <summary>For how many seconds the block should be banned in case collateral check failed.</summary>
         private readonly int collateralCheckBanDurationSeconds;
 
         public CheckCollateralFullValidationRule(IInitialBlockDownloadState ibdState, ICollateralChecker collateralChecker,
             ISlotsManager slotsManager, IDateTimeProvider dateTime, Network network, CounterChainNetworkWrapper counterChainNetwork)
         {
-            this.network = network;
-            this.counterChainNetwork = counterChainNetwork.CounterChainNetwork;
+            this.network = counterChainNetwork.CounterChainNetwork;
             this.encoder = new CollateralHeightCommitmentEncoder();
             this.ibdState = ibdState;
             this.collateralChecker = collateralChecker;
             this.slotsManager = slotsManager;
             this.dateTime = dateTime;
 
-            this.collateralCheckBanDurationSeconds = (int)(this.network.Consensus.Options as PoAConsensusOptions).TargetSpacingSeconds / 2;
+            this.collateralCheckBanDurationSeconds = (int)(network.Consensus.Options as PoAConsensusOptions).TargetSpacingSeconds / 2;
         }
 
         public override Task RunAsync(RuleContext context)
@@ -71,7 +68,7 @@ namespace Stratis.Features.FederatedPeg.Collateral
             this.Logger.LogDebug("Commitment is: {0}.", commitmentHeight);
 
             int counterChainHeight = this.collateralChecker.GetCounterChainConsensusHeight();
-            int maxReorgLength = AddressIndexer.GetMaxReorgOrFallbackMaxReorg(this.counterChainNetwork);
+            int maxReorgLength = AddressIndexer.GetMaxReorgOrFallbackMaxReorg(this.network);
 
             // Check if commitment height is less than `mainchain consensus tip height - MaxReorg`.
             if (commitmentHeight > counterChainHeight - maxReorgLength)

--- a/src/Stratis.Features.FederatedPeg/Collateral/CheckCollateralFullValidationRule.cs
+++ b/src/Stratis.Features.FederatedPeg/Collateral/CheckCollateralFullValidationRule.cs
@@ -26,7 +26,7 @@ namespace Stratis.Features.FederatedPeg.Collateral
 
         private readonly CollateralHeightCommitmentEncoder encoder;
 
-        private readonly Network network;
+        private readonly Network counterChainNetwork;
 
         /// <summary>For how many seconds the block should be banned in case collateral check failed.</summary>
         private readonly int collateralCheckBanDurationSeconds;
@@ -34,7 +34,7 @@ namespace Stratis.Features.FederatedPeg.Collateral
         public CheckCollateralFullValidationRule(IInitialBlockDownloadState ibdState, ICollateralChecker collateralChecker,
             ISlotsManager slotsManager, IDateTimeProvider dateTime, Network network, CounterChainNetworkWrapper counterChainNetwork)
         {
-            this.network = counterChainNetwork.CounterChainNetwork;
+            this.counterChainNetwork = counterChainNetwork.CounterChainNetwork;
             this.encoder = new CollateralHeightCommitmentEncoder();
             this.ibdState = ibdState;
             this.collateralChecker = collateralChecker;
@@ -68,7 +68,7 @@ namespace Stratis.Features.FederatedPeg.Collateral
             this.Logger.LogDebug("Commitment is: {0}.", commitmentHeight);
 
             int counterChainHeight = this.collateralChecker.GetCounterChainConsensusHeight();
-            int maxReorgLength = AddressIndexer.GetMaxReorgOrFallbackMaxReorg(this.network);
+            int maxReorgLength = AddressIndexer.GetMaxReorgOrFallbackMaxReorg(this.counterChainNetwork);
 
             // Check if commitment height is less than `mainchain consensus tip height - MaxReorg`.
             if (commitmentHeight > counterChainHeight - maxReorgLength)

--- a/src/Stratis.Features.FederatedPeg/Collateral/CheckCollateralFullValidationRule.cs
+++ b/src/Stratis.Features.FederatedPeg/Collateral/CheckCollateralFullValidationRule.cs
@@ -68,6 +68,8 @@ namespace Stratis.Features.FederatedPeg.Collateral
             this.Logger.LogDebug("Commitment is: {0}.", commitmentHeight);
 
             int counterChainHeight = this.collateralChecker.GetCounterChainConsensusHeight();
+
+            // Get the maxiumum reorg length of the counter chain network.
             int maxReorgLength = AddressIndexer.GetMaxReorgOrFallbackMaxReorg(this.counterChainNetwork);
 
             // Check if commitment height is less than `mainchain consensus tip height - MaxReorg`.

--- a/src/Stratis.Features.FederatedPeg/Collateral/CollateralChecker.cs
+++ b/src/Stratis.Features.FederatedPeg/Collateral/CollateralChecker.cs
@@ -13,7 +13,10 @@ using Stratis.Bitcoin.Features.BlockStore.AddressIndexing;
 using Stratis.Bitcoin.Features.BlockStore.Controllers;
 using Stratis.Bitcoin.Features.PoA;
 using Stratis.Bitcoin.Features.PoA.Events;
+using Stratis.Bitcoin.Interfaces;
 using Stratis.Bitcoin.Signals;
+using Stratis.Bitcoin.Utilities;
+using Stratis.Features.FederatedPeg.CounterChain;
 using Stratis.Features.FederatedPeg.Interfaces;
 
 namespace Stratis.Features.FederatedPeg.Collateral
@@ -40,7 +43,11 @@ namespace Stratis.Features.FederatedPeg.Collateral
         private readonly ISignals signals;
         private readonly IAsyncProvider asyncProvider;
 
+        private readonly IInitialBlockDownloadState ibdState;
+
         private readonly ILogger logger;
+
+        private readonly Network network;
 
         /// <summary>Protects access to <see cref="balancesDataByAddress"/> and <see cref="counterChainConsensusTipHeight"/>.</summary>
         private readonly object locker;
@@ -74,8 +81,9 @@ namespace Stratis.Features.FederatedPeg.Collateral
             this.federationManager = federationManager;
             this.signals = signals;
             this.asyncProvider = asyncProvider;
+            this.network = network;
 
-            this.maxReorgLength = AddressIndexer.GetMaxReorgOrFallbackMaxReorg(network);
+            this.maxReorgLength = AddressIndexer.GetMaxReorgOrFallbackMaxReorg(settings.CounterChainNetwork);
             this.cancellationSource = new CancellationTokenSource();
             this.locker = new object();
             this.balancesDataByAddress = new Dictionary<string, AddressIndexerData>();

--- a/src/Stratis.Features.FederatedPeg/Collateral/CollateralChecker.cs
+++ b/src/Stratis.Features.FederatedPeg/Collateral/CollateralChecker.cs
@@ -43,11 +43,7 @@ namespace Stratis.Features.FederatedPeg.Collateral
         private readonly ISignals signals;
         private readonly IAsyncProvider asyncProvider;
 
-        private readonly IInitialBlockDownloadState ibdState;
-
         private readonly ILogger logger;
-
-        private readonly Network network;
 
         /// <summary>Protects access to <see cref="balancesDataByAddress"/> and <see cref="counterChainConsensusTipHeight"/>.</summary>
         private readonly object locker;
@@ -81,7 +77,6 @@ namespace Stratis.Features.FederatedPeg.Collateral
             this.federationManager = federationManager;
             this.signals = signals;
             this.asyncProvider = asyncProvider;
-            this.network = network;
 
             this.maxReorgLength = AddressIndexer.GetMaxReorgOrFallbackMaxReorg(settings.CounterChainNetwork);
             this.cancellationSource = new CancellationTokenSource();

--- a/src/Stratis.Features.FederatedPeg/Collateral/CollateralFeature.cs
+++ b/src/Stratis.Features.FederatedPeg/Collateral/CollateralFeature.cs
@@ -52,6 +52,7 @@ namespace Stratis.Features.FederatedPeg.Collateral
                         services.AddSingleton<CollateralVotingController>();
 
                         services.AddSingleton<IRuleRegistration, SmartContractCollateralPoARuleRegistration>();
+                        services.AddSingleton<CheckCollateralFullValidationRule>();
                         services.AddSingleton<IConsensusRuleEngine>(f =>
                         {
                             PoAConsensusRuleEngine concreteRuleEngine = f.GetService<PoAConsensusRuleEngine>();

--- a/src/Stratis.Features.FederatedPeg/Collateral/SmartContractCollateralPoARuleRegistration.cs
+++ b/src/Stratis.Features.FederatedPeg/Collateral/SmartContractCollateralPoARuleRegistration.cs
@@ -23,17 +23,20 @@ namespace Stratis.Features.FederatedPeg.Collateral
 
         private readonly ICollateralChecker collateralChecker;
 
+        private readonly CheckCollateralFullValidationRule checkCollateralFullValidationRule;
+
         private readonly IDateTimeProvider dateTime;
 
         public SmartContractCollateralPoARuleRegistration(Network network, IStateRepositoryRoot stateRepositoryRoot, IContractExecutorFactory executorFactory,
             ICallDataSerializer callDataSerializer, ISenderRetriever senderRetriever, IReceiptRepository receiptRepository, ICoinView coinView,
             IEnumerable<IContractTransactionPartialValidationRule> partialTxValidationRules, IEnumerable<IContractTransactionFullValidationRule> fullTxValidationRules,
-            IInitialBlockDownloadState ibdState, ISlotsManager slotsManager, ICollateralChecker collateralChecker, IDateTimeProvider dateTime)
+            IInitialBlockDownloadState ibdState, ISlotsManager slotsManager, ICollateralChecker collateralChecker, IDateTimeProvider dateTime, CheckCollateralFullValidationRule checkCollateralFullValidationRule)
         : base(network, stateRepositoryRoot, executorFactory, callDataSerializer, senderRetriever, receiptRepository, coinView, partialTxValidationRules, fullTxValidationRules)
         {
             this.ibdState = ibdState;
             this.slotsManager = slotsManager;
             this.collateralChecker = collateralChecker;
+            this.checkCollateralFullValidationRule = checkCollateralFullValidationRule;
             this.dateTime = dateTime;
         }
 
@@ -45,7 +48,7 @@ namespace Stratis.Features.FederatedPeg.Collateral
             // see https://dev.azure.com/Stratisplatformuk/StratisBitcoinFullNode/_workitems/edit/3770
             // TODO: re-design how rules gets called, which order they have and prevent a rule to change internal service statuses (rules should just check)
             int saveCoinviewRulePosition = consensus.FullValidationRules.FindIndex(c => c is SaveCoinviewRule);
-            consensus.FullValidationRules.Insert(saveCoinviewRulePosition, new CheckCollateralFullValidationRule(this.ibdState, this.collateralChecker, this.slotsManager, this.dateTime, this.network));
+            consensus.FullValidationRules.Insert(saveCoinviewRulePosition, this.checkCollateralFullValidationRule);
         }
     }
 }

--- a/src/Stratis.Features.FederatedPeg/CounterChain/CounterChainSettings.cs
+++ b/src/Stratis.Features.FederatedPeg/CounterChain/CounterChainSettings.cs
@@ -26,11 +26,13 @@ namespace Stratis.Features.FederatedPeg.CounterChain
         /// <inheritdoc />
         public Network CounterChainNetwork { get; set; }
 
-        public CounterChainSettings(NodeSettings nodeSettings, Network counterChainNetwork)
+        public CounterChainSettings(NodeSettings nodeSettings, CounterChainNetworkWrapper counterChainNetworkWrapper)
         {
             Guard.NotNull(nodeSettings, nameof(nodeSettings));
 
             TextFileConfiguration configReader = nodeSettings.ConfigReader;
+
+            Network counterChainNetwork = counterChainNetworkWrapper.CounterChainNetwork;
 
             this.CounterChainApiHost = configReader.GetOrDefault(CounterChainApiHostParam, "localhost");
             this.CounterChainApiPort = configReader.GetOrDefault(CounterChainApiPortParam, counterChainNetwork.DefaultAPIPort);


### PR DESCRIPTION
In comparisons involving `maxReorgLength` and `counterChainConsensusTipHeight` one would expect that the `maxReorgLength` is that of the counter chain. However that is not the case. This PR fixes that by:
- first fixing the `CounterChainNetwork` value on the `CounterChainSettings` class.
- using the value to determine the `maxReorgLength` to use in the comparison.

`CollateralChecker.cs:`
```
        public CollateralChecker(ILoggerFactory loggerFactory, IHttpClientFactory httpClientFactory, ICounterChainSettings settings,
            IFederationManager federationManager, ISignals signals, Network network, IAsyncProvider asyncProvider)
        {
...
            this.maxReorgLength = AddressIndexer.GetMaxReorgOrFallbackMaxReorg(settings.CounterChainNetwork);

...
            lock (this.locker)
            {
                if (heightToCheckAt > this.counterChainConsensusTipHeight - this.maxReorgLength)
                {
                    this.logger.LogTrace("(-)[INVALID_CHECK_HEIGHT]:false");
                    return false;
                }
            }
```

`CheckCollateralFullValidationRule.cs:`
```
        public CheckCollateralFullValidationRule(IInitialBlockDownloadState ibdState, ICollateralChecker collateralChecker,
            ISlotsManager slotsManager, IDateTimeProvider dateTime, Network network, CounterChainNetworkWrapper counterChainNetwork)
        {
            this.network = counterChainNetwork.CounterChainNetwork;
...
        public override Task RunAsync(RuleContext context)
        {
            int maxReorgLength = AddressIndexer.GetMaxReorgOrFallbackMaxReorg(this.network);

            // Check if commitment height is less than `mainchain consensus tip height - MaxReorg`.
            if (commitmentHeight > counterChainHeight - maxReorgLength)
            {
```