### PR TITLE
Add payment details unconditionally to HDPayments

### DIFF
--- a/src/Stratis.Bitcoin.Features.ColdStaking.Tests/ColdStakingManagerTest.cs
+++ b/src/Stratis.Bitcoin.Features.ColdStaking.Tests/ColdStakingManagerTest.cs
@@ -145,8 +145,7 @@ namespace Stratis.Bitcoin.Features.ColdStaking.Tests
             Assert.Single(spendingAddress.Transactions);
             Assert.Equal(transaction.GetHash(), spentAddressResult.Transactions.ElementAt(0).SpendingDetails.TransactionId);
             Assert.Equal(2, transaction.Outputs.Count);
-            Assert.Equal(transaction.Outputs[1].Value, spentAddressResult.Transactions.ElementAt(0).SpendingDetails.Payments.ElementAt(0).Amount);
-            Assert.Equal(transaction.Outputs[1].ScriptPubKey, spentAddressResult.Transactions.ElementAt(0).SpendingDetails.Payments.ElementAt(0).DestinationScriptPubKey);
+            Assert.True(spentAddressResult.Transactions.ElementAt(0).SpendingDetails.Payments.Any(p => p.DestinationScriptPubKey == transaction.Outputs[1].ScriptPubKey && p.Amount == transaction.Outputs[1].Value));
 
             Assert.Single(wallet.AccountsRoot.ElementAt(0).Accounts.ElementAt(0).InternalAddresses.ElementAt(0).Transactions);
             TransactionData changeAddressResult = wallet.AccountsRoot.ElementAt(0).Accounts.ElementAt(0).InternalAddresses.ElementAt(0).Transactions.ElementAt(0);

--- a/src/Stratis.Bitcoin.Features.Wallet.Tests/WalletManagerTest.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet.Tests/WalletManagerTest.cs
@@ -1480,8 +1480,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
             HdAddress spentAddressResult = wallet.AccountsRoot.ElementAt(0).Accounts.ElementAt(0).ExternalAddresses.ElementAt(0);
             Assert.Single(spendingAddress.Transactions);
             Assert.Equal(transaction.GetHash(), spentAddressResult.Transactions.ElementAt(0).SpendingDetails.TransactionId);
-            Assert.Equal(transaction.Outputs[1].Value, spentAddressResult.Transactions.ElementAt(0).SpendingDetails.Payments.ElementAt(0).Amount);
-            Assert.Equal(transaction.Outputs[1].ScriptPubKey, spentAddressResult.Transactions.ElementAt(0).SpendingDetails.Payments.ElementAt(0).DestinationScriptPubKey);
+            Assert.True(spentAddressResult.Transactions.ElementAt(0).SpendingDetails.Payments.Any(p => p.DestinationScriptPubKey == transaction.Outputs[1].ScriptPubKey && p.Amount == transaction.Outputs[1].Value));
 
             Assert.Single(wallet.AccountsRoot.ElementAt(0).Accounts.ElementAt(0).ExternalAddresses.ElementAt(1).Transactions);
             TransactionData destinationAddressResult = wallet.AccountsRoot.ElementAt(0).Accounts.ElementAt(0).ExternalAddresses.ElementAt(1).Transactions.ElementAt(0);
@@ -1707,8 +1706,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
             HdAddress spentAddressResult = wallet.AccountsRoot.ElementAt(0).Accounts.ElementAt(0).ExternalAddresses.ElementAt(0);
             Assert.Single(spendingAddress.Transactions);
             Assert.Equal(transaction.GetHash(), spentAddressResult.Transactions.ElementAt(0).SpendingDetails.TransactionId);
-            Assert.Equal(transaction.Outputs[1].Value, spentAddressResult.Transactions.ElementAt(0).SpendingDetails.Payments.ElementAt(0).Amount);
-            Assert.Equal(transaction.Outputs[1].ScriptPubKey, spentAddressResult.Transactions.ElementAt(0).SpendingDetails.Payments.ElementAt(0).DestinationScriptPubKey);
+            Assert.True(spentAddressResult.Transactions.ElementAt(0).SpendingDetails.Payments.Any(p => p.DestinationScriptPubKey == transaction.Outputs[1].ScriptPubKey && p.Amount == transaction.Outputs[1].Value));
 
             Assert.Single(wallet.AccountsRoot.ElementAt(0).Accounts.ElementAt(0).InternalAddresses.ElementAt(0).Transactions);
             TransactionData changeAddressResult = wallet.AccountsRoot.ElementAt(0).Accounts.ElementAt(0).InternalAddresses.ElementAt(0).Transactions.ElementAt(0);
