### PR TITLE
[RPC] Fixed parsing of floats

### DIFF
--- a/src/Stratis.Bitcoin.Features.RPC/RPCMiddleware.cs
+++ b/src/Stratis.Bitcoin.Features.RPC/RPCMiddleware.cs
@@ -220,6 +220,8 @@ namespace Stratis.Bitcoin.Features.RPC
                 using (StreamReader streamReader = new StreamReader(responseMemoryStream))
                 using (JsonTextReader textReader = new JsonTextReader(streamReader))
                 {
+                    // Ensure floats are parsed as decimals and not as doubles.
+                    textReader.FloatParseHandling = FloatParseHandling.Decimal;
                     response = await JObject.LoadAsync(textReader);
                 }
             }
@@ -231,6 +233,9 @@ namespace Stratis.Bitcoin.Features.RPC
                 using (StreamReader streamReader = new StreamReader(context.Response.Body, Encoding.Default, true, 1024, true))
                 using (JsonTextReader textReader = new JsonTextReader(streamReader))
                 {
+                    // Ensure floats are parsed as decimals and not as doubles.
+                    textReader.FloatParseHandling = FloatParseHandling.Decimal;
+
                     string val = streamReader.ReadToEnd();
                     context.Response.Body.Position = 0;
                     response = await JObject.LoadAsync(textReader);

--- a/src/Stratis.Bitcoin.Features.RPC/RPCMiddleware.cs
+++ b/src/Stratis.Bitcoin.Features.RPC/RPCMiddleware.cs
@@ -217,8 +217,8 @@ namespace Stratis.Bitcoin.Features.RPC
                     throw new Exception("Method not found");
 
                 responseMemoryStream.Position = 0;
-                using (StreamReader streamReader = new StreamReader(responseMemoryStream))
-                using (JsonTextReader textReader = new JsonTextReader(streamReader))
+                using (var streamReader = new StreamReader(responseMemoryStream))
+                using (var textReader = new JsonTextReader(streamReader))
                 {
                     // Ensure floats are parsed as decimals and not as doubles.
                     textReader.FloatParseHandling = FloatParseHandling.Decimal;
@@ -230,8 +230,8 @@ namespace Stratis.Bitcoin.Features.RPC
                 await this.HandleRpcInvokeExceptionAsync(context, ex);
 
                 context.Response.Body.Position = 0;
-                using (StreamReader streamReader = new StreamReader(context.Response.Body, Encoding.Default, true, 1024, true))
-                using (JsonTextReader textReader = new JsonTextReader(streamReader))
+                using (var streamReader = new StreamReader(context.Response.Body, Encoding.Default, true, 1024, true))
+                using (var textReader = new JsonTextReader(streamReader))
                 {
                     // Ensure floats are parsed as decimals and not as doubles.
                     textReader.FloatParseHandling = FloatParseHandling.Decimal;

--- a/src/Stratis.Bitcoin.Features.RPC/RPCRouteHandler.cs
+++ b/src/Stratis.Bitcoin.Features.RPC/RPCRouteHandler.cs
@@ -44,6 +44,8 @@ namespace Stratis.Bitcoin.Features.RPC
             using (StreamReader streamReader = new StreamReader(context.HttpContext.Request.Body))
             using (JsonTextReader textReader = new JsonTextReader(streamReader))
             {
+                // Ensure floats are parsed as decimals and not as doubles.
+                textReader.FloatParseHandling = FloatParseHandling.Decimal;
                 request = await JObject.LoadAsync(textReader);
             }
             


### PR DESCRIPTION
When we write response using `JsonTextWriter` and then later on read the response using `JsonTextReader`, by default all floats are converted to double even if original value was decimal. This PR ensures values are converted to decimal so we don't get precision issues and scientific notation formats returns (i.e. 2e10-5) 

https://github.com/JamesNK/Newtonsoft.Json/issues/1904
