### PR TITLE
 ColdStaking feature no longer needs to print wallet help

### DIFF
--- a/src/Stratis.Bitcoin.Features.ColdStaking/ColdStakingFeature.cs
+++ b/src/Stratis.Bitcoin.Features.ColdStaking/ColdStakingFeature.cs
@@ -126,7 +126,7 @@ namespace Stratis.Bitcoin.Features.ColdStaking
         /// <param name="network">The network to extract values from.</param>
         public static void PrintHelp(Network network)
         {
-            WalletSettings.PrintHelp(network);
+            // The wallet feature will print the help.
         }
 
         /// <summary>
@@ -136,7 +136,7 @@ namespace Stratis.Bitcoin.Features.ColdStaking
         /// <param name="network">The network to base the defaults off.</param>
         public static void BuildDefaultConfigurationFile(StringBuilder builder, Network network)
         {
-            WalletSettings.BuildDefaultConfigurationFile(builder, network);
+            // The wallet feature will add its own settings to the config.
         }
 
         private void AddInlineStats(StringBuilder benchLogs)

--- a/src/Stratis.Bitcoin.Features.ColdStaking/ColdStakingFeature.cs
+++ b/src/Stratis.Bitcoin.Features.ColdStaking/ColdStakingFeature.cs
@@ -6,22 +6,17 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using NBitcoin;
-using NBitcoin.Policy;
 using Stratis.Bitcoin.Builder;
 using Stratis.Bitcoin.Builder.Feature;
 using Stratis.Bitcoin.Configuration;
 using Stratis.Bitcoin.Configuration.Logging;
 using Stratis.Bitcoin.Connection;
-using Stratis.Bitcoin.Consensus;
 using Stratis.Bitcoin.Features.BlockStore;
-using Stratis.Bitcoin.Features.ColdStaking.Controllers;
 using Stratis.Bitcoin.Features.MemoryPool;
 using Stratis.Bitcoin.Features.RPC;
 using Stratis.Bitcoin.Features.Wallet;
 using Stratis.Bitcoin.Features.Wallet.Broadcasting;
-using Stratis.Bitcoin.Features.Wallet.Controllers;
 using Stratis.Bitcoin.Features.Wallet.Interfaces;
-using Stratis.Bitcoin.Interfaces;
 using Stratis.Bitcoin.Utilities;
 
 namespace Stratis.Bitcoin.Features.ColdStaking
@@ -115,6 +110,9 @@ namespace Stratis.Bitcoin.Features.ColdStaking
             this.broadcasterBehavior = broadcasterBehavior;
             this.nodeSettings = nodeSettings;
             this.walletSettings = walletSettings;
+
+            nodeStats.RemoveStats(StatsType.Component, typeof(WalletFeature).Name);
+            nodeStats.RemoveStats(StatsType.Inline, typeof(WalletFeature).Name);
 
             nodeStats.RegisterStats(this.AddComponentStats, StatsType.Component, this.GetType().Name);
             nodeStats.RegisterStats(this.AddInlineStats, StatsType.Inline, this.GetType().Name, 800);

--- a/src/Stratis.Bitcoin.Features.ColdStaking/ColdStakingFeature.cs
+++ b/src/Stratis.Bitcoin.Features.ColdStaking/ColdStakingFeature.cs
@@ -196,11 +196,6 @@ namespace Stratis.Bitcoin.Features.ColdStaking
         /// <inheritdoc />
         public override Task InitializeAsync()
         {
-            this.coldStakingManager.Start();
-            this.walletSyncManager.Start();
-            this.addressBookManager.Initialize();
-
-            this.connectionManager.Parameters.TemplateBehaviors.Add(this.broadcasterBehavior);
 
             return Task.CompletedTask;
         }
@@ -208,8 +203,6 @@ namespace Stratis.Bitcoin.Features.ColdStaking
         /// <inheritdoc />
         public override void Dispose()
         {
-            this.coldStakingManager.Stop();
-            this.walletSyncManager.Stop();
         }
     }
 

--- a/src/Stratis.Bitcoin/Utilities/NodeStats.cs
+++ b/src/Stratis.Bitcoin/Utilities/NodeStats.cs
@@ -14,8 +14,16 @@ namespace Stratis.Bitcoin.Utilities
         /// <summary>Registers action that will be used to append node stats when they are being collected.</summary>
         /// <param name="appendStatsAction">Action that will be invoked during stats collection.</param>
         /// <param name="statsType">Type of stats.</param>
+        /// <param name="componentName">The component name.</param>
         /// <param name="priority">Stats priority that will be used to determine invocation priority of stats collection.</param>
         void RegisterStats(Action<StringBuilder> appendStatsAction, StatsType statsType, string componentName, int priority = 0);
+
+        /// <summary>
+        /// Removes stats previously registered.
+        /// </summary>
+        /// <param name="statsType">Type of stats.</param>
+        /// <param name="componentName">The component name.</param>
+        void RemoveStats(StatsType statsType, string componentName);
 
         /// <summary>Collects inline stats and then feature stats.</summary>
         string GetStats();
@@ -60,6 +68,15 @@ namespace Stratis.Bitcoin.Utilities
                 });
 
                 this.stats = this.stats.OrderByDescending(x => x.Priority).ToList();
+            }
+        }
+
+        /// <inheritdoc />
+        public void RemoveStats(StatsType statsType, string componentName)
+        {
+            lock (this.locker)
+            {
+                this.stats.Remove(this.stats.Where(s => s.StatsType == statsType && s.ComponentName == componentName).FirstOrDefault());
             }
         }
 


### PR DESCRIPTION
The cold staking feature is now pulling in the wallet feature. So a few changes are needed:
1. Avoid printing help twice. CS should no longer print help on behalf of the wallet.
2. Don't display stats twice. CS displays all the stats so the wallet stats should be turned off.
3. Remove duplicated calls from CS. The wallet already calls `Start` or `Intitialize` on some dependencies. No need for CS to do it again.

See https://github.com/stratisproject/StratisBitcoinFullNode/pull/3860.