### PR TITLE
Returning deployment results in getblockchaininfo rpc method

### DIFF
--- a/src/NBitcoin/BIP9Deployments.cs
+++ b/src/NBitcoin/BIP9Deployments.cs
@@ -7,15 +7,16 @@ namespace NBitcoin
         /// <summary>Special flag for timeout to indicate always active.</summary>
         public const long AlwaysActive = -1;
 
-        public BIP9DeploymentsParameters(int bit, DateTimeOffset startTime, DateTimeOffset timeout)
+        public BIP9DeploymentsParameters(string name, int bit, DateTimeOffset startTime, DateTimeOffset timeout)
         {
             this.Bit = bit;
             this.StartTime = startTime;
             this.Timeout = timeout;
+            this.Name = name.ToLower();
         }
 
-        public BIP9DeploymentsParameters(int bit, long startTime, long timeout)
-            : this(bit, (DateTimeOffset) Utils.UnixTimeToDateTime(startTime), Utils.UnixTimeToDateTime(timeout))
+        public BIP9DeploymentsParameters(string name, int bit, long startTime, long timeout)
+            : this(name, bit, (DateTimeOffset) Utils.UnixTimeToDateTime(startTime), Utils.UnixTimeToDateTime(timeout))
         {
 
         }
@@ -37,5 +38,12 @@ namespace NBitcoin
             get;
             private set;
         }
+
+        public string Name 
+        {
+            get;
+            private set;
+        }
+
     }
 }

