### PR TITLE
Fix for immature coin balance (#4051)

### DIFF
--- a/src/Stratis.Bitcoin.Features.Miner.Tests/PosMintingTest.cs
+++ b/src/Stratis.Bitcoin.Features.Miner.Tests/PosMintingTest.cs
@@ -569,11 +569,7 @@ namespace Stratis.Bitcoin.Features.Miner.Tests
             utxoDescription.UtxoSet.SetPrivatePropertyValue("Time", chainTip.Header.Time);
             utxoDescription.UtxoSet.SetPrivatePropertyValue("IsCoinstake", isCoinstake);
 
-            // Only add the UTXO if it would have been selected by the "GetSpendable*" methods.
-            int requiredDepth = ((PosConsensusOptions)this.network.Consensus.Options).GetStakeMinConfirmations(chainTip.Height + 1, this.network) - 1;
-            int depth =  chainTip.Height + 1- this.chainIndexer.GetHeader(utxoDescription.HashBlock).Height;
-            if (depth >= requiredDepth)
-                descriptions.Add(utxoDescription);
+            descriptions.Add(utxoDescription);
 
             List<UtxoStakeDescription> suitableCoins = miner.GetUtxoStakeDescriptionsSuitableForStakingAsync(descriptions, chainTip, chainTip.Header.Time + 64, long.MaxValue).GetAwaiter().GetResult();
             return suitableCoins.Count == 1;

--- a/src/Stratis.Bitcoin.Features.Miner.Tests/PosMintingTest.cs
+++ b/src/Stratis.Bitcoin.Features.Miner.Tests/PosMintingTest.cs
@@ -428,9 +428,8 @@ namespace Stratis.Bitcoin.Features.Miner.Tests
         [Fact]
         public void CoinstakeAge_BeforeActivation_Testnet()
         {
-            Assert.True(this.WasUtxoSelectedForStaking(KnownNetworks.StratisTest, 1000, 1000 - 8)); // utxo depth is 9, mining block at 10
-
-            Assert.False(this.WasUtxoSelectedForStaking(KnownNetworks.StratisTest, 1000, 1000 - 7)); // utxo depth is 8, mining block at 9
+            Assert.True(this.WasUtxoSelectedForStaking(KnownNetworks.StratisTest, 1000, 1000 - 8, false)); // utxo depth is 9, mining block at 10
+            Assert.False(this.WasUtxoSelectedForStaking(KnownNetworks.StratisTest, 1000, 1000 - 7, false)); // utxo depth is 8, mining block at 9
         }
 
         /// <summary>This is a test of coinstake age softfork activation on testnet.</summary>
@@ -441,9 +440,8 @@ namespace Stratis.Bitcoin.Features.Miner.Tests
             int activationHeight = PosConsensusOptions.CoinstakeMinConfirmationActivationHeightTestnet;
             int afterActivationHeight = activationHeight + 1000;
 
-            Assert.True(this.WasUtxoSelectedForStaking(KnownNetworks.StratisTest, afterActivationHeight, afterActivationHeight - 18));
-
-            Assert.False(this.WasUtxoSelectedForStaking(KnownNetworks.StratisTest, afterActivationHeight, afterActivationHeight - 17));
+            Assert.True(this.WasUtxoSelectedForStaking(KnownNetworks.StratisTest, afterActivationHeight, afterActivationHeight - 18, false));
+            Assert.False(this.WasUtxoSelectedForStaking(KnownNetworks.StratisTest, afterActivationHeight, afterActivationHeight - 17, false));
         }
 
         /// <summary>This is a test of coinstake age softfork activation on testnet.</summary>
@@ -453,11 +451,9 @@ namespace Stratis.Bitcoin.Features.Miner.Tests
         {
             int activationHeight = PosConsensusOptions.CoinstakeMinConfirmationActivationHeightTestnet;
 
-            Assert.True(this.WasUtxoSelectedForStaking(KnownNetworks.StratisTest, activationHeight - 2, activationHeight - 10)); // mining block before activation
-
-            Assert.True(this.WasUtxoSelectedForStaking(KnownNetworks.StratisTest, activationHeight - 1, activationHeight - 19)); // mining activation block
-
-            Assert.False(this.WasUtxoSelectedForStaking(KnownNetworks.StratisTest, activationHeight - 1, activationHeight - 18)); // mining activation block
+            Assert.True(this.WasUtxoSelectedForStaking(KnownNetworks.StratisTest, activationHeight - 2, activationHeight - 10, false)); // mining block before activation
+            Assert.True(this.WasUtxoSelectedForStaking(KnownNetworks.StratisTest, activationHeight - 1, activationHeight - 19, false)); // mining activation block
+            Assert.False(this.WasUtxoSelectedForStaking(KnownNetworks.StratisTest, activationHeight - 1, activationHeight - 18, false)); // mining activation block
         }
 
         /// <summary>This is a test of coinstake age softfork activation on mainnet.</summary>
