### PR TITLE
[P2P] Attempt to fix self endpoint tracker

### DIFF
--- a/src/Stratis.Bitcoin.Features.Consensus/Behaviors/ProvenHeadersReservedSlotsBehavior.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/Behaviors/ProvenHeadersReservedSlotsBehavior.cs
@@ -98,6 +98,10 @@ namespace Stratis.Bitcoin.Features.Consensus.Behaviors
 
         private bool DoesPeerSupportsPH(VersionPayload peerVersion)
         {
+            // TODO: Need to diagnose how this occurs. Is it possible errors were previously getting squashed elsewhere?
+            if (peerVersion == null)
+                return false;
+
             return peerVersion.Version >= NBitcoin.Protocol.ProtocolVersion.PROVEN_HEADER_VERSION;
         }
 

--- a/src/Stratis.Bitcoin.Features.Consensus/Behaviors/ProvenHeadersReservedSlotsBehavior.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/Behaviors/ProvenHeadersReservedSlotsBehavior.cs
@@ -98,7 +98,6 @@ namespace Stratis.Bitcoin.Features.Consensus.Behaviors
 
         private bool DoesPeerSupportsPH(VersionPayload peerVersion)
         {
-            // TODO: Need to diagnose how this occurs. Is it possible errors were previously getting squashed elsewhere?
             if (peerVersion == null)
                 return false;
 

--- a/src/Stratis.Bitcoin.Tests/P2P/SelfEndpointTrackerTests.cs
+++ b/src/Stratis.Bitcoin.Tests/P2P/SelfEndpointTrackerTests.cs
@@ -3,6 +3,7 @@ using Stratis.Bitcoin.Configuration;
 using Stratis.Bitcoin.Configuration.Logging;
 using Stratis.Bitcoin.Networks;
 using Stratis.Bitcoin.P2P;
+using Stratis.Bitcoin.Utilities.Extensions;
 using Xunit;
 
 namespace Stratis.Bitcoin.Tests.P2P
@@ -73,7 +74,7 @@ namespace Stratis.Bitcoin.Tests.P2P
             this.selfEndpointTracker.UpdateAndAssignMyExternalAddress(oldIpEndpoint, false);
             this.selfEndpointTracker.UpdateAndAssignMyExternalAddress(oldIpEndpoint, false);
 
-            Assert.True(this.selfEndpointTracker.MyExternalAddress.Equals(oldIpEndpoint));
+            Assert.True(this.selfEndpointTracker.MyExternalAddress.Address.Equals(oldIpEndpoint.MapToIpv6().Address));
             Assert.Equal(initialPeerScore + 1, this.selfEndpointTracker.MyExternalAddressPeerScore);
         }
 
@@ -89,7 +90,7 @@ namespace Stratis.Bitcoin.Tests.P2P
             Assert.Equal(initialPeerScore, this.selfEndpointTracker.MyExternalAddressPeerScore);
 
             this.selfEndpointTracker.UpdateAndAssignMyExternalAddress(newIpEndpoint, false);
-            Assert.True(this.selfEndpointTracker.MyExternalAddress.Equals(oldIpEndpoint));
+            Assert.True(this.selfEndpointTracker.MyExternalAddress.Address.Equals(oldIpEndpoint.MapToIpv6().Address));
             Assert.Equal(initialPeerScore - 1, this.selfEndpointTracker.MyExternalAddressPeerScore);
         }
 
@@ -108,7 +109,7 @@ namespace Stratis.Bitcoin.Tests.P2P
             this.selfEndpointTracker.UpdateAndAssignMyExternalAddress(newIpEndpoint2, false);
             this.selfEndpointTracker.UpdateAndAssignMyExternalAddress(newIpEndpoint3, false);
 
-            Assert.True(this.selfEndpointTracker.MyExternalAddress.Equals(newIpEndpoint3));
+            Assert.True(this.selfEndpointTracker.MyExternalAddress.Address.Equals(newIpEndpoint3.MapToIpv6().Address));
             Assert.Equal(1, this.selfEndpointTracker.MyExternalAddressPeerScore);
         }
 

