### PR TITLE
Workaround for SQLite decimal precision issues

### DIFF
--- a/src/Stratis.Features.SQLiteWalletRepository.Tests/DBParameterTests.cs
+++ b/src/Stratis.Features.SQLiteWalletRepository.Tests/DBParameterTests.cs
@@ -18,10 +18,8 @@ namespace Stratis.Features.SQLiteWalletRepository.Tests
                 Thread.CurrentThread.CurrentCulture = ci;
                 Thread.CurrentThread.CurrentUICulture = ci;
 
-                Assert.Equal("1234.56789", DBParameter.Create(1234.56789m));
                 Assert.Equal("1234", DBParameter.Create((int)1234));
                 Assert.Equal("1234", DBParameter.Create((long)1234));
-                Assert.Equal("0.00001", DBParameter.Create(0.00001m));
             }
 
             Thread.CurrentThread.CurrentCulture = culture;

--- a/src/Stratis.Features.SQLiteWalletRepository/SQLiteWalletRepository.cs
+++ b/src/Stratis.Features.SQLiteWalletRepository/SQLiteWalletRepository.cs
@@ -144,10 +144,11 @@ namespace Stratis.Features.SQLiteWalletRepository
 
                     HDWallet wallet = conn.GetWalletByName(walletName);
                     var walletContainer = new WalletContainer(conn, wallet, new ProcessBlocksInfo(conn, null, wallet));
-                    this.Wallets[walletName] = walletContainer;
 
                     walletContainer.AddressesOfInterest.AddAll(wallet.WalletId);
                     walletContainer.TransactionsOfInterest.AddAll(wallet.WalletId);
+
+                    this.Wallets[walletName] = walletContainer;
 
                     this.logger.LogDebug("Added '{0}` to wallet collection.", wallet.Name);
                 }
@@ -161,10 +162,11 @@ namespace Stratis.Features.SQLiteWalletRepository
                 foreach (HDWallet wallet in HDWallet.GetAll(conn))
                 {
                     var walletContainer = new WalletContainer(conn, wallet, this.processBlocksInfo);
-                    this.Wallets[wallet.Name] = walletContainer;
 
                     walletContainer.AddressesOfInterest.AddAll(wallet.WalletId);
                     walletContainer.TransactionsOfInterest.AddAll(wallet.WalletId);
+
+                    this.Wallets[wallet.Name] = walletContainer;
 
                     this.logger.LogDebug("Added '{0}` to wallet collection.", wallet.Name);
                 }

--- a/src/Stratis.Features.SQLiteWalletRepository/SQLiteWalletRepository.cs
+++ b/src/Stratis.Features.SQLiteWalletRepository/SQLiteWalletRepository.cs
@@ -676,7 +676,7 @@ namespace Stratis.Features.SQLiteWalletRepository
                 throw new WalletException($"No account with the name '{accountReference.AccountName}' could be found.");
 
             return conn.GetUsedAddresses(account.WalletId, account.AccountIndex, isChange ? 1 : 0, int.MaxValue).Select(a =>
-                (this.ToHdAddress(a), new Money(a.ConfirmedAmount, MoneyUnit.BTC), new Money(a.TotalAmount, MoneyUnit.BTC)));
+                (this.ToHdAddress(a), new Money(a.ConfirmedAmount), new Money(a.TotalAmount)));
         }
 
         /// <inheritdoc />
@@ -1195,7 +1195,7 @@ namespace Stratis.Features.SQLiteWalletRepository
                 transactionData.ScriptPubKey.ToHex())
                 .Where(p => p.SpendIsChange == (isChange ? 1 : 0)).Select(p => new PaymentDetails()
                 {
-                    Amount = new Money((decimal)p.SpendValue, MoneyUnit.BTC),
+                    Amount = new Money(p.SpendValue),
                     DestinationScriptPubKey = new Script(Encoders.Hex.DecodeData(p.SpendScriptPubKey)),
                     OutputIndex = p.SpendIndex
                 }).ToList();
@@ -1221,9 +1221,9 @@ namespace Stratis.Features.SQLiteWalletRepository
             DBConnection conn = walletContainer.Conn;
             HDAccount account = conn.GetAccountByName(walletAccountReference.WalletName, walletAccountReference.AccountName);
 
-            (decimal total, decimal confirmed, decimal spendable) = HDTransactionData.GetBalance(conn, account.WalletId, account.AccountIndex, address, currentChainHeight, coinBaseMaturity ?? (int)this.Network.Consensus.CoinbaseMaturity, confirmations);
+            (long total, long confirmed, long spendable) = HDTransactionData.GetBalance(conn, account.WalletId, account.AccountIndex, address, currentChainHeight, coinBaseMaturity ?? (int)this.Network.Consensus.CoinbaseMaturity, confirmations);
 
