### PR TITLE
Remove duplicated logs

### DIFF
--- a/Documentation/ImportantOnly_NLog.config
+++ b/Documentation/ImportantOnly_NLog.config
@@ -11,9 +11,6 @@
     <target name="debugConsensusFile" xsi:type="AsyncWrapper" queueLimit="10000" overflowAction="Block" batchSize="1000">
       <target xsi:type="File" fileName="consensus.txt" archiveNumbering="Date" maxArchiveFiles="3" archiveEvery="Day" layout="[${longdate:universalTime=true} ${threadid}${mdlc:item=id}] ${level:uppercase=true}: ${callsite} ${message}" encoding="utf-8" />
     </target>
-    <target name="debugCHTandCMFile" xsi:type="AsyncWrapper" queueLimit="10000" overflowAction="Block" batchSize="1000">
-      <target xsi:type="File" fileName="CHTandCM.txt" archiveNumbering="Date" maxArchiveFiles="3" archiveEvery="Day" layout="[${longdate:universalTime=true} ${threadid}${mdlc:item=id}] ${level:uppercase=true}: ${callsite} ${message}" encoding="utf-8" />
-    </target>
     <target name="debugCoinViewsFile" xsi:type="AsyncWrapper" queueLimit="10000" overflowAction="Block" batchSize="1000">
       <target xsi:type="File" fileName="coinview.txt" archiveNumbering="Date" maxArchiveFiles="3" archiveEvery="Day" layout="[${longdate:universalTime=true} ${threadid}${mdlc:item=id}] ${level:uppercase=true}: ${callsite} ${message}" encoding="utf-8" />
     </target>
@@ -39,9 +36,6 @@
     <logger name="Stratis.Bitcoin.Features.Consensus.*" minlevel="Debug" writeTo="debugConsensusFile" />
     <logger name="Stratis.Bitcoin.Consensus.*" minlevel="Debug" writeTo="debugConsensusFile" />
     <logger name="Stratis.Features.FederatedPeg.Collateral.CheckCollateralFullValidationRule" minlevel="Debug" writeTo="debugConsensusFile" />
-
-    <logger name="Stratis.Bitcoin.Consensus.ChainedHeaderTree" minlevel="Debug" writeTo="debugCHTandCMFile" />
-    <logger name="Stratis.Bitcoin.Consensus.ConsensusManager" minlevel="Debug" writeTo="debugCHTandCMFile" />
 
     <logger name="Stratis.Bitcoin.Features.Consensus.CoinViews.*" minlevel="Debug" writeTo="debugCoinViewsFile" />
 


### PR DESCRIPTION
We already have the consensus logs which contains the logs for the CHT and CM, so the extra logs are just taking up space.

The CMB logs are also being duplicated but because that file contains other useful info I've left it for now.