### PR TITLE
[FN] Fix "Coins awaiting maturity" balance while staking

### DIFF
--- a/src/Stratis.Bitcoin.Features.Miner.Tests/PosMintingTest.cs
+++ b/src/Stratis.Bitcoin.Features.Miner.Tests/PosMintingTest.cs
@@ -249,7 +249,7 @@ namespace Stratis.Bitcoin.Features.Miner.Tests
             this.dateTimeProvider.Setup(c => c.GetAdjustedTimeAsUnixTimestamp())
                 .Returns(this.chainIndexer.Tip.Header.Time + 16);
             var ct = CancellationToken.None;
-            (var utxoStakeDescriptions, _) = await this.posMinting.GetUtxoStakeDescriptionsAsync(walletSecret, ct);
+            var utxoStakeDescriptions = await this.posMinting.GetUtxoStakeDescriptionsAsync(walletSecret, ct);
             
             utxoStakeDescriptions.Select(d => d.TxOut.Value).Where(v => v < this.posMinting.MinimumStakingCoinValue)
                 .Should().BeEmpty("small coins should not be included");

--- a/src/Stratis.Bitcoin.Features.Miner.Tests/PosMintingTest.cs
+++ b/src/Stratis.Bitcoin.Features.Miner.Tests/PosMintingTest.cs
@@ -249,9 +249,8 @@ namespace Stratis.Bitcoin.Features.Miner.Tests
             this.dateTimeProvider.Setup(c => c.GetAdjustedTimeAsUnixTimestamp())
                 .Returns(this.chainIndexer.Tip.Header.Time + 16);
             var ct = CancellationToken.None;
-            var utxoStakeDescriptions = await this.posMinting.GetUtxoStakeDescriptionsAsync(walletSecret, ct);
-
-
+            (var utxoStakeDescriptions, _) = await this.posMinting.GetUtxoStakeDescriptionsAsync(walletSecret, ct);
+            
             utxoStakeDescriptions.Select(d => d.TxOut.Value).Where(v => v < this.posMinting.MinimumStakingCoinValue)
                 .Should().BeEmpty("small coins should not be included");
             utxoStakeDescriptions.Select(d => d.TxOut.Value).Where(v => v >= this.posMinting.MinimumStakingCoinValue)

--- a/src/Stratis.Bitcoin.Features.Miner/Interfaces/IPosMinting.cs
+++ b/src/Stratis.Bitcoin.Features.Miner/Interfaces/IPosMinting.cs
@@ -54,8 +54,8 @@ namespace Stratis.Bitcoin.Features.Miner.Interfaces
         /// Calculates the total balance from all UTXOs in the wallet that are mature.
         /// </summary>
         /// <param name="utxoStakeDescriptions">Description of coins in the wallet that will be used for staking.</param>
-        /// <returns>Total balance from all UTXOs in the wallet that are mature.</returns>
-        Task<Money> GetMatureBalanceAsync(List<UtxoStakeDescription> utxoStakeDescriptions);
+        /// <returns>Total balance from all UTXOs in the wallet that are mature, and the total immature balance.</returns>
+        Task<(Money balance, Money immature)> GetMatureBalanceAsync(List<UtxoStakeDescription> utxoStakeDescriptions);
 
         /// <summary>
         /// Estimates the total staking weight of the network.

--- a/src/Stratis.Bitcoin.Features.Miner/Models/GetStakingInfoModel.cs
+++ b/src/Stratis.Bitcoin.Features.Miner/Models/GetStakingInfoModel.cs
@@ -48,6 +48,10 @@ namespace Stratis.Bitcoin.Features.Miner.Models
         [JsonProperty(PropertyName = "netStakeWeight")]
         public long NetStakeWeight { get; set; }
 
+        /// <summary>The amount in the wallet which is not suitable for staking due to having insufficient confirmations.</summary>
+        [JsonProperty(PropertyName = "immature")]
+        public long Immature { get; set; }
+
         /// <summary>Expected time of the node to find new block in seconds.</summary>
         [JsonProperty(PropertyName = "expectedTime")]
         public long ExpectedTime { get; set; }
@@ -67,6 +71,7 @@ namespace Stratis.Bitcoin.Features.Miner.Models
                 SearchInterval = this.SearchInterval,
                 Weight = this.Weight,
                 NetStakeWeight = this.NetStakeWeight,
+                Immature = this.Immature,
                 ExpectedTime = this.ExpectedTime
             };
 
@@ -111,6 +116,7 @@ namespace Stratis.Bitcoin.Features.Miner.Models
             this.SearchInterval = 0;
             this.Weight = 0;
             this.NetStakeWeight = 0;
