### PR TITLE
[FN] Make foreign controllers visible to framework

### DIFF
--- a/src/Stratis.Bitcoin.Features.Api/Startup.cs
+++ b/src/Stratis.Bitcoin.Features.Api/Startup.cs
@@ -67,7 +67,7 @@ namespace Stratis.Bitcoin.Features.Api
                 })
                 // add serializers for NBitcoin objects
                 .AddJsonOptions(options => Utilities.JsonConverters.Serializer.RegisterFrontConverters(options.SerializerSettings))
-                .AddControllers(this.fullNode.Services.Features);
+                .AddControllers(this.fullNode.Services.Features, services);
 
             // Register the Swagger generator, defining one or more Swagger documents
             services.AddSwaggerGen(setup =>

--- a/src/Stratis.Bitcoin.Features.SmartContracts/Wallet/SmartContractWalletFeature.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts/Wallet/SmartContractWalletFeature.cs
@@ -124,6 +124,8 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Wallet
                     services.AddSingleton<IBroadcasterManager, FullNodeBroadcasterManager>();
                     services.AddSingleton<BroadcasterBehavior>();
                     services.AddSingleton<WalletSettings>();
+
+                    services.AddTransient<WalletRPCController>();
                 });
             });
 

--- a/src/Stratis.Bitcoin/Base/BaseFeature.cs
+++ b/src/Stratis.Bitcoin/Base/BaseFeature.cs
@@ -18,6 +18,7 @@ using Stratis.Bitcoin.Connection;
 using Stratis.Bitcoin.Consensus;
 using Stratis.Bitcoin.Consensus.Rules;
 using Stratis.Bitcoin.Consensus.Validators;
+using Stratis.Bitcoin.Controllers;
 using Stratis.Bitcoin.EventBus;
 using Stratis.Bitcoin.Interfaces;
 using Stratis.Bitcoin.P2P;
@@ -460,6 +461,9 @@ namespace Stratis.Bitcoin.Base
 
                     // Console
                     services.AddSingleton<INodeStats, NodeStats>();
+
+                    // Controller
+                    services.AddTransient<NodeController>();
                 });
             });
 


### PR DESCRIPTION
We already automatically include feature assemblies (in `MvcBuilderExtensions.AddControllers`). Since these assemblies would also include the controllers of these features there are usually no issues with the framework discovering the controllers. However when a feature wants to include a controller from another feature that is not explicitly added to the builder, the controller's assembly needs to be included explicitly. This PR makes it possible to do that and fixes the SmartContract feature so that it causes the wallet's assembly to be included for use by the framework during controller discovery.

See https://stratisplatformuk.visualstudio.com/StratisBitcoinFullNode/_workitems/edit/4201