@@ -465,9 +461,8 @@ namespace Stratis.Bitcoin.Features.Miner.Tests
         [Fact]
         public void CoinstakeAge_BeforeActivation_Mainnet()
         {
-            Assert.True(this.WasUtxoSelectedForStaking(KnownNetworks.StratisMain, 1000, 1000 - 48)); // utxo depth is 49, mining block at 50
-
-            Assert.False(this.WasUtxoSelectedForStaking(KnownNetworks.StratisMain, 1000, 1000 - 47)); // utxo depth is 48, mining block at 49
+            Assert.True(this.WasUtxoSelectedForStaking(KnownNetworks.StratisMain, 1000, 1000 - 48, false)); // utxo depth is 49, mining block at 50
+            Assert.False(this.WasUtxoSelectedForStaking(KnownNetworks.StratisMain, 1000, 1000 - 47, false)); // utxo depth is 48, mining block at 49
         }
 
         /// <summary>This is a test of coinstake age softfork activation on mainnet.</summary>
@@ -478,26 +473,78 @@ namespace Stratis.Bitcoin.Features.Miner.Tests
             int activationHeight = PosConsensusOptions.CoinstakeMinConfirmationActivationHeightMainnet;
             int afterActivationHeight = activationHeight + 1000;
 
-            Assert.True(this.WasUtxoSelectedForStaking(KnownNetworks.StratisMain, afterActivationHeight, afterActivationHeight - 498));
+            Assert.True(this.WasUtxoSelectedForStaking(KnownNetworks.StratisMain, afterActivationHeight, afterActivationHeight - 498, false));
+            Assert.False(this.WasUtxoSelectedForStaking(KnownNetworks.StratisMain, afterActivationHeight, afterActivationHeight - 497, false));
+        }
 
-            Assert.False(this.WasUtxoSelectedForStaking(KnownNetworks.StratisMain, afterActivationHeight, afterActivationHeight - 497));
+        [Fact]
+        public void CoinstakeAge_PrevOutIsCoinstake_BeforeActivation_Testnet()
+        {
+            Assert.True(this.WasUtxoSelectedForStaking(KnownNetworks.StratisTest, 1000, 1000 - 8, true)); // utxo depth is 9, mining block at 10
+            Assert.False(this.WasUtxoSelectedForStaking(KnownNetworks.StratisTest, 1000, 1000 - 7, true)); // utxo depth is 8, mining block at 9
+        }
+
+        /// <summary>This is a test of coinstake age softfork activation on testnet.</summary>
+        /// <remarks><see cref="PosConsensusOptions.GetStakeMinConfirmations"/></remarks>
+        [Fact]
+        public void CoinstakeAge_PrevOutIsCoinstake_AfterActivation_Testnet()
+        {
+            int activationHeight = PosConsensusOptions.CoinstakeMinConfirmationActivationHeightTestnet;
+            int afterActivationHeight = activationHeight + 1000;
+
+            Assert.True(this.WasUtxoSelectedForStaking(KnownNetworks.StratisTest, afterActivationHeight, afterActivationHeight - 18, true));
+            Assert.False(this.WasUtxoSelectedForStaking(KnownNetworks.StratisTest, afterActivationHeight, afterActivationHeight - 17, true));
+        }
+
+        /// <summary>This is a test of coinstake age softfork activation on testnet.</summary>
+        /// <remarks><see cref="PosConsensusOptions.GetStakeMinConfirmations"/></remarks>
+        [Fact]
+        public void CoinstakeAge_PrevOutIsCoinstake_AtTheActivation_Testnet()
+        {
+            int activationHeight = PosConsensusOptions.CoinstakeMinConfirmationActivationHeightTestnet;
+
+            Assert.True(this.WasUtxoSelectedForStaking(KnownNetworks.StratisTest, activationHeight - 2, activationHeight - 10, true)); // mining block before activation
+            Assert.True(this.WasUtxoSelectedForStaking(KnownNetworks.StratisTest, activationHeight - 1, activationHeight - 19, true)); // mining activation block
+            Assert.False(this.WasUtxoSelectedForStaking(KnownNetworks.StratisTest, activationHeight - 1, activationHeight - 18, true)); // mining activation block
         }
 
         /// <summary>This is a test of coinstake age softfork activation on mainnet.</summary>
         /// <remarks><see cref="PosConsensusOptions.GetStakeMinConfirmations"/></remarks>
         [Fact]
