### PR TITLE
Update Fody Adapter NuGet version to prevent "Method not found" error…

### DIFF
--- a/src/Stratis.Bitcoin/Stratis.Bitcoin.csproj
+++ b/src/Stratis.Bitcoin/Stratis.Bitcoin.csproj
@@ -28,7 +28,7 @@
     <PackageReference Include="DBreeze" Version="1.89.0" />
     <PackageReference Include="NLog" Version="5.0.0-beta09" />
     <PackageReference Include="NLog.Extensions.Logging" Version="1.0.0-rtm-beta5" />
-    <PackageReference Include="Stratis.FodyNlogAdapter" Version="3.0.0.4-beta" />
+    <PackageReference Include="Stratis.FodyNlogAdapter" Version="3.0.4.1" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.0.2" />
     <PackageReference Include="System.Reactive" Version="4.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Diagnostics" Version="2.1.1" />


### PR DESCRIPTION
Currently, when attempting to start the miner node for a local network within the LSC-tutorial, a Fody Adapter "Method not found" exception is thrown when attempting to create the Genesis block. This change simply updates the Fody Adapter to the latest version, resolving the issue.