### PR TITLE
Postpone reading payment details when transaction data is read

### DIFF
--- a/src/Stratis.Bitcoin.Features.Wallet.Tests/WalletManagerTest.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet.Tests/WalletManagerTest.cs
@@ -3164,8 +3164,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
             walletManager.ProcessTransaction(transaction1);
 
             // The first transaction should be present in the wallet.
-            Assert.True(walletRepository.GetWalletAddressLookup(wallet.Name).Contains(destinationAddress.ScriptPubKey, out AddressIdentifier addressIdentifier));
-            Assert.Contains(walletRepository.GetAllTransactions(addressIdentifier), t => t.Id == transaction1.GetHash());
+            Assert.Contains(walletRepository.GetAllTransactions(destinationAddress), t => t.Id == transaction1.GetHash());
 
             // Now add transaction 2 via block.
             Block block2 = this.Network.CreateBlock();
@@ -3177,10 +3176,10 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
             walletManager.ProcessBlock(block2, header2);
 
             // The first transaction should no longer be present in the wallet.
-            Assert.DoesNotContain(walletRepository.GetAllTransactions(addressIdentifier), t => t.Id == transaction1.GetHash());
+            Assert.DoesNotContain(walletRepository.GetAllTransactions(destinationAddress), t => t.Id == transaction1.GetHash());
 
             // The second transaction should be present.
-            Assert.Contains(walletRepository.GetAllTransactions(addressIdentifier), t => t.Id == transaction2.GetHash());
+            Assert.Contains(walletRepository.GetAllTransactions(destinationAddress), t => t.Id == transaction2.GetHash());
         }
 
         [Fact]

--- a/src/Stratis.Bitcoin.Features.Wallet/AccountRoot.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/AccountRoot.cs
@@ -71,7 +71,7 @@ namespace Stratis.Bitcoin.Features.Wallet
             if (this.walletRepository == null)
                 return this.accounts.Contains(account);
 
-            return this.walletRepository.GetAccounts(this.wallet.Name).Any(a => a.Index == account.Index);
+            return this.walletRepository.GetAccounts(this.wallet).Any(a => a.Index == account.Index);
         }
 
         public void CopyTo(HdAccount[] arr, int index)
