### PR TITLE
Update top-up tracker scope from block to batch

### DIFF
--- a/src/Stratis.Features.SQLiteWalletRepository/External/ITransactionsToLists.cs
+++ b/src/Stratis.Features.SQLiteWalletRepository/External/ITransactionsToLists.cs
@@ -79,9 +79,6 @@ namespace Stratis.Features.SQLiteWalletRepository.External
             IWalletTransactionLookup transactionsOfInterest = this.transactionsOfInterest;
             IWalletAddressLookup addressesOfInterest = this.addressesOfInterest;
 
-            // Used for tracking address top-up requirements.
-            var trackers = new Dictionary<TopUpTracker, TopUpTracker>();
-
             foreach (Transaction tx in transactions)
             {
                 // Build temp.PrevOuts
@@ -170,9 +167,6 @@ namespace Stratis.Features.SQLiteWalletRepository.External
             // Convert relevant information in the block to information that can be joined to the wallet tables.
             IWalletTransactionLookup transactionsOfInterest = this.transactionsOfInterest;
             IWalletAddressLookup addressesOfInterest = this.addressesOfInterest;
-
-            // Used for tracking address top-up requirements.
-            var trackers = new Dictionary<TopUpTracker, TopUpTracker>();
 
             foreach (TransactionData transactionData in transactions)
             {

--- a/src/Stratis.Features.SQLiteWalletRepository/Tables/TempTable.cs
+++ b/src/Stratis.Features.SQLiteWalletRepository/Tables/TempTable.cs
@@ -36,6 +36,15 @@ namespace Stratis.Features.SQLiteWalletRepository.Tables
 
     internal class TempRow
     {
+        private PropertyInfo[] GetProperties()
+        {
+            return this.GetType().GetProperties().Where(p => p.SetMethod != null).ToArray();
+        }
+
+        public override string ToString()
+        {
+            return string.Join(", ", this.GetProperties().Select(p => $"{p.Name}={DBParameter.Create(p.GetValue(this))}"));
+        }
     }
 
     internal class TempTable : List<TempRow>

--- a/src/Stratis.Features.SQLiteWalletRepository/TransactionsToLists.cs
+++ b/src/Stratis.Features.SQLiteWalletRepository/TransactionsToLists.cs
@@ -34,7 +34,7 @@ namespace Stratis.Features.SQLiteWalletRepository
                 SpendTxId = spendTxId.ToString(),
                 SpendIndex = spendIndex,
                 SpendTxTotalOut = totalOut.Satoshi
-            });
+            };
 
             this.conn.Repository.logger.LogTrace("Recording spend: {0}", prevOut.ToString());
             this.processBlocksInfo.PrevOuts.Add(prevOut);

--- a/src/Stratis.Features.SQLiteWalletRepository/TransactionsToLists.cs
+++ b/src/Stratis.Features.SQLiteWalletRepository/TransactionsToLists.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+﻿using Microsoft.Extensions.Logging;
 using NBitcoin;
 using Stratis.Bitcoin.Features.Wallet.Interfaces;
 using Stratis.Bitcoin.Interfaces;