-            return (new Money(total, MoneyUnit.BTC), new Money(confirmed, MoneyUnit.BTC), new Money(spendable, MoneyUnit.BTC));
+            return (new Money(total), new Money(confirmed), new Money(spendable));
         }
 
         /// <inheritdoc />

--- a/src/Stratis.Features.SQLiteWalletRepository/SQLiteWalletRepositoryExt.cs
+++ b/src/Stratis.Features.SQLiteWalletRepository/SQLiteWalletRepositoryExt.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using NBitcoin;
 using NBitcoin.DataEncoders;
 using Stratis.Bitcoin.Features.Wallet;
@@ -62,7 +60,7 @@ namespace Stratis.Features.SQLiteWalletRepository
         {
             var res = new TransactionData()
             {
-                Amount = new Money(transactionData.Value, MoneyUnit.BTC),
+                Amount = new Money(transactionData.Value),
                 BlockHash = (transactionData.OutputBlockHash == null) ? null : uint256.Parse(transactionData.OutputBlockHash),
                 BlockHeight = transactionData.OutputBlockHeight,
                 CreationTime = DateTimeOffset.FromUnixTimeSeconds(transactionData.OutputTxTime),

--- a/src/Stratis.Features.SQLiteWalletRepository/Tables/DBParameter.cs
+++ b/src/Stratis.Features.SQLiteWalletRepository/Tables/DBParameter.cs
@@ -18,9 +18,6 @@ namespace Stratis.Features.SQLiteWalletRepository.Tables
                 case string strProp:
                     return $"'{strProp.Replace("'", "''")}'";
 
-                case decimal decProp:
-                    return decProp.ToString("0.#############################", CultureInfo.InvariantCulture);
-
                 case int intProp:
                     return intProp.ToString("F0", CultureInfo.InvariantCulture);
 

--- a/src/Stratis.Features.SQLiteWalletRepository/Tables/HDAddress.cs
+++ b/src/Stratis.Features.SQLiteWalletRepository/Tables/HDAddress.cs
@@ -5,8 +5,8 @@ namespace Stratis.Features.SQLiteWalletRepository.Tables
 {
     internal class HDAddressWithBalances : HDAddress
     {
-        public decimal ConfirmedAmount { get; set; }
-        public decimal TotalAmount { get; set; }
+        public long ConfirmedAmount { get; set; }
+        public long TotalAmount { get; set; }
     }
 
     internal class HDAddress

--- a/src/Stratis.Features.SQLiteWalletRepository/Tables/HDPayment.cs
+++ b/src/Stratis.Features.SQLiteWalletRepository/Tables/HDPayment.cs
@@ -10,7 +10,7 @@ namespace Stratis.Features.SQLiteWalletRepository.Tables
         public int OutputIndex { get; set; }
         public int SpendIndex { get; set; }
         public string SpendScriptPubKey { get; set; }
-        public decimal SpendValue { get; set; }
+        public long SpendValue { get; set; }
         public int SpendIsChange { get; set; }
 
         internal static IEnumerable<string> CreateScript()
@@ -24,7 +24,7 @@ namespace Stratis.Features.SQLiteWalletRepository.Tables
                 ScriptPubKey        TEXT NOT NULL,
                 SpendIndex          INTEGER NOT NULL,
                 SpendScriptPubKey   TEXT,
-                SpendValue          DECIMAL NOT NULL,
+                SpendValue          INTEGER NOT NULL,
                 SpendIsChange       INTEGER NOT NULL,
                 PRIMARY KEY(SpendTxTime, SpendTxId, OutputTxId, OutputIndex, ScriptPubKey, SpendIndex)
             )";

--- a/src/Stratis.Features.SQLiteWalletRepository/Tables/HDTransactionData.cs
+++ b/src/Stratis.Features.SQLiteWalletRepository/Tables/HDTransactionData.cs
@@ -12,7 +12,7 @@ namespace Stratis.Features.SQLiteWalletRepository.Tables
         public string RedeemScript { get; set; }
         public string ScriptPubKey { get; set; }
         public string Address { get; set; }
-        public decimal Value { get; set; }
+        public long Value { get; set; }
         public long OutputTxTime { get; set; }
         public string OutputTxId { get; set; }
         public int OutputIndex { get; set; }
@@ -24,7 +24,7 @@ namespace Stratis.Features.SQLiteWalletRepository.Tables
         public int? SpendBlockHeight { get; set; }
         public int SpendTxIsCoinBase { get; set; }
         public string SpendBlockHash { get; set; }
-        public decimal? SpendTxTotalOut { get; set; }
+        public long? SpendTxTotalOut { get; set; }
 
         internal static IEnumerable<string> CreateScript()
         {
@@ -37,7 +37,7 @@ namespace Stratis.Features.SQLiteWalletRepository.Tables
                 RedeemScript        TEXT NOT NULL,
                 ScriptPubKey        TEXT NOT NULL,
                 Address             TEXT NOT NULL,
-                Value               DECIMAL NOT NULL,
+                Value               INTEGER NOT NULL,
                 OutputBlockHeight   INTEGER,
                 OutputBlockHash     TEXT,
                 OutputTxIsCoinBase  INTEGER NOT NULL,
@@ -49,7 +49,7 @@ namespace Stratis.Features.SQLiteWalletRepository.Tables
                 SpendTxIsCoinBase   INTEGER,
                 SpendTxTime         INTEGER,
                 SpendTxId           TEXT,
-                SpendTxTotalOut     DECIMAL,
+                SpendTxTotalOut     INTEGER,
                 PRIMARY KEY(WalletId, AccountIndex, AddressType, AddressIndex, OutputTxId, OutputIndex)
             )";
 
@@ -115,12 +115,12 @@ namespace Stratis.Features.SQLiteWalletRepository.Tables
 
         public class BalanceData
         {
-            public decimal TotalBalance { get; set; }
-            public decimal SpendableBalance { get; set; }
-            public decimal ConfirmedBalance { get; set; }
+            public long TotalBalance { get; set; }
+            public long SpendableBalance { get; set; }
+            public long ConfirmedBalance { get; set; }
         }
 
-        internal static (decimal total, decimal confirmed, decimal spendable) GetBalance(DBConnection conn, int walletId, int accountIndex, (int type, int index)? address, int currentChainHeight, int coinbaseMaturity, int confirmations = 0)
+        internal static (long total, long confirmed, long spendable) GetBalance(DBConnection conn, int walletId, int accountIndex, (int type, int index)? address, int currentChainHeight, int coinbaseMaturity, int confirmations = 0)
         {
             int maxConfirmationHeight = (currentChainHeight + 1) - confirmations;
             int maxCoinBaseHeight = currentChainHeight - (int)coinbaseMaturity;

--- a/src/Stratis.Features.SQLiteWalletRepository/Tables/TempOutput.cs
+++ b/src/Stratis.Features.SQLiteWalletRepository/Tables/TempOutput.cs
@@ -11,7 +11,7 @@
         public long OutputTxTime { get; set; }
         public string OutputTxId { get; set; }
         public int OutputIndex { get; set; }
-        public decimal Value { get; set; }
+        public long Value { get; set; }
         public int IsChange { get; set; }
 
         public TempOutput() : base() { }

--- a/src/Stratis.Features.SQLiteWalletRepository/Tables/TempPrevOut.cs
+++ b/src/Stratis.Features.SQLiteWalletRepository/Tables/TempPrevOut.cs
@@ -11,7 +11,7 @@
         public long SpendTxTime { get; set; }
         public string SpendTxId { get; set; }
         public int SpendIndex { get; set; }
-        public decimal SpendTxTotalOut { get; set; }
+        public long SpendTxTotalOut { get; set; }
 
         public TempPrevOut() : base() { }
     }

--- a/src/Stratis.Features.SQLiteWalletRepository/Tables/TempTable.cs
+++ b/src/Stratis.Features.SQLiteWalletRepository/Tables/TempTable.cs
@@ -61,11 +61,8 @@ namespace Stratis.Features.SQLiteWalletRepository.Tables
         {
             string type = "TEXT";
 
-            if (info.PropertyType == typeof(int))
+            if (info.PropertyType == typeof(int) || info.PropertyType == typeof(long))
                 return "INT";
-
-            if (info.PropertyType == typeof(decimal))
-                return "DECIMAL";
 
             return type;
         }

--- a/src/Stratis.Features.SQLiteWalletRepository/TransactionsToLists.cs
+++ b/src/Stratis.Features.SQLiteWalletRepository/TransactionsToLists.cs
@@ -35,7 +35,7 @@ namespace Stratis.Features.SQLiteWalletRepository
                 SpendTxTime = spendTime,
                 SpendTxId = spendTxId.ToString(),
                 SpendIndex = spendIndex,
-                SpendTxTotalOut = totalOut.ToDecimal(MoneyUnit.BTC)
+                SpendTxTotalOut = totalOut.Satoshi
             });
         }
 
@@ -57,7 +57,7 @@ namespace Stratis.Features.SQLiteWalletRepository
                 OutputTxTime = creationTime,
                 OutputTxId = outputTxId.ToString(),
                 OutputIndex = outputIndex,
-                Value = txOut.Value.ToDecimal(MoneyUnit.BTC),
+                Value = txOut.Value.Satoshi,
                 IsChange = isChange ? 1 : 0
             });
         }


### PR DESCRIPTION
SQLite's decimal type inaccuracies add up when summing over large numbers of values. Currently summation results can even be non-deterministic, being dependent on the order in which values arrived in the database.

At the root of this issue is SQLite's underlying use of floating point values in its decimal implementation.

As such we get rid of the decimal type and use integer values (satoshis) instead.

https://dev.azure.com/Stratisplatformuk/StratisBitcoinFullNode/_workitems/edit/4520.

This is the first change in what is currently expected to be a two-part fix.
