### PR TITLE
Fix rpc default binding

### DIFF
--- a/src/Stratis.Bitcoin.Features.RPC.Tests/RPCSettingsTest.cs
+++ b/src/Stratis.Bitcoin.Features.RPC.Tests/RPCSettingsTest.cs
@@ -202,6 +202,84 @@ namespace Stratis.Bitcoin.Features.RPC.Tests
             Assert.Empty(urls);
         }
 
+        [Fact]
+        public void GetUrls_NoBindsConfigured_AllowIp_Configured_Returns_DefaultBindings()
+        {
+            string dir = CreateTestDir(this);
+            string confFile = Path.Combine(dir, "bitcoin.conf");
+            var configLines = new List<string>()
+            {
+                "server=true",
+                "rpcuser=testuser",
+                "rpcpassword=testpassword",
+                "rpcallowip=0.0.0.0"
+            };
+
+            WriteConfigurationToFile(confFile, configLines);
+
+            var nodeSettings = new NodeSettings(this.Network, args: new string[] { "-conf=" + confFile });
+
+            var rpcSettings = new RpcSettings(nodeSettings);
+            string[] urls = rpcSettings.GetUrls();
+
+            Assert.Equal("http://[::]:18332/", urls[0]);
+            Assert.Equal("http://0.0.0.0:18332/", urls[1]);
+        }
+
+        [Fact]
+        public void GetUrls_NoBindsConfigured_NoUserPassword_AllowIp_Configured_Returns_DefaultBindings()
+        {
+            string dir = CreateTestDir(this);
+            string confFile = Path.Combine(dir, "bitcoin.conf");
+            var configLines = new List<string>()
+            {
+                "server=true",
+                "rpcallowip=0.0.0.0"
+            };
+
+            WriteConfigurationToFile(confFile, configLines);
+
+            var nodeSettings = new NodeSettings(this.Network, args: new string[] { "-conf=" + confFile });
+
+            var rpcSettings = new RpcSettings(nodeSettings);
+            string[] urls = rpcSettings.GetUrls();
+
+            Assert.Equal("http://[::]:18332/", urls[0]);
+            Assert.Equal("http://0.0.0.0:18332/", urls[1]);
+        }
+
+
+        [Fact]
+        public void Load_ValidNodeSettings_UpdatesRpcSettingsFromNodeSettings_Empty_Username_And_Password()
+        {
+            string dir = CreateTestDir(this);
+            string confFile = Path.Combine(dir, "bitcoin.conf");
+            var configLines = new List<string>()
+            {
+                "server=true",
+                "rpcport=1378",
+                "rpcallowip=0.0.0.0",
+                "rpcbind=127.0.0.1"
+            };
+
+            WriteConfigurationToFile(confFile, configLines);
+
+            var nodeSettings = new NodeSettings(this.Network, args: new string[] { "-conf=" + confFile });
+
+            var rpcSettings = new RpcSettings(nodeSettings);
+
+            Assert.True(rpcSettings.Server);
+            Assert.Equal(1378, rpcSettings.RPCPort);
+            Assert.Equal(null, rpcSettings.RpcUser);
+            Assert.Equal(null, rpcSettings.RpcPassword);
+            Assert.NotEmpty(rpcSettings.Bind);
+            Assert.Equal("127.0.0.1:1378", rpcSettings.Bind[0].ToString());
+            Assert.NotEmpty(rpcSettings.DefaultBindings);
+            Assert.Equal("127.0.0.1:1378", rpcSettings.DefaultBindings[0].ToString());
+            Assert.NotEmpty(rpcSettings.AllowIp);
+            Assert.Equal("0.0.0.0", rpcSettings.AllowIp[0].ToString());
+        }
+
         private static void WriteConfigurationToFile(string confFile, List<string> configurationFileLines)
         {
             File.WriteAllLines(confFile, configurationFileLines.ToArray());

--- a/src/Stratis.Bitcoin.Features.RPC/RpcSettings.cs
+++ b/src/Stratis.Bitcoin.Features.RPC/RpcSettings.cs
@@ -108,7 +108,7 @@ namespace Stratis.Bitcoin.Features.RPC
                 if (this.AllowIp.Count == 0)
                 {
                     if (this.Bind.Count > 0)
-                        logger.LogWarning("WARNING: RPC bind selection (-rpcbind) was ignored because allowed ip's (-rpcallowip) were not specified, refusing to allow everyone to connect");
+                        this.logger.LogWarning("WARNING: RPC bind selection (-rpcbind) was ignored because allowed ip's (-rpcallowip) were not specified, refusing to allow everyone to connect");
 
                     this.Bind.Clear();
                     this.Bind.Add(new IPEndPoint(IPAddress.Parse("::1"), this.RPCPort));

--- a/src/Stratis.Bitcoin.Features.RPC/RpcSettings.cs
+++ b/src/Stratis.Bitcoin.Features.RPC/RpcSettings.cs
@@ -100,27 +100,6 @@ namespace Stratis.Bitcoin.Features.RPC
                 {
                     throw new ConfigurationException("Invalid rpcbind value");
                 }
-            }
-        }
-
-        /// <summary>
-        /// Checks the validity of the RPC settings or forces them to be valid.
-        /// </summary>
-        /// <param name="logger">Logger to use.</param>
-        private void CheckConfigurationValidity(ILogger logger)
-        {
-            // Check that the settings are valid or force them to be valid
-            // (Note that these values will not be set if server = false in the config)
-            if (this.RpcPassword == null && this.RpcUser != null)
-                throw new ConfigurationException("rpcpassword should be provided");
-            if (this.RpcUser == null && this.RpcPassword != null)
-                throw new ConfigurationException("rpcuser should be provided");
-
-            // We can now safely assume that server was set to true in the config or that the
-            // "AddRpc" callback provided a user and password implying that the Rpc feature will be used.
-            if (this.RpcPassword != null && this.RpcUser != null)
-            {
-                // this.Server = true;
 
                 // If the "Bind" list has not been specified via callback..
                 if (this.Bind.Count == 0)
@@ -142,6 +121,20 @@ namespace Stratis.Bitcoin.Features.RPC
                     this.Bind.Add(new IPEndPoint(IPAddress.Parse("0.0.0.0"), this.RPCPort));
                 }
             }
+        }
+
+        /// <summary>
+        /// Checks the validity of the RPC settings or forces them to be valid.
+        /// </summary>
+        /// <param name="logger">Logger to use.</param>
+        private void CheckConfigurationValidity(ILogger logger)
+        {
+            // Check that the settings are valid or force them to be valid
+            // (Note that these values will not be set if server = false in the config)
+            if (this.RpcPassword == null && this.RpcUser != null)
+                throw new ConfigurationException("rpcpassword should be provided");
+            if (this.RpcUser == null && this.RpcPassword != null)
+                throw new ConfigurationException("rpcuser should be provided");
         }
 
         /// <summary> Prints the help information on how to configure the rpc settings to the logger.</summary>


### PR DESCRIPTION
Closes #3959.

Note: this just replicates the original RPC default binding behaviour, which is expressed kind of strangely.

@dangershony @zeptin @quantumagi do these defaults look correct to you:
- If allowip isn't specified, use "::1" and "127.0.0.1".
- If allowip is specified, but no bindings are specified and there's no default bindings, use "::" and "0.0.0.0".