### PR TITLE
Improve performance of GetHistory Request using lookups.

### DIFF
--- a/src/Stratis.Bitcoin.Features.Wallet.Tests/WalletControllerTest.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet.Tests/WalletControllerTest.cs
@@ -43,6 +43,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
             string[] resultingWords = (viewResult.Value as string).Split(' ');
 
             Assert.Equal(12, resultingWords.Length);
+            
             foreach (string word in resultingWords)
             {
                 int index = -1;

--- a/src/Stratis.Bitcoin.Features.Wallet.Tests/WalletControllerTest.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet.Tests/WalletControllerTest.cs
@@ -48,7 +48,6 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
                 int index = -1;
                 Assert.True(Wordlist.English.WordExists(word, out index));
             }
-            
         }
 
         [Fact]

--- a/src/Stratis.Bitcoin.Features.Wallet.Tests/WalletControllerTest.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet.Tests/WalletControllerTest.cs
@@ -48,6 +48,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
                 int index = -1;
                 Assert.True(Wordlist.English.WordExists(word, out index));
             }
+            
         }
 
         [Fact]

--- a/src/Stratis.Bitcoin.Features.Wallet/Controllers/WalletController.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Controllers/WalletController.cs
@@ -451,7 +451,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Controllers
                     
                     // Represents a sublist containing only the transactions that have already been spent.
                     var spendingDetails = items.Where(t => t.Transaction.SpendingDetails != null)
-                        .ToLookup(s => s.Transaction.Id, s => s);
+                        .ToLookup(s => s.Transaction.SpendingDetails.TransactionId, s => s);
 
                     // Represents a sublist of 'change' transactions.
                     // NB: Not currently used

--- a/src/Stratis.Bitcoin.Features.Wallet/Controllers/WalletController.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Controllers/WalletController.cs
@@ -477,7 +477,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Controllers
                         {
                             // We look for the output(s) related to our spending input.
                             List<FlatHistory> relatedOutputs = lookup.Contains(transaction.Id)
-                                ? lookup[transaction.Id].Where(h =>
+                                ? lookup[transaction.SpendingDetails.TransactionId].Where(h =>
                                     h.Transaction.IsCoinStake != null && h.Transaction.IsCoinStake.Value).ToList()
                                 : null;
                             


### PR DESCRIPTION
This PR improves performance of `GetHistory()` ~3x by using lookups for `txId`