### PR TITLE
Updated the MaxFutureDriftSeconds to 10 seconds

### DIFF
--- a/src/Stratis.Bitcoin.Features.PoA/BasePoAFeatureConsensusRules/HeaderTimeChecksPoARule.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/BasePoAFeatureConsensusRules/HeaderTimeChecksPoARule.cs
@@ -13,7 +13,7 @@ namespace Stratis.Bitcoin.Features.PoA.BasePoAFeatureConsensusRules
     public class HeaderTimeChecksPoARule : HeaderValidationConsensusRule
     {
         /// <summary>Up to how many seconds headers's timestamp can be in the future to be considered valid.</summary>
-        public const int MaxFutureDriftSeconds = 5;
+        public const int MaxFutureDriftSeconds = 10;
 
         private ISlotsManager slotsManager;
 


### PR DESCRIPTION
The proposed 5 seconds difference is in the relation to the reference clock as since two nodes could be at the opposite side of the spectrum (i.e. one node having time -5 second while the other + 5 sec) the maximum difference we can account for is 10 seconds.