### PR TITLE
Remove ConnectHeaderException

### DIFF
--- a/src/Stratis.Bitcoin.Tests/Base/ConsensusManagerBehaviorTests.cs
+++ b/src/Stratis.Bitcoin.Tests/Base/ConsensusManagerBehaviorTests.cs
@@ -122,7 +122,7 @@ namespace Stratis.Bitcoin.Tests.Base
                 {
                     Assert.Equal(this.headers[14].Header, presentedHeaders.First());
 
-                    throw new ConnectHeaderException();
+                    return new ConnectNewHeadersResult() { CantConnect = true };
                 });
 
             ConnectNewHeadersResult result = await behavior.ConsensusTipChangedAsync();
@@ -382,7 +382,9 @@ namespace Stratis.Bitcoin.Tests.Base
         public async Task ProcessHeadersAsync_SyncWhenCacheIsEmptyAsync()
         {
             this.helper.CreateAndAttachBehavior(this.headers[10], null, null, NetworkPeerState.HandShaked,
-                (presentedHeaders, triggerDownload) => { throw new ConnectHeaderException(); });
+                (presentedHeaders, triggerDownload) => {
+                    return new ConnectNewHeadersResult() { CantConnect = true };
+                });
 
             await this.helper.ReceivePayloadAsync(new HeadersPayload(this.headers.Skip(13).Take(8).Select(x => x.Header)));
 

--- a/src/Stratis.Bitcoin.Tests/Consensus/ChainedHeaderTreeTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Consensus/ChainedHeaderTreeTest.cs
@@ -84,7 +84,7 @@ namespace Stratis.Bitcoin.Tests.Consensus
             TestContext testContext = new TestContextBuilder().Build();
             ChainedHeaderTree chainedHeaderTree = testContext.ChainedHeaderTree;
 
-            Assert.Throws<ConnectHeaderException>(() => chainedHeaderTree.ConnectNewHeaders(1, new List<BlockHeader>(new[] { testContext.Network.GetGenesis().Header })));
+            Assert.True(chainedHeaderTree.ConnectNewHeaders(1, new List<BlockHeader>(new[] { testContext.Network.GetGenesis().Header })).CantConnect);
         }
 
         /// <summary>

--- a/src/Stratis.Bitcoin/Consensus/ChainedHeaderTree.cs
+++ b/src/Stratis.Bitcoin/Consensus/ChainedHeaderTree.cs
@@ -634,6 +634,21 @@ namespace Stratis.Bitcoin.Consensus
         {
             Guard.NotNull(headers, nameof(headers));
 
+            if (!this.chainedHeadersByHash.ContainsKey(headers[0].HashPrevBlock))
+            {
+                this.logger.LogTrace("(-)[HEADER_COULD_NOT_CONNECT]");
+                return new ConnectNewHeadersResult() { CantConnect = true };
+            }
+
+            uint256 lastHash = headers.Last().GetHash();
+            if (this.chainedHeadersByHash.ContainsKey(lastHash))
+            {
+                this.AddOrReplacePeerTip(networkPeerId, lastHash);
+
+                this.logger.LogTrace("(-)[NO_NEW_HEADERS]");
+                return new ConnectNewHeadersResult() { Consumed = this.chainedHeadersByHash[lastHash] };
+            }
+
             List<ChainedHeader> newChainedHeaders = this.CreateNewHeaders(headers, out bool insufficientInfo, out bool cantConnect);
 
             if (cantConnect)

--- a/src/Stratis.Bitcoin/Consensus/ChainedHeaderTree.cs
+++ b/src/Stratis.Bitcoin/Consensus/ChainedHeaderTree.cs
@@ -1004,9 +1004,10 @@ namespace Stratis.Bitcoin.Consensus
             ChainedHeader previousChainedHeader;
             if (!this.chainedHeadersByHash.TryGetValue(headers[newHeaderIndex].HashPrevBlock, out previousChainedHeader))
             {
+                cantConnect = true;
+
                 this.logger.LogDebug("Previous hash '{0}' of block hash '{1}' was not found.", headers[newHeaderIndex].GetHash(), headers[newHeaderIndex].HashPrevBlock);
                 this.logger.LogTrace("(-)[PREVIOUS_HEADER_NOT_FOUND]");
-                cantConnect = true;
                 return null;
             }
 

--- a/src/Stratis.Bitcoin/Consensus/ConsensusExceptions.cs
+++ b/src/Stratis.Bitcoin/Consensus/ConsensusExceptions.cs
@@ -21,13 +21,6 @@ namespace Stratis.Bitcoin.Consensus
         }
     }
 
-    public class ConnectHeaderException : ConsensusException
-    {
-        public ConnectHeaderException() : base()
-        {
-        }
-    }
-
     /// <summary>
     /// This throws when the header of a previously block that failed
     /// partial or full validation and was marked as invalid is passed to the node.

--- a/src/Stratis.Bitcoin/Consensus/ConsensusManager.cs
+++ b/src/Stratis.Bitcoin/Consensus/ConsensusManager.cs
@@ -122,7 +122,7 @@ namespace Stratis.Bitcoin.Consensus
         private readonly ConsensusManagerPerformanceCounter performanceCounter;
 
         private readonly ConsensusSettings consensusSettings;
-        
+
         private readonly IDateTimeProvider dateTimeProvider;
 
         private bool isIbd;
