### PR TITLE
Corrected the test so that it now fails due to known issue with SplitCoins API

### DIFF
--- a/src/Stratis.Bitcoin.IntegrationTests/ConsensusManagerTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/ConsensusManagerTests.cs
@@ -536,7 +536,7 @@ namespace Stratis.Bitcoin.IntegrationTests
                         WalletName = minerA.WalletName,
                         AccountName = "account 0",
                         WalletPassword = minerA.WalletPassword,
-                        TotalAmountToSplit = network.Consensus.PremineReward.ToString(),
+                        TotalAmountToSplit = (minerA.MinerHDAddress.Transactions.Sum(t => t.Amount) / 100000000).ToString(),
                         UtxosCount = 2
                     })
                     .ReceiveJson<WalletSendTransactionModel>().Result;


### PR DESCRIPTION
The test didn't split the whole wallet balance and thus it was always succeeding.
Modified the test to call splitcoins on full wallet balance which resulted in test failing.