### PR TITLE
Add Address to HDAddress table

### DIFF
--- a/src/Stratis.Bitcoin.Tests.Wallet.Common/WalletTestsHelpers.cs
+++ b/src/Stratis.Bitcoin.Tests.Wallet.Common/WalletTestsHelpers.cs
@@ -460,8 +460,9 @@ namespace Stratis.Bitcoin.Tests.Wallet.Common
                 {
                     Index = i,
                     HdPath = $"{addressCollection.HdPath}/{i}",
-                    Address = key.PubKey.GetAddress(network).ToString(),
-                    ScriptPubKey = key.ScriptPubKey
+                    Address = key.PubKey.Hash.ScriptPubKey.GetDestinationAddress(network).ToString(),
+                    Pubkey = key.PubKey.ScriptPubKey,
+                    ScriptPubKey = key.PubKey.Hash.ScriptPubKey
                 };
 
                 addressCollection.Add(address);

--- a/src/Stratis.Features.SQLiteWalletRepository/Commands/ProcessBlockCommands.cs
+++ b/src/Stratis.Features.SQLiteWalletRepository/Commands/ProcessBlockCommands.cs
@@ -71,6 +71,7 @@ namespace Stratis.Features.SQLiteWalletRepository.Commands
                 ,      A.AddressIndex
                 ,      T.RedeemScript
                 ,      T.ScriptPubKey
+                ,      T.Address
                 ,      T.Value
                 ,      T.OutputBlockHeight
                 ,      T.OutputBlockHash
@@ -142,6 +143,7 @@ namespace Stratis.Features.SQLiteWalletRepository.Commands
                 ,      TD.AddressIndex
                 ,      TD.RedeemScript
                 ,      TD.ScriptPubKey
+                ,      TD.Address
                 ,      TD.Value
                 ,      TD.OutputBlockHeight
                 ,      TD.OutputBlockHash

--- a/src/Stratis.Features.SQLiteWalletRepository/DBConnection.cs
+++ b/src/Stratis.Features.SQLiteWalletRepository/DBConnection.cs
@@ -221,6 +221,7 @@ namespace Stratis.Features.SQLiteWalletRepository
             foreach (HdAddress hdAddress in hdAddresses)
             {
                 HDAddress address = this.Repository.CreateAddress(account, addressType, hdAddress.Index);
+                address.Address = hdAddress.Address;
                 address.ScriptPubKey = hdAddress.ScriptPubKey?.ToHex();
                 address.PubKey = hdAddress.Pubkey?.ToHex();
 

--- a/src/Stratis.Features.SQLiteWalletRepository/SQLiteWalletRepository.cs
+++ b/src/Stratis.Features.SQLiteWalletRepository/SQLiteWalletRepository.cs
@@ -1098,7 +1098,7 @@ namespace Stratis.Features.SQLiteWalletRepository
                         AddressType = (int)transactionData.AddressType,
                         PubKey = "", // pubKey.ScriptPubKey.ToHex(),  - See TODO
                         ScriptPubKey = transactionData.ScriptPubKey,
-                        Address = Script.FromHex(transactionData.ScriptPubKey).GetDestinationAddress(this.Network).ToString()
+                        Address = transactionData.Address
                     })
                 };
             }

--- a/src/Stratis.Features.SQLiteWalletRepository/SQLiteWalletRepository.cs
+++ b/src/Stratis.Features.SQLiteWalletRepository/SQLiteWalletRepository.cs
@@ -518,7 +518,7 @@ namespace Stratis.Features.SQLiteWalletRepository
                 AddressIndex = addressIndex,
                 PubKey = pubKeyScript?.ToHex(),
                 ScriptPubKey = scriptPubKey?.ToHex(),
-                Address = scriptPubKey.GetDestinationAddress(this.Network).ToString()
+                Address = scriptPubKey?.GetDestinationAddress(this.Network).ToString() ?? ""
             };
         }
 