--- a/src/Stratis.Bitcoin.Features.Miner.Tests/PosBlockAssemblerTest.cs
+++ b/src/Stratis.Bitcoin.Features.Miner.Tests/PosBlockAssemblerTest.cs
@@ -189,7 +189,7 @@ namespace Stratis.Bitcoin.Features.Miner.Tests
             {
                 var newOptions = new PosConsensusOptions();
                 this.stratisTest.Consensus.Options = newOptions;
-                this.stratisTest.Consensus.BIP9Deployments[0] = new BIP9DeploymentsParameters(19,
+                this.stratisTest.Consensus.BIP9Deployments[0] = new BIP9DeploymentsParameters("Test",19,
                     new DateTimeOffset(new DateTime(2016, 1, 1, 0, 0, 0, DateTimeKind.Utc)),
                     new DateTimeOffset(new DateTime(2018, 1, 1, 0, 0, 0, DateTimeKind.Utc)));
 

--- a/src/Stratis.Bitcoin.Features.Miner.Tests/PowBlockAssemblerTest.cs
+++ b/src/Stratis.Bitcoin.Features.Miner.Tests/PowBlockAssemblerTest.cs
@@ -133,7 +133,7 @@ namespace Stratis.Bitcoin.Features.Miner.Tests
             {
                 var newOptions = new ConsensusOptions();
                 this.testNet.Consensus.Options = newOptions;
-                this.testNet.Consensus.BIP9Deployments[0] = new BIP9DeploymentsParameters(19,
+                this.testNet.Consensus.BIP9Deployments[0] = new BIP9DeploymentsParameters("Test", 19,
                     new DateTimeOffset(new DateTime(2016, 1, 1, 0, 0, 0, DateTimeKind.Utc)),
                     new DateTimeOffset(new DateTime(2018, 1, 1, 0, 0, 0, DateTimeKind.Utc)));
 

--- a/src/Stratis.Bitcoin.Features.RPC/Controllers/FullNodeController.cs
+++ b/src/Stratis.Bitcoin.Features.RPC/Controllers/FullNodeController.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
@@ -6,6 +7,8 @@ using Microsoft.Extensions.Logging;
 using NBitcoin;
 using NBitcoin.DataEncoders;
 using Stratis.Bitcoin.Base;
+using Stratis.Bitcoin.Base.Deployments;
+using Stratis.Bitcoin.Base.Deployments.Models;
 using Stratis.Bitcoin.Configuration;
 using Stratis.Bitcoin.Consensus;
 using Stratis.Bitcoin.Controllers;
@@ -455,7 +458,65 @@ namespace Stratis.Bitcoin.Features.RPC.Controllers
                 blockchainInfo.VerificationProgress = (double)blockchainInfo.Blocks / blockchainInfo.Headers;
             }
 
+            // softfork deployments
+            blockchainInfo.SoftForks = new List<SoftForks>();
+
+            foreach (var consensusBuriedDeployment in Enum.GetValues(typeof(BuriedDeployments)))
+            {
+                bool active = this.ChainIndexer.Height >= this.Network.Consensus.BuriedDeployments[(BuriedDeployments) consensusBuriedDeployment];
+                blockchainInfo.SoftForks.Add(new SoftForks
+                {
+                    Id = consensusBuriedDeployment.ToString().ToLower(),
+                    Version = (int)consensusBuriedDeployment + 2, // hack
+                    Status = new SoftForksStatus {Status = active}
+                });
+            }
+
+            // softforkbip9 deployments
+            blockchainInfo.SoftForksBip9 = new Dictionary<string, SoftForksBip9>();
+
+            ConsensusRuleEngine ruleEngine = this.ConsensusManager.ConsensusRules as ConsensusRuleEngine;
+            ThresholdState[] thresholdStates = ruleEngine.NodeDeployments.BIP9.GetStates(this.ChainIndexer.Tip.Previous);
+            List<ThresholdStateModel> metrics = ruleEngine.NodeDeployments.BIP9.GetThresholdStateMetrics(this.ChainIndexer.Tip.Previous, thresholdStates);
+
+            foreach (ThresholdStateModel metric in metrics.Where(m => !m.DeploymentName.ToLower().Contains("test"))) // to remove the test dummy 
+            {
+                // TODO: Deployment timeout may not be implemented yet
+
+                // Deployments with timeout value of 0 are hidden.
+                // A timeout value of 0 guarantees a softfork will never be activated.
+                // This is used when softfork codes are merged without specifying the deployment schedule.
+                if (metric.TimeTimeOut?.Ticks > 0)
+                    blockchainInfo.SoftForksBip9.Add(metric.DeploymentName, this.CreateSoftForksBip9(metric, thresholdStates[metric.DeploymentIndex]));
+            }
+            
+            // TODO: Implement blockchainInfo.warnings
             return blockchainInfo;
+        }
+
+        private SoftForksBip9 CreateSoftForksBip9(ThresholdStateModel metric, ThresholdState state)
+        {
+            var softForksBip9 = new SoftForksBip9()
+            {
+                Status = metric.ThresholdState.ToLower(),
+                Bit = this.Network.Consensus.BIP9Deployments[metric.DeploymentIndex].Bit,
+                StartTime = metric.TimeStart?.ToUnixTimestamp() ?? 0,
+                Timeout = metric.TimeTimeOut?.ToUnixTimestamp() ?? 0,
+                Since = metric.SinceHeight
+            };
+
+            if (state == ThresholdState.Started)
+            {
+                softForksBip9.Statistics = new SoftForksBip9Statistics();
+
+                softForksBip9.Statistics.Period = metric.ConfirmationPeriod;
+                softForksBip9.Statistics.Threshold = metric.Threshold;
+                softForksBip9.Statistics.Count = metric.Blocks;
+                softForksBip9.Statistics.Elapsed = metric.Height - metric.PeriodStartHeight;
+                softForksBip9.Statistics.Possible = (softForksBip9.Statistics.Period - softForksBip9.Statistics.Threshold) >= (softForksBip9.Statistics.Elapsed - softForksBip9.Statistics.Count);
+            }
+
+            return softForksBip9;
         }
 
         private ChainedHeader GetTransactionBlock(uint256 trxid)

--- a/src/Stratis.Bitcoin.Features.RPC/Models/BlockchainInfoModel.cs
+++ b/src/Stratis.Bitcoin.Features.RPC/Models/BlockchainInfoModel.cs
@@ -1,4 +1,5 @@
-﻿using NBitcoin;
+﻿using System.Collections.Generic;
+using NBitcoin;
 using Newtonsoft.Json;
 
 namespace Stratis.Bitcoin.Features.RPC.Models
@@ -78,5 +79,69 @@ namespace Stratis.Bitcoin.Features.RPC.Models
 
         [JsonProperty(PropertyName = "pruned")]
         public bool IsPruned { get; set; }
+
+        [JsonProperty(PropertyName = "softforks")]
+        public List<SoftForks> SoftForks { get; set; }
+
+        [JsonProperty(PropertyName = "bip9_softforks")]
+        public Dictionary<string, SoftForksBip9> SoftForksBip9 { get; set; }
+    }
+
+    public class SoftForks
+    {
+        [JsonProperty(PropertyName = "id")]
+        public string Id { get; set; }
+
+        [JsonProperty(PropertyName = "version")]
+        public int Version { get; set; }
+
+        [JsonProperty(PropertyName = "reject")]
+        public SoftForksStatus Status { get; set; }
+    }
+
+    public class SoftForksStatus
+    {
+        [JsonProperty(PropertyName = "status")]
+        public bool Status { get; set; }
+    }
+
+    public class SoftForksBip9
+    {
+        [JsonProperty(PropertyName = "status")]
+        public string Status { get; set; }
+
+        [JsonProperty(PropertyName = "startTime")]
+        public int StartTime { get; set; }
+
+        [JsonProperty(PropertyName = "timeout")]
+        public int Timeout { get; set; }
+
+        [JsonProperty(PropertyName = "since")]
+        public int Since { get; set; }
+
+        [JsonProperty(PropertyName = "bit")]
+        public int Bit { get; set; }
+
+        [JsonProperty(PropertyName = "statistics")]
+        public SoftForksBip9Statistics Statistics { get; set; }
+
+    }
+
+    public class SoftForksBip9Statistics
+    {
+        [JsonProperty(PropertyName = "period")]
+        public int Period { get; set; }
+
+        [JsonProperty(PropertyName = "threshold")]
+        public int Threshold { get; set; }
+
+        [JsonProperty(PropertyName = "elapsed")]
+        public int Elapsed { get; set; }
+
+        [JsonProperty(PropertyName = "count")]
+        public int Count { get; set; }
+
+        [JsonProperty(PropertyName = "possible")]
+        public bool Possible { get; set; }
     }
 }

