### PR TITLE
[SC] Fix for IO Exception

### DIFF
--- a/src/Stratis.Bitcoin.Features.BlockStore/BlockRepository.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/BlockRepository.cs
@@ -397,7 +397,7 @@ namespace Stratis.Bitcoin.Features.BlockStore
             // however we need to find how byte arrays are sorted in DBreeze.
             using (DBreeze.Transactions.Transaction transaction = this.DBreeze.GetTransaction())
             {
-                transaction.SynchronizeTables(BlockTableName, TransactionTableName);
+                transaction.SynchronizeTables(BlockTableName, TransactionTableName, CommonTableName);
                 this.OnInsertBlocks(transaction, blocks);
 
                 // Commit additions


### PR DESCRIPTION
Fix for `Could not save blocks to the block repository. Exiting due to 'Transaction commit failed on table "Common"!'`

We should synchronize all tables that are modified as part of the same transaction as per https://github.com/hhblaze/DBreeze/issues/15. Currently, we only sync `BlockTableName` and  `TransactionTableName` which can lead to IO exception. `SaveTipHashAndHeight` call modifies Common table and therefore should be added to a sync call.