### PR TITLE
[RPC] Fix RPC call for decoding transaction

### DIFF
--- a/src/Stratis.Bitcoin.Features.RPC.Tests/Controller/FullNodeControllerTest.cs
+++ b/src/Stratis.Bitcoin.Features.RPC.Tests/Controller/FullNodeControllerTest.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Net;
 using System.Threading.Tasks;
+using FluentAssertions;
 using Moq;
 using NBitcoin;
 using NBitcoin.DataEncoders;
@@ -642,6 +643,14 @@ namespace Stratis.Bitcoin.Features.RPC.Tests.Controller
 
             bool isValid = result.IsValid;
             Assert.True(isValid);
+        }
+
+        [Fact]
+        public void GivenInvalidTxHex_WhenCallingDecodeRawTransaction_ArgumentExceptionIsThrown()
+        {
+            this.fullNode.SetupGet(p => p.Network).Returns(this.network);
+            Action rpcCall = () => this.controller.DecodeRawTransaction("12345");
+            rpcCall.Should().Throw<ArgumentException>();
         }
 
         private Transaction CreateTransaction()

--- a/src/Stratis.Bitcoin.Features.RPC/Controllers/FullNodeController.cs
+++ b/src/Stratis.Bitcoin.Features.RPC/Controllers/FullNodeController.cs
@@ -191,6 +191,10 @@ namespace Stratis.Bitcoin.Features.RPC.Controllers
             {
                 return new TransactionVerboseModel(this.FullNode.Network.CreateTransaction(hex), this.Network);
             }
+            catch (FormatException ex)
+            {
+                throw new ArgumentException(nameof(hex), ex.Message);
+            }
             catch (Exception)
             {
                 return null;


### PR DESCRIPTION
When passing invalid hex for decoding transaction RPC should give you an appropriate error and not "Method not found"