### PR TITLE
Correct query for spendable balance

### DIFF
--- a/src/Stratis.Bitcoin.IntegrationTests/Wallet/WalletOperationsTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/Wallet/WalletOperationsTests.cs
@@ -991,6 +991,10 @@ namespace Stratis.Bitcoin.IntegrationTests.Wallet
         [Fact]
         public async Task FundsReceivedByAddressAsync()
         {
+            // TODO: These tests are all in the situation where the wallet is ahead of the ChainIndexer.
+            // They don't make much sense. How could the chain be at height 0 but we have new "Money(10150100000000)" Confirmed???
+            // The tests should be checking a real situation, like where the wallet is at block N and the ChainIndexer is also at block N (or higher).
+
             // Arrange.
             string address = "TRCT9QP3ipb6zCvW15yKoEtaU418UaKVE2";
 
@@ -1005,9 +1009,8 @@ namespace Stratis.Bitcoin.IntegrationTests.Wallet
             addressBalance.AmountConfirmed.Should().Be(new Money(10150100000000));
             addressBalance.AmountUnconfirmed.Should().Be(Money.Zero);
 
-            // The spendable amount will be 0 as the prebuilt wallet transaction adds the transaction at height 36
-            // whilst the chain indexer is 0.
-            addressBalance.SpendableAmount.Should().Be(new Money(0));
+            // The total that we have received to this address, apart from coinbases/staking which require maturity.
+            addressBalance.SpendableAmount.Should().Be(new Money(1500, MoneyUnit.BTC));
         }
 
         [Fact]

--- a/src/Stratis.Bitcoin.IntegrationTests/Wallet/WalletTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/Wallet/WalletTests.cs
@@ -64,6 +64,14 @@ namespace Stratis.Bitcoin.IntegrationTests.Wallet
 
                 long receivetotal = stratisReceiver.FullNode.WalletManager().GetSpendableTransactionsInWallet(WalletName).Sum(s => s.Transaction.Amount);
                 Assert.Equal(Money.COIN * 100, receivetotal);
+
+                // Check that on the sending node, the Spendable Balance includes unconfirmed transactions.
+                // The transaction will have consumed 3 outputs, leaving us 3, and will also return us some as change.
+                // Change is always the First output because Shuffle is false!
+                Money expectedSenderSpendableBalance = Money.COIN * 3 * 50 + trx.Outputs.First().Value; 
+                AccountBalance senderBalance = stratisSender.FullNode.WalletManager().GetBalances(WalletName).First();
+                Assert.Equal(expectedSenderSpendableBalance, senderBalance.SpendableAmount);
+
                 Assert.Null(stratisReceiver.FullNode.WalletManager().GetSpendableTransactionsInWallet(WalletName).First().Transaction.BlockHeight);
 
                 // Generate two new blocks so the transaction is confirmed

--- a/src/Stratis.Features.SQLiteWalletRepository/Tables/HDTransactionData.cs
+++ b/src/Stratis.Features.SQLiteWalletRepository/Tables/HDTransactionData.cs
@@ -141,9 +141,16 @@ namespace Stratis.Features.SQLiteWalletRepository.Tables
             string strMaxConfirmationHeight = DBParameter.Create(maxConfirmationHeight);
             string strMaxCoinBaseHeight = DBParameter.Create(maxCoinBaseHeight);
 
+            // If confirmations is 0, then we want no restrictions on the max confirmation height. Even NULL height is allowed. (aka unconfirmed).
+            // IF confirmations is 1 or more, then we don't want NULL height and the restriction should be applied.
+            string confirmationsQuery = confirmations == 0
+                                        ? ""
+                                        : $"OutputBlockHeight <= {strMaxConfirmationHeight} AND ";
+
             var balanceData = conn.FindWithQuery<BalanceData>($@"
                 SELECT SUM(Value) TotalBalance
-                ,      SUM(CASE WHEN OutputBlockHeight <= {strMaxConfirmationHeight} AND (OutputTxIsCoinBase = 0 OR OutputBlockHeight <= {strMaxCoinBaseHeight}) THEN Value ELSE 0 END) SpendableBalance
+                ,      SUM(CASE WHEN {confirmationsQuery} (OutputTxIsCoinBase = 0 OR OutputBlockHeight <= {strMaxCoinBaseHeight})
+                       THEN Value ELSE 0 END) SpendableBalance
                 ,      SUM(CASE WHEN OutputBlockHeight IS NOT NULL THEN Value ELSE 0 END) ConfirmedBalance
                 FROM   HDTransactionData
                 WHERE  (WalletId, AccountIndex) IN (SELECT {strWalletId}, {strAccountIndex})


### PR DESCRIPTION
Fixes https://stratisplatformuk.visualstudio.com/StratisBitcoinFullNode/_boards/board/t/StratisBitcoinFullNode%20Team/Stories/?workitem=4553

The added check to the WalletTest, the 2nd file, fails before this change. Passes after.