-        public void CoinstakeAge_AtTheActivation_Mainnet()
+        public void CoinstakeAge_PrevOutIsCoinstake_BeforeActivation_Mainnet()
+        {
+            // The logic here is that, before the activation, a coinstake UTXO requires 50 confirmations on mainnet to be used as a staking candidate.
+            // So if the chain tip is 1000, and the UTXO height is (1000 - 48) = 952, it currently has depth 49.
+            // Therefore a newly staked block using this UTXO would have precisely 50 confirmations.
+            Assert.True(this.WasUtxoSelectedForStaking(KnownNetworks.StratisMain, 1000, 1000 - 48, true)); // utxo depth is 49, mining block at 50
+            Assert.False(this.WasUtxoSelectedForStaking(KnownNetworks.StratisMain, 1000, 1000 - 47, true)); // utxo depth is 48, mining block at 49
+        }
+
+        /// <summary>This is a test of coinstake age softfork activation on mainnet.</summary>
+        /// <remarks><see cref="PosConsensusOptions.GetStakeMinConfirmations"/></remarks>
+        [Fact]
+        public void CoinstakeAge_PrevOutIsCoinstake_AfterActivation_Mainnet()
+        {
+            int activationHeight = PosConsensusOptions.CoinstakeMinConfirmationActivationHeightMainnet;
+            int afterActivationHeight = activationHeight + 1000;
+
+            Assert.True(this.WasUtxoSelectedForStaking(KnownNetworks.StratisMain, afterActivationHeight, afterActivationHeight - 498, true));
+            Assert.False(this.WasUtxoSelectedForStaking(KnownNetworks.StratisMain, afterActivationHeight, afterActivationHeight - 497, true));
+        }
+
+        /// <summary>This is a test of coinstake age softfork activation on mainnet.</summary>
+        /// <remarks><see cref="PosConsensusOptions.GetStakeMinConfirmations"/></remarks>
+        [Fact]
+        public void CoinstakeAge_PrevOutIsCoinstake_AtTheActivation_Mainnet()
         {
             int activationHeight = PosConsensusOptions.CoinstakeMinConfirmationActivationHeightMainnet;
 
-            Assert.True(this.WasUtxoSelectedForStaking(KnownNetworks.StratisMain, activationHeight - 2, activationHeight - 50)); // mining block before activation
-
-            Assert.True(this.WasUtxoSelectedForStaking(KnownNetworks.StratisMain, activationHeight - 1, activationHeight - 499)); // mining activation block
-
-            Assert.False(this.WasUtxoSelectedForStaking(KnownNetworks.StratisMain, activationHeight - 1, activationHeight - 498)); // mining activation block
+            Assert.True(this.WasUtxoSelectedForStaking(KnownNetworks.StratisMain, activationHeight - 2, activationHeight - 50, true)); // mining block before activation
+            Assert.True(this.WasUtxoSelectedForStaking(KnownNetworks.StratisMain, activationHeight - 1, activationHeight - 499, true)); // mining activation block
+            Assert.False(this.WasUtxoSelectedForStaking(KnownNetworks.StratisMain, activationHeight - 1, activationHeight - 498, true)); // mining activation block
         }
 