@@ -1795,8 +1793,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
             HdAddress spentAddressResult = wallet.AccountsRoot.ElementAt(0).Accounts.ElementAt(0).ExternalAddresses.ElementAt(0);
             Assert.Single(spendingAddress.Transactions);
             Assert.Equal(transaction.GetHash(), spentAddressResult.Transactions.ElementAt(0).SpendingDetails.TransactionId);
-            Assert.Equal(transaction.Outputs[1].Value, spentAddressResult.Transactions.ElementAt(0).SpendingDetails.Payments.ElementAt(0).Amount);
-            Assert.Equal(transaction.Outputs[1].ScriptPubKey, spentAddressResult.Transactions.ElementAt(0).SpendingDetails.Payments.ElementAt(0).DestinationScriptPubKey);
+            Assert.True(spentAddressResult.Transactions.ElementAt(0).SpendingDetails.Payments.Any(p => p.DestinationScriptPubKey == transaction.Outputs[1].ScriptPubKey && p.Amount == transaction.Outputs[1].Value));
             Assert.Equal(blockHeight - 1, spentAddressResult.Transactions.ElementAt(0).BlockHeight);
 
             Assert.Single(wallet.AccountsRoot.ElementAt(0).Accounts.ElementAt(0).ExternalAddresses.ElementAt(1).Transactions);
@@ -1888,8 +1885,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
             HdAddress spentAddressResult = wallet.AccountsRoot.ElementAt(0).Accounts.ElementAt(0).ExternalAddresses.ElementAt(0);
             Assert.Single(spendingAddress.Transactions);
             Assert.Equal(transaction.GetHash(), spentAddressResult.Transactions.ElementAt(0).SpendingDetails.TransactionId);
-            Assert.Equal(transaction.Outputs[1].Value, spentAddressResult.Transactions.ElementAt(0).SpendingDetails.Payments.ElementAt(0).Amount);
-            Assert.Equal(transaction.Outputs[1].ScriptPubKey, spentAddressResult.Transactions.ElementAt(0).SpendingDetails.Payments.ElementAt(0).DestinationScriptPubKey);
+            Assert.True(spentAddressResult.Transactions.ElementAt(0).SpendingDetails.Payments.Any(p => p.DestinationScriptPubKey == transaction.Outputs[1].ScriptPubKey && p.Amount == transaction.Outputs[1].Value));
             Assert.Equal(chainInfo.block.GetHash(), spentAddressResult.Transactions.ElementAt(0).BlockHash);
 
             Assert.Single(wallet.AccountsRoot.ElementAt(0).Accounts.ElementAt(0).ExternalAddresses.ElementAt(1).Transactions);
@@ -2430,8 +2426,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
             HdAddress spentAddressResult = wallet.AccountsRoot.ElementAt(0).Accounts.ElementAt(0).ExternalAddresses.ElementAt(0);
             Assert.Single(spendingAddress.Transactions);
             Assert.Equal(transaction.GetHash(), spentAddressResult.Transactions.ElementAt(0).SpendingDetails.TransactionId);
-            Assert.Equal(transaction.Outputs[1].Value, spentAddressResult.Transactions.ElementAt(0).SpendingDetails.Payments.ElementAt(0).Amount);
-            Assert.Equal(transaction.Outputs[1].ScriptPubKey, spentAddressResult.Transactions.ElementAt(0).SpendingDetails.Payments.ElementAt(0).DestinationScriptPubKey);
+            Assert.True(spentAddressResult.Transactions.ElementAt(0).SpendingDetails.Payments.Any(p => p.DestinationScriptPubKey == transaction.Outputs[1].ScriptPubKey && p.Amount == transaction.Outputs[1].Value));
 
             Assert.Single(wallet.AccountsRoot.ElementAt(0).Accounts.ElementAt(0).ExternalAddresses.ElementAt(1).Transactions);
             TransactionData destinationAddressResult = wallet.AccountsRoot.ElementAt(0).Accounts.ElementAt(0).ExternalAddresses.ElementAt(1).Transactions.ElementAt(0);

--- a/src/Stratis.Features.SQLiteWalletRepository/Commands/ProcessBlockCommands.cs
+++ b/src/Stratis.Features.SQLiteWalletRepository/Commands/ProcessBlockCommands.cs
@@ -120,6 +120,7 @@ namespace Stratis.Features.SQLiteWalletRepository.Commands
                 JOIN    temp.TempOutput O
                 ON      O.OutputTxTime = T.SpendTxTime
                 AND     O.OutputTxId = T.SpendTxId
+                AND     O.ScriptPubKey IS NULL
                 JOIN    HDTransactionData TD
                 ON      TD.OutputTxId = T.OutputTxId
                 AND     TD.OutputIndex = T.OutputIndex

