### PR TITLE
[RPC] Fix for RPC ListUnspent default parameter binding

### DIFF
--- a/src/Stratis.Bitcoin.Features.RPC.Tests/RPCParametersValueProviderTest.cs
+++ b/src/Stratis.Bitcoin.Features.RPC.Tests/RPCParametersValueProviderTest.cs
@@ -152,7 +152,6 @@ namespace Stratis.Bitcoin.Features.RPC.Tests
             {
                 this.actionContext.ActionDescriptor.Parameters.Add(new ControllerParameterDescriptor { Name = parameterInfo.Name, ParameterInfo = parameterInfo });
             }
-            
 
             var result = this.provider.GetValue("minConfirmations");
 

--- a/src/Stratis.Bitcoin.Features.RPC.Tests/RPCParametersValueProviderTest.cs
+++ b/src/Stratis.Bitcoin.Features.RPC.Tests/RPCParametersValueProviderTest.cs
@@ -1,10 +1,16 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
 using System.Threading.Tasks;
+using FluentAssertions;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.Controllers;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.Routing;
 using Newtonsoft.Json.Linq;
+using Stratis.Bitcoin.Features.RPC.Controllers;
+using Stratis.Bitcoin.Features.Wallet;
 using Xunit;
 
 namespace Stratis.Bitcoin.Features.RPC.Tests
@@ -131,6 +137,26 @@ namespace Stratis.Bitcoin.Features.RPC.Tests
             bool result = this.provider.ContainsPrefix("rpc_");
 
             Assert.False(result);
+        }
+
+        [Fact]
+        public void WhenNoParametersPassedAttemptToUseDefaultValueFromAction()
+        {
+            this.actionContext.RouteData = new RouteData();
+
+            string obj = "{}";
+            this.actionContext.RouteData.Values.Add("req", JObject.Parse(obj));
+            this.actionContext.ActionDescriptor = new ActionDescriptor();
+            this.actionContext.ActionDescriptor.Parameters = new List<ParameterDescriptor>();
+            foreach (var parameterInfo in typeof(WalletRPCController).GetMethod("ListUnspent")?.GetParameters() ?? Array.Empty<ParameterInfo>())
+            {
+                this.actionContext.ActionDescriptor.Parameters.Add(new ControllerParameterDescriptor { Name = parameterInfo.Name, ParameterInfo = parameterInfo });
+            }
+            
+
+            var result = this.provider.GetValue("minConfirmations");
+
+            result.FirstValue.Should().Be("1");
         }
 
         [Fact]

--- a/src/Stratis.Bitcoin.Features.RPC/RPCParametersValueProvider.cs
+++ b/src/Stratis.Bitcoin.Features.RPC/RPCParametersValueProvider.cs
@@ -58,18 +58,17 @@ namespace Stratis.Bitcoin.Features.RPC
             if (key == null)
                 return null;
 
-            if (this.context.ActionContext.RouteData?.Values == null || (this.context.ActionContext.RouteData.Values.Count == 0))
+            var actionContext = this.context.ActionContext;
+            if (actionContext.RouteData?.Values == null || (actionContext.RouteData.Values.Count == 0))
                 return null;
 
-            var req = this.context.ActionContext.RouteData.Values["req"] as JObject;
+            var req = actionContext.RouteData.Values["req"] as JObject;
             if (req == null)
                 return null;
 
-            var actionParameters = this.context.ActionContext.ActionDescriptor.Parameters;
-            if ((this.context.ActionContext.ActionDescriptor == null) || (actionParameters == null))
-                return null;
+            var actionParameters = actionContext.ActionDescriptor?.Parameters;
+            ParameterDescriptor parameter = actionParameters?.FirstOrDefault(p => p.Name == key);
 
-            ParameterDescriptor parameter = actionParameters.FirstOrDefault(p => p.Name == key);
             if (parameter == null)
                 return null;
 

--- a/src/Stratis.Bitcoin.Features.RPC/RPCParametersValueProvider.cs
+++ b/src/Stratis.Bitcoin.Features.RPC/RPCParametersValueProvider.cs
@@ -65,15 +65,23 @@ namespace Stratis.Bitcoin.Features.RPC
             if (req == null)
                 return null;
 
-            if ((this.context.ActionContext.ActionDescriptor == null) || (this.context.ActionContext.ActionDescriptor.Parameters == null))
+            var actionParameters = this.context.ActionContext.ActionDescriptor.Parameters;
+            if ((this.context.ActionContext.ActionDescriptor == null) || (actionParameters == null))
                 return null;
 
-            ParameterDescriptor parameter = this.context.ActionContext.ActionDescriptor.Parameters.FirstOrDefault(p => p.Name == key);
+            ParameterDescriptor parameter = actionParameters.FirstOrDefault(p => p.Name == key);
             if (parameter == null)
                 return null;
 
-            int index = this.context.ActionContext.ActionDescriptor.Parameters.IndexOf(parameter);
+            int index = actionParameters.IndexOf(parameter);
+
             var parameters = (JArray)req["params"];
+            if (parameters == null)
+            {
+                var parameterInfo = (parameter as ControllerParameterDescriptor)?.ParameterInfo;
+                return parameterInfo?.DefaultValue?.ToString();
+            }
+
             if ((index < 0) || (index >= parameters.Count))
                 return null;
 


### PR DESCRIPTION
This fixes the case when controller action has all parameters optional with default values and RPC call parameter list is empty/null.

Currently, `NullReferenceException` is thrown. With this fix, the default value for the parameter is used.

