### PR TITLE
First optimizations for RPC method "gettransaction"

### DIFF
--- a/src/Stratis.Bitcoin.Features.Wallet/Interfaces/IWalletRepository.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Interfaces/IWalletRepository.cs
@@ -226,11 +226,23 @@ namespace Stratis.Bitcoin.Features.Wallet.Interfaces
         /// Returns <see cref="TransactionData"/> records in the wallet acting as inputs to the given transaction.
         /// </summary>
         /// <param name="walletName">The name of the wallet.</param>
+        /// <param name="accountName">An optional account name.</param>
         /// <param name="transactionTime">The transaction creation time.</param>
         /// <param name="transactionId">The transaction id.</param>
         /// <param name="includePayments">Set to <c>true</c> to include payment details.</param>
         /// <returns><see cref="TransactionData"/> records in the wallet acting as inputs to the given transaction.</returns>
-        IEnumerable<TransactionData> GetTransactionInputs(string walletName, DateTimeOffset? transactionTime, uint256 transactionId = null, bool includePayments = false);
+        IEnumerable<TransactionData> GetTransactionInputs(string walletName, string accountName, DateTimeOffset? transactionTime, uint256 transactionId, bool includePayments = false);
+
+        /// <summary>
+        /// Returns <see cref="TransactionData"/> records in the wallet acting as outputs to the given transaction.
+        /// </summary>
+        /// <param name="walletName">The name of the wallet.</param>
+        /// <param name="accountName">An optional account name.</param>
+        /// <param name="transactionTime">The transaction creation time.</param>
+        /// <param name="transactionId">The transaction id.</param>
+        /// <param name="includePayments">Set to <c>true</c> to include payment details.</param>
+        /// <returns><see cref="TransactionData"/> records in the wallet acting as inputs to the given transaction.</returns>
+        IEnumerable<TransactionData> GetTransactionOutputs(string walletName, string accountName, DateTimeOffset? transactionTime, uint256 transactionId, bool includePayments = false);
 
         /// <summary>
         /// Determines address groupings.

