### PR TITLE
Constraint violation on HDAddress insert

### DIFF
--- a/src/Stratis.Features.SQLiteWalletRepository/SQLiteWalletRepository.cs
+++ b/src/Stratis.Features.SQLiteWalletRepository/SQLiteWalletRepository.cs
@@ -821,7 +821,7 @@ namespace Stratis.Features.SQLiteWalletRepository
 
                                     // Ensure that any new addresses are present in the database before accessing the HDAddress table.
                                     foreach (AddressIdentifier addressIdentifier in round.AddressesOfInterest.GetTentative())
-                                        conn.Insert(this.CreateAddress(addressIdentifier));
+                                        conn.InsertOrReplace(this.CreateAddress(addressIdentifier));
 
                                     this.logger.LogDebug("Processing block '{0}'.", chainedHeader);
 
@@ -1091,7 +1091,15 @@ namespace Stratis.Features.SQLiteWalletRepository
                 {
                     this.logger.LogDebug("Processing transaction '{0}'.", transaction.GetHash());
 
+                    // Ensure that any new addresses are present in the database before accessing the HDAddress table.
+                    foreach (AddressIdentifier addressIdentifier in processBlocksInfo.AddressesOfInterest.GetTentative())
+                        conn.InsertOrReplace(this.CreateAddress(addressIdentifier));
+
                     conn.ProcessTransactions(txToScript, wallet);
+
+                    processBlocksInfo.AddressesOfInterest.Confirm();
+                    processBlocksInfo.TransactionsOfInterest.Confirm();
+
                     conn.Commit();
                 }
                 catch (Exception ex)

--- a/src/Stratis.Features.SQLiteWalletRepository/SQLiteWalletRepository.cs
+++ b/src/Stratis.Features.SQLiteWalletRepository/SQLiteWalletRepository.cs
@@ -821,7 +821,12 @@ namespace Stratis.Features.SQLiteWalletRepository
 
                                     // Ensure that any new addresses are present in the database before accessing the HDAddress table.
                                     foreach (AddressIdentifier addressIdentifier in round.AddressesOfInterest.GetTentative())
+                                    {
+                                        Guard.Assert(!string.IsNullOrEmpty(addressIdentifier.ScriptPubKey));
+                                        Guard.Assert(!string.IsNullOrEmpty(addressIdentifier.PubKeyScript));
+
                                         conn.InsertOrReplace(this.CreateAddress(addressIdentifier));
+                                    }
 
                                     this.logger.LogDebug("Processing block '{0}'.", chainedHeader);
 
@@ -1093,7 +1098,12 @@ namespace Stratis.Features.SQLiteWalletRepository
 
                     // Ensure that any new addresses are present in the database before accessing the HDAddress table.
                     foreach (AddressIdentifier addressIdentifier in processBlocksInfo.AddressesOfInterest.GetTentative())
+                    {
+                        Guard.Assert(!string.IsNullOrEmpty(addressIdentifier.ScriptPubKey));
+                        Guard.Assert(!string.IsNullOrEmpty(addressIdentifier.PubKeyScript));
+
                         conn.InsertOrReplace(this.CreateAddress(addressIdentifier));
+                    }
 
                     conn.ProcessTransactions(txToScript, wallet);
 


### PR DESCRIPTION
https://dev.azure.com/Stratisplatformuk/StratisBitcoinFullNode/_workitems/edit/4515.

We are getting a constraint violation on inserting addresses. So the motivation for this change is that we should insert instead of replacing if there is a chance of encountering the same address twice. Also, as an added safety measure we add Guards to detect if we have a null or empty field - which would lead to a reduction in uniqueness of the key fields. 