### PR TITLE
Fix Wallet Broadcast Performance + ChainTip Calculation

### DIFF
--- a/src/Stratis.Bitcoin.Features.SignalR/Broadcasters/CirrusWalletInfoBroadcaster.cs
+++ b/src/Stratis.Bitcoin.Features.SignalR/Broadcasters/CirrusWalletInfoBroadcaster.cs
@@ -17,14 +17,14 @@ namespace Stratis.Bitcoin.Features.SignalR.Broadcasters
     /// <summary>
     /// Broadcasts current staking information to SignalR clients
     /// </summary>
-    public class WalletInfoBroadcaster : ClientBroadcasterBase
+    public class CirrusWalletInfoBroadcaster : ClientBroadcasterBase
     {
         private readonly IWalletManager walletManager;
         private readonly IConnectionManager connectionManager;
         private readonly IConsensusManager consensusManager;
         private readonly ChainIndexer chainIndexer;
 
-        public WalletInfoBroadcaster(
+        public CirrusWalletInfoBroadcaster(
             ILoggerFactory loggerFactory,
             IWalletManager walletManager,
             IConsensusManager consensusManager,
@@ -62,7 +62,19 @@ namespace Stratis.Bitcoin.Features.SignalR.Broadcasters
                             HdPath = account.HdPath,
                             AmountConfirmed = balance.AmountConfirmed,
                             AmountUnconfirmed = balance.AmountUnconfirmed,
-                            SpendableAmount = balance.SpendableAmount
+                            SpendableAmount = balance.SpendableAmount,
+                            Addresses = account.GetCombinedAddresses().Select(address =>
+                            {
+                                (Money confirmedAmount, Money unConfirmedAmount) = address.GetBalances();
+                                return new AddressModel
+                                {
+                                    Address = address.Address,
+                                    IsUsed = address.Transactions.Any(),
+                                    IsChange = address.IsChangeAddress(),
+                                    AmountConfirmed = confirmedAmount,
+                                    AmountUnconfirmed = unConfirmedAmount
+                                };
+                            })
                         };
 
                         accountBalanceModels.Add(accountBalanceModel);

--- a/src/Stratis.Bitcoin/Consensus/ConsensusManager.cs
+++ b/src/Stratis.Bitcoin/Consensus/ConsensusManager.cs
@@ -80,6 +80,9 @@ namespace Stratis.Bitcoin.Consensus
         public ChainedHeader Tip { get; private set; }
 
         /// <inheritdoc />
+        public int? HeaderTip => this.chainedHeaderTree.GetBestPeerTip()?.Height ?? this.Tip.Height;
+
+        /// <inheritdoc />
         public IConsensusRuleEngine ConsensusRules { get; private set; }
 
         /// <summary>

--- a/src/Stratis.Bitcoin/Consensus/IConsensusManager.cs
+++ b/src/Stratis.Bitcoin/Consensus/IConsensusManager.cs
@@ -49,6 +49,11 @@ namespace Stratis.Bitcoin.Consensus
         void PeerDisconnected(int peerId);
 
         /// <summary>
+        /// Gets the Header Tip
+        /// </summary>
+        int? HeaderTip { get; }
+
+        /// <summary>
         /// Provides block data for the given block hashes.
         /// </summary>
         /// <remarks>

--- a/src/Stratis.CirrusD/Program.cs
+++ b/src/Stratis.CirrusD/Program.cs
@@ -80,7 +80,7 @@ namespace Stratis.CirrusD
 
                     options.ClientEventBroadcasters = new[]
                     {
-                        (Broadcaster: typeof(WalletInfoBroadcaster),
+                        (Broadcaster: typeof(CirrusWalletInfoBroadcaster),
                             ClientEventBroadcasterSettings: new ClientEventBroadcasterSettings
                             {
                                 BroadcastFrequencySeconds = 5


### PR DESCRIPTION
Update IConsensusManager to expose ChainTip from ChainHeaderTree for better representation of % Sync Complete when in IBD Mode.

This PR also adds separate CirrusWalletInfoBroadcaster for CirrusD and remove the Balance Calculation per address on StratisMain.