@@ -93,7 +93,7 @@ namespace Stratis.Bitcoin.Features.Wallet
 
         public IEnumerable<HdAccount> GetAccounts(Func<HdAccount, bool> accountFilter = null)
         {
-            var accounts = (this.walletRepository == null) ? this.accounts : this.walletRepository.GetAccounts(this.wallet.Name);
+            var accounts = (this.walletRepository == null) ? this.accounts : this.walletRepository.GetAccounts(this.AccountRoot.Wallet);
 
             if (accountFilter != null)
                 accounts = accounts.Where(accountFilter);

--- a/src/Stratis.Bitcoin.Features.Wallet/Interfaces/IWalletRepository.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Interfaces/IWalletRepository.cs
@@ -251,10 +251,10 @@ namespace Stratis.Bitcoin.Features.Wallet.Interfaces
         /// <summary>
         /// Get the accounts in the wallet.
         /// </summary>
-        /// <param name="walletName">The name of the wallet to get the accounts for.</param>
+        /// <param name="hdWallet">The wallet to get the accounts for.</param>
         /// <param name="accountName">Specifies a specific account to return.</param>
         /// <returns>The accounts in the wallet.</returns>
-        IEnumerable<HdAccount> GetAccounts(string walletName, string accountName = null);
+        IEnumerable<HdAccount> GetAccounts(Wallet hdWallet, string accountName = null);
 
         /// <summary>
         /// Get the names of the wallets in the repository.

--- a/src/Stratis.Bitcoin.Features.Wallet/Interfaces/IWalletRepository.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Interfaces/IWalletRepository.cs
@@ -213,36 +213,33 @@ namespace Stratis.Bitcoin.Features.Wallet.Interfaces
         /// <summary>
         /// Gets the wallet's <see cref="TransactionData"/> records. Records are sorted by transaction creation time and output index.
         /// </summary>
-        /// <param name="addressIdentifier">The HD Path (can be partial) of the transactions to get.</param>
+        /// <param name="hdAddress">The address for which to retrieve transactions.</param>
         /// <param name="limit">The maximum number of records to return.</param>
         /// <param name="prev">The record preceding the first record to be returned. Can be <c>null</c> to return the first record.</param>
         /// <param name="descending">The default is descending. Set to <c>false</c> to return records in ascending order.</param>
-        /// <param name="includePayments">Set this to include payment information.</param>
         /// <returns>The wallet's <see cref="TransactionData"/> records.</returns>
         /// <remarks>Spending details are not included.</remarks>
-        IEnumerable<TransactionData> GetAllTransactions(AddressIdentifier addressIdentifier, int limit = int.MaxValue, TransactionData prev = null, bool descending = true, bool includePayments = false);
+        IEnumerable<TransactionData> GetAllTransactions(HdAddress hdAddress, int limit = int.MaxValue, TransactionData prev = null, bool descending = true);
 
         /// <summary>
         /// Returns <see cref="TransactionData"/> records in the wallet acting as inputs to the given transaction.
         /// </summary>
-        /// <param name="walletName">The name of the wallet.</param>
-        /// <param name="accountName">An optional account name.</param>
+        /// <param name="account">The account.</param>
         /// <param name="transactionTime">The transaction creation time.</param>
         /// <param name="transactionId">The transaction id.</param>
         /// <param name="includePayments">Set to <c>true</c> to include payment details.</param>
         /// <returns><see cref="TransactionData"/> records in the wallet acting as inputs to the given transaction.</returns>
-        IEnumerable<TransactionData> GetTransactionInputs(string walletName, string accountName, DateTimeOffset? transactionTime, uint256 transactionId, bool includePayments = false);
+        IEnumerable<TransactionData> GetTransactionInputs(HdAccount account, DateTimeOffset? transactionTime, uint256 transactionId, bool includePayments = false);
 
         /// <summary>
         /// Returns <see cref="TransactionData"/> records in the wallet acting as outputs to the given transaction.
         /// </summary>
-        /// <param name="walletName">The name of the wallet.</param>
-        /// <param name="accountName">An optional account name.</param>
+        /// <param name="account">The account.</param>
         /// <param name="transactionTime">The transaction creation time.</param>
         /// <param name="transactionId">The transaction id.</param>
         /// <param name="includePayments">Set to <c>true</c> to include payment details.</param>
         /// <returns><see cref="TransactionData"/> records in the wallet acting as inputs to the given transaction.</returns>
-        IEnumerable<TransactionData> GetTransactionOutputs(string walletName, string accountName, DateTimeOffset? transactionTime, uint256 transactionId, bool includePayments = false);
+        IEnumerable<TransactionData> GetTransactionOutputs(HdAccount account, DateTimeOffset? transactionTime, uint256 transactionId, bool includePayments = false);
 
         /// <summary>
         /// Determines address groupings.
@@ -297,6 +294,15 @@ namespace Stratis.Bitcoin.Features.Wallet.Interfaces
         /// <param name="count">The maximum number of addresses to return.</param>
         /// <returns>The addresses associated with an account.</returns>
         IEnumerable<HdAddress> GetAccountAddresses(WalletAccountReference accountReference, int addressType, int count);
+
+        /// <summary>
+        /// Gets the payment details of a transaction.
+        /// </summary>
+        /// <param name="walletName">The name of the wallet.</param>
+        /// <param name="transactionData">The transaction to get the payment details for.</param>
+        /// <param name="isChange">Whether to get payment or change details.</param>
+        /// <returns>Returns the payment or change details.</returns>
+        IEnumerable<PaymentDetails> GetPaymentDetails(string walletName, TransactionData transactionData, bool isChange);
 
         /// <summary>
         /// Adds watch-only addresses.

--- a/src/Stratis.Bitcoin.Features.Wallet/SpendingDetails.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/SpendingDetails.cs
@@ -39,20 +39,7 @@ namespace Stratis.Bitcoin.Features.Wallet
         {
             this.isChange = isChange;
             this.spendingDetails = spendingDetails;
-
-            if (this.repository == null)
-            {
-                this.payments = payments.ToList();
-                return;
-            }
-
-            if (this.repository != null && payments != null)
-                foreach (PaymentDetails payment in payments)
-                    this.Add(payment);
-        }
-
-        public PaymentCollection(SpendingDetails spendingDetails)
-        {
+            this.payments = payments?.ToList() ?? new List<PaymentDetails>();
         }
 
         public void Add(PaymentDetails payment)

--- a/src/Stratis.Bitcoin.Features.Wallet/TransactionData.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/TransactionData.cs
@@ -11,6 +11,9 @@ namespace Stratis.Bitcoin.Features.Wallet
     /// </summary>
     public class TransactionData
     {
+        [JsonIgnore]
+        public TransactionCollection TransactionCollection { get; set; }
+
         /// <summary>
         /// Transaction id.
         /// </summary>

--- a/src/Stratis.Bitcoin.Features.Wallet/Wallet.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Wallet.cs
@@ -172,6 +172,7 @@ namespace Stratis.Bitcoin.Features.Wallet
         /// <returns>A list of all the transactions in the wallet.</returns>
         public IEnumerable<TransactionData> GetAllTransactions(DateTimeOffset? transactionTime = null, uint256 spendingTransactionId = null)
         {
+            /*
             if (this.WalletRepository != null)
             {
                 if (transactionTime != null && spendingTransactionId != null)
@@ -185,7 +186,7 @@ namespace Stratis.Bitcoin.Features.Wallet
                         yield return txData;
                 }
             }
-            else
+            else */
             {
                 List<HdAccount> accounts = this.GetAccounts().ToList();
 
@@ -386,35 +387,6 @@ namespace Stratis.Bitcoin.Features.Wallet
             IEnumerable<HdAccount> accounts = this.GetAccounts(accountFilter);
 
             return accounts.SelectMany(x => x.GetSpendableTransactions(currentChainHeight, this.Network.Consensus.CoinbaseMaturity, confirmations));
-        }
-
-        /// <summary>
-        /// Calculates the fee paid by the user on a transaction sent.
-        /// </summary>
-        /// <param name="transactionId">The transaction id to look for.</param>
-        /// <returns>The fee paid.</returns>
-        public Money GetSentTransactionFee(DateTimeOffset transactionTime, uint256 transactionId)
-        {
-            List<TransactionData> allTransactions = this.GetAllTransactions(transactionTime, transactionId).ToList();
-
-            // Get a list of all the inputs spent in this transaction.
-            List<TransactionData> inputsSpentInTransaction = allTransactions.Where(t => t.SpendingDetails?.TransactionId == transactionId).ToList();
-
-            if (!inputsSpentInTransaction.Any())
-            {
-                throw new WalletException("Not a sent transaction");
-            }
-
-            // Get the details of the spending transaction, which can be found on any input spent.
-            SpendingDetails spendingTransaction = inputsSpentInTransaction.Select(s => s.SpendingDetails).First();
-
-            // Get the change.
-            long change = spendingTransaction.Change.Sum(o => o.Amount);
-
-            Money inputsAmount = new Money(inputsSpentInTransaction.Sum(i => i.Amount));
-            Money outputsAmount = new Money(spendingTransaction.Payments.Sum(p => p.Amount) + change);
-
-            return inputsAmount - outputsAmount;
         }
     }
 }

--- a/src/Stratis.Bitcoin.Features.Wallet/Wallet.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Wallet.cs
@@ -255,7 +255,7 @@ namespace Stratis.Bitcoin.Features.Wallet
         {
             // TODO: IEnumerable<HdAccount> accounts = this.WalletManager.GetAccounts(this.Name);
             //       Only WalletManager shiuld reference repository directly?
-            IEnumerable<HdAccount> accounts = (this.WalletRepository == null) ? this.AccountsRoot.First().Accounts : this.WalletRepository.GetAccounts(this.Name);
+            IEnumerable<HdAccount> accounts = (this.WalletRepository == null) ? this.AccountsRoot.First().Accounts : this.WalletRepository.GetAccounts(this);
 
             return accounts.Concat(new[] { new HdAccount() { Index = -1 } })
                 .Where(NormalAccounts)

--- a/src/Stratis.Bitcoin.Features.Wallet/WalletManager.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/WalletManager.cs
@@ -376,7 +376,7 @@ namespace Stratis.Bitcoin.Features.Wallet
             Wallet wallet = this.GetWallet(walletName);
 
             // Sign the message.
-            HdAddress hdAddress = this.WalletRepository.GetAccounts(walletName).SelectMany(a => this.WalletRepository.GetUsedAddresses(
+            HdAddress hdAddress = this.WalletRepository.GetAccounts(wallet).SelectMany(a => this.WalletRepository.GetUsedAddresses(
                 new WalletAccountReference(walletName, a.Name), false)).Select(a => a.address).FirstOrDefault(addr => addr.Address.ToString() == externalAddress);
 
             Key privateKey = wallet.GetExtendedPrivateKeyForAddress(password, hdAddress).PrivateKey;
@@ -879,7 +879,7 @@ namespace Stratis.Bitcoin.Features.Wallet
             {
                 int tipHeight = this.ChainIndexer.Height;
 
-                //Need to make this work for single account but initially just scroll through accounts
+                Wallet hdWallet = this.WalletRepository.GetWallet(walletName);
                 foreach (HdAccount hdAccount in this.WalletRepository.GetAccounts(hdWallet, accountName))
                 {
                     (Money totalAmount, Money confirmedAmount, Money spendableAmount) = this.WalletRepository.GetAccountBalance(new WalletAccountReference(walletName, hdAccount.Name), tipHeight, confirmations: confirmations);

--- a/src/Stratis.Bitcoin.Features.Wallet/WalletManager.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/WalletManager.cs
@@ -376,7 +376,7 @@ namespace Stratis.Bitcoin.Features.Wallet
             Wallet wallet = this.GetWallet(walletName);
 
             // Sign the message.
-            HdAddress hdAddress = this.WalletRepository.GetAccounts(walletName).SelectMany(a => this.WalletRepository.GetUsedAddresses(
+            HdAddress hdAddress = this.WalletRepository.GetAccounts(wallet).SelectMany(a => this.WalletRepository.GetUsedAddresses(
                 new WalletAccountReference(walletName, a.Name), int.MaxValue, false)).FirstOrDefault(addr => addr.Address.ToString() == externalAddress);
 
             Key privateKey = wallet.GetExtendedPrivateKeyForAddress(password, hdAddress).PrivateKey;
@@ -867,10 +867,11 @@ namespace Stratis.Bitcoin.Features.Wallet
         {
             lock (this.lockObject)
             {
-                int tipHeight = this.GetWallet(walletName).AccountsRoot.First().LastBlockSyncedHeight ?? 0;
+                Wallet hdWallet = this.GetWallet(walletName);
+                int tipHeight = hdWallet.AccountsRoot.First().LastBlockSyncedHeight ?? 0;
 
                 //Need to make this work for single account but initially just scroll through accounts
-                foreach (HdAccount hdAccount in this.WalletRepository.GetAccounts(walletName, accountName))
+                foreach (HdAccount hdAccount in this.WalletRepository.GetAccounts(hdWallet, accountName))
                 {
                     (Money totalAmount, Money confirmedAmount, Money spendableAmount) = this.WalletRepository.GetAccountBalance(new WalletAccountReference(walletName, hdAccount.Name), tipHeight);
 

--- a/src/Stratis.Bitcoin.Features.Wallet/WalletRPCController.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/WalletRPCController.cs
@@ -213,7 +213,8 @@ namespace Stratis.Bitcoin.Features.Wallet
 
             WalletAccountReference accountReference = this.GetWalletAccountReference();
 
-            HdAccount hdAccount = this.walletManager.WalletRepository.GetAccounts(accountReference.WalletName, accountReference.AccountName).First();
+            Wallet hdWallet = this.walletManager.WalletRepository.GetWallet(accountReference.WalletName);
+            HdAccount hdAccount = this.walletManager.WalletRepository.GetAccounts(hdWallet, accountReference.AccountName).First();
 
             IWalletAddressReadOnlyLookup addressLookup = this.walletManager.WalletRepository.GetWalletAddressLookup(accountReference.WalletName);
 

--- a/src/Stratis.Bitcoin.Features.Wallet/WalletRPCController.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/WalletRPCController.cs
@@ -213,6 +213,8 @@ namespace Stratis.Bitcoin.Features.Wallet
 
             WalletAccountReference accountReference = this.GetWalletAccountReference();
 
+            HdAccount hdAccount = this.walletManager.WalletRepository.GetAccounts(accountReference.WalletName, accountReference.AccountName).First();
+
             IWalletAddressReadOnlyLookup addressLookup = this.walletManager.WalletRepository.GetWalletAddressLookup(accountReference.WalletName);
 
             bool IsChangeAddress(Script scriptPubKey)
@@ -221,9 +223,9 @@ namespace Stratis.Bitcoin.Features.Wallet
             }
 
             // Get the transaction from the wallet by looking into received and send transactions.
-            List<TransactionData> receivedTransactions = this.walletManager.WalletRepository.GetTransactionOutputs(accountReference.WalletName, accountReference.AccountName, null, trxid, true)
+            List<TransactionData> receivedTransactions = this.walletManager.WalletRepository.GetTransactionOutputs(hdAccount, null, trxid, true)
                 .Where(td => !IsChangeAddress(td.ScriptPubKey)).ToList();
-            List<TransactionData> sentTransactions = this.walletManager.WalletRepository.GetTransactionInputs(accountReference.WalletName, accountReference.AccountName, null, trxid, true).ToList();
+            List<TransactionData> sentTransactions = this.walletManager.WalletRepository.GetTransactionInputs(hdAccount, null, trxid, true).ToList();
 
             TransactionData firstReceivedTransaction = receivedTransactions.FirstOrDefault();
             TransactionData firstSendTransaction = sentTransactions.FirstOrDefault();

--- a/src/Stratis.Bitcoin.Features.Wallet/WalletSyncManager.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/WalletSyncManager.cs
@@ -104,7 +104,7 @@ namespace Stratis.Bitcoin.Features.Wallet
         public void Stop()
         {
             this.syncCancellationToken.Cancel();
-            this.walletSynchronisationLoop?.Dispose();
+            this.walletSynchronisationLoop?.RunningTask.GetAwaiter().GetResult();
             this.signals.Unsubscribe(this.transactionAddedSubscription);
             this.signals.Unsubscribe(this.transactionRemovedSubscription);
 

--- a/src/Stratis.Features.SQLiteWalletRepository.Tests/WalletRepositoryTests.cs
+++ b/src/Stratis.Features.SQLiteWalletRepository.Tests/WalletRepositoryTests.cs
@@ -295,9 +295,10 @@ namespace Stratis.Features.SQLiteWalletRepository.Tests
                     Assert.Equal(Money.COIN * 9, (long)outputs2[0].Transaction.Amount);
 
                     // Check the wallet history.
-                    List<AccountHistory> accountHistories = repo.GetHistory(account.WalletName, account.AccountName).ToList();
-                    Assert.Single(accountHistories);
-                    List<FlatHistory> history = accountHistories[0].History.ToList();
+                    Wallet wallet = repo.GetWallet(account.WalletName);
+                    HdAccount hdAccount = repo.GetAccounts(wallet, account.AccountName).First();
+                    AccountHistory accountHistory = repo.GetHistory(hdAccount);
+                    List<FlatHistory> history = accountHistory.History.ToList();
                     Assert.Equal(2, history.Count);
 
                     // Verify 100 coins sent to first unused external address in the wallet.

--- a/src/Stratis.Features.SQLiteWalletRepository/SQLiteWalletRepository.cs
+++ b/src/Stratis.Features.SQLiteWalletRepository/SQLiteWalletRepository.cs
@@ -995,11 +995,10 @@ namespace Stratis.Features.SQLiteWalletRepository
         {
             WalletContainer walletContainer = this.GetWalletContainer(walletAccountReference.WalletName);
             DBConnection conn = walletContainer.Conn;
-            HDAccount account = conn.GetAccountByName(walletAccountReference.WalletName, walletAccountReference.AccountName);
 
-            var hdAccount = this.ToHdAccount(account);
+            HdAccount hdAccount = this.GetAccounts(walletAccountReference.WalletName, walletAccountReference.AccountName).FirstOrDefault();
 
-            foreach (HDTransactionData transactionData in conn.GetSpendableOutputs(account.WalletId, account.AccountIndex, currentChainHeight, coinBaseMaturity ?? this.Network.Consensus.CoinbaseMaturity, confirmations))
+            foreach (HDTransactionData transactionData in conn.GetSpendableOutputs(walletContainer.Wallet.WalletId, hdAccount.Index, currentChainHeight, coinBaseMaturity ?? this.Network.Consensus.CoinbaseMaturity, confirmations))
             {
                 // TODO: This will take time and is possible not needed.
                 /*
@@ -1010,21 +1009,60 @@ namespace Stratis.Features.SQLiteWalletRepository
                 */
                 int tdConfirmations = (transactionData.OutputBlockHeight == null) ? 0 : (currentChainHeight + 1) - (int)transactionData.OutputBlockHeight;
 
+                HdAddress hdAddress = this.ToHdAddress(new HDAddress()
+                {
+                    AccountIndex = transactionData.AccountIndex,
+                    AddressIndex = transactionData.AddressIndex,
+                    AddressType = (int)transactionData.AddressType,
+                    PubKey = "", // pubKey.ScriptPubKey.ToHex(),  - See TODO
+                    ScriptPubKey = transactionData.ScriptPubKey
+                });
+
+                hdAddress.AddressCollection = (hdAddress.AddressType == 0) ? hdAccount.ExternalAddresses : hdAccount.InternalAddresses;
+
                 yield return new UnspentOutputReference()
                 {
                     Account = hdAccount,
-                    Transaction = this.ToTransactionData(transactionData, HDPayment.GetAllPayments(conn, transactionData.SpendTxTime ?? 0, transactionData.SpendTxId, transactionData.OutputTxId, transactionData.OutputIndex, transactionData.ScriptPubKey)),
+                    Transaction = this.ToTransactionData(transactionData, hdAddress.Transactions),
                     Confirmations = tdConfirmations,
-                    Address = this.ToHdAddress(new HDAddress()
-                    {
-                        AccountIndex = transactionData.AccountIndex,
-                        AddressIndex = transactionData.AddressIndex,
-                        AddressType = (int)transactionData.AddressType,
-                        PubKey = "", // pubKey.ScriptPubKey.ToHex(),  - See TODO
-                        ScriptPubKey = transactionData.ScriptPubKey
-                    })
+                    Address = hdAddress
                 };
             }
+        }
+
+        /// <inheritdoc />
+        public IEnumerable<PaymentDetails> GetPaymentDetails(string walletName, TransactionData transactionData, bool isChange)
+        {
+            WalletContainer walletContainer = this.GetWalletContainer(walletName);
+
+            DBConnection conn = walletContainer.Conn;
+
+            SpendingDetails spendingDetails = transactionData.SpendingDetails;
+
+            var res = HDPayment.GetAllPayments(conn,
+                spendingDetails.CreationTime.ToUnixTimeSeconds(),
+                spendingDetails.TransactionId.ToString(),
+                transactionData.Id.ToString(),
+                transactionData.Index,
+                transactionData.ScriptPubKey.ToHex())
+                .Where(p => p.SpendIsChange == (isChange ? 1 : 0)).Select(p => new PaymentDetails()
+                {
+                    Amount = new Money((decimal)p.SpendValue, MoneyUnit.BTC),
+                    DestinationScriptPubKey = new Script(Encoders.Hex.DecodeData(p.SpendScriptPubKey)),
+                    OutputIndex = p.SpendIndex
+                }).ToList();
+
+            if (transactionData.SpendingDetails == null || this.ScriptAddressReader == null)
+                return res;
+
+            var lookup = res.Select(d => d.DestinationScriptPubKey).Distinct().ToDictionary(d => d, d => (string)null);
+            foreach (Script script in lookup.Keys.ToList())
+                lookup[script] = this.ScriptAddressReader.GetAddressFromScriptPubKey(this.Network, script);
+
+            foreach (PaymentDetails paymentDetails in res)
+                paymentDetails.DestinationAddress = lookup[paymentDetails.DestinationScriptPubKey];
+
+            return res;
         }
 
         /// <inheritdoc />
@@ -1053,23 +1091,23 @@ namespace Stratis.Features.SQLiteWalletRepository
         }
 
         /// <inheritdoc />
-        public IEnumerable<TransactionData> GetAllTransactions(AddressIdentifier addressIdentifier, int limit = int.MaxValue, TransactionData prev = null, bool descending = true, bool includePayments = false)
+        public IEnumerable<TransactionData> GetAllTransactions(HdAddress hdAddress, int limit = int.MaxValue, TransactionData prev = null, bool descending = true)
         {
-            WalletContainer walletContainer = this.Wallets.Values.FirstOrDefault(wc => wc.Wallet.WalletId == addressIdentifier.WalletId);
-            DBConnection conn = walletContainer.Conn;
+            HdAccount hdAccount = hdAddress.AddressCollection.Account;
+            Wallet hdWallet = hdAccount.AccountRoot.Wallet;
+
+            WalletContainer walletContainer = this.GetWalletContainer(hdWallet.Name);
+            (HDWallet wallet, DBConnection conn) = (walletContainer.Wallet, walletContainer.Conn);
 
             var prevTran = (prev == null) ? null : new HDTransactionData() {
                 OutputTxTime = prev.CreationTime.ToUnixTimeSeconds(),
                 OutputIndex = prev.Index
             };
 
-            foreach (HDTransactionData tranData in HDTransactionData.GetAllTransactions(conn, addressIdentifier.WalletId,
-                addressIdentifier.AccountIndex, addressIdentifier.AddressType, addressIdentifier.AddressIndex, limit, prevTran, descending))
+            foreach (HDTransactionData tranData in HDTransactionData.GetAllTransactions(conn, wallet.WalletId,
+                hdAccount.Index, hdAddress.AddressType, hdAddress.Index, limit, prevTran, descending))
             {
-                var payments = includePayments ? HDPayment.GetAllPayments(conn, tranData.SpendTxTime ?? 0, tranData.SpendTxId, tranData.OutputTxId,
-                    tranData.OutputIndex, tranData.ScriptPubKey) : new HDPayment[] { };
-
-                yield return this.ToTransactionData(tranData, payments);
+                yield return this.ToTransactionData(tranData, hdAddress.Transactions);
             }
         }
 
@@ -1124,7 +1162,7 @@ namespace Stratis.Features.SQLiteWalletRepository
                         history.Add(new FlatHistory()
                         {
                             Address = hdAddress,
-                            Transaction = this.ToTransactionData(transaction, HDPayment.GetAllPayments(conn, transaction.SpendTxTime ?? 0, transaction.SpendTxId, transaction.OutputTxId, transaction.OutputIndex, transaction.ScriptPubKey))
+                            Transaction = this.ToTransactionData(transaction, hdAddress.Transactions)
                         });
                     }
                 }
@@ -1138,36 +1176,80 @@ namespace Stratis.Features.SQLiteWalletRepository
         }
 
         /// <inheritdoc />
-        public IEnumerable<TransactionData> GetTransactionInputs(string walletName, string accountName, DateTimeOffset? transactionTime, uint256 transactionId, bool includePayments = false)
+        public IEnumerable<TransactionData> GetTransactionInputs(HdAccount hdAccount, DateTimeOffset? transactionTime, uint256 transactionId, bool includePayments = false)
         {
-            WalletContainer walletContainer = this.GetWalletContainer(walletName);
+            Wallet hdWallet = hdAccount.AccountRoot.Wallet;
+
+            WalletContainer walletContainer = this.GetWalletContainer(hdWallet.Name);
             (HDWallet wallet, DBConnection conn) = (walletContainer.Wallet, walletContainer.Conn);
 
-            int? accountIndex = (accountName == null) ? (int?)null : conn.GetAccountByName(wallet.Name, accountName).AccountIndex;
+            var addressDict = new Dictionary<AddressIdentifier, HdAddress>();
 
-            foreach (HDTransactionData tranData in HDTransactionData.FindTransactionInputs(conn, wallet.WalletId, accountIndex, transactionTime?.ToUnixTimeSeconds(), transactionId.ToString()))
+            foreach (HDTransactionData tranData in HDTransactionData.FindTransactionInputs(conn, wallet.WalletId, hdAccount.Index, transactionTime?.ToUnixTimeSeconds(), transactionId.ToString()))
             {
-                var payments = includePayments ? HDPayment.GetAllPayments(conn, tranData.SpendTxTime ?? 0, tranData.SpendTxId, tranData.OutputTxId,
-                    tranData.OutputIndex, tranData.ScriptPubKey) : new HDPayment[] { };
+                var outPoint = new OutPoint(uint256.Parse(tranData.OutputTxId), tranData.OutputIndex);
+                if (!walletContainer.TransactionsOfInterest.Contains(outPoint, out HashSet<AddressIdentifier> addresses))
+                    continue;
 
-                yield return this.ToTransactionData(tranData, payments);
+                AddressIdentifier addressIdentifier = addresses.First(a => a.WalletId == tranData.WalletId && a.AccountIndex == tranData.AccountIndex);
+
+                if (!addressDict.TryGetValue(addressIdentifier, out HdAddress hdAddress))
+                {
+                    hdAddress = this.ToHdAddress(new HDAddress()
+                    {
+                        WalletId = addressIdentifier.WalletId,
+                        AccountIndex = (int)addressIdentifier.AccountIndex,
+                        AddressType = (int)addressIdentifier.AddressType,
+                        AddressIndex = (int)addressIdentifier.AddressIndex,
+                        ScriptPubKey = addressIdentifier.ScriptPubKey
+                    });
+
+                    hdAddress.Transactions = new TransactionCollection(hdAddress);
+                    hdAddress.AddressCollection = (hdAddress.AddressType == 0) ? hdAccount.ExternalAddresses : hdAccount.InternalAddresses;
+
+                    addressDict[addressIdentifier] = hdAddress;
+                }
+
+                yield return this.ToTransactionData(tranData, hdAddress.Transactions);
             }
         }
 
         /// <inheritdoc />
-        public IEnumerable<TransactionData> GetTransactionOutputs(string walletName, string accountName, DateTimeOffset? transactionTime, uint256 transactionId, bool includePayments = false)
+        public IEnumerable<TransactionData> GetTransactionOutputs(HdAccount hdAccount, DateTimeOffset? transactionTime, uint256 transactionId, bool includePayments = false)
         {
-            WalletContainer walletContainer = this.GetWalletContainer(walletName);
+            Wallet hdWallet = hdAccount.AccountRoot.Wallet;
+
+            WalletContainer walletContainer = this.GetWalletContainer(hdWallet.Name);
             (HDWallet wallet, DBConnection conn) = (walletContainer.Wallet, walletContainer.Conn);
 
-            int? accountIndex = (accountName == null) ? (int?)null : conn.GetAccountByName(wallet.Name, accountName).AccountIndex;
+            var addressDict = new Dictionary<AddressIdentifier, HdAddress>();
 
-            foreach (HDTransactionData tranData in HDTransactionData.FindTransactionOutputs(conn, wallet.WalletId, accountIndex, transactionTime?.ToUnixTimeSeconds(), transactionId.ToString()))
+            foreach (HDTransactionData tranData in HDTransactionData.FindTransactionOutputs(conn, wallet.WalletId, hdAccount.Index, transactionTime?.ToUnixTimeSeconds(), transactionId.ToString()))
             {
-                var payments = includePayments ? HDPayment.GetAllPayments(conn, tranData.SpendTxTime ?? 0, tranData.SpendTxId, tranData.OutputTxId,
-                    tranData.OutputIndex, tranData.ScriptPubKey) : new HDPayment[] { };
+                var outPoint = new OutPoint(uint256.Parse(tranData.OutputTxId), tranData.OutputIndex);
+                if (!walletContainer.TransactionsOfInterest.Contains(outPoint, out HashSet<AddressIdentifier> addresses))
+                    continue;
 
-                yield return this.ToTransactionData(tranData, payments);
+                AddressIdentifier addressIdentifier = addresses.First(a => a.WalletId == tranData.WalletId && a.AccountIndex == tranData.AccountIndex);
+
+                if (!addressDict.TryGetValue(addressIdentifier, out HdAddress hdAddress))
+                {
+                    hdAddress = this.ToHdAddress(new HDAddress()
+                    {
+                        WalletId = addressIdentifier.WalletId,
+                        AccountIndex = (int)addressIdentifier.AccountIndex,
+                        AddressType = (int)addressIdentifier.AddressType,
+                        AddressIndex = (int)addressIdentifier.AddressIndex,
+                        ScriptPubKey = addressIdentifier.ScriptPubKey
+                    });
+
+                    hdAddress.Transactions = new TransactionCollection(hdAddress);
+                    hdAddress.AddressCollection = (hdAddress.AddressType == 0) ? hdAccount.ExternalAddresses : hdAccount.InternalAddresses;
+
+                    addressDict[addressIdentifier] = hdAddress;
+                }
+
+                yield return this.ToTransactionData(tranData, hdAddress.Transactions);
             }
         }
 

--- a/src/Stratis.Features.SQLiteWalletRepository/SQLiteWalletRepository.cs
+++ b/src/Stratis.Features.SQLiteWalletRepository/SQLiteWalletRepository.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using ConcurrentCollections;
 using Microsoft.Extensions.Logging;
 using NBitcoin;
+using NBitcoin.DataEncoders;
 using Stratis.Bitcoin.Configuration;
 using Stratis.Bitcoin.Features.Wallet;
 using Stratis.Bitcoin.Features.Wallet.Interfaces;

--- a/src/Stratis.Features.SQLiteWalletRepository/Tables/HDPayment.cs
+++ b/src/Stratis.Features.SQLiteWalletRepository/Tables/HDPayment.cs
@@ -42,7 +42,7 @@ namespace Stratis.Features.SQLiteWalletRepository.Tables
                 SELECT  *
                 FROM    HDPayment
                 WHERE   SpendTxTime = ?
-                AND     SpendTxID = ?
+                AND     SpendTxId = ?
                 AND     OutputTxId = ?
                 AND     OutputIndex = ?
                 AND     ScriptPubKey = ?


### PR DESCRIPTION
The purpose of this PR is to optimize the reading of transaction data. Currently payment details are included with the transaction data being read. We want to only read the payment details when the property associated with the payment details is accessed. This is achieved by creating a class that implements this behavior and by defining the payment (and change) property to be an instance of that class. Additional changes cascade out of this approach.