--- a/src/Stratis.Bitcoin.Features.Wallet/Wallet.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Wallet.cs
@@ -176,7 +176,7 @@ namespace Stratis.Bitcoin.Features.Wallet
             {
                 if (transactionTime != null && spendingTransactionId != null)
                 {
-                    foreach (TransactionData txData in this.WalletRepository.GetTransactionInputs(this.Name, transactionTime, spendingTransactionId, includePayments: true))
+                    foreach (TransactionData txData in this.WalletRepository.GetTransactionInputs(this.Name, null, transactionTime, spendingTransactionId, includePayments: true))
                         yield return txData;
                 }
                 else

--- a/src/Stratis.Bitcoin.Features.Wallet/WalletRPCController.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/WalletRPCController.cs
@@ -222,10 +222,10 @@ namespace Stratis.Bitcoin.Features.Wallet
             // Get the transaction from the wallet by looking into received and send transactions.
             List<TransactionData> receivedTransactions = this.walletManager.WalletRepository.GetTransactionOutputs(accountReference.WalletName, accountReference.AccountName, null, trxid, true)
                 .Where(td => !IsChangeAddress(td.ScriptPubKey)).ToList();
-            List<TransactionData> sendTransactions = this.walletManager.WalletRepository.GetTransactionInputs(accountReference.WalletName, accountReference.AccountName, null, trxid, true).ToList();
+            List<TransactionData> sentTransactions = this.walletManager.WalletRepository.GetTransactionInputs(accountReference.WalletName, accountReference.AccountName, null, trxid, true).ToList();
 
             TransactionData firstReceivedTransaction = receivedTransactions.FirstOrDefault();
-            TransactionData firstSendTransaction = sendTransactions.FirstOrDefault();
+            TransactionData firstSendTransaction = sentTransactions.FirstOrDefault();
             if (firstReceivedTransaction == null && firstSendTransaction == null)
                 throw new RPCServerException(RPCErrorCode.RPC_INVALID_ADDRESS_OR_KEY, "Invalid or non-wallet transaction id.");
 
@@ -306,7 +306,7 @@ namespace Stratis.Bitcoin.Features.Wallet
                     // Get the change.
                     long change = spendingDetails.Change.Sum(o => o.Amount);
 
-                    Money inputsAmount = new Money(sendTransactions.Sum(i => i.Amount));
+                    Money inputsAmount = new Money(sentTransactions.Sum(i => i.Amount));
                     Money outputsAmount = new Money(spendingDetails.Payments.Sum(p => p.Amount) + change);
 
                     feeSent = inputsAmount - outputsAmount;

--- a/src/Stratis.Bitcoin.Features.Wallet/WalletRPCController.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/WalletRPCController.cs
@@ -212,9 +212,6 @@ namespace Stratis.Bitcoin.Features.Wallet
 
             WalletAccountReference accountReference = this.GetWalletAccountReference();
 
-            HdAccount account = this.walletManager.GetAccounts(accountReference.WalletName).Single(a => a.Name == accountReference.AccountName);
-            List<HdAddress> addresses = account.GetCombinedAddresses().ToList();
-
             IWalletAddressReadOnlyLookup addressLookup = this.walletManager.WalletRepository.GetWalletAddressLookup(accountReference.WalletName);
 
             bool IsChangeAddress(Script scriptPubKey)
@@ -338,7 +335,7 @@ namespace Stratis.Bitcoin.Features.Wallet
 
                 model.Details.Add(new GetTransactionDetailsModel
                 {
-                    Address = addresses.First(a => a.Transactions.Contains(trxInWallet)).Address,
+                    Address = trxInWallet.ScriptPubKey.GetDestinationAddress(this.Network).ToString(),
                     Category = category,
                     Amount = trxInWallet.Amount.ToDecimal(MoneyUnit.BTC),
                     OutputIndex = trxInWallet.Index

--- a/src/Stratis.Features.SQLiteWalletRepository/SQLiteWalletRepositoryExt.cs
+++ b/src/Stratis.Features.SQLiteWalletRepository/SQLiteWalletRepositoryExt.cs
@@ -76,6 +76,7 @@ namespace Stratis.Features.SQLiteWalletRepository
                 SpendingDetails = (transactionData.SpendTxId == null) ? null : new SpendingDetails()
                 {
                     BlockHeight = transactionData.SpendBlockHeight,
+                    BlockHash = string.IsNullOrEmpty(transactionData.SpendBlockHash) ? null : uint256.Parse(transactionData.SpendBlockHash),
                     // BlockIndex // Not used currently.
                     CreationTime = DateTimeOffset.FromUnixTimeSeconds((long)transactionData.SpendTxTime),
                     IsCoinStake = transactionData.SpendTxIsCoinBase == 1,

--- a/src/Stratis.Features.SQLiteWalletRepository/Tables/HDTransactionData.cs
+++ b/src/Stratis.Features.SQLiteWalletRepository/Tables/HDTransactionData.cs
@@ -122,26 +122,28 @@ namespace Stratis.Features.SQLiteWalletRepository.Tables
         }
 
         // Finds account transactions acting as inputs to other wallet transactions - i.e. not a complete list of transaction inputs.
-        internal static IEnumerable<HDTransactionData> FindTransactionInputs(DBConnection conn, int walletId, long? transactionTime, string transactionId)
+        internal static IEnumerable<HDTransactionData> FindTransactionInputs(DBConnection conn, int walletId, int? accountIndex, long? transactionTime, string transactionId)
         {
             return conn.Query<HDTransactionData>($@"
                 SELECT  *
                 FROM    HDTransactionData
-                WHERE   WalletId = {walletId}
-                AND     AccountIndex IN (SELECT AccountIndex FROM HDAccount WHERE WalletId = {walletId}) { ((transactionTime == null && transactionId == null) ? "" : $@"
-                AND     SpendTxTime = {transactionTime}
-                AND     SpendTxId = '{transactionId}'")}");
+                WHERE   WalletId = {walletId} {((accountIndex != null) ? $@"
+                AND     AccountIndex = {accountIndex}" : $@"
+                AND     AccountIndex IN (SELECT AccountIndex FROM HDAccount WHERE WalletId = {walletId})")} { ((transactionTime == null) ? "" : $@"
+                AND     SpendTxTime = {transactionTime}")}
+                AND     SpendTxId = '{transactionId}'");
         }
 
         // Finds the wallet transaction data related to a transaction - i.e. not a complete list of transaction outputs.
-        internal static IEnumerable<HDTransactionData> FindTransactionOutputs(DBConnection conn, int walletId, int transactionTime, string transactionId)
+        internal static IEnumerable<HDTransactionData> FindTransactionOutputs(DBConnection conn, int walletId, int? accountIndex, long? transactionTime, string transactionId)
         {
             return conn.Query<HDTransactionData>($@"
                 SELECT  *
                 FROM    HDTransactionData
-                WHERE   WalletId = {walletId}
-                AND     AccountIndex IN (SELECT AccountIndex FROM HDAccount WHERE WalletId = {walletId})
-                AND     OutputTxTime = {transactionTime}
+                WHERE   WalletId = {walletId} {((accountIndex != null) ? $@"
+                AND     AccountIndex = {accountIndex}" : $@"
+                AND     AccountIndex IN (SELECT AccountIndex FROM HDAccount WHERE WalletId = {walletId})")} { ((transactionTime == null) ? "" : $@"
+                AND     OutputTxTime = {transactionTime}")}
                 AND     OutputTxId = '{transactionId}'");
         }
     }


### PR DESCRIPTION
6x speed improvement (`GetTransactionOnTransactionReceivedToMultipleAddressesAsync` context)

```
                // 0.01885383474 sec
                // 0.1129

                long flagFall = DateTime.Now.Ticks;
                for (int x = 0; x < 10000; x++)
                    rpcSendingNode.SendCommand(RPCOperations.gettransaction, txId.ToString());
                long time = DateTime.Now.Ticks - flagFall;
```