### PR TITLE
Add non-standard output scripts to wallet database

### DIFF
--- a/src/Stratis.Features.SQLiteWalletRepository/External/ITransactionsToLists.cs
+++ b/src/Stratis.Features.SQLiteWalletRepository/External/ITransactionsToLists.cs
@@ -69,6 +69,11 @@ namespace Stratis.Features.SQLiteWalletRepository.External
                         break;
                 }
             }
+            else
+            {
+                // Some kind of non-standard script. We should still return it here.
+                yield return redeemScript;
+            }
         }
 
         public bool ProcessTransactions(IEnumerable<Transaction> transactions, HashHeightPair block, uint256 fixedTxId = null, long? blockTime = null)


### PR DESCRIPTION
When the SQL wallet db is being built, it currently ignores output scripts that do not conform to a known format. However these are still "valid" scripts and should also be included in the wallet database. I _believe_ this is inline with the previous wallet behaviour.

In practice what this means is that smart contract output scripts will also be included in the wallet DB.

See https://stratisplatformuk.visualstudio.com/StratisBitcoinFullNode/_workitems/edit/4489.