--- a/src/Stratis.Bitcoin.IntegrationTests/ColdStakingTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/ColdStakingTests.cs
@@ -37,7 +37,7 @@ namespace Stratis.Bitcoin.IntegrationTests
                 var network = new StratisOverrideRegTest();
 
                 // Set the date ranges such that ColdStaking will 'Start' immediately after the initial confirmation window.
-                network.Consensus.BIP9Deployments[StratisBIP9Deployments.ColdStaking] = new BIP9DeploymentsParameters(1, 0, DateTime.Now.AddDays(50).ToUnixTimestamp());
+                network.Consensus.BIP9Deployments[StratisBIP9Deployments.ColdStaking] = new BIP9DeploymentsParameters("Test", 1, 0, DateTime.Now.AddDays(50).ToUnixTimestamp());
 
                 // Set a small confirmation window to reduce time taken by this test.
                 network.Consensus.MinerConfirmationWindow = 10;

--- a/src/Stratis.Bitcoin.IntegrationTests/SegWitTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/SegWitTests.cs
@@ -38,7 +38,7 @@ namespace Stratis.Bitcoin.IntegrationTests
                 // Core (in version 0.15.1) only mines segwit blocks above a certain height on regtest
                 // See issue for more details https://github.com/stratisproject/StratisBitcoinFullNode/issues/1028
                 BIP9DeploymentsParameters prevSegwitDeployment = KnownNetworks.RegTest.Consensus.BIP9Deployments[BitcoinBIP9Deployments.Segwit];