--- a/src/Stratis.Features.SQLiteWalletRepository/SQLiteWalletRepository.cs
+++ b/src/Stratis.Features.SQLiteWalletRepository/SQLiteWalletRepository.cs
@@ -517,7 +517,8 @@ namespace Stratis.Features.SQLiteWalletRepository
                 AddressType = addressType,
                 AddressIndex = addressIndex,
                 PubKey = pubKeyScript?.ToHex(),
-                ScriptPubKey = scriptPubKey?.ToHex()
+                ScriptPubKey = scriptPubKey?.ToHex(),
+                Address = scriptPubKey.GetDestinationAddress(this.Network).ToString()
             };
         }
 
@@ -601,7 +602,8 @@ namespace Stratis.Features.SQLiteWalletRepository
                 AddressType = (int)addressId.AddressType,
                 AddressIndex = (int)addressId.AddressIndex,
                 PubKey = addressId.PubKeyScript,
-                ScriptPubKey = addressId.ScriptPubKey
+                ScriptPubKey = addressId.ScriptPubKey,
+                Address = Script.FromHex(addressId.ScriptPubKey).GetDestinationAddress(this.Network).ToString()
             };
         }
 
@@ -1095,7 +1097,8 @@ namespace Stratis.Features.SQLiteWalletRepository
                         AddressIndex = transactionData.AddressIndex,
                         AddressType = (int)transactionData.AddressType,
                         PubKey = "", // pubKey.ScriptPubKey.ToHex(),  - See TODO
-                        ScriptPubKey = transactionData.ScriptPubKey
+                        ScriptPubKey = transactionData.ScriptPubKey,
+                        Address = Script.FromHex(transactionData.ScriptPubKey).GetDestinationAddress(this.Network).ToString()
                     })
                 };
             }

--- a/src/Stratis.Features.SQLiteWalletRepository/SQLiteWalletRepository.cs
+++ b/src/Stratis.Features.SQLiteWalletRepository/SQLiteWalletRepository.cs
@@ -280,7 +280,7 @@ namespace Stratis.Features.SQLiteWalletRepository
                 else
                     this.logger.LogDebug("Wallet {0} rewound to height {1} (hash='{2}').", walletName, lastBlockSynced.Height, lastBlockSynced.HashBlock);
 
