### PR TITLE
[RPC] Fixes to bring decoderawtransaciton RPC call closer to BTC client

### DIFF
--- a/src/NBitcoin.Tests/pos_transaction_tests.cs
+++ b/src/NBitcoin.Tests/pos_transaction_tests.cs
@@ -1235,17 +1235,16 @@ namespace NBitcoin.Tests
         [Trait("UnitTest", "UnitTest")]
         public void CanBuildWitTransaction()
         {
-            this.stratisMain.Consensus.Options.WitnessScaleFactor = 4;
             Action<Transaction, TransactionBuilder> AssertEstimatedSize = (tx, b) =>
             {
                 int expectedVSize = tx.GetVirtualSize(KnownNetworks.StratisMain.Consensus.Options.WitnessScaleFactor);
                 int actualVSize = b.EstimateSize(tx, true);
                 int expectedSize = tx.GetSerializedSize();
                 int actualSize = b.EstimateSize(tx, false);
-                Assert.True(Math.Abs(expectedVSize - actualVSize) < Math.Abs(expectedVSize - actualSize));
-                Assert.True(Math.Abs(expectedSize - actualSize) < Math.Abs(expectedSize - actualVSize));
-                Assert.True(Math.Abs(expectedVSize - actualVSize) < Math.Abs(expectedSize - actualVSize));
-                Assert.True(Math.Abs(expectedSize - actualSize) < Math.Abs(expectedVSize - actualSize));
+                Assert.True(Math.Abs(expectedVSize - actualVSize) <= Math.Abs(expectedVSize - actualSize));
+                Assert.True(Math.Abs(expectedSize - actualSize) <= Math.Abs(expectedSize - actualVSize));
+                Assert.True(Math.Abs(expectedVSize - actualVSize) <= Math.Abs(expectedSize - actualVSize));
+                Assert.True(Math.Abs(expectedSize - actualSize) <= Math.Abs(expectedVSize - actualSize));
 
                 decimal error = (decimal)Math.Abs(expectedVSize - actualVSize) / Math.Min(expectedVSize, actualSize);
                 Assert.True(error < 0.01m);

--- a/src/NBitcoin.Tests/pos_transaction_tests.cs
+++ b/src/NBitcoin.Tests/pos_transaction_tests.cs
@@ -1235,9 +1235,10 @@ namespace NBitcoin.Tests
         [Trait("UnitTest", "UnitTest")]
         public void CanBuildWitTransaction()
         {
+            this.stratisMain.Consensus.Options.WitnessScaleFactor = 4;
             Action<Transaction, TransactionBuilder> AssertEstimatedSize = (tx, b) =>
             {
-                int expectedVSize = tx.GetVirtualSize(KnownNetworks.Main.Consensus.Options.WitnessScaleFactor);
+                int expectedVSize = tx.GetVirtualSize(KnownNetworks.StratisMain.Consensus.Options.WitnessScaleFactor);
                 int actualVSize = b.EstimateSize(tx, true);
                 int expectedSize = tx.GetSerializedSize();
                 int actualSize = b.EstimateSize(tx, false);

--- a/src/NBitcoin.Tests/pos_transaction_tests.cs
+++ b/src/NBitcoin.Tests/pos_transaction_tests.cs
@@ -1237,7 +1237,7 @@ namespace NBitcoin.Tests
         {
             Action<Transaction, TransactionBuilder> AssertEstimatedSize = (tx, b) =>
             {
-                int expectedVSize = tx.GetVirtualSize(KnownNetworks.Main.Consensus.Options);
+                int expectedVSize = tx.GetVirtualSize(KnownNetworks.Main.Consensus.Options.WitnessScaleFactor);
                 int actualVSize = b.EstimateSize(tx, true);
                 int expectedSize = tx.GetSerializedSize();
                 int actualSize = b.EstimateSize(tx, false);

--- a/src/NBitcoin.Tests/pos_transaction_tests.cs
+++ b/src/NBitcoin.Tests/pos_transaction_tests.cs
@@ -1237,7 +1237,7 @@ namespace NBitcoin.Tests
         {
             Action<Transaction, TransactionBuilder> AssertEstimatedSize = (tx, b) =>
             {
-                int expectedVSize = tx.GetVirtualSize();
+                int expectedVSize = tx.GetVirtualSize(KnownNetworks.Main.Consensus.Options);
                 int actualVSize = b.EstimateSize(tx, true);
                 int expectedSize = tx.GetSerializedSize();
                 int actualSize = b.EstimateSize(tx, false);

--- a/src/NBitcoin.Tests/transaction_tests.cs
+++ b/src/NBitcoin.Tests/transaction_tests.cs
@@ -1428,7 +1428,7 @@ namespace NBitcoin.Tests
         {
             Action<Transaction, TransactionBuilder> AssertEstimatedSize = (tx, b) =>
             {
-                int expectedVSize = tx.GetVirtualSize();
+                int expectedVSize = tx.GetVirtualSize(KnownNetworks.Main.Consensus.Options);
                 int actualVSize = b.EstimateSize(tx, true);
                 int expectedSize = tx.GetSerializedSize();
                 int actualSize = b.EstimateSize(tx, false);

--- a/src/NBitcoin.Tests/transaction_tests.cs
+++ b/src/NBitcoin.Tests/transaction_tests.cs
@@ -1428,7 +1428,7 @@ namespace NBitcoin.Tests
         {
             Action<Transaction, TransactionBuilder> AssertEstimatedSize = (tx, b) =>
             {
-                int expectedVSize = tx.GetVirtualSize(KnownNetworks.Main.Consensus.Options);
+                int expectedVSize = tx.GetVirtualSize(KnownNetworks.Main.Consensus.Options.WitnessScaleFactor);
                 int actualVSize = b.EstimateSize(tx, true);
                 int expectedSize = tx.GetSerializedSize();
                 int actualSize = b.EstimateSize(tx, false);

--- a/src/NBitcoin/FeeRate.cs
+++ b/src/NBitcoin/FeeRate.cs
@@ -58,9 +58,9 @@ namespace NBitcoin
                 nFee = this._FeePerK.Satoshi;
             return nFee;
         }
-        public Money GetFee(Transaction tx)
+        public Money GetFee(Transaction tx, ConsensusOptions options)
         {
-            return GetFee(tx.GetVirtualSize());
+            return GetFee(tx.GetVirtualSize(options));
         }
 
         public override bool Equals(object obj)

--- a/src/NBitcoin/FeeRate.cs
+++ b/src/NBitcoin/FeeRate.cs
@@ -58,9 +58,9 @@ namespace NBitcoin
                 nFee = this._FeePerK.Satoshi;
             return nFee;
         }
-        public Money GetFee(Transaction tx, ConsensusOptions options)
+        public Money GetFee(Transaction tx, int witnessScaleFactor)
         {
-            return GetFee(tx.GetVirtualSize(options));
+            return GetFee(tx.GetVirtualSize(witnessScaleFactor));
         }
 
         public override bool Equals(object obj)

--- a/src/NBitcoin/Transaction.cs
+++ b/src/NBitcoin/Transaction.cs
@@ -1473,21 +1473,21 @@ namespace NBitcoin
             return @in;
         }
 
-        public static readonly int WITNESS_SCALE_FACTOR = 4;
         /// <summary>
         /// Size of the transaction discounting the witness (Used for fee calculation)
         /// </summary>
         /// <returns>Transaction size</returns>
-        public int GetVirtualSize()
+        public int GetVirtualSize(ConsensusOptions options)
         {
+            var scaleFactor = options.WitnessScaleFactor;
             int totalSize = this.GetSerializedSize(TransactionOptions.Witness);
             int strippedSize = this.GetSerializedSize(TransactionOptions.None);
             // This implements the weight = (stripped_size * 4) + witness_size formula,
             // using only serialization with and without witness data. As witness_size
             // is equal to total_size - stripped_size, this formula is identical to:
             // weight = (stripped_size * 3) + total_size.
-            int weight = strippedSize * (WITNESS_SCALE_FACTOR - 1) + totalSize;
-            return (weight + WITNESS_SCALE_FACTOR - 1) / WITNESS_SCALE_FACTOR;
+            int weight = strippedSize * (scaleFactor - 1) + totalSize;
+            return (weight + scaleFactor - 1) / scaleFactor;
         }
 
         public TxIn AddInput(Transaction prevTx, int outIndex)
@@ -1720,12 +1720,12 @@ namespace NBitcoin
         /// </summary>
         /// <param name="spentCoins">Coins being spent</param>
         /// <returns>Fee or null if some spent coins are missing or if spentCoins is null</returns>
-        public FeeRate GetFeeRate(ICoin[] spentCoins)
+        public FeeRate GetFeeRate(ConsensusOptions options, ICoin[] spentCoins)
         {
             Money fee = GetFee(spentCoins);
             if(fee == null)
                 return null;
-            return new FeeRate(fee, GetVirtualSize());
+            return new FeeRate(fee, GetVirtualSize(options));
         }
 
         public bool IsFinal(ChainedHeader block)

--- a/src/NBitcoin/Transaction.cs
+++ b/src/NBitcoin/Transaction.cs
@@ -1473,7 +1473,7 @@ namespace NBitcoin
             return @in;
         }
 
-        internal static readonly int WITNESS_SCALE_FACTOR = 4;
+        public static readonly int WITNESS_SCALE_FACTOR = 4;
         /// <summary>
         /// Size of the transaction discounting the witness (Used for fee calculation)
         /// </summary>

--- a/src/NBitcoin/Transaction.cs
+++ b/src/NBitcoin/Transaction.cs
@@ -1476,18 +1476,18 @@ namespace NBitcoin
         /// <summary>
         /// Size of the transaction discounting the witness (Used for fee calculation)
         /// </summary>
+        /// <param name="witnessScaleFactor">Witness scale factor from network settings (i.e. 4 for BTC).</param>
         /// <returns>Transaction size</returns>
-        public int GetVirtualSize(ConsensusOptions options)
+        public int GetVirtualSize(int witnessScaleFactor)
         {
-            var scaleFactor = options.WitnessScaleFactor;
             int totalSize = this.GetSerializedSize(TransactionOptions.Witness);
             int strippedSize = this.GetSerializedSize(TransactionOptions.None);
             // This implements the weight = (stripped_size * 4) + witness_size formula,
             // using only serialization with and without witness data. As witness_size
             // is equal to total_size - stripped_size, this formula is identical to:
             // weight = (stripped_size * 3) + total_size.
-            int weight = strippedSize * (scaleFactor - 1) + totalSize;
-            return (weight + scaleFactor - 1) / scaleFactor;
+            int weight = strippedSize * (witnessScaleFactor - 1) + totalSize;
+            return (weight + witnessScaleFactor - 1) / witnessScaleFactor;
         }
 
         public TxIn AddInput(Transaction prevTx, int outIndex)
@@ -1718,14 +1718,15 @@ namespace NBitcoin
         /// <summary>
         /// Calculate the fee rate of the transaction
         /// </summary>
+        /// <param name="witnessScaleFactor">Witness scale factor from network settings (i.e. 4 for BTC).</param>
         /// <param name="spentCoins">Coins being spent</param>
         /// <returns>Fee or null if some spent coins are missing or if spentCoins is null</returns>
-        public FeeRate GetFeeRate(ConsensusOptions options, ICoin[] spentCoins)
+        public FeeRate GetFeeRate(int witnessScaleFactor, ICoin[] spentCoins)
         {
             Money fee = GetFee(spentCoins);
             if(fee == null)
                 return null;
-            return new FeeRate(fee, GetVirtualSize(options));
+            return new FeeRate(fee, GetVirtualSize(witnessScaleFactor));
         }
 
         public bool IsFinal(ChainedHeader block)

--- a/src/NBitcoin/TransactionBuilder.cs
+++ b/src/NBitcoin/TransactionBuilder.cs
@@ -1464,7 +1464,7 @@ namespace NBitcoin
         {
             if (tx == null)
                 throw new ArgumentNullException("tx");
-            return Verify(tx, expectedFeeRate == null ? null : expectedFeeRate.GetFee(tx, this.Network.Consensus.Options), out errors);
+            return Verify(tx, expectedFeeRate == null ? null : expectedFeeRate.GetFee(tx, this.Network.Consensus.Options.WitnessScaleFactor), out errors);
         }
 
         /// <summary>
@@ -1475,7 +1475,7 @@ namespace NBitcoin
         /// <returns>Detected errors</returns>
         public TransactionPolicyError[] Check(Transaction tx, FeeRate expectedFeeRate)
         {
-            return Check(tx, expectedFeeRate == null ? null : expectedFeeRate.GetFee(tx, this.Network.Consensus.Options));
+            return Check(tx, expectedFeeRate == null ? null : expectedFeeRate.GetFee(tx, this.Network.Consensus.Options.WitnessScaleFactor));
         }
 
         /// <summary>

--- a/src/NBitcoin/TransactionBuilder.cs
+++ b/src/NBitcoin/TransactionBuilder.cs
@@ -1213,7 +1213,7 @@ namespace NBitcoin
             int witSize = 0;
             int baseSize = 0;
             EstimateScriptSigSize(c, ref witSize, ref baseSize);
-            var vSize = witSize / Transaction.WITNESS_SCALE_FACTOR + baseSize;
+            var vSize = witSize / this.Network.Consensus.Options.WitnessScaleFactor + baseSize;
 
             return c.Amount >= this.FilterUneconomicalCoinsRate.GetFee(vSize);
         }
@@ -1464,7 +1464,7 @@ namespace NBitcoin
         {
             if (tx == null)
                 throw new ArgumentNullException("tx");
-            return Verify(tx, expectedFeeRate == null ? null : expectedFeeRate.GetFee(tx), out errors);
+            return Verify(tx, expectedFeeRate == null ? null : expectedFeeRate.GetFee(tx, this.Network.Consensus.Options), out errors);
         }
 
         /// <summary>
@@ -1475,7 +1475,7 @@ namespace NBitcoin
         /// <returns>Detected errors</returns>
         public TransactionPolicyError[] Check(Transaction tx, FeeRate expectedFeeRate)
         {
-            return Check(tx, expectedFeeRate == null ? null : expectedFeeRate.GetFee(tx));
+            return Check(tx, expectedFeeRate == null ? null : expectedFeeRate.GetFee(tx, this.Network.Consensus.Options));
         }
 
         /// <summary>
@@ -1565,7 +1565,7 @@ namespace NBitcoin
                 baseSize += 41;
             }
 
-            return (virtualSize ? witSize / Transaction.WITNESS_SCALE_FACTOR + baseSize : witSize + baseSize);
+            return (virtualSize ? witSize / this.Network.Consensus.Options.WitnessScaleFactor + baseSize : witSize + baseSize);
         }
 
         private void EstimateScriptSigSize(ICoin coin, ref int witSize, ref int baseSize)

--- a/src/Stratis.Bitcoin.Features.MemoryPool.Tests/FeeTests.cs
+++ b/src/Stratis.Bitcoin.Features.MemoryPool.Tests/FeeTests.cs
@@ -43,7 +43,7 @@ namespace Stratis.Bitcoin.Features.MemoryPool.Tests
             var txf = new Transaction();
             txf.AddInput(new TxIn(garbage));
             txf.AddOutput(new TxOut(0L, Script.Empty));
-            var baseRate = new FeeRate(basefee, txf.GetVirtualSize());
+            var baseRate = new FeeRate(basefee, txf.GetVirtualSize(KnownNetworks.TestNet.Consensus.Options));
 
             // Create a fake block
             var block = new List<Transaction>();

--- a/src/Stratis.Bitcoin.Features.MemoryPool.Tests/FeeTests.cs
+++ b/src/Stratis.Bitcoin.Features.MemoryPool.Tests/FeeTests.cs
@@ -43,7 +43,7 @@ namespace Stratis.Bitcoin.Features.MemoryPool.Tests
             var txf = new Transaction();
             txf.AddInput(new TxIn(garbage));
             txf.AddOutput(new TxOut(0L, Script.Empty));
-            var baseRate = new FeeRate(basefee, txf.GetVirtualSize(KnownNetworks.TestNet.Consensus.Options));
+            var baseRate = new FeeRate(basefee, txf.GetVirtualSize(KnownNetworks.TestNet.Consensus.Options.WitnessScaleFactor));
 
             // Create a fake block
             var block = new List<Transaction>();

--- a/src/Stratis.Bitcoin.Features.MemoryPool.Tests/MemoryPoolTransactionTests.cs
+++ b/src/Stratis.Bitcoin.Features.MemoryPool.Tests/MemoryPoolTransactionTests.cs
@@ -310,7 +310,7 @@ namespace Stratis.Bitcoin.Features.MemoryPool.Tests
             var tx2 = new Transaction();
             tx2.AddOutput(new TxOut(new Money(2 * Money.COIN), new Script(OpcodeType.OP_11, OpcodeType.OP_EQUAL)));
             pool.AddUnchecked(tx2.GetHash(), entry.Fee(new Money(20000L)).Priority(9.0).FromTx(tx2));
-            int tx2Size = tx2.GetVirtualSize();
+            int tx2Size = tx2.GetVirtualSize(KnownNetworks.TestNet.Consensus.Options);
 
             /* lowest fee */
             var tx3 = new Transaction();
@@ -355,7 +355,7 @@ namespace Stratis.Bitcoin.Features.MemoryPool.Tests
             var tx6 = new Transaction();
             tx6.AddOutput(new TxOut(new Money(20 * Money.COIN), new Script(OpcodeType.OP_11, OpcodeType.OP_EQUAL)));
             pool.AddUnchecked(tx6.GetHash(), entry.Fee(new Money(0L)).FromTx(tx6));
-            int tx6Size = tx6.GetVirtualSize();
+            int tx6Size = tx6.GetVirtualSize(KnownNetworks.TestNet.Consensus.Options);
             Assert.Equal(6, pool.Size);
             // Ties are broken by hash
             if (tx3.GetHash() < tx6.GetHash())
@@ -367,7 +367,7 @@ namespace Stratis.Bitcoin.Features.MemoryPool.Tests
             var tx7 = new Transaction();
             tx7.AddInput(new TxIn(new OutPoint(tx6.GetHash(), 0), new Script(OpcodeType.OP_11)));
             tx7.AddOutput(new TxOut(new Money(10 * Money.COIN), new Script(OpcodeType.OP_11, OpcodeType.OP_EQUAL)));
-            int tx7Size = tx7.GetVirtualSize();
+            int tx7Size = tx7.GetVirtualSize(KnownNetworks.TestNet.Consensus.Options);
             Money fee = (20000 / tx2Size) * (tx7Size + tx6Size) - 1;
             pool.AddUnchecked(tx7.GetHash(), entry.Fee(fee).FromTx(tx7));
             Assert.Equal(7, pool.Size);
@@ -426,12 +426,12 @@ namespace Stratis.Bitcoin.Features.MemoryPool.Tests
             Assert.True(pool.Exists(tx2.GetHash()));
             Assert.True(pool.Exists(tx3.GetHash()));
 
-            pool.TrimToSize(tx1.GetVirtualSize()); // mempool is limited to tx1's size in memory usage, so nothing fits
+            pool.TrimToSize(tx1.GetVirtualSize(KnownNetworks.TestNet.Consensus.Options)); // mempool is limited to tx1's size in memory usage, so nothing fits
             Assert.True(!pool.Exists(tx1.GetHash()));
             Assert.True(!pool.Exists(tx2.GetHash()));
             Assert.True(!pool.Exists(tx3.GetHash()));
 
-            var maxFeeRateRemoved = new FeeRate(25000, tx3.GetVirtualSize() + tx2.GetVirtualSize());
+            var maxFeeRateRemoved = new FeeRate(25000, tx3.GetVirtualSize(KnownNetworks.TestNet.Consensus.Options) + tx2.GetVirtualSize(KnownNetworks.TestNet.Consensus.Options));
             Assert.Equal(pool.GetMinFee(1).FeePerK, maxFeeRateRemoved.FeePerK + 1000);
 
             var tx4 = new Transaction();

--- a/src/Stratis.Bitcoin.Features.MemoryPool.Tests/MemoryPoolTransactionTests.cs
+++ b/src/Stratis.Bitcoin.Features.MemoryPool.Tests/MemoryPoolTransactionTests.cs
@@ -310,7 +310,7 @@ namespace Stratis.Bitcoin.Features.MemoryPool.Tests
             var tx2 = new Transaction();
             tx2.AddOutput(new TxOut(new Money(2 * Money.COIN), new Script(OpcodeType.OP_11, OpcodeType.OP_EQUAL)));
             pool.AddUnchecked(tx2.GetHash(), entry.Fee(new Money(20000L)).Priority(9.0).FromTx(tx2));
-            int tx2Size = tx2.GetVirtualSize(KnownNetworks.TestNet.Consensus.Options);
+            int tx2Size = tx2.GetVirtualSize(KnownNetworks.TestNet.Consensus.Options.WitnessScaleFactor);
 
             /* lowest fee */
             var tx3 = new Transaction();
@@ -355,7 +355,7 @@ namespace Stratis.Bitcoin.Features.MemoryPool.Tests
             var tx6 = new Transaction();
             tx6.AddOutput(new TxOut(new Money(20 * Money.COIN), new Script(OpcodeType.OP_11, OpcodeType.OP_EQUAL)));
             pool.AddUnchecked(tx6.GetHash(), entry.Fee(new Money(0L)).FromTx(tx6));
-            int tx6Size = tx6.GetVirtualSize(KnownNetworks.TestNet.Consensus.Options);
+            int tx6Size = tx6.GetVirtualSize(KnownNetworks.TestNet.Consensus.Options.WitnessScaleFactor);
             Assert.Equal(6, pool.Size);
             // Ties are broken by hash
             if (tx3.GetHash() < tx6.GetHash())
@@ -367,7 +367,7 @@ namespace Stratis.Bitcoin.Features.MemoryPool.Tests
             var tx7 = new Transaction();
             tx7.AddInput(new TxIn(new OutPoint(tx6.GetHash(), 0), new Script(OpcodeType.OP_11)));
             tx7.AddOutput(new TxOut(new Money(10 * Money.COIN), new Script(OpcodeType.OP_11, OpcodeType.OP_EQUAL)));
-            int tx7Size = tx7.GetVirtualSize(KnownNetworks.TestNet.Consensus.Options);
+            int tx7Size = tx7.GetVirtualSize(KnownNetworks.TestNet.Consensus.Options.WitnessScaleFactor);
             Money fee = (20000 / tx2Size) * (tx7Size + tx6Size) - 1;
             pool.AddUnchecked(tx7.GetHash(), entry.Fee(fee).FromTx(tx7));
             Assert.Equal(7, pool.Size);
@@ -426,12 +426,12 @@ namespace Stratis.Bitcoin.Features.MemoryPool.Tests
             Assert.True(pool.Exists(tx2.GetHash()));
             Assert.True(pool.Exists(tx3.GetHash()));
 
-            pool.TrimToSize(tx1.GetVirtualSize(KnownNetworks.TestNet.Consensus.Options)); // mempool is limited to tx1's size in memory usage, so nothing fits
+            pool.TrimToSize(tx1.GetVirtualSize(KnownNetworks.TestNet.Consensus.Options.WitnessScaleFactor)); // mempool is limited to tx1's size in memory usage, so nothing fits
             Assert.True(!pool.Exists(tx1.GetHash()));
             Assert.True(!pool.Exists(tx2.GetHash()));
             Assert.True(!pool.Exists(tx3.GetHash()));
 
-            var maxFeeRateRemoved = new FeeRate(25000, tx3.GetVirtualSize(KnownNetworks.TestNet.Consensus.Options) + tx2.GetVirtualSize(KnownNetworks.TestNet.Consensus.Options));
+            var maxFeeRateRemoved = new FeeRate(25000, tx3.GetVirtualSize(KnownNetworks.TestNet.Consensus.Options.WitnessScaleFactor) + tx2.GetVirtualSize(KnownNetworks.TestNet.Consensus.Options.WitnessScaleFactor));
             Assert.Equal(pool.GetMinFee(1).FeePerK, maxFeeRateRemoved.FeePerK + 1000);
 
             var tx4 = new Transaction();

--- a/src/Stratis.Bitcoin.Features.MemoryPool/TxMemPoolEntry.cs
+++ b/src/Stratis.Bitcoin.Features.MemoryPool/TxMemPoolEntry.cs
@@ -221,7 +221,7 @@ namespace Stratis.Bitcoin.Features.MemoryPool
         /// <returns>The transaction size.</returns>
         public long GetTxSize()
         {
-            return (long)this.Transaction.GetVirtualSize(this.consensusOptions);
+            return (long)this.Transaction.GetVirtualSize(this.consensusOptions.WitnessScaleFactor);
         }
 
         /// <summary>

--- a/src/Stratis.Bitcoin.Features.MemoryPool/TxMemPoolEntry.cs
+++ b/src/Stratis.Bitcoin.Features.MemoryPool/TxMemPoolEntry.cs
@@ -57,6 +57,9 @@ namespace Stratis.Bitcoin.Features.MemoryPool
         /// <summary>Priority when entering the memory pool.</summary>
         private double entryPriority;
 
+        /// <summary> Proof of work consensus options.</summary>
+        private readonly ConsensusOptions consensusOptions;
+
         /// <summary>
         /// Constructs a transaction memory pool entry.
         /// </summary>
@@ -85,6 +88,7 @@ namespace Stratis.Bitcoin.Features.MemoryPool
             this.SpendsCoinbase = spendsCoinbase;
             this.SigOpCost = nSigOpsCost;
             this.LockPoints = lp;
+            this.consensusOptions = consensusOptions;
 
             this.TxWeight = MempoolValidator.GetTransactionWeight(transaction, consensusOptions);
             this.nModSize = MempoolValidator.CalculateModifiedSize(this.Transaction.GetSerializedSize(), this.Transaction, consensusOptions);
@@ -217,7 +221,7 @@ namespace Stratis.Bitcoin.Features.MemoryPool
         /// <returns>The transaction size.</returns>
         public long GetTxSize()
         {
-            return (long)this.Transaction.GetVirtualSize();
+            return (long)this.Transaction.GetVirtualSize(this.consensusOptions);
         }
 
         /// <summary>

--- a/src/Stratis.Bitcoin.Features.RPC.Tests/Controller/FullNodeControllerTest.cs
+++ b/src/Stratis.Bitcoin.Features.RPC.Tests/Controller/FullNodeControllerTest.cs
@@ -653,6 +653,20 @@ namespace Stratis.Bitcoin.Features.RPC.Tests.Controller
             rpcCall.Should().Throw<ArgumentException>();
         }
 
+        [Fact]
+        public void GivenValidTxHexWithoutSegwit_WhenCallingDecodeRawTransaction_WeightShouldBe4TimesTheSize()
+        {
+            this.fullNode.SetupGet(p => p.Network).Returns(this.network);
+            var txId = new uint256(1243124);
+            Transaction transaction = this.CreateTransaction();
+            var decodedTx = this.controller.DecodeRawTransaction(transaction.ToHex());
+            decodedTx.Should().BeOfType<TransactionVerboseModel>();
+
+            var verboseTx = (TransactionVerboseModel) decodedTx;
+            verboseTx.Weight.Should().Be(verboseTx.VSize * 4);
+            verboseTx.Hex.Should().BeNullOrEmpty();
+        }
+
         private Transaction CreateTransaction()
         {
             var transaction = new Transaction();

--- a/src/Stratis.Bitcoin.Features.RPC.Tests/Controller/FullNodeControllerTest.cs
+++ b/src/Stratis.Bitcoin.Features.RPC.Tests/Controller/FullNodeControllerTest.cs
@@ -663,7 +663,7 @@ namespace Stratis.Bitcoin.Features.RPC.Tests.Controller
             decodedTx.Should().BeOfType<TransactionVerboseModel>();
 
             var verboseTx = (TransactionVerboseModel) decodedTx;
-            verboseTx.Weight.Should().Be(verboseTx.VSize * 4);
+            verboseTx.Weight.Should().Be(verboseTx.VSize * 4 - 3);
             verboseTx.Hex.Should().BeNullOrEmpty();
         }
 

--- a/src/Stratis.Bitcoin.Features.RPC/Controllers/FullNodeController.cs
+++ b/src/Stratis.Bitcoin.Features.RPC/Controllers/FullNodeController.cs
@@ -191,7 +191,7 @@ namespace Stratis.Bitcoin.Features.RPC.Controllers
             {
                 var transaction = new TransactionVerboseModel(this.FullNode.Network.CreateTransaction(hex), this.Network);
 
-                // Clear hex to not include it into the output. Hex is already known to the client.
+                // Clear hex to not include it into the output. Hex is already known to the client. This will reduce response size.
                 transaction.Hex = null;
                 return transaction;
             }

--- a/src/Stratis.Bitcoin.Features.RPC/Controllers/FullNodeController.cs
+++ b/src/Stratis.Bitcoin.Features.RPC/Controllers/FullNodeController.cs
@@ -189,7 +189,11 @@ namespace Stratis.Bitcoin.Features.RPC.Controllers
         {
             try
             {
-                return new TransactionVerboseModel(this.FullNode.Network.CreateTransaction(hex), this.Network);
+                var transaction = new TransactionVerboseModel(this.FullNode.Network.CreateTransaction(hex), this.Network);
+
+                // Clear hex to not include it into the output. Hex is already known to the client.
+                transaction.Hex = null;
+                return transaction;
             }
             catch (FormatException ex)
             {

--- a/src/Stratis.Bitcoin.Tests/Models/TransactionModelsTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Models/TransactionModelsTest.cs
@@ -54,7 +54,7 @@ namespace Stratis.Bitcoin.Tests.Models
         [Fact]
         public void TransactionModelVerboseRenderTest()
         {
-            var expectedPropertyNameOrder = new string[] { "hex", "txid", "hash", "version", "size", "vsize", "locktime", "vin", "vout" };
+            var expectedPropertyNameOrder = new string[] { "hex", "txid", "hash", "version", "size", "vsize", "weight", "locktime", "vin", "vout" };
             JObject obj = JObject.FromObject(this.txBlock460373CoinbaseModelVerbose);
             Assert.True(obj.HasValues);
 
@@ -68,7 +68,7 @@ namespace Stratis.Bitcoin.Tests.Models
             var actualLocktime = obj.Value<int?>("locktime");
             IEnumerable<string> actualPropertyNameOrder = obj.Children().Select(o => (o as JProperty)?.Name);
 
-            Assert.Equal(9, actualElements);
+            Assert.Equal(10, actualElements);
             Assert.Equal(TxBlock460373CoinbaseHex, actualHex);
             Assert.Equal(TxBlock460373CoinbaseHash, actualTxid);
             Assert.Equal(TxBlock460373CoinbaseHash, actualHash);

--- a/src/Stratis.Bitcoin/Controllers/Models/TransactionModel.cs
+++ b/src/Stratis.Bitcoin/Controllers/Models/TransactionModel.cs
@@ -25,7 +25,7 @@ namespace Stratis.Bitcoin.Controllers.Models
             this.Hex = trx?.ToHex();
         }
 
-        /// <summary>The transaction hash.</summary>
+        /// <summary>The transaction in hexadecimal format.</summary>
         [JsonProperty(Order = 0, PropertyName = "hex", NullValueHandling = NullValueHandling.Ignore)]
         public string Hex { get; set; }
 
@@ -79,9 +79,7 @@ namespace Stratis.Bitcoin.Controllers.Models
 
                 // size = (weight + WITNESS_SCALE_FACTOR - 1) / WITNESS_SCALE_FACTOR;
                 // hence, weight = size * WITNESS_SCALE_FACTOR - (WITNESS_SCALE_FACTOR - 1) (only subtract if has witness).
-                this.Weight = this.VSize * network.Consensus.Options.WitnessScaleFactor;
-                if (trx.HasWitness)
-                    this.Weight -= (network.Consensus.Options.WitnessScaleFactor - 1);
+                this.Weight = this.VSize * network.Consensus.Options.WitnessScaleFactor - (network.Consensus.Options.WitnessScaleFactor - 1);
 
                 this.VIn = trx.Inputs.Select(txin => new Vin(txin.PrevOut, txin.Sequence, txin.ScriptSig)).ToList();
 

--- a/src/Stratis.Bitcoin/Controllers/Models/TransactionModel.cs
+++ b/src/Stratis.Bitcoin/Controllers/Models/TransactionModel.cs
@@ -26,7 +26,7 @@ namespace Stratis.Bitcoin.Controllers.Models
         }
 
         /// <summary>The hashed transaction.</summary>
-        [JsonProperty(Order = 0, PropertyName = "hex")]
+        [JsonProperty(Order = 0, PropertyName = "hex", NullValueHandling = NullValueHandling.Ignore)]
         public string Hex { get; set; }
 
         public override string ToString()
@@ -76,6 +76,10 @@ namespace Stratis.Bitcoin.Controllers.Models
                 this.VSize = trx.HasWitness ? trx.GetVirtualSize() : trx.GetSerializedSize();
                 this.Version = trx.Version;
                 this.LockTime = trx.LockTime;
+
+                // size = (weight + WITNESS_SCALE_FACTOR - 1) / WITNESS_SCALE_FACTOR;
+                // hence, weight = size * WITNESS_SCALE_FACTOR - 3 (only subtract 3 if has witness).
+                this.Weight = this.VSize * Transaction.WITNESS_SCALE_FACTOR - (trx.HasWitness ? 3 : 0);
 
                 this.VIn = trx.Inputs.Select(txin => new Vin(txin.PrevOut, txin.Sequence, txin.ScriptSig)).ToList();
 

--- a/src/Stratis.Bitcoin/Controllers/Models/TransactionModel.cs
+++ b/src/Stratis.Bitcoin/Controllers/Models/TransactionModel.cs
@@ -25,7 +25,7 @@ namespace Stratis.Bitcoin.Controllers.Models
             this.Hex = trx?.ToHex();
         }
 
-        /// <summary>The hashed transaction.</summary>
+        /// <summary>The transaction hash.</summary>
         [JsonProperty(Order = 0, PropertyName = "hex", NullValueHandling = NullValueHandling.Ignore)]
         public string Hex { get; set; }
 

--- a/src/Stratis.Bitcoin/Controllers/Models/TransactionModel.cs
+++ b/src/Stratis.Bitcoin/Controllers/Models/TransactionModel.cs
@@ -73,7 +73,7 @@ namespace Stratis.Bitcoin.Controllers.Models
                 this.TxId = trx.GetHash().ToString();
                 this.Hash = trx.HasWitness ? trx.GetWitHash().ToString() : trx.GetHash().ToString();
                 this.Size = trx.GetSerializedSize();
-                this.VSize = trx.HasWitness ? trx.GetVirtualSize(network.Consensus.Options) : trx.GetSerializedSize();
+                this.VSize = trx.HasWitness ? trx.GetVirtualSize(network.Consensus.Options.WitnessScaleFactor) : trx.GetSerializedSize();
                 this.Version = trx.Version;
                 this.LockTime = trx.LockTime;
 

--- a/src/Stratis.Bitcoin/Controllers/Models/TransactionModel.cs
+++ b/src/Stratis.Bitcoin/Controllers/Models/TransactionModel.cs
@@ -73,13 +73,15 @@ namespace Stratis.Bitcoin.Controllers.Models
                 this.TxId = trx.GetHash().ToString();
                 this.Hash = trx.HasWitness ? trx.GetWitHash().ToString() : trx.GetHash().ToString();
                 this.Size = trx.GetSerializedSize();
-                this.VSize = trx.HasWitness ? trx.GetVirtualSize() : trx.GetSerializedSize();
+                this.VSize = trx.HasWitness ? trx.GetVirtualSize(network.Consensus.Options) : trx.GetSerializedSize();
                 this.Version = trx.Version;
                 this.LockTime = trx.LockTime;
 
                 // size = (weight + WITNESS_SCALE_FACTOR - 1) / WITNESS_SCALE_FACTOR;
-                // hence, weight = size * WITNESS_SCALE_FACTOR - 3 (only subtract 3 if has witness).
-                this.Weight = this.VSize * Transaction.WITNESS_SCALE_FACTOR - (trx.HasWitness ? 3 : 0);
+                // hence, weight = size * WITNESS_SCALE_FACTOR - (WITNESS_SCALE_FACTOR - 1) (only subtract if has witness).
+                this.Weight = this.VSize * network.Consensus.Options.WitnessScaleFactor;
+                if (trx.HasWitness)
+                    this.Weight -= (network.Consensus.Options.WitnessScaleFactor - 1);
 
                 this.VIn = trx.Inputs.Select(txin => new Vin(txin.PrevOut, txin.Sequence, txin.ScriptSig)).ToList();
 


### PR DESCRIPTION
Brings decoderawtransaciton  closer to the BTC client by removing hex property from the response to reduce size and adding `weight` field. 

where weight is `The transaction's weight (between vsize*4 - 3 and vsize*4)`

https://github.com/bitcoin/bitcoin/blob/048e456fc40821939e8becd2d53e0352d9451be2/src/rpc/rawtransaction.cpp#L438

