### PR TITLE
Gateway integration test improved

### DIFF
--- a/src/Stratis.Bitcoin.IntegrationTests.Common/ReadyData/ReadyBlockchain.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests.Common/ReadyData/ReadyBlockchain.cs
@@ -40,5 +40,6 @@ namespace Stratis.Bitcoin.IntegrationTests.Common.ReadyData
         public static string BitcoinRegTest150NoWallet = @"ReadyData/RegTest150NoWallet.zip";
 
         public static string StratisXMainnet15K = @"ReadyData/StratisXOver15K.zip";
+        public static string StratisMainnet9500 = @"ReadyData/StratisMain9500.zip";
     }
 }

--- a/src/Stratis.Bitcoin.IntegrationTests.Common/Stratis.Bitcoin.IntegrationTests.Common.csproj
+++ b/src/Stratis.Bitcoin.IntegrationTests.Common/Stratis.Bitcoin.IntegrationTests.Common.csproj
@@ -59,6 +59,9 @@
     <None Update="ReadyData\RegTest150NoWallet.zip">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="ReadyData\StratisMain9500.zip">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="ReadyData\StratisRegTest100Listener.zip">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/src/Stratis.Bitcoin.IntegrationTests/Compatibility/StratisXTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/Compatibility/StratisXTests.cs
@@ -400,7 +400,7 @@ namespace Stratis.Bitcoin.IntegrationTests.Compatibility
         }
 
         [Fact]
-        public void GatewayNodeCanSyncFirst15KBlocks()
+        public void GatewayNodeCanSyncBeforeAndAfterLastCheckpointPowAndPoS()
         {
             Network network = new StratisMain10KCheckpoint();
 
@@ -418,8 +418,11 @@ namespace Stratis.Bitcoin.IntegrationTests.Compatibility
                 var gatewayParameters = new NodeConfigParameters();
                 gatewayParameters.Add("regtest", "0");
                 gatewayParameters.Add("gateway", "1");
+                gatewayParameters.Add("txindex", "0");
                 gatewayParameters.Add("whitelist", stratisXNode.Endpoint.ToString());
-                CoreNode gatewayNode = builder.CreateStratisPosNode(network, configParameters: gatewayParameters, isGateway:true);
+                CoreNode gatewayNode =
+                    builder.CreateStratisPosNode(network, configParameters: gatewayParameters, isGateway: true)
+                    .WithReadyBlockchainData(ReadyBlockchain.StratisMainnet9500);
 
                 gatewayNode.Start();
                 stratisXNode.Start();
@@ -429,7 +432,7 @@ namespace Stratis.Bitcoin.IntegrationTests.Compatibility
 
                 gatewayNodeRpc.AddNode(stratisXNode.Endpoint);
 
-                TestBase.WaitLoop(() => gatewayNode.FullNode.ChainIndexer.Height >= 15_000, waitTimeSeconds: 600);
+                TestBase.WaitLoop(() => gatewayNode.FullNode.ChainIndexer.Height >= 13_000, waitTimeSeconds: 600);
             }
         }
 


### PR DESCRIPTION
- Test now only syncs 3500 blocks compared to 15000.
- Still syncs before and after last checkpoint.
- Still syncs both PoW and PoS blocks.
- No txindex on the Stratis node.

Should be a bit more reliable.