### PR TITLE
[P2P] Allow inbound connections to be whitelisted

### DIFF
--- a/src/Stratis.Bitcoin/Connection/ConnectionManagerBehavior.cs
+++ b/src/Stratis.Bitcoin/Connection/ConnectionManagerBehavior.cs
@@ -64,7 +64,7 @@ namespace Stratis.Bitcoin.Connection
             INetworkPeer peer = this.AttachedPeer;
             if (peer != null)
             {
-                if (this.connectionManager.ConnectionSettings.Whitelist.Exists(e => e.Match(peer.PeerEndPoint)))
+                if (this.connectionManager.ConnectionSettings.Whitelist.Exists(e => e.MatchIpOnly(peer.PeerEndPoint)))
                 {
                     this.Whitelisted = true;
                 }

--- a/src/Stratis.Bitcoin/P2P/Peer/NetworkPeerCollection.cs
+++ b/src/Stratis.Bitcoin/P2P/Peer/NetworkPeerCollection.cs
@@ -5,6 +5,7 @@ using System.Net;
 using ConcurrentCollections;
 using NBitcoin;
 using Stratis.Bitcoin.Utilities;
+using TracerAttributes;
 
 namespace Stratis.Bitcoin.P2P.Peer
 {
@@ -109,11 +110,13 @@ namespace Stratis.Bitcoin.P2P.Peer
             return this.networkPeers.FirstOrDefault(n => n.MatchRemoteIPAddress(ip, port));
         }
 
+        [NoTrace]
         public IEnumerator<INetworkPeer> GetEnumerator()
         {
             return this.networkPeers.GetEnumerator();
         }
 
+        [NoTrace]
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
         {
             return this.GetEnumerator();


### PR DESCRIPTION
Inbound connections will be on an ephemeral port rather than the default port, and thus cannot be matched via endpoint