### PR TITLE
[Consensus] Add ban time and ban reason to reconnect chain result.

### DIFF
--- a/src/Stratis.Bitcoin/Consensus/ConsensusManager.cs
+++ b/src/Stratis.Bitcoin/Consensus/ConsensusManager.cs
@@ -673,6 +673,11 @@ namespace Stratis.Bitcoin.Consensus
 
             // Add peers that needed to be banned as a result of a failure to connect blocks.
             // Otherwise they get lost as we are returning a different ConnnectBlocksResult.
+            // We also need to set the ban reason and ban time otherwise it is not known why
+            // connecting the new chain failed and hence why the peer is being disconnected in 
+            // peer banning.
+            reconnectionResult.BanReason = connectBlockResult.BanReason;
+            reconnectionResult.BanDurationSeconds = connectBlockResult.BanDurationSeconds;
             reconnectionResult.PeersToBan = connectBlockResult.PeersToBan;
 
             return reconnectionResult;


### PR DESCRIPTION
See the additional comment on the change.

This relates to situations where "unknown" ban reasons are shown in the logs.