--- a/src/Stratis.Bitcoin/Connection/ConnectionManager.cs
+++ b/src/Stratis.Bitcoin/Connection/ConnectionManager.cs
@@ -160,7 +160,10 @@ namespace Stratis.Bitcoin.Connection
             // If external IP address supplied this overrides all.
             if (this.ConnectionSettings.ExternalEndpoint != null)
             {
-                this.selfEndpointTracker.UpdateAndAssignMyExternalAddress(this.ConnectionSettings.ExternalEndpoint, true);
+                if (this.ConnectionSettings.ExternalEndpoint.Address.Equals(IPAddress.Loopback))
+                    this.selfEndpointTracker.UpdateAndAssignMyExternalAddress(this.ConnectionSettings.ExternalEndpoint, false);
+                else
+                    this.selfEndpointTracker.UpdateAndAssignMyExternalAddress(this.ConnectionSettings.ExternalEndpoint, true);
             }
             else
             {

--- a/src/Stratis.Bitcoin/P2P/Peer/NetworkPeer.cs
+++ b/src/Stratis.Bitcoin/P2P/Peer/NetworkPeer.cs
@@ -814,11 +814,13 @@ namespace Stratis.Bitcoin.P2P.Peer
             }
             catch (OperationCanceledException e)
             {
-                this.logger.LogDebug("Operation canceled during handshake.");
+                this.logger.LogDebug("Operation canceled during outbound connection handshake.");
+                throw;
             }
             catch (Exception e)
             {
-                this.logger.LogDebug("Exception during handshake: " + e);
+                this.logger.LogDebug("Exception during outbound connection handshake: " + e);
+                throw;
             }
             finally
             {

--- a/src/Stratis.Bitcoin/P2P/Peer/NetworkPeer.cs
+++ b/src/Stratis.Bitcoin/P2P/Peer/NetworkPeer.cs
@@ -316,6 +316,11 @@ namespace Stratis.Bitcoin.P2P.Peer
             this.asyncProvider = asyncProvider;
             this.onDisconnectedAsyncContext = new AsyncLocal<DisconnectedExecutionAsyncContext>();
 
+            if (inbound)
+            {
+                Console.WriteLine("Test");
+            }
+
             this.ConnectionParameters = parameters ?? new NetworkPeerConnectionParameters();
             this.MyVersion = this.ConnectionParameters.CreateVersion(this.selfEndpointTracker.MyExternalAddress, this.PeerEndPoint, network, this.dateTimeProvider.GetTimeOffset());
 
@@ -729,11 +734,15 @@ namespace Stratis.Bitcoin.P2P.Peer
         /// <inheritdoc/>
         public async Task VersionHandshakeAsync(NetworkPeerRequirement requirements, CancellationToken cancellationToken)
         {
+            // Note that this method gets called for outbound peers. When our peer is inbound we receive the initial version handshake from the initiating peer, and it is handled via this.ProcessMessageAsync() only.
+
             // In stratisX, the equivalent functionality is contained in main.cpp, method ProcessMessage()
 
             requirements = requirements ?? new NetworkPeerRequirement();
-            using (var listener = new NetworkPeerListener(this, this.asyncProvider))
+            NetworkPeerListener listener = null;
+            try
             {
+                listener = new NetworkPeerListener(this, this.asyncProvider);
                 this.logger.LogDebug("Sending my version.");
                 await this.SendMessageAsync(this.MyVersion, cancellationToken).ConfigureAwait(false);
 
@@ -753,7 +762,7 @@ namespace Stratis.Bitcoin.P2P.Peer
                             versionReceived = true;
 
                             this.PeerVersion = versionPayload;
-                            if (!versionPayload.AddressReceiver.Address.Equals(this.MyVersion.AddressFrom.Address))
+                            if (!versionPayload.AddressReceiver.Address.MapToIPv6().Equals(this.MyVersion.AddressFrom.Address.MapToIPv6()))
                             {
                                 this.logger.LogDebug("Different external address detected by the node '{0}' instead of '{1}'.", versionPayload.AddressReceiver.Address, this.MyVersion.AddressFrom.Address);
                             }
@@ -776,7 +785,12 @@ namespace Stratis.Bitcoin.P2P.Peer
 
                             this.logger.LogDebug("Sending version acknowledgement.");
                             await this.SendMessageAsync(new VerAckPayload(), cancellationToken).ConfigureAwait(false);
-                            this.selfEndpointTracker.UpdateAndAssignMyExternalAddress(versionPayload.AddressFrom, false);
+
+                            // Note that we only update our external address data from information returned by outbound peers.
+                            // TODO: Is this due to a security assumption or is it an oversight? There is a higher risk the inbounds could be spoofing what they claim our external IP is. We would then use it in future version payloads, so that could be considered an attack.
+                            // For outbounds: AddressFrom is our current external endpoint from our perspective, and could easily be incorrect if it has been automatically detected from local NICs.
+                            // Whereas AddressReceiver is the endpoint from the peer's perspective, so we update our view using that.
+                            this.selfEndpointTracker.UpdateAndAssignMyExternalAddress(versionPayload.AddressReceiver, false);
                             break;
 
                         case VerAckPayload verAckPayload:
@@ -802,6 +816,18 @@ namespace Stratis.Bitcoin.P2P.Peer
 
                 // Ask the just-handshaked peer for the peers they know about to aid in our own peer discovery.
                 await this.SendMessageAsync(new GetAddrPayload(), cancellationToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException e)
+            {
+                this.logger.LogDebug("Operation canceled during handshake.");
+            }
+            catch (Exception e)
+            {
+                this.logger.LogDebug("Exception during handshake: " + e);
+            }
+            finally
+            {
+                listener?.Dispose();
             }
         }
 

--- a/src/Stratis.Bitcoin/P2P/Peer/NetworkPeer.cs
+++ b/src/Stratis.Bitcoin/P2P/Peer/NetworkPeer.cs
@@ -812,14 +812,8 @@ namespace Stratis.Bitcoin.P2P.Peer
                 // Ask the just-handshaked peer for the peers they know about to aid in our own peer discovery.
                 await this.SendMessageAsync(new GetAddrPayload(), cancellationToken).ConfigureAwait(false);
             }
-            catch (OperationCanceledException e)
+            catch
             {
-                this.logger.LogDebug("Operation canceled during outbound connection handshake.");
-                throw;
-            }
-            catch (Exception e)
-            {
-                this.logger.LogDebug("Exception during outbound connection handshake: " + e);
                 throw;
             }
             finally

--- a/src/Stratis.Bitcoin/P2P/Peer/NetworkPeer.cs
+++ b/src/Stratis.Bitcoin/P2P/Peer/NetworkPeer.cs
@@ -316,11 +316,6 @@ namespace Stratis.Bitcoin.P2P.Peer
             this.asyncProvider = asyncProvider;
             this.onDisconnectedAsyncContext = new AsyncLocal<DisconnectedExecutionAsyncContext>();
 
-            if (inbound)
-            {
-                Console.WriteLine("Test");
-            }
-
             this.ConnectionParameters = parameters ?? new NetworkPeerConnectionParameters();
             this.MyVersion = this.ConnectionParameters.CreateVersion(this.selfEndpointTracker.MyExternalAddress, this.PeerEndPoint, network, this.dateTimeProvider.GetTimeOffset());
 

--- a/src/Stratis.Bitcoin/P2P/Peer/NetworkPeerServer.cs
+++ b/src/Stratis.Bitcoin/P2P/Peer/NetworkPeerServer.cs
@@ -227,6 +227,7 @@ namespace Stratis.Bitcoin.P2P.Peer
             }
 
             var clientLocalEndPoint = tcpClient.Client.LocalEndPoint as IPEndPoint;
