### PR TITLE
Ensure that the RPCClient will work even if the server is listening on all interfaces

### DIFF
--- a/src/Stratis.Bitcoin.Features.RPC/RPCClientFactory.cs
+++ b/src/Stratis.Bitcoin.Features.RPC/RPCClientFactory.cs
@@ -30,7 +30,7 @@ namespace Stratis.Bitcoin.Features.RPC
             Guard.NotNull(network, nameof(network));
             Guard.NotNull(rpcSettings, nameof(rpcSettings));
 
-            return new RPCClient(rpcSettings, address.ToString(), network);
+            return new RPCClient(rpcSettings, address, network);
         }
     }
 }


### PR DESCRIPTION
This PR addresses an issue whereby the swagger call to the RPC method will fail if the RPC server is bound to listen on 0.0.0.0.

The solution will work in the case of the RPC binding to all interfaces or dedicated single interface.