@@ -280,6 +280,12 @@ namespace Stratis.Bitcoin.Consensus
                 {
                     this.logger.LogTrace("(-)[NO_HEADERS_CONNECTED]:null");
                     return null;
+                }
+
+                if (connectNewHeadersResult.CantConnect)
+                {
+                    this.logger.LogTrace("(-)[NOTHING_CONNECTED]:null");
+                    return connectNewHeadersResult;
                 }
 
                 if (connectNewHeadersResult.Consumed == null)

--- a/src/Stratis.Bitcoin/Consensus/ConsensusManagerBehavior.cs
+++ b/src/Stratis.Bitcoin/Consensus/ConsensusManagerBehavior.cs
@@ -460,26 +460,27 @@ namespace Stratis.Bitcoin.Consensus
             try
             {
                 result = this.ConsensusManager.HeadersPresented(peer, headers, triggerDownload);
-            }
-            catch (ConnectHeaderException)
-            {
-                // This is typically thrown when the first header refers to a previous block hash that is not in
-                // the header tree currently. This is not regarded as bannable, as it could be a legitimate reorg.
-                this.logger.LogDebug("Unable to connect headers.");
 
-                if (this.CheckIfUnsolicitedFutureHeader(headers))
+                if (result?.CantConnect ?? false)
                 {
-                    // However, during IBD it is much more likely that the unconnectable header is an unsolicited
-                    // block advertisement. In that case we just ignore the failed header and don't modify the cache.
-                    // TODO: Review more closely what Bitcoin Core does here - they seem to allow 8 unconnectable headers before
-                    // applying partial DoS points to a peer. Incorporate that into rate limiting code?
-                    this.logger.LogTrace("(-)[HEADER_FUTURE_CANT_CONNECT_2]");
-                }
-                else
-                {
-                    // Resync in case we can't connect the header.
-                    this.cachedHeaders.Clear();
-                    await this.ResyncAsync().ConfigureAwait(false);
+                    // This is typically thrown when the first header refers to a previous block hash that is not in
+                    // the header tree currently. This is not regarded as bannable, as it could be a legitimate reorg.
+                    this.logger.LogDebug("Unable to connect headers.");
+
+                    if (this.CheckIfUnsolicitedFutureHeader(headers))
+                    {
+                        // However, during IBD it is much more likely that the unconnectable header is an unsolicited
+                        // block advertisement. In that case we just ignore the failed header and don't modify the cache.
+                        // TODO: Review more closely what Bitcoin Core does here - they seem to allow 8 unconnectable headers before
+                        // applying partial DoS points to a peer. Incorporate that into rate limiting code?
+                        this.logger.LogTrace("(-)[HEADER_FUTURE_CANT_CONNECT_2]");
+                    }
+                    else
+                    {
+                        // Resync in case we can't connect the header.
+                        this.cachedHeaders.Clear();
+                        await this.ResyncAsync().ConfigureAwait(false);
+                    }
                 }
             }
             catch (ConsensusRuleException exception)

--- a/src/Stratis.Bitcoin/Consensus/IConsensusManager.cs
+++ b/src/Stratis.Bitcoin/Consensus/IConsensusManager.cs
@@ -34,7 +34,6 @@ namespace Stratis.Bitcoin.Consensus
         /// <param name="headers">The list of new headers.</param>
         /// <param name="triggerDownload">Specifies if the download should be scheduled for interesting blocks.</param>
         /// <returns>Information about consumed headers.</returns>
-        /// <exception cref="ConnectHeaderException">Thrown when first presented header can't be connected to any known chain in the tree.</exception>
         /// <exception cref="CheckpointMismatchException">Thrown if checkpointed header doesn't match the checkpoint hash.</exception>
         /// <exception cref="MaxReorgViolationException">Thrown in case maximum reorganization rule is violated.</exception>
         /// <exception cref="ConsensusErrorException">Thrown if header validation failed.</exception>


### PR DESCRIPTION
**Repro Steps:**
Exception
[2019-04-15 10:42:52.4229 30] TRACE: Stratis.Bitcoin.Consensus.PerformanceCounters.ConsensusManager.ConsensusManagerPerformanceCounter.<MeasureTotalConnectionTime>b__2_0 (-)
[2019-04-15 10:42:52.4229 29] TRACE: Stratis.Bitcoin.Consensus.ChainedHeaderTree.ConnectNewHeaders (-)$exception:Stratis.Bitcoin.Consensus.ConnectHeaderException: Exception of type 'Stratis.Bitcoin.Consensus.ConnectHeaderException' was thrown.
   at Stratis.Bitcoin.Consensus.ChainedHeaderTree.ConnectNewHeaders(Int32 networkPeerId, List`1 headers) in C:\Code\InternalTestnet_Data\Sources\StratisBitcoinFullNode\src\Stratis.Bitcoin\Consensus\ChainedHeaderTree.cs:line 644
[2019-04-15 10:42:52.4229 30] TRACE: Stratis.Bitcoin.Consensus.ConsensusManager+<OnPartialValidationSucceededAsync>d__52.MoveNext (-)

**Acceptance criteria:**
No exception is thrown. We need to look at refactoring this to not thrown exceptions but rather return something useful.


See https://dev.azure.com/Stratisplatformuk/StratisBitcoinFullNode/_workitems/edit/3555.