-        private bool WasUtxoSelectedForStaking(Network network, int chainTipHeight, int utxoHeight)
+        private bool WasUtxoSelectedForStaking(Network network, int chainTipHeight, int utxoHeight, bool isCoinstake)
         {
             this.network = network;
             this.network.Consensus.Options = new PosConsensusOptions();
@@ -511,13 +558,16 @@ namespace Stratis.Bitcoin.Features.Miner.Tests
 
             var descriptions = new List<UtxoStakeDescription>();
 
-            var utxoDescription = new UtxoStakeDescription();
-            utxoDescription.TxOut = new TxOut(new Money(100), new Mock<IDestination>().Object);
-            utxoDescription.OutPoint = new OutPoint(uint256.One, 0);
-            utxoDescription.HashBlock = chainTip.Previous.HashBlock;
+            var utxoDescription = new UtxoStakeDescription
+            {
+                TxOut = new TxOut(new Money(100), new Mock<IDestination>().Object),
+                OutPoint = new OutPoint(uint256.One, 0),
+                HashBlock = chainTip.Previous.HashBlock,
+                UtxoSet = new UnspentOutputs()
+            };
 
-            utxoDescription.UtxoSet = new UnspentOutputs();
             utxoDescription.UtxoSet.SetPrivatePropertyValue("Time", chainTip.Header.Time);
+            utxoDescription.UtxoSet.SetPrivatePropertyValue("IsCoinstake", isCoinstake);
 
             // Only add the UTXO if it would have been selected by the "GetSpendable*" methods.
             int requiredDepth = ((PosConsensusOptions)this.network.Consensus.Options).GetStakeMinConfirmations(chainTip.Height + 1, this.network) - 1;

--- a/src/Stratis.Bitcoin.Features.Miner/Staking/PosMinting.cs
+++ b/src/Stratis.Bitcoin.Features.Miner/Staking/PosMinting.cs
@@ -872,7 +872,7 @@ namespace Stratis.Bitcoin.Features.Miner.Staking
 
                             context.CoinstakeContext.CoinstakeTx.Outputs.Add(new TxOut(0, scriptPubKeyOut));
                             context.Result.KernelCoin = utxoStakeInfo;
-                            
+
                             context.Logger.LogDebug("Kernel accepted, coinstake input is '{0}', stopping work.", prevoutStake);
                         }
                         else context.Logger.LogDebug("Kernel found, but worker #{0} announced its kernel earlier, stopping work.", context.Result.KernelFoundIndex);
@@ -977,6 +977,12 @@ namespace Stratis.Bitcoin.Features.Miner.Staking
                 if (depth < 1)
                 {
                     this.logger.LogDebug("UTXO '{0}' is new or reorg happened.", utxoStakeDescription.OutPoint);
+                    continue;
+                }
+
+                if (depth < requiredDepth)
+                {
+                    this.logger.LogDebug("UTXO '{0}' depth {1} is lower than required minimum depth {2}.", utxoStakeDescription.OutPoint, depth, requiredDepth); this.logger.LogDebug("UTXO '{0}' depth {1} is lower than required minimum depth {2}.", utxoStakeDescription.OutPoint, depth, requiredDepth);
                     continue;
                 }
 

--- a/src/Stratis.Bitcoin.Features.Miner/Staking/PosMinting.cs
+++ b/src/Stratis.Bitcoin.Features.Miner/Staking/PosMinting.cs
@@ -596,7 +596,6 @@ namespace Stratis.Bitcoin.Features.Miner.Staking
             // Mark coinstake transaction.
             coinstakeContext.CoinstakeTx.Outputs.Add(new TxOut(Money.Zero, new Script()));
 
-            // TODO: Is the difference and duplication in logic between GetMatureBalanceAsync and GetStakeMinConfirmations acceptable?
             (Money balance, Money immature) = await this.GetMatureBalanceAsync(utxoStakeDescriptions).ConfigureAwait(false);
             this.rpcGetStakingInfoModel.Immature = immature.Satoshi;
 
@@ -962,9 +961,16 @@ namespace Stratis.Bitcoin.Features.Miner.Staking
             var res = new List<UtxoStakeDescription>();
 
             long currentValue = 0;
