### PR TITLE
[FN] Fix for failing transaction build

### DIFF
--- a/src/Stratis.Bitcoin.Features.Wallet/WalletTransactionHandler.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/WalletTransactionHandler.cs
@@ -52,15 +52,15 @@ namespace Stratis.Bitcoin.Features.Wallet
         {
             this.InitializeTransactionBuilder(context);
 
-            if (context.Shuffle)
-                context.TransactionBuilder.Shuffle();
-
-            const int maxRetries = 3;
+            const int maxRetries = 5;
             int retryCount = 0;
 
             TransactionPolicyError[] errors = null;
             while (retryCount <= maxRetries)
             {
+                if (context.Shuffle)
+                    context.TransactionBuilder.Shuffle();
+
                 Transaction transaction = context.TransactionBuilder.BuildTransaction(false);
                 if (context.Sign)
                 {


### PR DESCRIPTION
Moved shuffle inside the retry and updated retry count.

I have performed 500 "transaction build" requests via swagger and PowerShell and all succeded.

Prior to the change, I was getting about 1 in 10 failures.