@@ -12,19 +12,17 @@ namespace Stratis.Features.SQLiteWalletRepository
     {
         private readonly DBConnection conn;
         private readonly ProcessBlocksInfo processBlocksInfo;
-        private readonly Dictionary<TopUpTracker, TopUpTracker> trackers;
 
         internal TransactionsToLists(Network network, IScriptAddressReader scriptAddressReader, ProcessBlocksInfo processBlocksInfo)
             : base(network, scriptAddressReader, processBlocksInfo.TransactionsOfInterest, processBlocksInfo.AddressesOfInterest)
         {
             this.conn = processBlocksInfo.Conn;
             this.processBlocksInfo = processBlocksInfo;
-            this.trackers = new Dictionary<TopUpTracker, TopUpTracker>();
         }
 
         public override void RecordSpend(HashHeightPair block, TxIn txIn, string pubKeyScript, bool isCoinBase, long spendTime, Money totalOut, uint256 spendTxId, int spendIndex)
         {
-            this.processBlocksInfo.PrevOuts.Add(new TempPrevOut()
+            var prevOut = new TempPrevOut()
             {
                 OutputTxId = txIn.PrevOut.Hash.ToString(),
                 OutputIndex = (int)txIn.PrevOut.N,
@@ -36,13 +34,16 @@ namespace Stratis.Features.SQLiteWalletRepository
                 SpendTxId = spendTxId.ToString(),
                 SpendIndex = spendIndex,
                 SpendTxTotalOut = totalOut.ToDecimal(MoneyUnit.BTC)
-            });
+            };
+
+            this.conn.Repository.logger.LogTrace("Recording spend: {0}", prevOut.ToString());
+            this.processBlocksInfo.PrevOuts.Add(prevOut);
         }
 
         public override void RecordReceipt(HashHeightPair block, Script pubKeyScript, TxOut txOut, bool isCoinBase, long creationTime, uint256 outputTxId, int outputIndex, bool isChange)
         {
             // Record outputs received by our wallets.
-            this.processBlocksInfo.Outputs.Add(new TempOutput()
+            var output = new TempOutput()
             {
                 // For matching HDAddress.ScriptPubKey.
                 ScriptPubKey = pubKeyScript?.ToHex(),
@@ -59,17 +60,20 @@ namespace Stratis.Features.SQLiteWalletRepository
                 OutputIndex = outputIndex,
                 Value = txOut.Value.ToDecimal(MoneyUnit.BTC),
                 IsChange = isChange ? 1 : 0
-            });
+            };
+
+            this.conn.Repository.logger.LogTrace("Recording receipt: {0}", output.ToString());
+            this.processBlocksInfo.Outputs.Add(output);
         }
 
         public override ITopUpTracker GetTopUpTracker(AddressIdentifier address)
         {
             var key = new TopUpTracker(this.processBlocksInfo, address.WalletId, (int)address.AccountIndex, (int)address.AddressType);
-            if (!this.trackers.TryGetValue(key, out TopUpTracker tracker))
+            if (!this.processBlocksInfo.Trackers.TryGetValue(key, out TopUpTracker tracker))
             {
                 tracker = key;
                 tracker.ReadAccount();
-                this.trackers.Add(tracker, tracker);
+                this.processBlocksInfo.Trackers.Add(tracker, tracker);
             }
 
             return tracker;

--- a/src/Stratis.Features.SQLiteWalletRepository/WalletContainer.cs
+++ b/src/Stratis.Features.SQLiteWalletRepository/WalletContainer.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading;
+﻿using System.Collections.Generic;
+using System.Threading;
 using ConcurrentCollections;
 using NBitcoin;
 using Stratis.Bitcoin.Utilities;
@@ -22,6 +23,7 @@ namespace Stratis.Features.SQLiteWalletRepository
         internal HDWallet Wallet;
         internal ConcurrentHashSet<string> ParticipatingWallets;
         internal long NextScheduledCatchup;
+        internal Dictionary<TopUpTracker, TopUpTracker> Trackers;
 
         internal DBLock LockProcessBlocks;
 
@@ -39,6 +41,7 @@ namespace Stratis.Features.SQLiteWalletRepository
 
             this.AddressesOfInterest = processBlocksInfo?.AddressesOfInterest ?? new WalletAddressLookup(conn, wallet?.WalletId);
             this.TransactionsOfInterest = processBlocksInfo?.TransactionsOfInterest ?? new WalletTransactionLookup(conn, wallet?.WalletId);
+            this.Trackers = processBlocksInfo?.Trackers ?? new Dictionary<TopUpTracker, TopUpTracker>();
         }
     }
 


### PR DESCRIPTION
https://dev.azure.com/Stratisplatformuk/StratisBitcoinFullNode/_workitems/edit/4520/

Addresses created by the "address top-up trackers" are written to the database just before calling the scripts that process the data from a batch of blocks. However the tracker collection is being re-created for each block.

This PR also adds additional logging and extends a test case.