### PR TITLE
[FN] Fix for a FATAL exception when full validation fails

### DIFF
--- a/src/Stratis.Bitcoin.Features.PoA/PoAMiner.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/PoAMiner.cs
@@ -174,6 +174,14 @@ namespace Stratis.Bitcoin.Features.PoA
                     // but it should not halt the mining operation.
                     this.logger.LogWarning("Miner failed to mine block due to: '{0}'.", ce.ConsensusError.Message);
                 }
+                catch (ConsensusException ce)
+                {
+                    // Text from PosMinting:
+                    // All consensus exceptions (including translated ConsensusErrorException) should be ignored. It means that the miner
+                    // ran into problems while constructing block or verifying it
+                    // but it should not halt the mining operation.
+                    this.logger.LogWarning("Miner failed to mine block due to: '{0}'.", ce.Message);
+                }
                 catch (Exception exception)
                 {
                     this.logger.LogCritical("Exception occurred during mining: {0}", exception.ToString());


### PR DESCRIPTION
Currently, if we get full validation error we translate validation errors into `ConsensusException` which `PoAMiner` cannot handle. 

```
ConnectBlocksResult fullValidationResult = await this.FullyValidateLockedAsync(validationContext.ChainedHeaderToValidate, true).ConfigureAwait(false);
 if (!fullValidationResult.Succeeded)
{
    this.logger.LogDebug("Miner produced an invalid block, full validation failed: {0}", fullValidationResult.Error.Message);
    this.logger.LogTrace("(-)[FULL_VALIDATION_FAILED]");
    throw new ConsensusException(fullValidationResult.Error.Message);
}
```

Added a catch to handle consensus errors (similar to PoSMinting). Alternative approach would be to throw `ConsensusErrorException`