### PR TITLE
update `wallet-sync` for core

### DIFF
--- a/src/Stratis.Bitcoin.Features.LightWallet/LightWalletSyncManager.cs
+++ b/src/Stratis.Bitcoin.Features.LightWallet/LightWalletSyncManager.cs
@@ -243,7 +243,7 @@ namespace Stratis.Bitcoin.Features.LightWallet
         }
 
         /// <inheritdoc />
-        public void SyncFromDate(DateTime date)
+        public virtual void SyncFromDate(DateTime date, string walletName = null)
         {
             // Before we start syncing we need to make sure that the chain is at a certain level.
             // If the chain is behind the date from which we want to sync, we wait for it to catch up, and then we start syncing.

--- a/src/Stratis.Bitcoin.Features.Wallet.Tests/WalletControllerTest.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet.Tests/WalletControllerTest.cs
@@ -1314,6 +1314,59 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
         }
 
         [Fact]
+        public void WalletSyncFromDateReturnsOK()
+        {
+            string walletName = "myWallet";
+            DateTime syncDate = DateTime.Now.Subtract(new TimeSpan(1)).Date;
+
+            var mockWalletSyncManager = new Mock<IWalletSyncManager>();
+            mockWalletSyncManager.Setup(w => w.SyncFromDate(
+                It.Is<DateTime>((val) => val.Equals(syncDate)),
+                It.Is<string>(val => walletName.Equals(val))));
+
+            var controller = new WalletController(this.LoggerFactory.Object, new Mock<IWalletManager>().Object,
+                new Mock<IWalletTransactionHandler>().Object, mockWalletSyncManager.Object, It.IsAny<ConnectionManager>(),
+                this.Network, this.chainIndexer, new Mock<IBroadcasterManager>().Object, DateTimeProvider.Default);
+
+            IActionResult result = controller.SyncFromDate(new WalletSyncRequest
+            {
+                WalletName = walletName,
+                Date = DateTime.Now.Subtract(new TimeSpan(1)).Date
+            });
+
+            var viewResult = Assert.IsType<OkResult>(result);
+            mockWalletSyncManager.Verify();
+            Assert.NotNull(viewResult);
+            Assert.NotNull(viewResult.StatusCode == (int)HttpStatusCode.OK);
+        }
+
+        [Fact]
+        public void WalletSyncAllReturnsOK()
+        {
+            string walletName = "myWallet";
+
+            var mockWalletSyncManager = new Mock<IWalletSyncManager>();
+            mockWalletSyncManager.Setup(w => w.SyncFromHeight(
+                It.Is<int>((val) => val.Equals(0)),
+                It.Is<string>(val => walletName.Equals(val))));
+
+            var controller = new WalletController(this.LoggerFactory.Object, new Mock<IWalletManager>().Object,
+                new Mock<IWalletTransactionHandler>().Object, mockWalletSyncManager.Object, It.IsAny<ConnectionManager>(),
+                this.Network, this.chainIndexer, new Mock<IBroadcasterManager>().Object, DateTimeProvider.Default);
+
+            IActionResult result = controller.SyncFromDate(new WalletSyncRequest
+            {
+                WalletName = walletName,
+                All = true
+            });
+
+            var viewResult = Assert.IsType<OkResult>(result);
+            mockWalletSyncManager.Verify();
+            Assert.NotNull(viewResult);
+            Assert.NotNull(viewResult.StatusCode == (int)HttpStatusCode.OK);
+        }
+
+        [Fact]
         public void GetBalanceWithEmptyListOfAccountsReturnsWalletBalanceModel()
         {
             var accounts = new List<HdAccount>();

--- a/src/Stratis.Bitcoin.Features.Wallet/Controllers/WalletController.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Controllers/WalletController.cs
@@ -1355,14 +1355,21 @@ namespace Stratis.Bitcoin.Features.Wallet.Controllers
         /// <returns>A value of Ok if the resync was successful.</returns>
         [HttpPost]
         [Route("sync-from-date")]
-        public IActionResult SyncFromDate([FromBody] WalletSyncFromDateRequest request)
+        public IActionResult SyncFromDate([FromBody] WalletSyncRequest request)
         {
             if (!this.ModelState.IsValid)
             {
                 return ModelStateErrors.BuildErrorResponse(this.ModelState);
             }
 
-            this.walletSyncManager.SyncFromDate(request.Date);
+            if (!request.All)
+            {
+                this.walletSyncManager.SyncFromDate(request.Date, request.WalletName);
+            }
+            else
+            {
+                this.walletSyncManager.SyncFromHeight(0, request.WalletName);
+            }
 
             return this.Ok();
         }

--- a/src/Stratis.Bitcoin.Features.Wallet/Interfaces/IWalletSyncManager.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Interfaces/IWalletSyncManager.cs
@@ -36,7 +36,8 @@ namespace Stratis.Bitcoin.Features.Wallet.Interfaces
         /// Synchronize the wallet starting from the date passed as a parameter.
         /// </summary>
         /// <param name="date">The date from which to start the sync process.</param>
-        void SyncFromDate(DateTime date);
+        /// <param name="walletName">The wallet to sync or <c>null</c> to rewind and sync all wallet.</param>
+        void SyncFromDate(DateTime date, string walletName = null);
 
         /// <summary>
         /// Synchronize the wallet starting from the height passed as a parameter.

--- a/src/Stratis.Bitcoin.Features.Wallet/Models/RequestModels.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Models/RequestModels.cs
@@ -652,15 +652,25 @@ namespace Stratis.Bitcoin.Features.Wallet.Models
     /// <summary>
     /// A class containing the necessary parameters for a wallet resynchronization request.
     /// </summary>
-    public class WalletSyncFromDateRequest : RequestModel
+    public class WalletSyncRequest : RequestModel
     {
         /// <summary>
         /// The date and time from which to resync the wallet.
         /// </summary>
         [JsonConverter(typeof(IsoDateTimeConverter))]
         public DateTime Date { get; set; }
-    }
 
+        /// <summary>
+        /// Sync from start of wallet creation.
+        /// </summary>
+        public bool All { get; set; }
+
+        /// <summary>
+        /// The WalletName to Sync
+        /// </summary>
+        public string WalletName { get; set; }
+    }
+    
     /// <summary>
     /// A class containing the necessary parameters for a wallet stats request.
     /// </summary>

--- a/src/Stratis.Bitcoin.Features.Wallet/WalletSyncManager.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/WalletSyncManager.cs
@@ -126,15 +126,16 @@ namespace Stratis.Bitcoin.Features.Wallet
         }
 
         /// <inheritdoc />
-        public virtual void SyncFromDate(DateTime date)
+        public virtual void SyncFromDate(DateTime date, string walletName = null)
         {
             lock (this.lockObject)
             {
                 int syncFromHeight = this.chainIndexer.GetHeightAtTime(date);
 
-                this.SyncFromHeight(syncFromHeight);
+                this.SyncFromHeight(syncFromHeight, walletName);
             }
         }
+
 
         /// <inheritdoc />
         public virtual void SyncFromHeight(int height, string walletName = null)


### PR DESCRIPTION
This PR updates the `WalletController` to enable use of the WalletSync functionality from core.

This is because `remove-transactions` no longer works with the new SQL WalletDB