### PR TITLE
[Wallet Performance] Only get transactions with amount > 0 for balance and spendable transactions

### DIFF
--- a/src/Stratis.Features.SQLiteWalletRepository/Tables/HDTransactionData.cs
+++ b/src/Stratis.Features.SQLiteWalletRepository/Tables/HDTransactionData.cs
@@ -135,8 +135,8 @@ namespace Stratis.Features.SQLiteWalletRepository.Tables
                 FROM   HDTransactionData
                 WHERE  (WalletId, AccountIndex) IN (SELECT {strWalletId}, {strAccountIndex})
                 AND    SpendTxTime IS NULL { ((address == null) ? "" : $@"
-                AND    Value > 0
-                AND    (AddressType, AddressIndex) IN (SELECT {DBParameter.Create(address?.type)}, {DBParameter.Create(address?.index)})")}");
+                AND    (AddressType, AddressIndex) IN (SELECT {DBParameter.Create(address?.type)}, {DBParameter.Create(address?.index)})")}
+                AND    Value > 0");
 
             return (balanceData.TotalBalance, balanceData.ConfirmedBalance, balanceData.SpendableBalance);
         }

--- a/src/Stratis.Features.SQLiteWalletRepository/Tables/HDTransactionData.cs
+++ b/src/Stratis.Features.SQLiteWalletRepository/Tables/HDTransactionData.cs
@@ -105,6 +105,7 @@ namespace Stratis.Features.SQLiteWalletRepository.Tables
                 AND     SpendTxTime IS NULL {((confirmations == 0) ? "" : $@"
                 AND     OutputBlockHeight <= {strMaxConfirmationHeight}")}
                 AND     (OutputTxIsCoinBase = 0 OR OutputBlockHeight <= {strMaxCoinBaseHeight})
+                AND     Value > 0
                 ORDER   BY OutputBlockHeight
                 ,       OutputTxId
                 ,       OutputIndex");
@@ -134,6 +135,7 @@ namespace Stratis.Features.SQLiteWalletRepository.Tables
                 FROM   HDTransactionData
                 WHERE  (WalletId, AccountIndex) IN (SELECT {strWalletId}, {strAccountIndex})
                 AND    SpendTxTime IS NULL { ((address == null) ? "" : $@"
+                AND    Value > 0
                 AND    (AddressType, AddressIndex) IN (SELECT {DBParameter.Create(address?.type)}, {DBParameter.Create(address?.index)})")}");
 
             return (balanceData.TotalBalance, balanceData.ConfirmedBalance, balanceData.SpendableBalance);


### PR DESCRIPTION
Pretty massive performance improvement.

These are PoA mining coinbases. They can be ignored.