### PR TITLE
No caching wallet secrets

### DIFF
--- a/src/Stratis.Bitcoin.Features.Wallet/Interfaces/IWalletManager.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Interfaces/IWalletManager.cs
@@ -312,7 +312,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Interfaces
         /// <param name="password">The password used to decrypt the encrypted seed.</param>
         /// <param name="cache">whether to cache the private key for future use.</param>
         /// <returns>The private key.</returns>
-        ExtKey GetExtKey(WalletAccountReference accountReference, string password = "", bool cache = false);
+        ExtKey GetExtKey(WalletAccountReference accountReference, string password = "");
 
         /// <summary>
         /// Removes the specified transactions from the wallet and persist it.

--- a/src/Stratis.Bitcoin.Features.Wallet/WalletManager.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/WalletManager.cs
@@ -1199,7 +1199,7 @@ namespace Stratis.Bitcoin.Features.Wallet
 
         /// <inheritdoc />
         [NoTrace]
-        public ExtKey GetExtKey(WalletAccountReference accountReference, string password = "", bool cache = false)
+        public ExtKey GetExtKey(WalletAccountReference accountReference, string password = "")
         {
             Wallet wallet = this.GetWallet(accountReference.WalletName);
             string cacheKey = wallet.EncryptedSeed;
@@ -1212,13 +1212,6 @@ namespace Stratis.Bitcoin.Features.Wallet
             else
             {
                 privateKey = Key.Parse(wallet.EncryptedSeed, password, wallet.Network);
-            }
-
-            if (cache)
-            {
-                // The default duration the secret is cached is 5 minutes.
-                var timeOutDuration = new TimeSpan(0, 5, 0);
-                this.UnlockWallet(password, accountReference.WalletName, (int)timeOutDuration.TotalSeconds);
             }
 
             return new ExtKey(privateKey, wallet.ChainCode);

--- a/src/Stratis.Bitcoin.Features.Wallet/WalletRPCController.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/WalletRPCController.cs
@@ -111,8 +111,7 @@ namespace Stratis.Bitcoin.Features.Wallet
             TransactionBuildContext context = new TransactionBuildContext(this.FullNode.Network)
             {
                 AccountReference = this.GetWalletAccountReference(),
-                Recipients = new[] { new Recipient { Amount = Money.Coins(amount), ScriptPubKey = address.ScriptPubKey } }.ToList(),
-                CacheSecret = false
+                Recipients = new[] { new Recipient { Amount = Money.Coins(amount), ScriptPubKey = address.ScriptPubKey } }.ToList()
             };
 
             try
@@ -535,8 +534,7 @@ namespace Stratis.Bitcoin.Features.Wallet
                 AccountReference = accountReference,
                 MinConfirmations = minConf,
                 Shuffle = true, // We shuffle transaction outputs by default as it's better for anonymity.
-                Recipients = recipients,
-                CacheSecret = false
+                Recipients = recipients
             };
 
             // Set fee type for transaction build context.

--- a/src/Stratis.Bitcoin.Features.Wallet/WalletTransactionHandler.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/WalletTransactionHandler.cs
@@ -240,7 +240,7 @@ namespace Stratis.Bitcoin.Features.Wallet
                 return;
 
             Wallet wallet = this.walletManager.GetWallet(context.AccountReference.WalletName);
-            ExtKey seedExtKey = this.walletManager.GetExtKey(context.AccountReference, context.WalletPassword, context.CacheSecret);
+            ExtKey seedExtKey = this.walletManager.GetExtKey(context.AccountReference, context.WalletPassword);
 
             var signingKeys = new HashSet<ISecret>();
             Dictionary<OutPoint,UnspentOutputReference> outpointLookup = context.UnspentOutputs.ToDictionary(o => o.ToOutPoint(), o => o);
@@ -437,7 +437,6 @@ namespace Stratis.Bitcoin.Features.Wallet
             this.SelectedInputs = new List<OutPoint>();
             this.AllowOtherInputs = false;
             this.Sign = true;
-            this.CacheSecret = true;
         }
 
         /// <summary>
@@ -533,11 +532,6 @@ namespace Stratis.Bitcoin.Features.Wallet
         /// Whether the transaction should be signed or not.
         /// </summary>
         public bool Sign { get; set; }
-
-        /// <summary>
-        /// Whether the secret should be cached for 5 mins after it is used or not.
-        /// </summary>
-        public bool CacheSecret { get; set; }
 
         /// <summary>
         /// The timestamp to set on the transaction.


### PR DESCRIPTION
For https://stratisplatformuk.visualstudio.com/StratisBitcoinFullNode/_boards/board/t/StratisBitcoinFullNode%20Team/Stories/?workitem=4529

This code was nonsensical. The API calls that forwarded here required a password, but also cached secrets by default. So for the next 5 minutes it required a password and then did no validation on it. Incorrect passwords would still pass as correct.

I would rather remove this code so there is no ambiguity about the current functionality. Every operation requires a correct password.

At the point in the future when we might want to keep the wallet alive, we can do it correctly.