### PR TITLE
[RPC] Fix for decode rpc

### DIFF
--- a/src/Stratis.Bitcoin.Features.RPC/RPCMiddleware.cs
+++ b/src/Stratis.Bitcoin.Features.RPC/RPCMiddleware.cs
@@ -107,10 +107,11 @@ namespace Stratis.Bitcoin.Features.RPC
             request.EnableRewind();
 
             // Read the request.
-            byte[] requestBuffer = new byte[request.ContentLength.Value];
-            await request.Body.ReadAsync(requestBuffer, 0, requestBuffer.Length).ConfigureAwait(false);
-
-            string requestBody = Encoding.UTF8.GetString(requestBuffer);
+            string requestBody;
+            using (var reader = new StreamReader(request.Body))
+            {
+                requestBody = await reader.ReadToEndAsync().ConfigureAwait(false);
+            }
 
             request.Body.Position = 0;
 

--- a/src/Stratis.Bitcoin.Features.RPC/RPCMiddleware.cs
+++ b/src/Stratis.Bitcoin.Features.RPC/RPCMiddleware.cs
@@ -12,7 +12,6 @@ using NBitcoin.DataEncoders;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Stratis.Bitcoin.Configuration;
-using Stratis.Bitcoin.Consensus;
 using Stratis.Bitcoin.Features.RPC.Exceptions;
 using Stratis.Bitcoin.Utilities;
 using TracerAttributes;


### PR DESCRIPTION
This is the fix for large request body which is getting truncated during the read.

Issue is that for large streams `Body.ReadAsync` reads request in chunks and returns the number of remaining bytes, which we are not utilizing. We need to wrap reading in a while loop and keep reading until we have no bytes remaining.