+            // Add 1 to chainTip because this is being called in the context of trying to create a new block, which will have height (chainTip + 1).
+            // Subtract 1 from the required depth, because if a UTXO is in a block with height == requiredDepth it already has 1 confirmation.
+            // e.g. consider a hypothetical chain with the coinstake age requirement = 5, a prospective UTXO at height 3 and a chainTip of 10.
+            // Taking (chainTip + 1) into account, the UTXO has ((10 + 1) - 3 + 1) = 9 confirmations, meaning it easily has sufficient depth.
+            // Now consider a different UTXO at height 7. This has (10 + 1) - 7 + 1) = 5 confirmations, meaning it just barely qualifies.
             long requiredDepth = ((PosConsensusOptions)this.network.Consensus.Options).GetStakeMinConfirmations(chainTip.Height + 1, this.network) - 1;
             foreach (UtxoStakeDescription utxoStakeDescription in utxoStakeDescriptions.OrderByDescending(x => x.TxOut.Value))
             {
+                // Internally GetDepthInMainChainAsync uses chainTip instead of (chainTip + 1). That is why there is a later comparison to
+                // (depth < requiredDepth) instead of (depth <= requiredDepth).
                 int depth = await this.GetDepthInMainChainAsync(utxoStakeDescription).ConfigureAwait(false);
                 this.logger.LogDebug("Checking if UTXO '{0}' value {1} can be added, its depth is {2}.", utxoStakeDescription.OutPoint, utxoStakeDescription.TxOut.Value, depth);
 
@@ -980,6 +986,9 @@ namespace Stratis.Bitcoin.Features.Miner.Staking
                     continue;
                 }
 
+                // Under normal circumstances this maturity check will not trigger, as the requiredDepth calculation will have already filtered out
+                // a coinbase/coinstake with insufficient confirmations. However, see the comments within the GetBlocksCountToMaturityAsync method
+                // for the rationale of why we perform this check anyway.
                 int toMaturity = await this.GetBlocksCountToMaturityAsync(utxoStakeDescription).ConfigureAwait(false);
                 if (toMaturity > 0)
                 {
@@ -1000,16 +1009,27 @@ namespace Stratis.Bitcoin.Features.Miner.Staking
         }
 
         /// <summary>
-        /// Calculates blocks count till UTXO is considered mature for staking.
+        /// Calculates the number of blocks until a coinbase or coinstake UTXO is considered mature for staking.
         /// </summary>
         /// <param name="utxoStakeDescription">The UTXO stake description.</param>
         /// <returns>How many blocks are left till UTXO is considered mature for staking.</returns>
+        /// <remarks>Do NOT use this for general-purpose maturity calculations outside of <see cref="PosMinting"/> as it will give off-by-one errors.
+        /// This method is making the assumption that we are adding a new block to the chain, and thus reduces the maturity threshold by 1.</remarks>
         private async Task<int> GetBlocksCountToMaturityAsync(UtxoStakeDescription utxoStakeDescription)
         {
+            // The concept of maturity only applies to coinbase and coinstake outputs, so normal outputs do not have this restriction.
             if (!(utxoStakeDescription.UtxoSet.IsCoinbase || utxoStakeDescription.UtxoSet.IsCoinstake))
                 return 0;
 
-            return Math.Max(0, (int)this.network.Consensus.CoinbaseMaturity + 1 - await this.GetDepthInMainChainAsync(utxoStakeDescription).ConfigureAwait(false));
+            // Using CoinbaseMaturity here is not strictly correct. Due to the ProvenHeaderCoinstakeRule enforcing a unilateral prevOut depth equivalent
+            // to maxReorg, a mature UTXO is not necessarily old enough for staking. However, the minter also separately filters out UTXOs younger than
+            // the minimum required depth in the GetUtxoStakeDescriptionsSuitableForStakingAsync method. So this method retains the CoinbaseMaturity
+            // constant so that it returns an intuitive result, in case there are alternate network definitions where the coinstake age requirement is
+            // less than the maturity.
+            int minConf = (int)this.network.Consensus.CoinbaseMaturity;
+
+            // The reason why we subtract 1 here is because any newly staked block will be at (chainTip + 1), effectively giving an extra confirmation over and above the depth calculation.
+            return Math.Max(0, minConf - 1 - await this.GetDepthInMainChainAsync(utxoStakeDescription).ConfigureAwait(false));
         }
 
         /// <summary>
@@ -1028,6 +1048,7 @@ namespace Stratis.Bitcoin.Features.Miner.Staking
             if (chainedBlock == null)
                 return await this.mempoolLock.ReadAsync(() => this.mempool.Exists(utxoStakeDescription.UtxoSet.TransactionId) ? 0 : -1).ConfigureAwait(false);
 
+            // Add 1 because a transaction is considered to have 1 confirmation when it is in a block.
             return this.chainIndexer.Tip.Height - chainedBlock.Height + 1;
         }
 


### PR DESCRIPTION
* Fix for immature coin balance

* Remove erroneous depth check

* Additional coinstake maturity tests

* Correct logic

* Comment clarification

Relates to https://stratisplatformuk.visualstudio.com/StratisBitcoinFullNode/_workitems/edit/4561/.