+            this.Immature = 0;
             this.ExpectedTime = 0;
         }
     }

--- a/src/Stratis.Bitcoin.Features.Miner/Staking/PosMinting.cs
+++ b/src/Stratis.Bitcoin.Features.Miner/Staking/PosMinting.cs
@@ -608,8 +608,8 @@ namespace Stratis.Bitcoin.Features.Miner.Staking
             coinstakeContext.CoinstakeTx.Outputs.Add(new TxOut(Money.Zero, new Script()));
 
             // TODO: Is the difference and duplication in logic between GetMatureBalanceAsync and GetStakeMinConfirmations acceptable?
-            long balance = (await this.GetMatureBalanceAsync(utxoStakeDescriptions).ConfigureAwait(false)).Satoshi;
-            this.rpcGetStakingInfoModel.Immature = balance;
+            (Money balance, Money immature) = await this.GetMatureBalanceAsync(utxoStakeDescriptions).ConfigureAwait(false);
+            this.rpcGetStakingInfoModel.Immature = immature.Satoshi;
 
             if (balance <= this.targetReserveBalance)
             {
@@ -921,19 +921,24 @@ namespace Stratis.Bitcoin.Features.Miner.Staking
         }
 
         /// <inheritdoc/>
-        public async Task<Money> GetMatureBalanceAsync(List<UtxoStakeDescription> utxoStakeDescriptions)
+        public async Task<(Money balance, Money immature)> GetMatureBalanceAsync(List<UtxoStakeDescription> utxoStakeDescriptions)
         {
             var money = new Money(0);
+            var immature = new Money(0);
+
             foreach (UtxoStakeDescription utxoStakeDescription in utxoStakeDescriptions)
             {
                 // Must wait until coinbase is safely deep enough in the chain before valuing it.
                 if ((utxoStakeDescription.UtxoSet.IsCoinbase || utxoStakeDescription.UtxoSet.IsCoinstake) && (await this.GetBlocksCountToMaturityAsync(utxoStakeDescription).ConfigureAwait(false) > 0))
+                {
+                    immature += utxoStakeDescription.TxOut.Value;
                     continue;
+                }
 
                 money += utxoStakeDescription.TxOut.Value;
             }
 
-            return money;
+            return (money, immature);
         }
 
         /// <summary>

--- a/src/Stratis.Bitcoin.Features.Miner/Staking/PosMinting.cs
+++ b/src/Stratis.Bitcoin.Features.Miner/Staking/PosMinting.cs
@@ -406,7 +406,6 @@ namespace Stratis.Bitcoin.Features.Miner.Staking
                     return;
                 }
 
-                // Return a tuple also including immature wallet balance. This is so we avoid enumerating the entire wallet twice.
                 List<UtxoStakeDescription> utxoStakeDescriptions = await this.GetUtxoStakeDescriptionsAsync(walletSecret, cancellationToken).ConfigureAwait(false);
 
                 blockTemplate = blockTemplate ?? this.blockProvider.BuildPosBlock(chainTip, new Script());

--- a/src/Stratis.Bitcoin.Features.RPC.Tests/Models/GetStakingInfoTest.cs
+++ b/src/Stratis.Bitcoin.Features.RPC.Tests/Models/GetStakingInfoTest.cs
@@ -25,6 +25,7 @@ namespace Stratis.Bitcoin.Features.RPC.Tests.Models
             "weight",
             "netStakeWeight",
             "expectedTime",
+            "immature"
         };
 
         /// <summary>
@@ -61,7 +62,8 @@ namespace Stratis.Bitcoin.Features.RPC.Tests.Models
                 + "  \"searchInterval\": 16,\n"
                 + "  \"weight\": 98076279000000,\n"
                 + "  \"netStakeWeight\": 101187415332927,\n"
-                + "  \"expectedTime\": 66\n"
+                + "  \"expectedTime\": 66,\n"
+                + "  \"immature\": 100\n"
                 + "}\n";
 
             JObject obj = JObject.Parse(json);
@@ -80,6 +82,7 @@ namespace Stratis.Bitcoin.Features.RPC.Tests.Models
             Assert.Equal(98076279000000, model.Weight);
             Assert.Equal(101187415332927, model.NetStakeWeight);
             Assert.Equal(66, model.ExpectedTime);
+            Assert.Equal(100, model.Immature);
         }
     }
 }


### PR DESCRIPTION
Currently this balance uses spendability as the criteria, which is incorrect, as candidates UTXOs for staking need to have a higher minimum number of confirmations.

Will also require a minor modification to Stratis Core to use the new field in its calculation.