--- a/src/Stratis.Features.SQLiteWalletRepository/External/ITransactionsToLists.cs
+++ b/src/Stratis.Features.SQLiteWalletRepository/External/ITransactionsToLists.cs
@@ -116,8 +116,10 @@ namespace Stratis.Features.SQLiteWalletRepository.External
 
                     var destinations = this.GetDestinations(txOut.ScriptPubKey);
 
-                    if (addSpendTx && !destinations.Any(d => addressesOfInterest.Contains(d, out AddressIdentifier address2) && address2.AddressType == 1))
-                        this.RecordReceipt(block, null, txOut, tx.IsCoinBase | tx.IsCoinStake, blockTime ?? tx.Time, txId, i, false);
+                    bool isChange = destinations.Any(d => addressesOfInterest.Contains(d, out AddressIdentifier address2) && address2.AddressType == 1);
+
+                    if (addSpendTx)
+                        this.RecordReceipt(block, null, txOut, tx.IsCoinBase | tx.IsCoinStake, blockTime ?? tx.Time, txId, i, isChange);
 
                     foreach (Script pubKeyScript in destinations)
                     {

--- a/src/Stratis.Features.SQLiteWalletRepository/External/ITransactionsToLists.cs
+++ b/src/Stratis.Features.SQLiteWalletRepository/External/ITransactionsToLists.cs
@@ -114,10 +114,12 @@ namespace Stratis.Features.SQLiteWalletRepository.External
                     if (txOut.ScriptPubKey.ToBytes(true)[0] == (byte)OpcodeType.OP_RETURN)
                         continue;
 
-                    if (addSpendTx)
+                    var destinations = this.GetDestinations(txOut.ScriptPubKey);
+
+                    if (addSpendTx && !destinations.Any(d => addressesOfInterest.Contains(d, out AddressIdentifier address2) && address2.AddressType == 1))
                         this.RecordReceipt(block, null, txOut, tx.IsCoinBase | tx.IsCoinStake, blockTime ?? tx.Time, txId, i, false);
 
-                    foreach (Script pubKeyScript in this.GetDestinations(txOut.ScriptPubKey))
+                    foreach (Script pubKeyScript in destinations)
                     {
                         bool containsAddress = addressesOfInterest.Contains(pubKeyScript, out AddressIdentifier address);
 

--- a/src/Stratis.Features.SQLiteWalletRepository/External/ITransactionsToLists.cs
+++ b/src/Stratis.Features.SQLiteWalletRepository/External/ITransactionsToLists.cs
@@ -114,12 +114,15 @@ namespace Stratis.Features.SQLiteWalletRepository.External
                     if (txOut.ScriptPubKey.ToBytes(true)[0] == (byte)OpcodeType.OP_RETURN)
                         continue;
 
+                    if (addSpendTx)
+                        this.RecordReceipt(block, null, txOut, tx.IsCoinBase | tx.IsCoinStake, blockTime ?? tx.Time, txId, i, false);
+
                     foreach (Script pubKeyScript in this.GetDestinations(txOut.ScriptPubKey))
                     {
                         bool containsAddress = addressesOfInterest.Contains(pubKeyScript, out AddressIdentifier address);
 
                         // Paying to one of our addresses?
-                        if (addSpendTx || containsAddress)
+                        if (containsAddress)
                         {
                             // Check if top-up is required.
                             if (containsAddress && address != null)

--- a/src/Stratis.Features.SQLiteWalletRepository/TransactionsToLists.cs
+++ b/src/Stratis.Features.SQLiteWalletRepository/TransactionsToLists.cs
@@ -45,12 +45,12 @@ namespace Stratis.Features.SQLiteWalletRepository
             this.processBlocksInfo.Outputs.Add(new TempOutput()
             {
                 // For matching HDAddress.ScriptPubKey.
-                ScriptPubKey = pubKeyScript.ToHex(),
+                ScriptPubKey = pubKeyScript?.ToHex(),
 
                 // The ScriptPubKey from the txOut.
                 RedeemScript = txOut.ScriptPubKey.ToHex(),
 
-                Address = pubKeyScript.GetDestinationAddress(this.conn.Repository.Network).ToString(),
+                Address = pubKeyScript?.GetDestinationAddress(this.conn.Repository.Network).ToString() ?? "",
                 OutputBlockHeight = block?.Height,
                 OutputBlockHash = block?.Hash.ToString(),
                 OutputTxIsCoinBase = isCoinBase ? 1 : 0,


### PR DESCRIPTION
Some SC-related payments details are not showing up in the HDPayments table.

This PR relaxes the constrains under which the outputs of spending transactions are recorded.