### PR TITLE
Attempt to fix ConsensusManager_Fork_Occurs_When_Stake_Coins_Are_Spent_And_Found_In_Rewind_Data

### DIFF
--- a/src/Stratis.Bitcoin.IntegrationTests.Common/TestHelper.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests.Common/TestHelper.cs
@@ -134,7 +134,7 @@ namespace Stratis.Bitcoin.IntegrationTests.Common
         /// <returns>Returns <c>true</c> if the node is synced at a given height.</returns>
         public static bool IsNodeSyncedAtHeight(CoreNode node, int height)
         {
-            TestBase.WaitLoop(() => node.FullNode.ConsensusManager().Tip.Height == height);
+            TestBase.WaitLoopMessage(() => { return (node.FullNode.ConsensusManager().Tip.Height == height, $"Node height: {node.FullNode.ConsensusManager().Tip.Height}; Expected height: {height}"); });
             return true;
         }
 

--- a/src/Stratis.Bitcoin.IntegrationTests/ConsensusManagerTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/ConsensusManagerTests.cs
@@ -568,8 +568,8 @@ namespace Stratis.Bitcoin.IntegrationTests
                 // Sync the network, minerA should switch to minerB.
                 TestHelper.Connect(minerA, minerB);
 
-                TestBase.WaitLoopMessage(() => { return (TestHelper.IsNodeSyncedAtHeight(minerA, expectedValidChainHeight), $"MinerA.Tip {minerA.FullNode.ConsensusManager().Tip}, expectedValidChainHeight{expectedValidChainHeight}"); });
-                TestBase.WaitLoopMessage(() => { return (TestHelper.IsNodeSyncedAtHeight(minerB, expectedValidChainHeight), $"MinerB.Tip {minerB.FullNode.ConsensusManager().Tip}, expectedValidChainHeight{expectedValidChainHeight}"); });
+                TestHelper.IsNodeSyncedAtHeight(minerA, expectedValidChainHeight);
+                TestHelper.IsNodeSyncedAtHeight(minerB, expectedValidChainHeight);
             }
         }
 

--- a/src/Stratis.Bitcoin.IntegrationTests/ConsensusManagerTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/ConsensusManagerTests.cs
@@ -84,7 +84,7 @@ namespace Stratis.Bitcoin.IntegrationTests
 
         public class FailValidation15_2 : FailValidation
         {
-            public FailValidation15_2() : base(15,2)
+            public FailValidation15_2() : base(15, 2)
             {
             }
         }
@@ -508,7 +508,7 @@ namespace Stratis.Bitcoin.IntegrationTests
             }
         }
 
-        /// <remarks>This test assumes CoinbaseMaturity is 10 and at block 2 there is a huge premine, adjust the test if this changes.</remarks>
+        /// <summary>This test assumes CoinbaseMaturity is 10 and at block 2 there is a huge premine, adjust the test if this changes.</summary>
         [Fact]
         public void ConsensusManager_Fork_Occurs_When_Stake_Coins_Are_Spent_And_Found_In_Rewind_Data()
         {
@@ -568,8 +568,8 @@ namespace Stratis.Bitcoin.IntegrationTests
                 // Sync the network, minerA should switch to minerB.
                 TestHelper.Connect(minerA, minerB);
 
-                TestBase.WaitLoop(() => TestHelper.IsNodeSyncedAtHeight(minerA, expectedValidChainHeight));
-                TestBase.WaitLoop(() => TestHelper.IsNodeSyncedAtHeight(minerB, expectedValidChainHeight));
+                TestBase.WaitLoopMessage(() => { return (TestHelper.IsNodeSyncedAtHeight(minerA, expectedValidChainHeight), $"MinerA.Tip {minerA.FullNode.ConsensusManager().Tip}, expectedValidChainHeight{expectedValidChainHeight}"); });
+                TestBase.WaitLoopMessage(() => { return (TestHelper.IsNodeSyncedAtHeight(minerB, expectedValidChainHeight), $"MinerB.Tip {minerB.FullNode.ConsensusManager().Tip}, expectedValidChainHeight{expectedValidChainHeight}"); });
             }
         }
 

--- a/src/Stratis.Bitcoin.IntegrationTests/ConsensusManagerTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/ConsensusManagerTests.cs
@@ -557,7 +557,7 @@ namespace Stratis.Bitcoin.IntegrationTests
                 TestBase.WaitLoop(() => minerA.FullNode.ConsensusManager().Tip.Height == 25);
                 minterA.StopStake();
 
-                TestHelper.MineBlocks(minerB, 2); // this will push minerb total work to be highest
+                TestHelper.MineBlocks(minerB, 2); // this will push minerB total work to be highest
                 var minterB = minerB.FullNode.NodeService<IPosMinting>();
                 minterB.Stake(new WalletSecret() { WalletName = WalletName, WalletPassword = Password });
                 TestBase.WaitLoop(() => minerB.FullNode.ConsensusManager().Tip.Height == 27);


### PR DESCRIPTION
This test continuously fails the CI build. I've updated the wait loop helper that checks the height of the node to output some information when it fails. Once we know this I can investigate further.