### PR TITLE
Dont stop mining loop in case race condition lead to using output that was just spent

### DIFF
--- a/src/Stratis.Bitcoin.Features.PoA/PoAMiner.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/PoAMiner.cs
@@ -165,15 +165,18 @@ namespace Stratis.Bitcoin.Features.PoA
                 catch (OperationCanceledException)
                 {
                 }
-                // TODO: Find a better way to do this.
-                catch (ConsensusErrorException ce) when (ce.ConsensusError.Code == "invalid-collateral-amount")
+                catch (ConsensusErrorException ce) when (ce.ConsensusError.Code == PoAConsensusErrors.InvalidCollateralAmount.Code)
                 {
                     this.logger.LogInformation("Miner failed to mine block due to: '{0}'.", ce.ConsensusError.Message);
                 }
                 catch (Exception exception)
                 {
                     this.logger.LogCritical("Exception occurred during mining: {0}", exception.ToString());
-                    break;
+
+                    // This can happen due to the race condition, we shouldn't break mining loop because of this.
+                    // TODO: Find a better way to do this.
+                    if (exception.Message != "Output has already been spent.")
+                        break;
                 }
             }
         }


### PR DESCRIPTION
It seems that due to the race condition we might try to use output which was just spent on consensus chain

https://dev.azure.com/Stratisplatformuk/StratisBitcoinFullNode/_workitems/edit/4172