-                return (true, res.Select(i => (uint256.Parse(i.txId), DateTimeOffset.FromUnixTimeSeconds(i.creationTime))));
+                return (true, res.Select(i => (uint256.Parse(i.txId), DateTimeOffset.FromUnixTimeSeconds(i.creationTime))).ToList());
             }
             catch (Exception)
             {
@@ -1020,7 +1020,7 @@ namespace Stratis.Features.SQLiteWalletRepository
                 IEnumerable<(string txId, long creationTime)> res = conn.RemoveAllUnconfirmedTransactions(wallet.WalletId);
                 conn.Commit();
 
-                return res.Select(i => (uint256.Parse(i.txId), DateTimeOffset.FromUnixTimeSeconds(i.creationTime)));
+                return res.Select(i => (uint256.Parse(i.txId), DateTimeOffset.FromUnixTimeSeconds(i.creationTime))).ToList();
             }
             finally
             {

--- a/src/Stratis.Features.SQLiteWalletRepository/SQLiteWalletRepositoryExt.cs
+++ b/src/Stratis.Features.SQLiteWalletRepository/SQLiteWalletRepositoryExt.cs
@@ -47,11 +47,11 @@ namespace Stratis.Features.SQLiteWalletRepository
 
             var res = new HdAddress(null)
             {
-                Address = repo.ScriptAddressReader.GetAddressFromScriptPubKey(repo.Network, scriptPubKey),
+                Address = address.Address,
                 Index = address.AddressIndex,
                 AddressType = address.AddressType,
                 HdPath = repo.ToHdPath(address.AccountIndex, address.AddressType, address.AddressIndex),
-                ScriptPubKey = new Script(Encoders.Hex.DecodeData(address.ScriptPubKey)),
+                ScriptPubKey = scriptPubKey,
                 Pubkey = pubKeyScript
             };
 

--- a/src/Stratis.Features.SQLiteWalletRepository/Tables/HDAddress.cs
+++ b/src/Stratis.Features.SQLiteWalletRepository/Tables/HDAddress.cs
@@ -21,6 +21,7 @@ namespace Stratis.Features.SQLiteWalletRepository.Tables
         public int AddressIndex { get; set; }
         public string ScriptPubKey { get; set; }
         public string PubKey { get; set; }
+        public string Address { get; set; }
 
         internal static IEnumerable<string> CreateScript()
         {
@@ -32,6 +33,7 @@ namespace Stratis.Features.SQLiteWalletRepository.Tables
                 AddressIndex        INTEGER NOT NULL,
                 ScriptPubKey        TEXT    NOT NULL,
                 PubKey              TEXT,
+                Address             TEXT NOT NULL,
                 PRIMARY KEY(WalletId, AccountIndex, AddressType, AddressIndex)
             )";
 

--- a/src/Stratis.Features.SQLiteWalletRepository/Tables/HDTransactionData.cs
+++ b/src/Stratis.Features.SQLiteWalletRepository/Tables/HDTransactionData.cs
@@ -35,6 +35,7 @@ namespace Stratis.Features.SQLiteWalletRepository.Tables
                 AddressIndex        INTEGER NOT NULL,
                 RedeemScript        TEXT NOT NULL,
                 ScriptPubKey        TEXT NOT NULL,
+                Address             TEXT NOT NULL,
                 Value               DECIMAL NOT NULL,
                 OutputBlockHeight   INTEGER,
                 OutputBlockHash     TEXT,

--- a/src/Stratis.Features.SQLiteWalletRepository/Tables/HDTransactionData.cs
+++ b/src/Stratis.Features.SQLiteWalletRepository/Tables/HDTransactionData.cs
@@ -11,6 +11,7 @@ namespace Stratis.Features.SQLiteWalletRepository.Tables
         public int AddressIndex { get; set; }
         public string RedeemScript { get; set; }
         public string ScriptPubKey { get; set; }
+        public string Address { get; set; }
         public decimal Value { get; set; }
         public long OutputTxTime { get; set; }
         public string OutputTxId { get; set; }

--- a/src/Stratis.Features.SQLiteWalletRepository/Tables/TempOutput.cs
+++ b/src/Stratis.Features.SQLiteWalletRepository/Tables/TempOutput.cs
@@ -3,6 +3,7 @@
     internal class TempOutput : TempRow
     {
         public string ScriptPubKey { get; set; }
+        public string Address { get; set; }
         public string RedeemScript { get; set; }
         public int? OutputBlockHeight { get; set; }
         public string OutputBlockHash { get; set; }

--- a/src/Stratis.Features.SQLiteWalletRepository/TransactionsToLists.cs
+++ b/src/Stratis.Features.SQLiteWalletRepository/TransactionsToLists.cs
@@ -50,6 +50,7 @@ namespace Stratis.Features.SQLiteWalletRepository
                 // The ScriptPubKey from the txOut.
                 RedeemScript = txOut.ScriptPubKey.ToHex(),
 
+                Address = pubKeyScript.GetDestinationAddress(this.conn.Repository.Network).ToString(),
                 OutputBlockHeight = block?.Height,
                 OutputBlockHash = block?.Hash.ToString(),
                 OutputTxIsCoinBase = isCoinBase ? 1 : 0,


### PR DESCRIPTION
Adds an `Address` field to the `HDAddress`. The field is for display purposes only and the idea is to avoid having to convert `ScriptPubKey`s to addresses for API's that require an address - i.e. for optimization.