### PR TITLE
[FS] Fix null ref in periodic benchmark. Each daemon now only has 1 PoAConsensusRules

### DIFF
--- a/src/Stratis.Features.Collateral/CollateralFeature.cs
+++ b/src/Stratis.Features.Collateral/CollateralFeature.cs
@@ -2,7 +2,6 @@
 using Microsoft.Extensions.DependencyInjection;
 using Stratis.Bitcoin.Builder;
 using Stratis.Bitcoin.Builder.Feature;
-using Stratis.Bitcoin.Consensus;
 using Stratis.Bitcoin.Features.Miner;
 using Stratis.Bitcoin.Features.PoA;
 using Stratis.Bitcoin.Features.SmartContracts;
@@ -52,7 +51,6 @@ namespace Stratis.Features.Collateral
                         services.AddSingleton<ICollateralChecker, CollateralChecker>();
 
                         new SmartContractCollateralPoARuleRegistration().RegisterRules(services);
-                        services.AddSingleton<IConsensusRuleEngine, PoAConsensusRuleEngine>();
                     });
             });
 

--- a/src/Stratis.Features.FederatedPeg.IntegrationTests/NodeInitialisationTests.cs
+++ b/src/Stratis.Features.FederatedPeg.IntegrationTests/NodeInitialisationTests.cs
@@ -7,6 +7,7 @@ using Flurl;
 using Flurl.Http;
 using Moq;
 using NBitcoin;
+using Stratis.Bitcoin.Consensus;
 using Stratis.Bitcoin.Features.BlockStore.Controllers;
 using Stratis.Bitcoin.Features.PoA;
 using Stratis.Bitcoin.IntegrationTests;
@@ -55,6 +56,8 @@ namespace Stratis.Features.FederatedPeg.IntegrationTests
                 user.Start();
 
                 Assert.Equal(CoreNodeState.Running, user.State);
+
+                VerifyNodeComposition(user);
             }
         }
 
@@ -70,6 +73,8 @@ namespace Stratis.Features.FederatedPeg.IntegrationTests
                 this.StartNodeWithMockCounterNodeAPI(miner);
 
                 Assert.Equal(CoreNodeState.Running, miner.State);
+
+                VerifyNodeComposition(miner);
             }
         }
 
@@ -102,6 +107,8 @@ namespace Stratis.Features.FederatedPeg.IntegrationTests
                 this.StartNodeWithMockCounterNodeAPI(gateway);
 
                 Assert.Equal(CoreNodeState.Running, gateway.State);
+
+                VerifyNodeComposition(gateway);
             }
         }
 
@@ -119,6 +126,8 @@ namespace Stratis.Features.FederatedPeg.IntegrationTests
                 gateway.Start();
 
                 Assert.Equal(CoreNodeState.Running, gateway.State);
+
+                VerifyNodeComposition(gateway);
             }
         }
 
@@ -203,6 +212,18 @@ namespace Stratis.Features.FederatedPeg.IntegrationTests
                 //await side.MineBlocksAsync(DepositConfirmations + 1);
                 //TestBase.WaitLoop(() => main.FullNode.NodeService<ICrossChainTransferStore>().NextMatureDepositHeight > 0);
             }
+        }
+
+        /// <summary>
+        /// Verifies that the created node has certain properties.
+        /// </summary>
+        private static void VerifyNodeComposition(CoreNode node)
+        {
+            // TODO: Add more checks about the sanctity of the node. And break methods down if needed.
+
+            // We only want one consensus rule engine. Others can sneak in and will break the periodic log.
+            IEnumerable<IConsensusRuleEngine> consensusRuleEngines = node.FullNode.NodeService<IEnumerable<IConsensusRuleEngine>>();
+            Assert.Single(consensusRuleEngines);
         }
     }
 

--- a/src/Stratis.Features.FederatedPeg.IntegrationTests/NodeInitialisationTests.cs
+++ b/src/Stratis.Features.FederatedPeg.IntegrationTests/NodeInitialisationTests.cs
@@ -219,7 +219,7 @@ namespace Stratis.Features.FederatedPeg.IntegrationTests
         /// </summary>
         private static void VerifyNodeComposition(CoreNode node)
         {
-            // TODO: Add more checks about the sanctity of the node. And break methods down if needed.
+            // TODO: Add more checks about the sanctity of the node. And add specific checks per particular daemon.
 
             // We only want one consensus rule engine. Others can sneak in and will break the periodic log.
             IEnumerable<IConsensusRuleEngine> consensusRuleEngines = node.FullNode.NodeService<IEnumerable<IConsensusRuleEngine>>();

--- a/src/Stratis.Features.FederatedPeg/FederatedPegFeature.cs
+++ b/src/Stratis.Features.FederatedPeg/FederatedPegFeature.cs
@@ -14,6 +14,7 @@ using Stratis.Bitcoin.Builder.Feature;
 using Stratis.Bitcoin.Configuration;
 using Stratis.Bitcoin.Configuration.Logging;
 using Stratis.Bitcoin.Connection;
+using Stratis.Bitcoin.Consensus;
 using Stratis.Bitcoin.Features.Api;
 using Stratis.Bitcoin.Features.Consensus;
 using Stratis.Bitcoin.Features.Consensus.CoinViews;
@@ -447,7 +448,7 @@ namespace Stratis.Features.FederatedPeg
                     services.AddSingleton<MinerSettings>();
 
                     // Consensus Rules
-                    services.AddSingleton<PoAConsensusRuleEngine>();
+                    services.AddSingleton<IConsensusRuleEngine, PoAConsensusRuleEngine>();
                 });
             });
 


### PR DESCRIPTION
https://stratisplatformuk.visualstudio.com/StratisBitcoinFullNode/_workitems/edit/4264.