-                KnownNetworks.RegTest.Consensus.BIP9Deployments[BitcoinBIP9Deployments.Segwit] = new BIP9DeploymentsParameters(1, 0, DateTime.Now.AddDays(50).ToUnixTimestamp());
+                KnownNetworks.RegTest.Consensus.BIP9Deployments[BitcoinBIP9Deployments.Segwit] = new BIP9DeploymentsParameters("Test", 1, 0, DateTime.Now.AddDays(50).ToUnixTimestamp());
 
                 try
                 {

--- a/src/Stratis.Bitcoin.Networks/BitcoinMain.cs
+++ b/src/Stratis.Bitcoin.Networks/BitcoinMain.cs
@@ -61,9 +61,9 @@ namespace Stratis.Bitcoin.Networks
 
             var bip9Deployments = new BitcoinBIP9Deployments
             {
-                [BitcoinBIP9Deployments.TestDummy] = new BIP9DeploymentsParameters(28, 1199145601, 1230767999),
-                [BitcoinBIP9Deployments.CSV] = new BIP9DeploymentsParameters(0, 1462060800, 1493596800),
-                [BitcoinBIP9Deployments.Segwit] = new BIP9DeploymentsParameters(1, 1479168000, 1510704000)
+                [BitcoinBIP9Deployments.TestDummy] = new BIP9DeploymentsParameters("TestDummy", 28, 1199145601, 1230767999),
+                [BitcoinBIP9Deployments.CSV] = new BIP9DeploymentsParameters("CSV", 0, 1462060800, 1493596800),
+                [BitcoinBIP9Deployments.Segwit] = new BIP9DeploymentsParameters("Segwit", 1, 1479168000, 1510704000)
             };
 
             this.Consensus = new NBitcoin.Consensus(

--- a/src/Stratis.Bitcoin.Networks/BitcoinRegTest.cs
+++ b/src/Stratis.Bitcoin.Networks/BitcoinRegTest.cs
@@ -45,9 +45,9 @@ namespace Stratis.Bitcoin.Networks
 
             var bip9Deployments = new BitcoinBIP9Deployments
             {
-                [BitcoinBIP9Deployments.TestDummy] = new BIP9DeploymentsParameters(28, 0, 999999999),
-                [BitcoinBIP9Deployments.CSV] = new BIP9DeploymentsParameters(0, 0, 999999999),
-                [BitcoinBIP9Deployments.Segwit] = new BIP9DeploymentsParameters(1, BIP9DeploymentsParameters.AlwaysActive, 999999999)
+                [BitcoinBIP9Deployments.TestDummy] = new BIP9DeploymentsParameters("TestDummy", 28, 0, 999999999),
+                [BitcoinBIP9Deployments.CSV] = new BIP9DeploymentsParameters("CSV",0, 0, 999999999),
+                [BitcoinBIP9Deployments.Segwit] = new BIP9DeploymentsParameters("Segwit", 1, BIP9DeploymentsParameters.AlwaysActive, 999999999)
             };
 
             this.Consensus = new NBitcoin.Consensus(

--- a/src/Stratis.Bitcoin.Networks/BitcoinTest.cs
+++ b/src/Stratis.Bitcoin.Networks/BitcoinTest.cs
@@ -46,9 +46,9 @@ namespace Stratis.Bitcoin.Networks
 
             var bip9Deployments = new BitcoinBIP9Deployments
             {
-                [BitcoinBIP9Deployments.TestDummy] = new BIP9DeploymentsParameters(28, 1199145601, 1230767999),
-                [BitcoinBIP9Deployments.CSV] = new BIP9DeploymentsParameters(0, 1456790400, 1493596800),
-                [BitcoinBIP9Deployments.Segwit] = new BIP9DeploymentsParameters(1, 1462060800, 1493596800)
+                [BitcoinBIP9Deployments.TestDummy] = new BIP9DeploymentsParameters("TestDummy", 28, 1199145601, 1230767999),
+                [BitcoinBIP9Deployments.CSV] = new BIP9DeploymentsParameters("CSV", 0, 1456790400, 1493596800),
+                [BitcoinBIP9Deployments.Segwit] = new BIP9DeploymentsParameters("Segwit", 1, 1462060800, 1493596800)
             };
 
             this.Consensus = new NBitcoin.Consensus(

--- a/src/Stratis.Bitcoin.Networks/StratisMain.cs
+++ b/src/Stratis.Bitcoin.Networks/StratisMain.cs
@@ -90,7 +90,7 @@ namespace Stratis.Bitcoin.Networks
 
             var bip9Deployments = new StratisBIP9Deployments()
             {
-                [StratisBIP9Deployments.ColdStaking] = new BIP9DeploymentsParameters(2,
+                [StratisBIP9Deployments.ColdStaking] = new BIP9DeploymentsParameters("ColdStaking", 2,
                     new DateTime(2018, 12, 1, 0, 0, 0, DateTimeKind.Utc),
                     new DateTime(2019, 12, 1, 0, 0, 0, DateTimeKind.Utc))
             };

--- a/src/Stratis.Bitcoin.Networks/StratisRegTest.cs
+++ b/src/Stratis.Bitcoin.Networks/StratisRegTest.cs
@@ -68,7 +68,7 @@ namespace Stratis.Bitcoin.Networks
             var bip9Deployments = new StratisBIP9Deployments()
             {
                 // Always active on StratisRegTest.
-                [StratisBIP9Deployments.ColdStaking] = new BIP9DeploymentsParameters(1, BIP9DeploymentsParameters.AlwaysActive, 999999999)
+                [StratisBIP9Deployments.ColdStaking] = new BIP9DeploymentsParameters("ColdStaking", 1, BIP9DeploymentsParameters.AlwaysActive, 999999999)
             };
 
             this.Consensus = new NBitcoin.Consensus(

--- a/src/Stratis.Bitcoin.Networks/StratisTest.cs
+++ b/src/Stratis.Bitcoin.Networks/StratisTest.cs
@@ -71,7 +71,7 @@ namespace Stratis.Bitcoin.Networks
 
             var bip9Deployments = new StratisBIP9Deployments()
             {
-                [StratisBIP9Deployments.ColdStaking] = new BIP9DeploymentsParameters(2,
+                [StratisBIP9Deployments.ColdStaking] = new BIP9DeploymentsParameters("ColdStaking", 2,
                     new DateTime(2018, 11, 1, 0, 0, 0, DateTimeKind.Utc),
                     new DateTime(2019, 6, 1, 0, 0, 0, DateTimeKind.Utc))
             };

--- a/src/Stratis.Bitcoin/Base/Deployments/Models/ThresholdStateModel.cs
+++ b/src/Stratis.Bitcoin/Base/Deployments/Models/ThresholdStateModel.cs
@@ -12,6 +12,12 @@ namespace Stratis.Bitcoin.Base.Deployments.Models
         /// <summary>
         /// BIP9 deployment index for this soft fork.
         /// </summary>
+        [JsonProperty(PropertyName = "deploymentName")]
+        public string DeploymentName { get; set; }
+
+        /// <summary>
+        /// BIP9 deployment index for this soft fork.
+        /// </summary>
         [JsonProperty(PropertyName = "deploymentIndex")]
         public int DeploymentIndex { get; set; }
 
@@ -32,6 +38,12 @@ namespace Stratis.Bitcoin.Base.Deployments.Models
         /// </summary>
         [JsonProperty(PropertyName = "height")]
         public int Height { get; set; }
+
+        /// <summary>
+        /// Height of when the deployment started.
+        /// </summary>
+        [JsonProperty(PropertyName = "sinceHeight")]
+        public int SinceHeight { get; set; }
 
         /// <summary>
         /// The number of blocks in the each confirmation window.

--- a/src/Stratis.Bitcoin/Base/Deployments/ThresholdConditionCache.cs
+++ b/src/Stratis.Bitcoin/Base/Deployments/ThresholdConditionCache.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using NBitcoin;
 using Stratis.Bitcoin.Base.Deployments.Models;
 using Stratis.Bitcoin.Utilities;
@@ -77,6 +78,8 @@ namespace Stratis.Bitcoin.Base.Deployments
             {
                 if (this.consensus.BIP9Deployments[deploymentIndex] == null) continue;
 
+                string deploymentName = this.consensus.BIP9Deployments[deploymentIndex]?.Name;
+
                 DateTime? timeStart = this.consensus.BIP9Deployments[deploymentIndex]?.StartTime.Date;
                 DateTime? timeTimeout = this.consensus.BIP9Deployments[deploymentIndex]?.Timeout.Date;
                 int threshold = this.consensus.RuleChangeActivationThreshold;
@@ -111,8 +114,15 @@ namespace Stratis.Bitcoin.Base.Deployments
                     indexPrev = indexPrev.Previous;
                 }
 
+                // look in the cache for the hash of the first block an item was deployed
+
+                var firstSeenHash = this.cache.Reverse().FirstOrDefault(c => c.Value[deploymentIndex] != null);
+
+                int sinceHeight = indexPrev.FindAncestorOrSelf(firstSeenHash.Key).Height;
+
                 thresholdStateModels.Add(new ThresholdStateModel()
                 {
+                    DeploymentName = deploymentName,
                     DeploymentIndex = deploymentIndex,
                     ConfirmationPeriod = period,
                     Blocks = totalBlocks,
@@ -122,6 +132,7 @@ namespace Stratis.Bitcoin.Base.Deployments
                     TimeTimeOut = timeTimeout,
                     Threshold = threshold,
                     Height = currentHeight,
+                    SinceHeight = sinceHeight,
                     PeriodStartHeight = periodStartsHeader.Height,
                     PeriodEndHeight = periodEndsHeight,
                     StateValue = thresholdStates[deploymentIndex],


### PR DESCRIPTION
Adding the missing deployment parts for RPC
`softforks` and `bip9_softforks`

https://bitcoincore.org/en/doc/0.16.0/rpc/blockchain/getblockchaininfo/