+            var clientRemoteEndPoint = tcpClient.Client.RemoteEndPoint as IPEndPoint;
 
             bool endpointCanBeWhiteListed = this.connectionManagerSettings.Bind.Where(x => x.Whitelisted).Any(x => x.Endpoint.Contains(clientLocalEndPoint));
 
@@ -236,7 +237,7 @@ namespace Stratis.Bitcoin.P2P.Peer
                 return true;
             }
 
-            this.logger.LogDebug("Node '{0}' is not white listed during initial block download.", clientLocalEndPoint);
+            this.logger.LogDebug("Node '{0}' is not whitelisted via endpoint '{1}' during initial block download.", clientRemoteEndPoint, clientLocalEndPoint);
 
             return false;
         }

--- a/src/Stratis.Bitcoin/P2P/SelfEndpointTracker.cs
+++ b/src/Stratis.Bitcoin/P2P/SelfEndpointTracker.cs
@@ -2,6 +2,7 @@
 using ConcurrentCollections;
 using Microsoft.Extensions.Logging;
 using Stratis.Bitcoin.Configuration.Settings;
+using Stratis.Bitcoin.Utilities.Extensions;
 using TracerAttributes;
 
 namespace Stratis.Bitcoin.P2P
@@ -29,6 +30,8 @@ namespace Stratis.Bitcoin.P2P
         /// <inheritdoc/>
         public IPEndPoint MyExternalAddress { get; private set; }
 
