### PR TITLE
Filter out ineligible staking UTXOs

### DIFF
--- a/src/Stratis.Bitcoin.Features.Miner.Tests/PosMintingTest.cs
+++ b/src/Stratis.Bitcoin.Features.Miner.Tests/PosMintingTest.cs
@@ -525,7 +525,7 @@ namespace Stratis.Bitcoin.Features.Miner.Tests
 
             descriptions.Add(utxoDescription);
 
-            List<UtxoStakeDescription> suitableCoins = miner.GetUtxoStakeDescriptionsSuitableForStakingAsync(descriptions, chainTip, chainTip.Header.Time + 64, long.MaxValue).GetAwaiter().GetResult();
+            List<UtxoStakeDescription> suitableCoins = miner.GetUtxoStakeDescriptionsSuitableForStakingAsync(descriptions, chainTip.Header.Time + 64, long.MaxValue).GetAwaiter().GetResult();
             return suitableCoins.Count == 1;
         }
 

--- a/src/Stratis.Bitcoin.Features.Miner.Tests/PosMintingTest.cs
+++ b/src/Stratis.Bitcoin.Features.Miner.Tests/PosMintingTest.cs
@@ -55,7 +55,7 @@ namespace Stratis.Bitcoin.Features.Miner.Tests
         {
             this.consensusManager = new Mock<IConsensusManager>();
             this.network = KnownNetworks.StratisTest;
-            this.network.Consensus.Options = new ConsensusOptions();
+            this.network.Consensus.Options = new PosConsensusOptions();
             this.chainIndexer = new ChainIndexer(this.network);
             this.dateTimeProvider = new Mock<IDateTimeProvider>();
             this.initialBlockDownloadState = new Mock<IInitialBlockDownloadState>();

--- a/src/Stratis.Bitcoin.Features.Miner/Interfaces/IPosMinting.cs
+++ b/src/Stratis.Bitcoin.Features.Miner/Interfaces/IPosMinting.cs
@@ -54,9 +54,9 @@ namespace Stratis.Bitcoin.Features.Miner.Interfaces
         /// <summary>
         /// Calculates the total balance from all UTXOs in the wallet that are mature.
         /// </summary>
-        /// <param name="utxoStakeDescriptions">Description of coins in the wallet that will be used for staking.</param>
-        /// <returns>Total balance from all UTXOs in the wallet that are mature, and the total immature balance.</returns>
-        Task<(Money balance, Money immature)> GetMatureBalanceAsync(List<UtxoStakeDescription> utxoStakeDescriptions);
+        /// <param name="utxoStakeDescriptions">Description of coins in the wallet that will be used for staking, pre-filtered for suitable stake depth.</param>
+        /// <returns>Total balance from all UTXOs in the wallet that are mature.</returns>
+        Task<Money> GetMatureBalanceAsync(List<UtxoStakeDescription> utxoStakeDescriptions);
 
         /// <summary>
         /// Estimates the total staking weight of the network.

--- a/src/Stratis.Bitcoin.Features.Miner/Staking/PosMinting.cs
+++ b/src/Stratis.Bitcoin.Features.Miner/Staking/PosMinting.cs
@@ -439,7 +439,7 @@ namespace Stratis.Bitcoin.Features.Miner.Staking
             var utxoStakeDescriptions = new List<UtxoStakeDescription>();
 
             List<UnspentOutputReference> stakableUtxos = this.walletManager
-                .GetSpendableTransactionsInWalletForStaking(walletSecret.WalletName, 1)
+                .GetSpendableTransactionsInWalletForStaking(walletSecret.WalletName, (int)this.network.Consensus.CoinbaseMaturity)
                 .Where(utxo => utxo.Transaction.Amount >= this.MinimumStakingCoinValue) // exclude dust from stake process
                 .ToList();
 

--- a/src/Stratis.Bitcoin.Features.Miner/Staking/PosMinting.cs
+++ b/src/Stratis.Bitcoin.Features.Miner/Staking/PosMinting.cs
@@ -438,8 +438,11 @@ namespace Stratis.Bitcoin.Features.Miner.Staking
         {
             var utxoStakeDescriptions = new List<UtxoStakeDescription>();
 
+            var options = (PosConsensusOptions)this.network.Consensus.Options;
+            int minDepth = options.GetStakeMinConfirmations(this.chainIndexer.Height, this.network);
+
             List<UnspentOutputReference> stakableUtxos = this.walletManager
-                .GetSpendableTransactionsInWalletForStaking(walletSecret.WalletName, (int)this.network.Consensus.CoinbaseMaturity)
+                .GetSpendableTransactionsInWalletForStaking(walletSecret.WalletName, minDepth)
                 .Where(utxo => utxo.Transaction.Amount >= this.MinimumStakingCoinValue) // exclude dust from stake process
                 .ToList();
 


### PR DESCRIPTION
Not entirely sure why we weren't excluding UTXOs at this stage before. They get reprocessed later and filtered out, so there is redundant processing being done on every mining loop.

Possibly the staking stats are relying on every UTXO being considered, but even if that is the case, there should be a better way of doing it.