+        public int MyExternalPort { get; private set; }
+
         /// <summary>
         /// Initializes an instance of the self endpoint tracker.
         /// </summary>
@@ -38,6 +41,7 @@ namespace Stratis.Bitcoin.P2P
             this.lockObject = new object();
             this.IsMyExternalAddressFinal = false;
             this.MyExternalAddress = connectionManagerSettings.ExternalEndpoint;
+            this.MyExternalPort = connectionManagerSettings.Port;
             this.logger = loggerFactory.CreateLogger(this.GetType().FullName);
         }
 
@@ -74,7 +78,8 @@ namespace Stratis.Bitcoin.P2P
                 }
 
                 // If it was the same as value that was there we just increment the score by 1.
-                if (ipEndPoint.Equals(this.MyExternalAddress))
+                // Only the address portion is comparable, the port will be an ephemeral port != our server port if this is an outbound connection. So we replace it later with our configured port for self endpoint tracking.
+                if (ipEndPoint.MapToIpv6().Address.Equals(this.MyExternalAddress.MapToIpv6().Address))
                 {
                     this.MyExternalAddressPeerScore += 1;
                     this.logger.LogTrace("(-)[SUPPLIED_EXISTING]");
@@ -88,8 +93,9 @@ namespace Stratis.Bitcoin.P2P
                 // If the new score is 0 we replace the old one with the new one with score 1.
                 if (this.MyExternalAddressPeerScore <= 0)
                 {
-                    this.logger.LogDebug("Score for old endpoint '{0}' is <= 0. Updating endpoint to '{1}' and resetting peer score to 1.", this.MyExternalAddress, ipEndPoint);
-                    this.MyExternalAddress = ipEndPoint;
+                    var replacementEndpoint = new IPEndPoint(ipEndPoint.MapToIpv6().Address, this.MyExternalPort);
+                    this.logger.LogDebug("Score for old endpoint '{0}' is <= 0. Updating endpoint to '{1}' and resetting peer score to 1.", this.MyExternalAddress, replacementEndpoint);
+                    this.MyExternalAddress = replacementEndpoint;
                     this.MyExternalAddressPeerScore = 1;
                 }
             }


### PR DESCRIPTION
This tries to address a few things:

1. The externalip config setting defaults to loopback when it is not specified
2. This means that the self endpoint tracker was always regarding the loopback as the definitive external endpoint
3. So this has been corrected to not regard loopback as definitive ('final')
4. The matching of the endpoint seemed to have some inconsistencies in IPv4/IPv6 representation. For now, the endpoints are compared as addresses only (as ports reported by outbounds are always ephemeral) and are coerced to IPv6 representation when comparing
5. A `using` statement was removed & replaced with a try block; `using` statements can hide exceptions in some cases -> https://minddotout.wordpress.com/2012/12/27/the-c-using-statement-breaks-exception-handling/
6. Possibly as a result of  item 5, an exception was noted in the proven header slot behaviour. A check was added to prevent this, but it has not been definitively shown where the null is coming from

https://dev.azure.com/Stratisplatformuk/StratisBitcoinFullNode/_workitems/edit/4154