### PR TITLE
Apply 3.0.8.0 wallet service patch

### DIFF
--- a/src/NBitcoin/BIP39/Mnemonic.cs
+++ b/src/NBitcoin/BIP39/Mnemonic.cs
@@ -70,6 +70,33 @@ namespace NBitcoin
         {
 
         }
+        
+        public Mnemonic(string language, WordCount wordCount)
+            : this(Mnemonic.GetWordListForLanguage(language), GenerateEntropy(wordCount))
+        {
+        }
+
+        private static Wordlist GetWordListForLanguage(string language)
+        {
+            switch (language.ToLowerInvariant())
+            {
+                case "english":
+                   return Wordlist.English;
+                case "french":
+                    return Wordlist.French;
+                case "spanish":
+                    return Wordlist.Spanish;
+                case "japanese":
+                    return Wordlist.Japanese;
+                case "chinesetraditional":
+                    return Wordlist.ChineseTraditional;
+                case "chinesesimplified":
+                    return Wordlist.ChineseSimplified;
+                default:
+                    throw new FormatException(
+                        $"Invalid language '{language}'. Choices are: English, French, Spanish, Japanese, ChineseSimplified and ChineseTraditional.");
+            }
+        }
 
         private static byte[] GenerateEntropy(WordCount wordCount)
         {

--- a/src/Stratis.Bitcoin.Features.SignalR/Broadcasters/CirrusWalletInfoBroadcaster.cs
+++ b/src/Stratis.Bitcoin.Features.SignalR/Broadcasters/CirrusWalletInfoBroadcaster.cs
@@ -1,10 +1,7 @@
 using Microsoft.Extensions.Logging;
-using NBitcoin;
 using Stratis.Bitcoin.AsyncWork;
-using Stratis.Bitcoin.Connection;
-using Stratis.Bitcoin.Features.Wallet.Interfaces;
+using Stratis.Bitcoin.Features.Wallet.Services;
 using Stratis.Bitcoin.Utilities;
-using Stratis.Bitcoin.Consensus;
 
 namespace Stratis.Bitcoin.Features.SignalR.Broadcasters
 {
@@ -15,15 +12,11 @@ namespace Stratis.Bitcoin.Features.SignalR.Broadcasters
     {
         public CirrusWalletInfoBroadcaster(
             ILoggerFactory loggerFactory,
-            IWalletManager walletManager,
-            IConsensusManager consensusManager,
-            IConnectionManager connectionManager,
+            IWalletService walletService,
             IAsyncProvider asyncProvider,
             INodeLifetime nodeLifetime,
-            ChainIndexer chainIndexer,
             EventsHub eventsHub)
-            : base(loggerFactory, walletManager, consensusManager, connectionManager, asyncProvider, nodeLifetime,
-                chainIndexer, eventsHub, true)
+            : base(loggerFactory, walletService, asyncProvider, nodeLifetime, eventsHub, true)
         {
         }
     }

--- a/src/Stratis.Bitcoin.Features.SignalR/Broadcasters/StakingBroadcaster.cs
+++ b/src/Stratis.Bitcoin.Features.SignalR/Broadcasters/StakingBroadcaster.cs
@@ -1,4 +1,6 @@
 using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Stratis.Bitcoin.AsyncWork;
 using Stratis.Bitcoin.Features.Miner.Interfaces;
@@ -25,12 +27,15 @@ namespace Stratis.Bitcoin.Features.SignalR.Broadcasters
             this.posMinting = posMinting;
         }
 
-        protected override IEnumerable<IClientEvent> GetMessages()
+        protected override Task<IEnumerable<IClientEvent>> GetMessages(CancellationToken cancellationToken)
         {
             if (null != this.posMinting)
             {
-                yield return new StakingInfoClientEvent(this.posMinting.GetGetStakingInfoModel());
+                return Task.FromResult<IEnumerable<IClientEvent>>(new[]
+                    {(IClientEvent) new StakingInfoClientEvent(this.posMinting.GetGetStakingInfoModel())});
             }
+
+            return Task.FromResult((IEnumerable<IClientEvent>)new IClientEvent[0]);
         }
     }
 }

--- a/src/Stratis.Bitcoin.Features.SignalR/Events/WalletGeneralInfoClientEvent.cs
+++ b/src/Stratis.Bitcoin.Features.SignalR/Events/WalletGeneralInfoClientEvent.cs
@@ -14,6 +14,17 @@ namespace Stratis.Bitcoin.Features.SignalR.Events
 
     public class WalletGeneralInfoClientEvent : WalletGeneralInfoModel, IClientEvent
     {
+        public WalletGeneralInfoClientEvent(WalletGeneralInfoModel generalInfoModel)
+        {
+            this.WalletName = generalInfoModel.WalletName;
+            this.Network = generalInfoModel.Network;
+            this.ChainTip = generalInfoModel.ChainTip;
+            this.ConnectedNodes = generalInfoModel.ConnectedNodes;
+            this.CreationTime = generalInfoModel.CreationTime;
+            this.IsDecrypted = generalInfoModel.IsDecrypted;
+            this.IsChainSynced = generalInfoModel.IsChainSynced;
+            this.LastBlockSyncedHeight = generalInfoModel.LastBlockSyncedHeight;
+        }
         public Type NodeEventType => typeof(WalletGeneralInfo);
         
         public IEnumerable<AccountBalanceModel> AccountsBalances { get; set; }

--- a/src/Stratis.Bitcoin.Features.SignalR/EventsHub.cs
+++ b/src/Stratis.Bitcoin.Features.SignalR/EventsHub.cs
@@ -1,12 +1,29 @@
 using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.Logging;
 
 namespace Stratis.Bitcoin.Features.SignalR
 {
+    // ReSharper disable once ClassNeverInstantiated.Global
+    public class SignalRMessageArgs
+    {
+        public string Target { get; set; }
+        public Dictionary<string, string> Args { get; set; }
+
+        public string GetValue(string key)
+        {
+            return this.Args.ContainsKey(key) ? this.Args[key] : null;
+        }
+    }
+
     public class EventsHub : Hub
     {
+        private readonly IDictionary<string, List<Action<SignalRMessageArgs>>> featureSubscriptions
+            = new ConcurrentDictionary<string, List<Action<SignalRMessageArgs>>>(StringComparer.OrdinalIgnoreCase);
+
         private readonly ILogger<EventsHub> logger;
 
         public EventsHub(ILoggerFactory loggerFactory)
@@ -24,6 +41,44 @@ namespace Stratis.Bitcoin.Features.SignalR
         {
             this.logger.LogDebug("Client with id {id} disconnected", this.Context.ConnectionId);
             return base.OnDisconnectedAsync(exception);
+        }
+
+        /// <summary>Called using reflection from SignalR</summary> 
+        // ReSharper disable once UnusedMember.Global
+        public void SendMessage(SignalRMessageArgs message)
+        {
+            try
+            {
+                if (this.featureSubscriptions.ContainsKey(message.Target))
+                {
+                    this.featureSubscriptions[message.Target].ForEach(featureSubscription =>
+                    {
+                        featureSubscription.Invoke(message);
+                    });
+                }
+            }
+            catch (Exception e)
+            {
+                this.logger.LogError("Error SendMessage", e);
+            }
+        }
+
+        public void SubscribeToIncomingSignalRMessages(string target, Action<SignalRMessageArgs> subscription)
+        {
+            if (!this.featureSubscriptions.ContainsKey(target))
+            {
+                this.featureSubscriptions.TryAdd(target, new List<Action<SignalRMessageArgs>>());
+            }
+
+            this.featureSubscriptions[target].Add(subscription);
+        }
+
+        public void UnSubscribeToIncomingSignalRMessages(string target)
+        {
+            if (this.featureSubscriptions.ContainsKey(target))
+            {
+                this.featureSubscriptions.Remove(target);
+            }
         }
 
         public async Task SendToClientsAsync(IClientEvent @event)

--- a/src/Stratis.Bitcoin.Features.SignalR/Startup.cs
+++ b/src/Stratis.Bitcoin.Features.SignalR/Startup.cs
@@ -19,7 +19,7 @@ namespace Stratis.Bitcoin.Features.SignalR
                         "CorsPolicy",
                         builder =>
                         {
-                            var allowedDomains = new[] {"http://localhost", "http://localhost:4200"};
+                            var allowedDomains = new[] { "http://localhost", "http://localhost:4200" };
 
                             builder
                                 .WithOrigins(allowedDomains)

--- a/src/Stratis.Bitcoin.Features.SmartContracts/Wallet/SmartContractWalletFeature.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts/Wallet/SmartContractWalletFeature.cs
@@ -12,6 +12,7 @@ using Stratis.Bitcoin.Connection;
 using Stratis.Bitcoin.Features.Wallet;
 using Stratis.Bitcoin.Features.Wallet.Broadcasting;
 using Stratis.Bitcoin.Features.Wallet.Interfaces;
+using Stratis.Bitcoin.Features.Wallet.Services;
 using Stratis.Bitcoin.Utilities;
 
 namespace Stratis.Bitcoin.Features.SmartContracts.Wallet
@@ -134,6 +135,7 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Wallet
                     services.AddSingleton<BroadcasterBehavior>();
                     services.AddSingleton<WalletSettings>();
                     services.AddSingleton<IAddressBookManager, AddressBookManager>();
+                    services.AddSingleton<IWalletService, WalletService>();
 
                     services.AddTransient<WalletRPCController>();
                 });

--- a/src/Stratis.Bitcoin.Features.Wallet.Tests/Stratis.Bitcoin.Features.Wallet.Tests.csproj
+++ b/src/Stratis.Bitcoin.Features.Wallet.Tests/Stratis.Bitcoin.Features.Wallet.Tests.csproj
@@ -30,6 +30,8 @@
     <PackageReference Include="DBreeze" Version="1.89.0" />
     <PackageReference Include="FluentAssertions" Version="5.5.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
+    <PackageReference Include="Moq" Version="4.9.0" />
+    <PackageReference Include="Moq.AutoMock" Version="1.2.0.120" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/src/Stratis.Bitcoin.Features.Wallet.Tests/TestReadOnlyNetworkPeerCollection.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet.Tests/TestReadOnlyNetworkPeerCollection.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using Stratis.Bitcoin.P2P.Peer;
+
+namespace Stratis.Bitcoin.Features.Wallet.Tests
+{
+    public class TestReadOnlyNetworkPeerCollection : IReadOnlyNetworkPeerCollection
+    {
+        public event EventHandler<NetworkPeerEventArgs> Added;
+        public event EventHandler<NetworkPeerEventArgs> Removed;
+
+        private List<INetworkPeer> networkPeers;
+
+        public TestReadOnlyNetworkPeerCollection()
+        {
+            this.Added = new EventHandler<NetworkPeerEventArgs>((obj, eventArgs) => { });
+            this.Removed = new EventHandler<NetworkPeerEventArgs>((obj, eventArgs) => { });
+            this.networkPeers = new List<INetworkPeer>();
+        }
+
+        public TestReadOnlyNetworkPeerCollection(List<INetworkPeer> peers)
+        {
+            this.Added = new EventHandler<NetworkPeerEventArgs>((obj, eventArgs) => { });
+            this.Removed = new EventHandler<NetworkPeerEventArgs>((obj, eventArgs) => { });
+            this.networkPeers = peers;
+        }
+
+        public INetworkPeer FindByEndpoint(IPEndPoint endpoint)
+        {
+            return null;
+        }
+
+        public List<INetworkPeer> FindByIp(IPAddress ip)
+        {
+            return null;
+        }
+
+        public INetworkPeer FindLocal()
+        {
+            return null;
+        }
+
+        public IEnumerator<INetworkPeer> GetEnumerator()
+        {
+            return this.networkPeers.GetEnumerator();
+        }
+
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
+        {
+            return this.GetEnumerator();
+        }
+    }
+}

--- a/src/Stratis.Bitcoin.Features.Wallet.Tests/WalletControllerTest.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet.Tests/WalletControllerTest.cs
@@ -3,15 +3,21 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net;
+using System.Reflection;
 using System.Security;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
 using Moq;
+using Moq.AutoMock;
 using NBitcoin;
 using Stratis.Bitcoin.Connection;
+using Stratis.Bitcoin.Consensus;
 using Stratis.Bitcoin.Features.Wallet.Broadcasting;
 using Stratis.Bitcoin.Features.Wallet.Controllers;
 using Stratis.Bitcoin.Features.Wallet.Interfaces;
 using Stratis.Bitcoin.Features.Wallet.Models;
+using Stratis.Bitcoin.Features.Wallet.Services;
 using Stratis.Bitcoin.P2P.Peer;
 using Stratis.Bitcoin.Tests.Common;
 using Stratis.Bitcoin.Tests.Common.Logging;
@@ -25,6 +31,15 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
     public class WalletControllerTest : LogsTestBase
     {
         private readonly ChainIndexer chainIndexer;
+        private static readonly IDictionary<string, PropertyInfo> WordLists;
+        private readonly Dictionary<Type, object> configuredMocks = new Dictionary<Type, object>();
+
+        static WalletControllerTest()
+        {
+            WordLists = typeof(Wordlist)
+                .GetProperties(BindingFlags.Public | BindingFlags.Static).Where(p => p.PropertyType == typeof(Wordlist))
+                .ToDictionary(p => p.Name, p => p, StringComparer.OrdinalIgnoreCase);
+        }
 
         public WalletControllerTest()
         {
@@ -32,31 +47,30 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
         }
 
         [Fact]
-        public void GenerateMnemonicWithoutParametersCreatesMnemonicWithDefaults()
+        public async Task GenerateMnemonicWithoutParametersCreatesMnemonicWithDefaults()
         {
-            var controller = new WalletController(this.LoggerFactory.Object, new Mock<IWalletManager>().Object, new Mock<IWalletTransactionHandler>().Object, new Mock<IWalletSyncManager>().Object, It.IsAny<ConnectionManager>(), this.Network, this.chainIndexer, new Mock<IBroadcasterManager>().Object, DateTimeProvider.Default);
+            var controller = this.GetWalletController();
 
-            IActionResult result = controller.GenerateMnemonic();
+            IActionResult result = await controller.GenerateMnemonic();
 
             var viewResult = Assert.IsType<JsonResult>(result);
 
             string[] resultingWords = (viewResult.Value as string).Split(' ');
 
             Assert.Equal(12, resultingWords.Length);
-            
+
             foreach (string word in resultingWords)
             {
-                int index = -1;
-                Assert.True(Wordlist.English.WordExists(word, out index));
+                Assert.True(Wordlist.English.WordExists(word, out int _));
             }
         }
 
         [Fact]
-        public void GenerateMnemonicWithDifferentWordCountCreatesMnemonicWithCorrectNumberOfWords()
+        public async Task GenerateMnemonicWithDifferentWordCountCreatesMnemonicWithCorrectNumberOfWords()
         {
-            var controller = new WalletController(this.LoggerFactory.Object, new Mock<IWalletManager>().Object, new Mock<IWalletTransactionHandler>().Object, new Mock<IWalletSyncManager>().Object, It.IsAny<ConnectionManager>(), this.Network, this.chainIndexer, new Mock<IBroadcasterManager>().Object, DateTimeProvider.Default);
+            var controller = this.GetWalletController();
 
-            IActionResult result = controller.GenerateMnemonic(wordCount: 24);
+            IActionResult result = await controller.GenerateMnemonic(wordCount: 24);
 
             var viewResult = Assert.IsType<JsonResult>(result);
 
@@ -65,146 +79,37 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
             Assert.Equal(24, resultingWords.Length);
         }
 
-        [Fact]
-        public void GenerateMnemonicWithStrangeLanguageCasingReturnsCorrectMnemonic()
+        [Theory]
+        [InlineData("eNgLiSh", ' ')]
+        [InlineData("english", ' ')]
+        [InlineData("french", ' ')]
+        [InlineData("spanish", ' ')]
+        [InlineData("japanese", '　')]
+        [InlineData("chinesetraditional", ' ')]
+        [InlineData("chinesesimplified", ' ')]
+        public async Task GenerateMnemonicWithStrangeLanguageCasingReturnsCorrectMnemonic(string language,
+            char separator)
         {
-            var controller = new WalletController(this.LoggerFactory.Object, new Mock<IWalletManager>().Object, new Mock<IWalletTransactionHandler>().Object, new Mock<IWalletSyncManager>().Object, It.IsAny<ConnectionManager>(), this.Network, this.chainIndexer, new Mock<IBroadcasterManager>().Object, DateTimeProvider.Default);
+            var controller = this.GetWalletController();
+            var wordList = (Wordlist)WordLists[language].GetValue(null, null);
 
-            IActionResult result = controller.GenerateMnemonic("eNgLiSh");
+            IActionResult result = await controller.GenerateMnemonic(language);
 
             var viewResult = Assert.IsType<JsonResult>(result);
 
-            string[] resultingWords = (viewResult.Value as string).Split(' ');
+            string[] resultingWords = (viewResult.Value as string).Split(separator);
 
             Assert.Equal(12, resultingWords.Length);
-            foreach (string word in resultingWords)
-            {
-                int index = -1;
-                Assert.True(Wordlist.English.WordExists(word, out index));
-            }
+
+            Assert.True(resultingWords.All(word => wordList.WordExists(word, out int _)));
         }
 
         [Fact]
-        public void GenerateMnemonicWithEnglishWordListCreatesCorrectMnemonic()
+        public async Task GenerateMnemonicWithUnknownLanguageReturnsBadRequest()
         {
-            var controller = new WalletController(this.LoggerFactory.Object, new Mock<IWalletManager>().Object, new Mock<IWalletTransactionHandler>().Object, new Mock<IWalletSyncManager>().Object, It.IsAny<ConnectionManager>(), this.Network, this.chainIndexer, new Mock<IBroadcasterManager>().Object, DateTimeProvider.Default);
+            var controller = this.GetWalletController();
 
-            IActionResult result = controller.GenerateMnemonic("english");
-
-            var viewResult = Assert.IsType<JsonResult>(result);
-
-            string[] resultingWords = (viewResult.Value as string).Split(' ');
-
-            Assert.Equal(12, resultingWords.Length);
-            foreach (string word in resultingWords)
-            {
-                int index = -1;
-                Assert.True(Wordlist.English.WordExists(word, out index));
-            }
-        }
-
-        [Fact]
-        public void GenerateMnemonicWithFrenchWordListCreatesCorrectMnemonic()
-        {
-            var controller = new WalletController(this.LoggerFactory.Object, new Mock<IWalletManager>().Object, new Mock<IWalletTransactionHandler>().Object, new Mock<IWalletSyncManager>().Object, It.IsAny<ConnectionManager>(), this.Network, this.chainIndexer, new Mock<IBroadcasterManager>().Object, DateTimeProvider.Default);
-
-            IActionResult result = controller.GenerateMnemonic("french");
-
-            var viewResult = Assert.IsType<JsonResult>(result);
-
-            string[] resultingWords = (viewResult.Value as string).Split(' ');
-
-            Assert.Equal(12, resultingWords.Length);
-            foreach (string word in resultingWords)
-            {
-                int index = -1;
-                Assert.True(Wordlist.French.WordExists(word, out index));
-            }
-        }
-
-        [Fact]
-        public void GenerateMnemonicWithSpanishWordListCreatesCorrectMnemonic()
-        {
-            var controller = new WalletController(this.LoggerFactory.Object, new Mock<IWalletManager>().Object, new Mock<IWalletTransactionHandler>().Object, new Mock<IWalletSyncManager>().Object, It.IsAny<ConnectionManager>(), this.Network, this.chainIndexer, new Mock<IBroadcasterManager>().Object, DateTimeProvider.Default);
-
-            IActionResult result = controller.GenerateMnemonic("spanish");
-
-            var viewResult = Assert.IsType<JsonResult>(result);
-
-            string[] resultingWords = (viewResult.Value as string).Split(' ');
-
-            Assert.Equal(12, resultingWords.Length);
-            foreach (string word in resultingWords)
-            {
-                int index = -1;
-                Assert.True(Wordlist.Spanish.WordExists(word, out index));
-            }
-        }
-
-        [Fact]
-        public void GenerateMnemonicWithJapaneseWordListCreatesCorrectMnemonic()
-        {
-            var controller = new WalletController(this.LoggerFactory.Object, new Mock<IWalletManager>().Object, new Mock<IWalletTransactionHandler>().Object, new Mock<IWalletSyncManager>().Object, It.IsAny<ConnectionManager>(), this.Network, this.chainIndexer, new Mock<IBroadcasterManager>().Object, DateTimeProvider.Default);
-
-            IActionResult result = controller.GenerateMnemonic("japanese");
-
-            var viewResult = Assert.IsType<JsonResult>(result);
-
-            // japanese uses a JP space symbol.
-            string[] resultingWords = (viewResult.Value as string).Split('　');
-
-            Assert.Equal(12, resultingWords.Length);
-            foreach (string word in resultingWords)
-            {
-                int index = -1;
-                Assert.True(Wordlist.Japanese.WordExists(word, out index));
-            }
-        }
-
-        [Fact]
-        public void GenerateMnemonicWithChineseTraditionalWordListCreatesCorrectMnemonic()
-        {
-            var controller = new WalletController(this.LoggerFactory.Object, new Mock<IWalletManager>().Object, new Mock<IWalletTransactionHandler>().Object, new Mock<IWalletSyncManager>().Object, It.IsAny<ConnectionManager>(), this.Network, this.chainIndexer, new Mock<IBroadcasterManager>().Object, DateTimeProvider.Default);
-
-            IActionResult result = controller.GenerateMnemonic("chinesetraditional");
-
-            var viewResult = Assert.IsType<JsonResult>(result);
-
-            string[] resultingWords = (viewResult.Value as string).Split(' ');
-
-            Assert.Equal(12, resultingWords.Length);
-            foreach (string word in resultingWords)
-            {
-                int index = -1;
-                Assert.True(Wordlist.ChineseTraditional.WordExists(word, out index));
-            }
-        }
-
-        [Fact]
-        public void GenerateMnemonicWithChineseSimplifiedWordListCreatesCorrectMnemonic()
-        {
-            var controller = new WalletController(this.LoggerFactory.Object, new Mock<IWalletManager>().Object, new Mock<IWalletTransactionHandler>().Object, new Mock<IWalletSyncManager>().Object, It.IsAny<ConnectionManager>(), this.Network, this.chainIndexer, new Mock<IBroadcasterManager>().Object, DateTimeProvider.Default);
-
-            IActionResult result = controller.GenerateMnemonic("chinesesimplified");
-
-            var viewResult = Assert.IsType<JsonResult>(result);
-
-            string[] resultingWords = (viewResult.Value as string).Split(' ');
-
-            Assert.Equal(12, resultingWords.Length);
-            foreach (string word in resultingWords)
-            {
-                int index = -1;
-                Assert.True(Wordlist.ChineseSimplified.WordExists(word, out index));
-            }
-        }
-
-        [Fact]
-        public void GenerateMnemonicWithUnknownLanguageReturnsBadRequest()
-        {
-            var controller = new WalletController(this.LoggerFactory.Object, new Mock<IWalletManager>().Object, new Mock<IWalletTransactionHandler>().Object, new Mock<IWalletSyncManager>().Object, It.IsAny<ConnectionManager>(), this.Network, this.chainIndexer, new Mock<IBroadcasterManager>().Object, DateTimeProvider.Default);
-
-            IActionResult result = controller.GenerateMnemonic("invalidlanguage");
+            IActionResult result = await controller.GenerateMnemonic("invalidlanguage");
 
             var errorResult = Assert.IsType<ErrorResult>(result);
             var errorResponse = Assert.IsType<ErrorResponse>(errorResult.Value);
@@ -213,19 +118,26 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
             ErrorModel error = errorResponse.Errors[0];
             Assert.Equal(400, error.Status);
             Assert.StartsWith("System.FormatException", error.Description);
-            Assert.Equal("Invalid language 'invalidlanguage'. Choices are: English, French, Spanish, Japanese, ChineseSimplified and ChineseTraditional.", error.Message);
+            Assert.Equal(
+                "Invalid language 'invalidlanguage'. Choices are: English, French, Spanish, Japanese, ChineseSimplified and ChineseTraditional.",
+                error.Message);
         }
 
         [Fact]
-        public void CreateWalletSuccessfullyReturnsMnemonic()
+        public async Task CreateWalletSuccessfullyReturnsMnemonic()
         {
             var mnemonic = new Mnemonic(Wordlist.English, WordCount.Twelve);
-            var mockWalletCreate = new Mock<IWalletManager>();
-            mockWalletCreate.Setup(wallet => wallet.CreateWallet(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Mnemonic>())).Returns((null, mnemonic));
 
-            var controller = new WalletController(this.LoggerFactory.Object, mockWalletCreate.Object, new Mock<IWalletTransactionHandler>().Object, new Mock<IWalletSyncManager>().Object, It.IsAny<ConnectionManager>(), this.Network, this.chainIndexer, new Mock<IBroadcasterManager>().Object, DateTimeProvider.Default);
+            var mockWalletCreate = this.ConfigureMock<IWalletManager>(
+                mock =>
+                {
+                    mock.Setup(wallet => wallet.CreateWallet(It.IsAny<string>(), It.IsAny<string>(),
+                        It.IsAny<string>(), It.IsAny<Mnemonic>())).Returns((null, mnemonic));
+                });
 
-            IActionResult result = controller.Create(new WalletCreationRequest
+            var controller = this.GetWalletController();
+
+            IActionResult result = await controller.Create(new WalletCreationRequest
             {
                 Name = "myName",
                 Password = "",
@@ -239,15 +151,13 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
         }
 
         [Fact]
-        public void CreateWalletWithInvalidModelStateReturnsBadRequest()
+        public async Task CreateWalletWithInvalidModelStateReturnsBadRequest()
         {
-            var mnemonic = new Mnemonic(Wordlist.English, WordCount.Twelve);
-            var mockWalletCreate = new Mock<IWalletManager>();
+            var controller = this.GetWalletController();
 
-            var controller = new WalletController(this.LoggerFactory.Object, mockWalletCreate.Object, new Mock<IWalletTransactionHandler>().Object, new Mock<IWalletSyncManager>().Object, It.IsAny<ConnectionManager>(), this.Network, this.chainIndexer, new Mock<IBroadcasterManager>().Object, DateTimeProvider.Default);
             controller.ModelState.AddModelError("Name", "Name cannot be empty.");
 
-            IActionResult result = controller.Create(new WalletCreationRequest
+            IActionResult result = await controller.Create(new WalletCreationRequest
             {
                 Name = "",
                 Password = "",
@@ -263,16 +173,22 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
         }
 
         [Fact]
-        public void CreateWalletWithInvalidOperationExceptionReturnsConflict()
+        public async Task CreateWalletWithInvalidOperationExceptionReturnsConflict()
         {
             string errorMessage = "An error occurred.";
-            var mockWalletCreate = new Mock<IWalletManager>();
-            mockWalletCreate.Setup(wallet => wallet.CreateWallet(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Mnemonic>()))
-                .Throws(new WalletException(errorMessage));
 
-            var controller = new WalletController(this.LoggerFactory.Object, mockWalletCreate.Object, new Mock<IWalletTransactionHandler>().Object, new Mock<IWalletSyncManager>().Object, It.IsAny<ConnectionManager>(), this.Network, this.chainIndexer, new Mock<IBroadcasterManager>().Object, DateTimeProvider.Default);
+            var mockWalletCreate = this.ConfigureMock<IWalletManager>(
+                mock =>
+                {
+                    mock.Setup(wallet =>
+                            wallet.CreateWallet(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                                It.IsAny<Mnemonic>()))
+                        .Throws(new WalletException(errorMessage));
+                });
 
-            IActionResult result = controller.Create(new WalletCreationRequest
+            var controller = this.GetWalletController();
+
+            IActionResult result = await controller.Create(new WalletCreationRequest
             {
                 Name = "myName",
                 Password = "",
@@ -290,15 +206,21 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
         }
 
         [Fact]
-        public void CreateWalletWithNotSupportedExceptionExceptionReturnsBadRequest()
+        public async Task CreateWalletWithNotSupportedExceptionExceptionReturnsBadRequest()
         {
-            var mockWalletCreate = new Mock<IWalletManager>();
-            mockWalletCreate.Setup(wallet => wallet.CreateWallet(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Mnemonic>()))
-                .Throws(new NotSupportedException("Not supported"));
+            var mockWalletCreate = this.ConfigureMock<IWalletManager>(
+                mock =>
+                {
+                    mock.Setup(wallet =>
+                            wallet.CreateWallet(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                                It.IsAny<Mnemonic>()))
+                        .Throws(new NotSupportedException("Not supported"));
+                });
 
-            var controller = new WalletController(this.LoggerFactory.Object, mockWalletCreate.Object, new Mock<IWalletTransactionHandler>().Object, new Mock<IWalletSyncManager>().Object, It.IsAny<ConnectionManager>(), this.Network, this.chainIndexer, new Mock<IBroadcasterManager>().Object, DateTimeProvider.Default);
 
-            IActionResult result = controller.Create(new WalletCreationRequest
+            var controller = this.GetWalletController();
+
+            IActionResult result = await controller.Create(new WalletCreationRequest
             {
                 Name = "myName",
                 Password = "",
@@ -316,7 +238,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
         }
 
         [Fact]
-        public void RecoverWalletSuccessfullyReturnsWalletModel()
+        public async Task RecoverWalletSuccessfullyReturnsWalletModel()
         {
             var wallet = new Wallet
             {
@@ -324,15 +246,18 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
                 Network = NetworkHelpers.GetNetwork("mainnet")
             };
 
-            var mockWalletManager = new Mock<IWalletManager>();
-            mockWalletManager.Setup(w => w.RecoverWallet(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<DateTime>(), null, null)).Returns(wallet);
+            var mockWalletManager = this.ConfigureMock<IWalletManager>(
+                (mock) =>
+                    mock.Setup(w => w.RecoverWallet(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                        It.IsAny<DateTime>(), null, null)).Returns(wallet));
 
-            Mock<IWalletSyncManager> walletSyncManager = new Mock<IWalletSyncManager>();
-            walletSyncManager.Setup(w => w.WalletTip).Returns(new ChainedHeader(this.Network.GetGenesis().Header, this.Network.GetGenesis().Header.GetHash(), 3));
+            this.ConfigureMock<IWalletSyncManager>(mock =>
+                mock.Setup(w => w.WalletTip).Returns(new ChainedHeader(this.Network.GetGenesis().Header,
+                    this.Network.GetGenesis().Header.GetHash(), 3)));
 
-            var controller = new WalletController(this.LoggerFactory.Object, mockWalletManager.Object, new Mock<IWalletTransactionHandler>().Object, walletSyncManager.Object, It.IsAny<ConnectionManager>(), this.Network, this.chainIndexer, new Mock<IBroadcasterManager>().Object, DateTimeProvider.Default);
+            var controller = this.GetWalletController();
 
-            IActionResult result = controller.Recover(new WalletRecoveryRequest
+            IActionResult result = await controller.Recover(new WalletRecoveryRequest
             {
                 Name = "myWallet",
                 Password = "",
@@ -350,7 +275,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
         /// The wallet should continue syncing from X without jumpoing forward.
         /// </summary>
         [Fact]
-        public void RecoverWalletWithDatedAfterCurrentSyncHeightDoesNotMoveSyncHeight()
+        public async Task RecoverWalletWithDatedAfterCurrentSyncHeightDoesNotMoveSyncHeight()
         {
             var wallet = new Wallet
             {
@@ -358,20 +283,21 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
                 Network = NetworkHelpers.GetNetwork("mainnet")
             };
 
-            // The chain is at height 100.
-            ChainIndexer chainIndexer = WalletTestsHelpers.GenerateChainWithHeight(100, this.Network);
             DateTime lastBlockDateTime = chainIndexer.Tip.Header.BlockTime.DateTime;
 
-            var mockWalletManager = new Mock<IWalletManager>();
-            mockWalletManager.Setup(w => w.RecoverWallet(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<DateTime>(), null, null)).Returns(wallet);
+            var mockWalletManager = this.ConfigureMock<IWalletManager>(mock =>
+                mock.Setup(w => w.RecoverWallet(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                    It.IsAny<DateTime>(), null, null)).Returns(wallet));
 
-            Mock<IWalletSyncManager> walletSyncManager = new Mock<IWalletSyncManager>();
-            walletSyncManager.Setup(w => w.WalletTip).Returns(new ChainedHeader(this.Network.GetGenesis().Header, this.Network.GetGenesis().Header.GetHash(), 3));
+            Mock<IWalletSyncManager> walletSyncManager = this.ConfigureMock<IWalletSyncManager>(mock =>
+                mock.Setup(w => w.WalletTip).Returns(new ChainedHeader(this.Network.GetGenesis().Header,
+                    this.Network.GetGenesis().Header.GetHash(), 3)));
+
             walletSyncManager.Verify(w => w.SyncFromHeight(100, It.IsAny<string>()), Times.Never);
 
-            var controller = new WalletController(this.LoggerFactory.Object, mockWalletManager.Object, new Mock<IWalletTransactionHandler>().Object, walletSyncManager.Object, It.IsAny<ConnectionManager>(), this.Network, this.chainIndexer, new Mock<IBroadcasterManager>().Object, DateTimeProvider.Default);
+            var controller = this.GetWalletController();
 
-            IActionResult result = controller.Recover(new WalletRecoveryRequest
+            IActionResult result = await controller.Recover(new WalletRecoveryRequest
             {
                 Name = "myWallet",
                 Password = "",
@@ -386,14 +312,13 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
         }
 
         [Fact]
-        public void RecoverWalletWithInvalidModelStateReturnsBadRequest()
+        public async Task RecoverWalletWithInvalidModelStateReturnsBadRequest()
         {
-            var mockWalletManager = new Mock<IWalletManager>();
+            var controller = this.GetWalletController();
 
-            var controller = new WalletController(this.LoggerFactory.Object, mockWalletManager.Object, new Mock<IWalletTransactionHandler>().Object, new Mock<IWalletSyncManager>().Object, It.IsAny<ConnectionManager>(), this.Network, this.chainIndexer, new Mock<IBroadcasterManager>().Object, DateTimeProvider.Default);
             controller.ModelState.AddModelError("Password", "A password is required.");
 
-            IActionResult result = controller.Recover(new WalletRecoveryRequest
+            IActionResult result = await controller.Recover(new WalletRecoveryRequest
             {
                 Name = "myWallet",
                 Password = "",
@@ -410,16 +335,18 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
         }
 
         [Fact]
-        public void RecoverWalletWithInvalidOperationExceptionReturnsConflict()
+        public async Task RecoverWalletWithInvalidOperationExceptionReturnsConflict()
         {
             string errorMessage = "An error occurred.";
-            var mockWalletManager = new Mock<IWalletManager>();
-            mockWalletManager.Setup(w => w.RecoverWallet(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<DateTime>(), null, null))
-                .Throws(new WalletException(errorMessage));
 
-            var controller = new WalletController(this.LoggerFactory.Object, mockWalletManager.Object, new Mock<IWalletTransactionHandler>().Object, new Mock<IWalletSyncManager>().Object, It.IsAny<ConnectionManager>(), this.Network, this.chainIndexer, new Mock<IBroadcasterManager>().Object, DateTimeProvider.Default);
+            var mockWalletManager = this.ConfigureMock<IWalletManager>(mock =>
+                mock.Setup(w => w.RecoverWallet(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                        It.IsAny<DateTime>(), null, null))
+                    .Throws(new WalletException(errorMessage)));
 
-            IActionResult result = controller.Recover(new WalletRecoveryRequest
+            var controller = this.GetWalletController();
+
+            IActionResult result = await controller.Recover(new WalletRecoveryRequest
             {
                 Name = "myWallet",
                 Password = "",
@@ -437,15 +364,16 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
         }
 
         [Fact]
-        public void RecoverWalletWithFileNotFoundExceptionReturnsNotFound()
+        public async Task RecoverWalletWithFileNotFoundExceptionReturnsNotFound()
         {
-            var mockWalletManager = new Mock<IWalletManager>();
-            mockWalletManager.Setup(w => w.RecoverWallet(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<DateTime>(), null, null))
-                .Throws(new FileNotFoundException("File not found."));
+            var mockWalletManager = this.ConfigureMock<IWalletManager>(mock =>
+                mock.Setup(w => w.RecoverWallet(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                        It.IsAny<DateTime>(), null, null))
+                    .Throws(new FileNotFoundException("File not found.")));
 
-            var controller = new WalletController(this.LoggerFactory.Object, mockWalletManager.Object, new Mock<IWalletTransactionHandler>().Object, new Mock<IWalletSyncManager>().Object, It.IsAny<ConnectionManager>(), this.Network, this.chainIndexer, new Mock<IBroadcasterManager>().Object, DateTimeProvider.Default);
+            var controller = this.GetWalletController();
 
-            IActionResult result = controller.Recover(new WalletRecoveryRequest
+            IActionResult result = await controller.Recover(new WalletRecoveryRequest
             {
                 Name = "myWallet",
                 Password = "",
@@ -464,15 +392,16 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
         }
 
         [Fact]
-        public void RecoverWalletWithExceptionReturnsBadRequest()
+        public async Task RecoverWalletWithExceptionReturnsBadRequest()
         {
-            var mockWalletManager = new Mock<IWalletManager>();
-            mockWalletManager.Setup(w => w.RecoverWallet(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<DateTime>(), null, null))
-                .Throws(new FormatException("Formatting failed."));
+            var mockWalletManager = this.ConfigureMock<IWalletManager>(mock =>
+                mock.Setup(w => w.RecoverWallet(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                        It.IsAny<DateTime>(), null, null))
+                    .Throws(new FormatException("Formatting failed.")));
 
-            var controller = new WalletController(this.LoggerFactory.Object, mockWalletManager.Object, new Mock<IWalletTransactionHandler>().Object, new Mock<IWalletSyncManager>().Object, It.IsAny<ConnectionManager>(), this.Network, this.chainIndexer, new Mock<IBroadcasterManager>().Object, DateTimeProvider.Default);
+            var controller = this.GetWalletController();
 
-            IActionResult result = controller.Recover(new WalletRecoveryRequest
+            IActionResult result = await controller.Recover(new WalletRecoveryRequest
             {
                 Name = "myWallet",
                 Password = "",
@@ -491,24 +420,26 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
         }
 
         [Fact]
-        public void RecoverWalletViaExtPubKeySuccessfullyReturnsWalletModel()
+        public async Task RecoverWalletViaExtPubKeySuccessfullyReturnsWalletModel()
         {
             string walletName = "myWallet";
-            string extPubKey = "xpub661MyMwAqRbcEgnsMFfhjdrwR52TgicebTrbnttywb9zn3orkrzn6MHJrgBmKrd7MNtS6LAim44a6V2gizt3jYVPHGYq1MzAN849WEyoedJ";
+            string extPubKey =
+                "xpub661MyMwAqRbcEgnsMFfhjdrwR52TgicebTrbnttywb9zn3orkrzn6MHJrgBmKrd7MNtS6LAim44a6V2gizt3jYVPHGYq1MzAN849WEyoedJ";
 
-            this.RecoverWithExtPubAndCheckSuccessfulResponse(walletName, extPubKey);
+            await this.RecoverWithExtPubAndCheckSuccessfulResponse(walletName, extPubKey);
         }
 
         [Fact]
-        public void RecoverWalletViaExtPubKeySupportsStratisLegacyExtpubKey()
+        public async Task RecoverWalletViaExtPubKeySupportsStratisLegacyExtpubKey()
         {
             string walletName = "myWallet";
-            string extPubKey = "xq5hcJV8uJDLaNytrg6FphHY1vdqxP1rCPhAmp4xZwpxzYyYEscYEujAmNR5NrPfy9vzQ6BajEqtFezcyRe4zcGHH3dR6BKaKov43JHd8UYhBVy";
+            string extPubKey =
+                "xq5hcJV8uJDLaNytrg6FphHY1vdqxP1rCPhAmp4xZwpxzYyYEscYEujAmNR5NrPfy9vzQ6BajEqtFezcyRe4zcGHH3dR6BKaKov43JHd8UYhBVy";
 
-            this.RecoverWithExtPubAndCheckSuccessfulResponse(walletName, extPubKey);
+            await this.RecoverWithExtPubAndCheckSuccessfulResponse(walletName, extPubKey);
         }
 
-        private void RecoverWithExtPubAndCheckSuccessfulResponse(string walletName, string extPubKey)
+        private async Task RecoverWithExtPubAndCheckSuccessfulResponse(string walletName, string extPubKey)
         {
             var wallet = new Wallet
             {
@@ -516,18 +447,18 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
                 Network = KnownNetworks.StratisMain
             };
 
-            var walletManager = new Mock<IWalletManager>();
-            walletManager.Setup(w => w.RecoverWallet(walletName, It.IsAny<ExtPubKey>(), 1, It.IsAny<DateTime>(), null)).Returns(wallet);
+            var walletManager = this.ConfigureMock<IWalletManager>(mock =>
+                mock.Setup(w => w.RecoverWallet(walletName, It.IsAny<ExtPubKey>(), 1, It.IsAny<DateTime>(), null))
+                    .Returns(wallet));
 
-            Mock<IWalletSyncManager> walletSyncManager = new Mock<IWalletSyncManager>();
-            walletSyncManager.Setup(w => w.WalletTip).Returns(new ChainedHeader(this.Network.GetGenesis().Header, this.Network.GetGenesis().Header.GetHash(), 3));
+            this.ConfigureMockInstance(KnownNetworks.StratisMain);
+            this.ConfigureMock<IWalletSyncManager>(mock =>
+                mock.Setup(w => w.WalletTip).Returns(new ChainedHeader(this.Network.GetGenesis().Header,
+                    this.Network.GetGenesis().Header.GetHash(), 3)));
 
-            var controller = new WalletController(this.LoggerFactory.Object, walletManager.Object,
-                new Mock<IWalletTransactionHandler>().Object, walletSyncManager.Object,
-                It.IsAny<ConnectionManager>(), KnownNetworks.StratisMain, this.chainIndexer,
-                new Mock<IBroadcasterManager>().Object, DateTimeProvider.Default);
+            var controller = this.GetWalletController();
 
-            IActionResult result = controller.RecoverViaExtPubKey(new WalletExtPubRecoveryRequest
+            IActionResult result = await controller.RecoverViaExtPubKey(new WalletExtPubRecoveryRequest
             {
                 Name = walletName,
                 ExtPubKey = extPubKey,
@@ -545,11 +476,13 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
         /// and the user recovers a new wallet at height X + Y.
         /// The wallet should continue syncing from X without jumpoing forward.
         /// </summary>
+        /// <returns><placeholder>A <see cref="Task"/> representing the asynchronous unit test.</placeholder></returns>
         [Fact]
-        public void RecoverWalletWithExtPubDatedAfterCurrentSyncHeightDoesNotMoveSyncHeight()
+        public async Task RecoverWalletWithExtPubDatedAfterCurrentSyncHeightDoesNotMoveSyncHeight()
         {
             string walletName = "myWallet";
-            string extPubKey = "xpub661MyMwAqRbcEgnsMFfhjdrwR52TgicebTrbnttywb9zn3orkrzn6MHJrgBmKrd7MNtS6LAim44a6V2gizt3jYVPHGYq1MzAN849WEyoedJ";
+            string extPubKey =
+                "xpub661MyMwAqRbcEgnsMFfhjdrwR52TgicebTrbnttywb9zn3orkrzn6MHJrgBmKrd7MNtS6LAim44a6V2gizt3jYVPHGYq1MzAN849WEyoedJ";
 
             var wallet = new Wallet
             {
@@ -557,23 +490,24 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
                 Network = KnownNetworks.StratisMain
             };
 
-            // The chain is at height 100.
-            ChainIndexer chainIndexer = WalletTestsHelpers.GenerateChainWithHeight(100, this.Network);
             DateTime lastBlockDateTime = chainIndexer.Tip.Header.BlockTime.DateTime;
 
-            var walletManager = new Mock<IWalletManager>();
-            walletManager.Setup(w => w.RecoverWallet(It.IsAny<string>(), It.IsAny<ExtPubKey>(), 1, It.IsAny<DateTime>(), null)).Returns(wallet);
+            var walletManager = this.ConfigureMock<IWalletManager>(mock =>
+                mock.Setup(w =>
+                        w.RecoverWallet(It.IsAny<string>(), It.IsAny<ExtPubKey>(), 1, It.IsAny<DateTime>(), null))
+                    .Returns(wallet));
 
-            Mock<IWalletSyncManager> walletSyncManager = new Mock<IWalletSyncManager>();
-            walletSyncManager.Setup(w => w.WalletTip).Returns(new ChainedHeader(this.Network.GetGenesis().Header, this.Network.GetGenesis().Header.GetHash(), 3));
+            this.ConfigureMockInstance(KnownNetworks.StratisMain);
+
+            Mock<IWalletSyncManager> walletSyncManager = this.ConfigureMock<IWalletSyncManager>(mock =>
+                mock.Setup(w => w.WalletTip).Returns(new ChainedHeader(this.Network.GetGenesis().Header,
+                    this.Network.GetGenesis().Header.GetHash(), 3)));
+
             walletSyncManager.Verify(w => w.SyncFromHeight(100, It.IsAny<string>()), Times.Never);
 
-            var controller = new WalletController(this.LoggerFactory.Object, walletManager.Object,
-                new Mock<IWalletTransactionHandler>().Object, walletSyncManager.Object,
-                It.IsAny<ConnectionManager>(), KnownNetworks.StratisMain, chainIndexer,
-                new Mock<IBroadcasterManager>().Object, DateTimeProvider.Default);
+            var controller = this.GetWalletController();
 
-            IActionResult result = controller.RecoverViaExtPubKey(new WalletExtPubRecoveryRequest
+            IActionResult result = await controller.RecoverViaExtPubKey(new WalletExtPubRecoveryRequest
             {
                 Name = walletName,
                 ExtPubKey = extPubKey,
@@ -588,19 +522,19 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
         }
 
         [Fact]
-        public void LoadWalletSuccessfullyReturnsWalletModel()
+        public async Task LoadWalletSuccessfullyReturnsWalletModel()
         {
             var wallet = new Wallet
             {
                 Name = "myWallet",
                 Network = NetworkHelpers.GetNetwork("mainnet")
             };
-            var mockWalletManager = new Mock<IWalletManager>();
-            mockWalletManager.Setup(w => w.LoadWallet(It.IsAny<string>(), It.IsAny<string>())).Returns(wallet);
+            var mockWalletManager = this.ConfigureMock<IWalletManager>(mock =>
+                mock.Setup(w => w.LoadWallet(It.IsAny<string>(), It.IsAny<string>())).Returns(wallet));
 
-            var controller = new WalletController(this.LoggerFactory.Object, mockWalletManager.Object, new Mock<IWalletTransactionHandler>().Object, new Mock<IWalletSyncManager>().Object, It.IsAny<ConnectionManager>(), this.Network, this.chainIndexer, new Mock<IBroadcasterManager>().Object, DateTimeProvider.Default);
+            var controller = this.GetWalletController();
 
-            IActionResult result = controller.Load(new WalletLoadRequest
+            IActionResult result = await controller.Load(new WalletLoadRequest
             {
                 Name = "myWallet",
                 Password = ""
@@ -612,14 +546,13 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
         }
 
         [Fact]
-        public void LoadWalletWithInvalidModelReturnsBadRequest()
+        public async Task LoadWalletWithInvalidModelReturnsBadRequest()
         {
-            var mockWalletManager = new Mock<IWalletManager>();
+            var controller = this.GetWalletController();
 
-            var controller = new WalletController(this.LoggerFactory.Object, mockWalletManager.Object, new Mock<IWalletTransactionHandler>().Object, new Mock<IWalletSyncManager>().Object, It.IsAny<ConnectionManager>(), this.Network, this.chainIndexer, new Mock<IBroadcasterManager>().Object, DateTimeProvider.Default);
             controller.ModelState.AddModelError("Password", "A password is required.");
 
-            IActionResult result = controller.Load(new WalletLoadRequest
+            IActionResult result = await controller.Load(new WalletLoadRequest
             {
                 Name = "myWallet",
                 Password = ""
@@ -635,14 +568,15 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
         }
 
         [Fact]
-        public void LoadWalletWithFileNotFoundExceptionandReturnsNotFound()
+        public async Task LoadWalletWithFileNotFoundExceptionandReturnsNotFound()
         {
-            var mockWalletManager = new Mock<IWalletManager>();
-            mockWalletManager.Setup(wallet => wallet.LoadWallet(It.IsAny<string>(), It.IsAny<string>())).Throws<FileNotFoundException>();
+            var mockWalletManager = this.ConfigureMock<IWalletManager>(mock =>
+                mock.Setup(wallet => wallet.LoadWallet(It.IsAny<string>(), It.IsAny<string>()))
+                    .Throws<FileNotFoundException>());
 
-            var controller = new WalletController(this.LoggerFactory.Object, mockWalletManager.Object, new Mock<IWalletTransactionHandler>().Object, new Mock<IWalletSyncManager>().Object, It.IsAny<ConnectionManager>(), this.Network, this.chainIndexer, new Mock<IBroadcasterManager>().Object, DateTimeProvider.Default);
+            var controller = this.GetWalletController();
 
-            IActionResult result = controller.Load(new WalletLoadRequest
+            IActionResult result = await controller.Load(new WalletLoadRequest
             {
                 Name = "myName",
                 Password = ""
@@ -660,14 +594,15 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
         }
 
         [Fact]
-        public void LoadWalletWithSecurityExceptionandReturnsForbidden()
+        public async Task LoadWalletWithSecurityExceptionandReturnsForbidden()
         {
-            var mockWalletManager = new Mock<IWalletManager>();
-            mockWalletManager.Setup(wallet => wallet.LoadWallet(It.IsAny<string>(), It.IsAny<string>())).Throws<SecurityException>();
+            var mockWalletManager = this.ConfigureMock<IWalletManager>(mock =>
+                mock.Setup(wallet => wallet.LoadWallet(It.IsAny<string>(), It.IsAny<string>()))
+                    .Throws<SecurityException>());
 
-            var controller = new WalletController(this.LoggerFactory.Object, mockWalletManager.Object, new Mock<IWalletTransactionHandler>().Object, new Mock<IWalletSyncManager>().Object, It.IsAny<ConnectionManager>(), this.Network, this.chainIndexer, new Mock<IBroadcasterManager>().Object, DateTimeProvider.Default);
+            var controller = this.GetWalletController();
 
-            IActionResult result = controller.Load(new WalletLoadRequest
+            IActionResult result = await controller.Load(new WalletLoadRequest
             {
                 Name = "myName",
                 Password = ""
@@ -685,14 +620,15 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
         }
 
         [Fact]
-        public void LoadWalletWithOtherExceptionandReturnsBadRequest()
+        public async Task LoadWalletWithOtherExceptionandReturnsBadRequest()
         {
-            var mockWalletManager = new Mock<IWalletManager>();
-            mockWalletManager.Setup(wallet => wallet.LoadWallet(It.IsAny<string>(), It.IsAny<string>())).Throws<FormatException>();
+            var mockWalletManager = this.ConfigureMock<IWalletManager>(mock =>
+                mock.Setup(wallet => wallet.LoadWallet(It.IsAny<string>(), It.IsAny<string>()))
+                    .Throws<FormatException>());
 
-            var controller = new WalletController(this.LoggerFactory.Object, mockWalletManager.Object, new Mock<IWalletTransactionHandler>().Object, new Mock<IWalletSyncManager>().Object, It.IsAny<ConnectionManager>(), this.Network, this.chainIndexer, new Mock<IBroadcasterManager>().Object, DateTimeProvider.Default);
+            var controller = this.GetWalletController();
 
-            IActionResult result = controller.Load(new WalletLoadRequest
+            IActionResult result = await controller.Load(new WalletLoadRequest
             {
                 Name = "myName",
                 Password = ""
@@ -709,7 +645,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
         }
 
         [Fact]
-        public void GetGeneralInfoSuccessfullyReturnsWalletGeneralInfoModel()
+        public async Task GetGeneralInfoSuccessfullyReturnsWalletGeneralInfoModel()
         {
             var wallet = new Wallet
             {
@@ -728,22 +664,23 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
             var concurrentChain = new ChainIndexer(this.Network);
             ChainedHeader tip = WalletTestsHelpers.AppendBlock(this.Network, null, new[] { concurrentChain });
 
-            var connectionManagerMock = new Mock<IConnectionManager>();
-            connectionManagerMock.Setup(c => c.ConnectedPeers)
-                .Returns(new NetworkPeerCollection());
+            var connectionManagerMock = this.ConfigureMock<IConnectionManager>(mock =>
+                mock.Setup(c => c.ConnectedPeers)
+                    .Returns(new NetworkPeerCollection()));
 
-            var mockWalletManager = new Mock<IWalletManager>();
-            mockWalletManager.Setup(w => w.GetWallet("myWallet")).Returns(wallet);
+            var consensusManager =
+                this.ConfigureMock<IConsensusManager>(s => s.Setup(w => w.HeaderTip).Returns(tip.Height));
+
+            var mockWalletManager = this.ConfigureMock<IWalletManager>(mock =>
+                mock.Setup(w => w.GetWallet("myWallet")).Returns(wallet));
 
             string walletFileExtension = "wallet.json";
             string testWalletFileName = Path.ChangeExtension("myWallet", walletFileExtension);
             string testWalletPath = Path.Combine(AppContext.BaseDirectory, "stratisnode", testWalletFileName);
-            string folder = Path.GetDirectoryName(testWalletPath);
-            var files = new string[] { testWalletFileName };
 
-            var controller = new WalletController(this.LoggerFactory.Object, mockWalletManager.Object, new Mock<IWalletTransactionHandler>().Object, new Mock<IWalletSyncManager>().Object, connectionManagerMock.Object, this.Network, concurrentChain, new Mock<IBroadcasterManager>().Object, DateTimeProvider.Default);
+            var controller = this.GetWalletController();
 
-            IActionResult result = controller.GetGeneralInfo(new WalletName
+            IActionResult result = await controller.GetGeneralInfo(new WalletName
             {
                 Name = "myWallet"
             });
@@ -762,20 +699,21 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
         }
 
         [Fact]
-        public void GetGeneralInfoWithModelStateErrorReturnsBadRequest()
+        public async Task GetGeneralInfoWithModelStateErrorReturnsBadRequest()
         {
             var wallet = new Wallet
             {
                 Name = "myWallet",
             };
 
-            var mockWalletManager = new Mock<IWalletManager>();
-            mockWalletManager.Setup(w => w.GetWallet("myWallet")).Returns(wallet);
+            var mockWalletManager = this.ConfigureMock<IWalletManager>(mock =>
+                mock.Setup(w => w.GetWallet("myWallet")).Returns(wallet));
 
-            var controller = new WalletController(this.LoggerFactory.Object, mockWalletManager.Object, new Mock<IWalletTransactionHandler>().Object, new Mock<IWalletSyncManager>().Object, It.IsAny<ConnectionManager>(), this.Network, this.chainIndexer, new Mock<IBroadcasterManager>().Object, DateTimeProvider.Default);
+            var controller = this.GetWalletController();
+
             controller.ModelState.AddModelError("Name", "Invalid name.");
 
-            IActionResult result = controller.GetGeneralInfo(new WalletName
+            IActionResult result = await controller.GetGeneralInfo(new WalletName
             {
                 Name = "myWallet"
             });
@@ -790,14 +728,14 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
         }
 
         [Fact]
-        public void GetGeneralInfoWithExceptionReturnsBadRequest()
+        public async Task GetGeneralInfoWithExceptionReturnsBadRequest()
         {
-            var mockWalletManager = new Mock<IWalletManager>();
-            mockWalletManager.Setup(w => w.GetWallet("myWallet")).Throws<FormatException>();
+            var mockWalletManager = this.ConfigureMock<IWalletManager>(mock =>
+                mock.Setup(w => w.GetWallet("myWallet")).Throws<FormatException>());
 
-            var controller = new WalletController(this.LoggerFactory.Object, mockWalletManager.Object, new Mock<IWalletTransactionHandler>().Object, new Mock<IWalletSyncManager>().Object, It.IsAny<ConnectionManager>(), this.Network, this.chainIndexer, new Mock<IBroadcasterManager>().Object, DateTimeProvider.Default);
+            var controller = this.GetWalletController();
 
-            IActionResult result = controller.GetGeneralInfo(new WalletName
+            IActionResult result = await controller.GetGeneralInfo(new WalletName
             {
                 Name = "myWallet"
             });
@@ -813,22 +751,24 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
         }
 
         [Fact]
-        public void GetHistoryWithoutAddressesReturnsEmptyModel()
+        public async Task GetHistoryWithoutAddressesReturnsEmptyModel()
         {
             string walletName = "myWallet";
-            var mockWalletManager = new Mock<IWalletManager>();
-            mockWalletManager.Setup(w => w.GetHistory(walletName, WalletManager.DefaultAccount)).Returns(new List<AccountHistory>
-            {
-                new AccountHistory
-                {
-                    History = new List<FlatHistory>(),
-                    Account = new HdAccount()
-                }
-            });
+            var mockWalletManager = this.ConfigureMock<IWalletManager>(mock =>
+                mock.Setup(w => w.GetHistory(walletName, WalletManager.DefaultAccount)).Returns(
+                    new List<AccountHistory>
+                    {
+                        new AccountHistory
+                        {
+                            History = new List<FlatHistory>(),
+                            Account = new HdAccount()
+                        }
+                    }));
             mockWalletManager.Setup(w => w.GetWallet(walletName)).Returns(new Wallet());
 
-            var controller = new WalletController(this.LoggerFactory.Object, mockWalletManager.Object, new Mock<IWalletTransactionHandler>().Object, new Mock<IWalletSyncManager>().Object, It.IsAny<ConnectionManager>(), this.Network, this.chainIndexer, new Mock<IBroadcasterManager>().Object, DateTimeProvider.Default);
-            IActionResult result = controller.GetHistory(new WalletHistoryRequest
+            var controller = this.GetWalletController();
+
+            IActionResult result = await controller.GetHistory(new WalletHistoryRequest
             {
                 WalletName = walletName
             });
@@ -844,7 +784,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
         }
 
         [Fact]
-        public void GetHistoryWithValidModelWithoutTransactionSpendingDetailsReturnsWalletHistoryModel()
+        public async Task GetHistoryWithValidModelWithoutTransactionSpendingDetailsReturnsWalletHistoryModel()
         {
             string walletName = "myWallet";
             HdAddress address = WalletTestsHelpers.CreateAddress();
@@ -857,15 +797,18 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
 
             account.ExternalAddresses.Add(address);
 
-            List<FlatHistory> flat = addresses.SelectMany(s => s.Transactions.Select(t => new FlatHistory { Address = s, Transaction = t })).ToList();
+            List<FlatHistory> flat = addresses
+                .SelectMany(s => s.Transactions.Select(t => new FlatHistory { Address = s, Transaction = t })).ToList();
 
             var accountsHistory = new List<AccountHistory> { new AccountHistory { History = flat, Account = account } };
-            var mockWalletManager = new Mock<IWalletManager>();
-            mockWalletManager.Setup(w => w.GetHistory(walletName, WalletManager.DefaultAccount)).Returns(accountsHistory);
+            var mockWalletManager = this.ConfigureMock<IWalletManager>(mock =>
+                mock.Setup(w => w.GetHistory(walletName, WalletManager.DefaultAccount))
+                    .Returns(accountsHistory));
             mockWalletManager.Setup(w => w.GetWallet(walletName)).Returns(wallet);
 
-            var controller = new WalletController(this.LoggerFactory.Object, mockWalletManager.Object, new Mock<IWalletTransactionHandler>().Object, new Mock<IWalletSyncManager>().Object, It.IsAny<ConnectionManager>(), this.Network, this.chainIndexer, new Mock<IBroadcasterManager>().Object, DateTimeProvider.Default);
-            IActionResult result = controller.GetHistory(new WalletHistoryRequest
+            var controller = this.GetWalletController();
+
+            IActionResult result = await controller.GetHistory(new WalletHistoryRequest
             {
                 WalletName = walletName
             });
@@ -889,7 +832,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
         }
 
         [Fact]
-        public void GetHistoryWithCoinStakeWithMultipleInputs()
+        public async Task GetHistoryWithCoinStakeWithMultipleInputs()
         {
             const int numberOfCoinStakeInputs = 10;
             const string walletName = "myWallet";
@@ -898,12 +841,16 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
             // Set up a single address to have 10 transactions.
             for (int i = 0; i < numberOfCoinStakeInputs; i++)
             {
-                TransactionData transaction = WalletTestsHelpers.CreateTransaction(new uint256((ulong) i + 1), new Money(500000), 1, creationTime:DateTimeOffset.FromUnixTimeSeconds(i));
+                TransactionData transaction = WalletTestsHelpers.CreateTransaction(new uint256((ulong)i + 1),
+                    new Money(500000), 1, creationTime: DateTimeOffset.FromUnixTimeSeconds(i));
                 address.Transactions.Add(transaction);
             }
 
             // Make these transactions inputs to a new CoinStake transaction.
-            TransactionData coinStake = WalletTestsHelpers.CreateTransaction(new uint256((ulong) numberOfCoinStakeInputs + 1), address.Transactions.Sum(x => x.Amount) + Money.Coins(1), 2, creationTime: DateTimeOffset.FromUnixTimeSeconds(numberOfCoinStakeInputs));
+            TransactionData coinStake = WalletTestsHelpers.CreateTransaction(
+                new uint256((ulong)numberOfCoinStakeInputs + 1),
+                address.Transactions.Sum(x => x.Amount) + Money.Coins(1), 2,
+                creationTime: DateTimeOffset.FromUnixTimeSeconds(numberOfCoinStakeInputs));
             coinStake.IsCoinStake = true;
 
             foreach (var spentTransaction in address.Transactions)
@@ -925,15 +872,19 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
 
             account.ExternalAddresses.Add(address);
 
-            List<FlatHistory> flat = addresses.SelectMany(s => s.Transactions.Select(t => new FlatHistory { Address = s, Transaction = t })).ToList();
+            List<FlatHistory> flat = addresses
+                .SelectMany(s => s.Transactions.Select(t => new FlatHistory { Address = s, Transaction = t })).ToList();
 
             var accountsHistory = new List<AccountHistory> { new AccountHistory { History = flat, Account = account } };
-            var mockWalletManager = new Mock<IWalletManager>();
-            mockWalletManager.Setup(w => w.GetHistory(walletName, WalletManager.DefaultAccount)).Returns(accountsHistory);
+            var mockWalletManager = this.ConfigureMock<IWalletManager>();
+
+            mockWalletManager.Setup(w => w.GetHistory(walletName, WalletManager.DefaultAccount))
+                .Returns(accountsHistory);
             mockWalletManager.Setup(w => w.GetWallet(walletName)).Returns(wallet);
 
-            var controller = new WalletController(this.LoggerFactory.Object, mockWalletManager.Object, new Mock<IWalletTransactionHandler>().Object, new Mock<IWalletSyncManager>().Object, It.IsAny<ConnectionManager>(), this.Network, this.chainIndexer, new Mock<IBroadcasterManager>().Object, DateTimeProvider.Default);
-            IActionResult result = controller.GetHistory(new WalletHistoryRequest
+            var controller = GetWalletController();
+
+            IActionResult result = await controller.GetHistory(new WalletHistoryRequest
             {
                 WalletName = walletName
             });
@@ -945,7 +896,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
             Assert.Single(model.AccountsHistoryModel);
 
             AccountHistoryModel historyModel = model.AccountsHistoryModel.ElementAt(0);
-            
+
             // We should have 11 entries. The most recent is our stake. The other 10 are receives.
             Assert.Equal(numberOfCoinStakeInputs + 1, historyModel.TransactionsHistory.Count);
             TransactionItemModel resultingTransactionModel = historyModel.TransactionsHistory.ElementAt(0);
@@ -961,20 +912,24 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
         }
 
         [Fact]
-        public void GetHistoryWithValidModelWithTransactionSpendingDetailsReturnsWalletHistoryModel()
+        public async Task GetHistoryWithValidModelWithTransactionSpendingDetailsReturnsWalletHistoryModel()
         {
             string walletName = "myWallet";
             HdAddress changeAddress = WalletTestsHelpers.CreateAddress(changeAddress: true);
             HdAddress address = WalletTestsHelpers.CreateAddress();
             HdAddress destinationAddress = WalletTestsHelpers.CreateAddress();
 
-            TransactionData changeTransaction = WalletTestsHelpers.CreateTransaction(new uint256(2), new Money(275000), 1);
+            TransactionData changeTransaction =
+                WalletTestsHelpers.CreateTransaction(new uint256(2), new Money(275000), 1);
             changeAddress.Transactions.Add(changeTransaction);
 
-            PaymentDetails paymentDetails = WalletTestsHelpers.CreatePaymentDetails(new Money(200000), destinationAddress);
-            SpendingDetails spendingDetails = WalletTestsHelpers.CreateSpendingDetails(changeTransaction, paymentDetails);
+            PaymentDetails paymentDetails =
+                WalletTestsHelpers.CreatePaymentDetails(new Money(200000), destinationAddress);
+            SpendingDetails spendingDetails =
+                WalletTestsHelpers.CreateSpendingDetails(changeTransaction, paymentDetails);
 
-            TransactionData transaction = WalletTestsHelpers.CreateTransaction(new uint256(1), new Money(500000), 1, spendingDetails);
+            TransactionData transaction =
+                WalletTestsHelpers.CreateTransaction(new uint256(1), new Money(500000), 1, spendingDetails);
             address.Transactions.Add(transaction);
 
             var addresses = new List<HdAddress> { address };
@@ -984,15 +939,18 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
             account.ExternalAddresses.Add(address);
             account.InternalAddresses.Add(changeAddress);
 
-            List<FlatHistory> flat = addresses.SelectMany(s => s.Transactions.Select(t => new FlatHistory { Address = s, Transaction = t })).ToList();
+            List<FlatHistory> flat = addresses
+                .SelectMany(s => s.Transactions.Select(t => new FlatHistory { Address = s, Transaction = t })).ToList();
             var accountsHistory = new List<AccountHistory> { new AccountHistory { History = flat, Account = account } };
 
-            var mockWalletManager = new Mock<IWalletManager>();
-            mockWalletManager.Setup(w => w.GetHistory(walletName, WalletManager.DefaultAccount)).Returns(accountsHistory);
+            var mockWalletManager = this.ConfigureMock<IWalletManager>(mock =>
+                mock.Setup(w => w.GetHistory(walletName, WalletManager.DefaultAccount))
+                    .Returns(accountsHistory));
             mockWalletManager.Setup(w => w.GetWallet(walletName)).Returns(wallet);
 
-            var controller = new WalletController(this.LoggerFactory.Object, mockWalletManager.Object, new Mock<IWalletTransactionHandler>().Object, new Mock<IWalletSyncManager>().Object, It.IsAny<ConnectionManager>(), this.Network, this.chainIndexer, new Mock<IBroadcasterManager>().Object, DateTimeProvider.Default);
-            IActionResult result = controller.GetHistory(new WalletHistoryRequest
+            var controller = this.GetWalletController();
+
+            IActionResult result = await controller.GetHistory(new WalletHistoryRequest
             {
                 WalletName = walletName
             });
@@ -1033,7 +991,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
         }
 
         [Fact]
-        public void GetHistoryWithValidModelWithFeeBelowZeroSetsFeeToZero()
+        public async Task GetHistoryWithValidModelWithFeeBelowZeroSetsFeeToZero()
         {
             string walletName = "myWallet";
 
@@ -1041,13 +999,17 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
             HdAddress address = WalletTestsHelpers.CreateAddress();
             HdAddress destinationAddress = WalletTestsHelpers.CreateAddress();
 
-            TransactionData changeTransaction = WalletTestsHelpers.CreateTransaction(new uint256(2), new Money(310000), 1);
+            TransactionData changeTransaction =
+                WalletTestsHelpers.CreateTransaction(new uint256(2), new Money(310000), 1);
             changeAddress.Transactions.Add(changeTransaction);
 
-            PaymentDetails paymentDetails = WalletTestsHelpers.CreatePaymentDetails(new Money(200000), destinationAddress);
-            SpendingDetails spendingDetails = WalletTestsHelpers.CreateSpendingDetails(changeTransaction, paymentDetails);
+            PaymentDetails paymentDetails =
+                WalletTestsHelpers.CreatePaymentDetails(new Money(200000), destinationAddress);
+            SpendingDetails spendingDetails =
+                WalletTestsHelpers.CreateSpendingDetails(changeTransaction, paymentDetails);
 
-            TransactionData transaction = WalletTestsHelpers.CreateTransaction(new uint256(1), new Money(500000), 1, spendingDetails);
+            TransactionData transaction =
+                WalletTestsHelpers.CreateTransaction(new uint256(1), new Money(500000), 1, spendingDetails);
             address.Transactions.Add(transaction);
 
             var addresses = new List<HdAddress> { address, changeAddress };
@@ -1057,15 +1019,18 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
             account.ExternalAddresses.Add(address);
             account.InternalAddresses.Add(changeAddress);
 
-            List<FlatHistory> flat = addresses.SelectMany(s => s.Transactions.Select(t => new FlatHistory { Address = s, Transaction = t })).ToList();
+            List<FlatHistory> flat = addresses
+                .SelectMany(s => s.Transactions.Select(t => new FlatHistory { Address = s, Transaction = t })).ToList();
             var accountsHistory = new List<AccountHistory> { new AccountHistory { History = flat, Account = account } };
 
-            var mockWalletManager = new Mock<IWalletManager>();
-            mockWalletManager.Setup(w => w.GetHistory(walletName, WalletManager.DefaultAccount)).Returns(accountsHistory);
+            var mockWalletManager = this.ConfigureMock<IWalletManager>(mock =>
+                mock.Setup(w => w.GetHistory(walletName, WalletManager.DefaultAccount))
+                    .Returns(accountsHistory));
             mockWalletManager.Setup(w => w.GetWallet(walletName)).Returns(wallet);
 
-            var controller = new WalletController(this.LoggerFactory.Object, mockWalletManager.Object, new Mock<IWalletTransactionHandler>().Object, new Mock<IWalletSyncManager>().Object, It.IsAny<ConnectionManager>(), this.Network, this.chainIndexer, new Mock<IBroadcasterManager>().Object, DateTimeProvider.Default);
-            IActionResult result = controller.GetHistory(new WalletHistoryRequest
+            var controller = this.GetWalletController();
+
+            IActionResult result = await controller.GetHistory(new WalletHistoryRequest
             {
                 WalletName = walletName
             });
@@ -1087,7 +1052,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
         /// Tests that when a transaction has been sent that has multiple inputs to form the transaction these duplicate spending details do not show up multiple times in the history.
         /// </summary>
         [Fact]
-        public void GetHistoryWithDuplicateSpentTransactionsSelectsDistinctsSpentTransactionsForDuplicates()
+        public async Task GetHistoryWithDuplicateSpentTransactionsSelectsDistinctsSpentTransactionsForDuplicates()
         {
             string walletName = "myWallet";
 
@@ -1119,28 +1084,28 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
                 {
                     HdPath = $"m/44'/0'/0'/1/0",
                 },
-                new HdAddress(new []
+                new HdAddress(new[]
+                {
+                    new TransactionData
                     {
-                        new TransactionData
+                        Id = new uint256(14),
+                        Amount = new Money(30),
+                        BlockHeight = 6,
+                        SpendingDetails = new SpendingDetails
                         {
-                            Id = new uint256(14),
-                            Amount = new Money(30),
-                            BlockHeight = 6,
-                            SpendingDetails = new SpendingDetails
+                            TransactionId = new uint256(15),
+                            BlockHeight = 10,
+                            Payments = new List<PaymentDetails>
                             {
-                                TransactionId = new uint256(15),
-                                BlockHeight = 10,
-                                Payments = new List<PaymentDetails>
+                                new PaymentDetails
                                 {
-                                    new PaymentDetails
-                                    {
-                                        Amount = new Money(80),
-                                        DestinationAddress = "address1"
-                                    }
+                                    Amount = new Money(80),
+                                    DestinationAddress = "address1"
                                 }
                             }
                         }
-                    })
+                    }
+                })
                 {
                     HdPath = $"m/44'/0'/0'/1/1",
                     Index = 1
@@ -1156,15 +1121,18 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
                 else
                     account.InternalAddresses.Add(address);
 
-            List<FlatHistory> flat = addresses.SelectMany(s => s.Transactions.Select(t => new FlatHistory { Address = s, Transaction = t })).ToList();
+            List<FlatHistory> flat = addresses
+                .SelectMany(s => s.Transactions.Select(t => new FlatHistory { Address = s, Transaction = t })).ToList();
             var accountsHistory = new List<AccountHistory> { new AccountHistory { History = flat, Account = account } };
 
-            var mockWalletManager = new Mock<IWalletManager>();
-            mockWalletManager.Setup(w => w.GetWallet(walletName)).Returns(wallet);
-            mockWalletManager.Setup(w => w.GetHistory(walletName, WalletManager.DefaultAccount)).Returns(accountsHistory);
+            var mockWalletManager = this.ConfigureMock<IWalletManager>(mock =>
+                mock.Setup(w => w.GetWallet(walletName)).Returns(wallet));
+            mockWalletManager.Setup(w => w.GetHistory(walletName, WalletManager.DefaultAccount))
+                .Returns(accountsHistory);
 
-            var controller = new WalletController(this.LoggerFactory.Object, mockWalletManager.Object, new Mock<IWalletTransactionHandler>().Object, new Mock<IWalletSyncManager>().Object, It.IsAny<ConnectionManager>(), this.Network, this.chainIndexer, new Mock<IBroadcasterManager>().Object, DateTimeProvider.Default);
-            IActionResult result = controller.GetHistory(new WalletHistoryRequest
+            var controller = this.GetWalletController();
+
+            IActionResult result = await controller.GetHistory(new WalletHistoryRequest
             {
                 WalletName = walletName
             });
@@ -1192,15 +1160,17 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
         }
 
         [Fact]
-        public void GetHistoryWithExceptionReturnsBadRequest()
+        public async Task GetHistoryWithExceptionReturnsBadRequest()
         {
             string walletName = "myWallet";
-            var mockWalletManager = new Mock<IWalletManager>();
-            mockWalletManager.Setup(w => w.GetHistory("myWallet", WalletManager.DefaultAccount)).Throws(new InvalidOperationException("Issue retrieving wallets."));
+            var mockWalletManager = this.ConfigureMock<IWalletManager>(mock =>
+                mock.Setup(w => w.GetHistory("myWallet", WalletManager.DefaultAccount))
+                    .Throws(new InvalidOperationException("Issue retrieving wallets.")));
             mockWalletManager.Setup(w => w.GetWallet(walletName)).Returns(new Wallet());
 
-            var controller = new WalletController(this.LoggerFactory.Object, mockWalletManager.Object, new Mock<IWalletTransactionHandler>().Object, new Mock<IWalletSyncManager>().Object, It.IsAny<ConnectionManager>(), this.Network, this.chainIndexer, new Mock<IBroadcasterManager>().Object, DateTimeProvider.Default);
-            IActionResult result = controller.GetHistory(new WalletHistoryRequest
+            var controller = this.GetWalletController();
+
+            IActionResult result = await controller.GetHistory(new WalletHistoryRequest
             {
                 WalletName = walletName
             });
@@ -1216,7 +1186,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
         }
 
         [Fact]
-        public void GetHistoryWithChangeAddressesShouldIncludeSpentChangeAddesses()
+        public async Task GetHistoryWithChangeAddressesShouldIncludeSpentChangeAddesses()
         {
             string walletName = "myWallet";
 
@@ -1228,23 +1198,31 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
             HdAddress destinationAddress2 = WalletTestsHelpers.CreateAddress();
 
             // create transaction on change address
-            TransactionData changeTransaction = WalletTestsHelpers.CreateTransaction(new uint256(2), new Money(275000), 1);
+            TransactionData changeTransaction =
+                WalletTestsHelpers.CreateTransaction(new uint256(2), new Money(275000), 1);
             changeAddress.Transactions.Add(changeTransaction);
 
             // create transaction with spending details
-            PaymentDetails paymentDetails = WalletTestsHelpers.CreatePaymentDetails(new Money(200000), destinationAddress);
-            SpendingDetails spendingDetails = WalletTestsHelpers.CreateSpendingDetails(changeTransaction, paymentDetails);
-            TransactionData transaction = WalletTestsHelpers.CreateTransaction(new uint256(1), new Money(500000), 1, spendingDetails);
+            PaymentDetails paymentDetails =
+                WalletTestsHelpers.CreatePaymentDetails(new Money(200000), destinationAddress);
+            SpendingDetails spendingDetails =
+                WalletTestsHelpers.CreateSpendingDetails(changeTransaction, paymentDetails);
+            TransactionData transaction =
+                WalletTestsHelpers.CreateTransaction(new uint256(1), new Money(500000), 1, spendingDetails);
             address.Transactions.Add(transaction);
 
             // create transaction on change address
-            TransactionData changeTransaction2 = WalletTestsHelpers.CreateTransaction(new uint256(4), new Money(200000), 2);
+            TransactionData changeTransaction2 =
+                WalletTestsHelpers.CreateTransaction(new uint256(4), new Money(200000), 2);
             changeAddress2.Transactions.Add(changeTransaction2);
 
             // create transaction with spending details on change address
-            PaymentDetails paymentDetails2 = WalletTestsHelpers.CreatePaymentDetails(new Money(50000), destinationAddress2);
-            SpendingDetails spendingDetails2 = WalletTestsHelpers.CreateSpendingDetails(changeTransaction2, paymentDetails2);
-            TransactionData transaction2 = WalletTestsHelpers.CreateTransaction(new uint256(3), new Money(275000), 2, spendingDetails2);
+            PaymentDetails paymentDetails2 =
+                WalletTestsHelpers.CreatePaymentDetails(new Money(50000), destinationAddress2);
+            SpendingDetails spendingDetails2 =
+                WalletTestsHelpers.CreateSpendingDetails(changeTransaction2, paymentDetails2);
+            TransactionData transaction2 =
+                WalletTestsHelpers.CreateTransaction(new uint256(3), new Money(275000), 2, spendingDetails2);
             changeAddress.Transactions.Add(transaction2);
 
             var addresses = new List<HdAddress> { address, changeAddress, changeAddress2 };
@@ -1257,15 +1235,19 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
                 else
                     account.InternalAddresses.Add(addr);
 
-            List<FlatHistory> flat = addresses.SelectMany(s => s.Transactions.Select(t => new FlatHistory { Address = s, Transaction = t })).ToList();
+            List<FlatHistory> flat = addresses
+                .SelectMany(s => s.Transactions.Select(t => new FlatHistory { Address = s, Transaction = t })).ToList();
 
-            var mockWalletManager = new Mock<IWalletManager>();
+            var mockWalletManager = this.ConfigureMock<IWalletManager>();
+
             var accountsHistory = new List<AccountHistory> { new AccountHistory { History = flat, Account = account } };
-            mockWalletManager.Setup(w => w.GetHistory(walletName, WalletManager.DefaultAccount)).Returns(accountsHistory);
+            mockWalletManager.Setup(w =>
+                w.GetHistory(walletName, WalletManager.DefaultAccount)).Returns(accountsHistory);
             mockWalletManager.Setup(w => w.GetWallet(walletName)).Returns(wallet);
 
-            var controller = new WalletController(this.LoggerFactory.Object, mockWalletManager.Object, new Mock<IWalletTransactionHandler>().Object, new Mock<IWalletSyncManager>().Object, It.IsAny<ConnectionManager>(), this.Network, this.chainIndexer, new Mock<IBroadcasterManager>().Object, DateTimeProvider.Default);
-            IActionResult result = controller.GetHistory(new WalletHistoryRequest
+            var controller = this.GetWalletController();
+
+            IActionResult result = await controller.GetHistory(new WalletHistoryRequest
             {
                 WalletName = walletName
             });
@@ -1322,43 +1304,60 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
         }
 
         [Fact]
-        public void GetBalanceWithValidModelStateReturnsWalletBalanceModel()
+        public async Task GetBalanceWithValidModelStateReturnsWalletBalanceModel()
         {
             HdAccount account = WalletTestsHelpers.CreateAccount("account 1");
             HdAddress accountAddress1 = WalletTestsHelpers.CreateAddress();
-            accountAddress1.Transactions.Add(WalletTestsHelpers.CreateTransaction(new uint256(1), new Money(15000), null));
+            accountAddress1.Transactions.Add(
+                WalletTestsHelpers.CreateTransaction(new uint256(1), new Money(15000), null));
             accountAddress1.Transactions.Add(WalletTestsHelpers.CreateTransaction(new uint256(2), new Money(10000), 1));
 
             HdAddress accountAddress2 = WalletTestsHelpers.CreateAddress(true);
-            accountAddress2.Transactions.Add(WalletTestsHelpers.CreateTransaction(new uint256(3), new Money(20000), null));
-            accountAddress2.Transactions.Add(WalletTestsHelpers.CreateTransaction(new uint256(4), new Money(120000), 2));
+            accountAddress2.Transactions.Add(
+                WalletTestsHelpers.CreateTransaction(new uint256(3), new Money(20000), null));
+            accountAddress2.Transactions.Add(
+                WalletTestsHelpers.CreateTransaction(new uint256(4), new Money(120000), 2));
 
             account.ExternalAddresses.Add(accountAddress1);
             account.InternalAddresses.Add(accountAddress2);
 
             HdAccount account2 = WalletTestsHelpers.CreateAccount("account 2");
             HdAddress account2Address1 = WalletTestsHelpers.CreateAddress();
-            account2Address1.Transactions.Add(WalletTestsHelpers.CreateTransaction(new uint256(5), new Money(74000), null));
-            account2Address1.Transactions.Add(WalletTestsHelpers.CreateTransaction(new uint256(6), new Money(18700), 3));
+            account2Address1.Transactions.Add(
+                WalletTestsHelpers.CreateTransaction(new uint256(5), new Money(74000), null));
+            account2Address1.Transactions.Add(
+                WalletTestsHelpers.CreateTransaction(new uint256(6), new Money(18700), 3));
 
             HdAddress account2Address2 = WalletTestsHelpers.CreateAddress(true);
-            account2Address2.Transactions.Add(WalletTestsHelpers.CreateTransaction(new uint256(7), new Money(65000), null));
-            account2Address2.Transactions.Add(WalletTestsHelpers.CreateTransaction(new uint256(8), new Money(89300), 4));
+            account2Address2.Transactions.Add(
+                WalletTestsHelpers.CreateTransaction(new uint256(7), new Money(65000), null));
+            account2Address2.Transactions.Add(
+                WalletTestsHelpers.CreateTransaction(new uint256(8), new Money(89300), 4));
 
             account2.ExternalAddresses.Add(account2Address1);
             account2.InternalAddresses.Add(account2Address2);
 
             var accountsBalances = new List<AccountBalance>
             {
-                new AccountBalance { Account = account, AmountConfirmed = new Money(130000), AmountUnconfirmed = new Money(35000), SpendableAmount = new Money(130000) },
-                new AccountBalance { Account = account2, AmountConfirmed = new Money(108000), AmountUnconfirmed = new Money(139000), SpendableAmount = new Money(108000) }
+                new AccountBalance
+                {
+                    Account = account, AmountConfirmed = new Money(130000), AmountUnconfirmed = new Money(35000),
+                    SpendableAmount = new Money(130000)
+                },
+                new AccountBalance
+                {
+                    Account = account2, AmountConfirmed = new Money(108000), AmountUnconfirmed = new Money(139000),
+                    SpendableAmount = new Money(108000)
+                }
             };
 
-            var mockWalletManager = new Mock<IWalletManager>();
-            mockWalletManager.Setup(w => w.GetBalances("myWallet", WalletManager.DefaultAccount, It.IsAny<int>())).Returns(accountsBalances);
+            var mockWalletManager = this.ConfigureMock<IWalletManager>();
+            mockWalletManager.Setup(w => w.GetBalances("myWallet", WalletManager.DefaultAccount, It.IsAny<int>()))
+                .Returns(accountsBalances);
 
-            var controller = new WalletController(this.LoggerFactory.Object, mockWalletManager.Object, new Mock<IWalletTransactionHandler>().Object, new Mock<IWalletSyncManager>().Object, It.IsAny<ConnectionManager>(), this.Network, this.chainIndexer, new Mock<IBroadcasterManager>().Object, DateTimeProvider.Default);
-            IActionResult result = controller.GetBalance(new WalletBalanceRequest
+            var controller = this.GetWalletController();
+
+            IActionResult result = await controller.GetBalance(new WalletBalanceRequest
             {
                 WalletName = "myWallet"
             });
@@ -1387,7 +1386,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
         }
 
         [Fact]
-        public void WalletSyncFromDateReturnsOK()
+        public async Task WalletSyncFromDateReturnsOK()
         {
             string walletName = "myWallet";
             DateTime syncDate = DateTime.Now.Subtract(new TimeSpan(1)).Date;
@@ -1397,11 +1396,9 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
                 It.Is<DateTime>((val) => val.Equals(syncDate)),
                 It.Is<string>(val => walletName.Equals(val))));
 
-            var controller = new WalletController(this.LoggerFactory.Object, new Mock<IWalletManager>().Object,
-                new Mock<IWalletTransactionHandler>().Object, mockWalletSyncManager.Object, It.IsAny<ConnectionManager>(),
-                this.Network, this.chainIndexer, new Mock<IBroadcasterManager>().Object, DateTimeProvider.Default);
+            var controller = this.GetWalletController();
 
-            IActionResult result = controller.SyncFromDate(new WalletSyncRequest
+            IActionResult result = await controller.SyncFromDate(new WalletSyncRequest
             {
                 WalletName = walletName,
                 Date = DateTime.Now.Subtract(new TimeSpan(1)).Date
@@ -1414,7 +1411,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
         }
 
         [Fact]
-        public void WalletSyncAllReturnsOK()
+        public async Task WalletSyncAllReturnsOK()
         {
             string walletName = "myWallet";
 
@@ -1423,11 +1420,9 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
                 It.Is<int>((val) => val.Equals(0)),
                 It.Is<string>(val => walletName.Equals(val))));
 
-            var controller = new WalletController(this.LoggerFactory.Object, new Mock<IWalletManager>().Object,
-                new Mock<IWalletTransactionHandler>().Object, mockWalletSyncManager.Object, It.IsAny<ConnectionManager>(),
-                this.Network, this.chainIndexer, new Mock<IBroadcasterManager>().Object, DateTimeProvider.Default);
+            var controller = this.GetWalletController();
 
-            IActionResult result = controller.SyncFromDate(new WalletSyncRequest
+            IActionResult result = await controller.SyncFromDate(new WalletSyncRequest
             {
                 WalletName = walletName,
                 All = true
@@ -1440,15 +1435,16 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
         }
 
         [Fact]
-        public void GetBalanceWithEmptyListOfAccountsReturnsWalletBalanceModel()
+        public async Task GetBalanceWithEmptyListOfAccountsReturnsWalletBalanceModel()
         {
             var accounts = new List<HdAccount>();
             var mockWalletManager = new Mock<IWalletManager>();
             mockWalletManager.Setup(w => w.GetAccounts("myWallet"))
                 .Returns(accounts);
 
-            var controller = new WalletController(this.LoggerFactory.Object, mockWalletManager.Object, new Mock<IWalletTransactionHandler>().Object, new Mock<IWalletSyncManager>().Object, It.IsAny<ConnectionManager>(), this.Network, this.chainIndexer, new Mock<IBroadcasterManager>().Object, DateTimeProvider.Default);
-            IActionResult result = controller.GetBalance(new WalletBalanceRequest
+            var controller = this.GetWalletController();
+
+            IActionResult result = await controller.GetBalance(new WalletBalanceRequest
             {
                 WalletName = "myWallet",
                 AccountName = null
@@ -1462,13 +1458,12 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
         }
 
         [Fact]
-        public void GetBalanceWithInvalidValidModelStateReturnsBadRequest()
+        public async Task GetBalanceWithInvalidValidModelStateReturnsBadRequest()
         {
-            var mockWalletManager = new Mock<IWalletManager>();
+            var controller = this.GetWalletController();
 
-            var controller = new WalletController(this.LoggerFactory.Object, mockWalletManager.Object, new Mock<IWalletTransactionHandler>().Object, new Mock<IWalletSyncManager>().Object, It.IsAny<ConnectionManager>(), this.Network, this.chainIndexer, new Mock<IBroadcasterManager>().Object, DateTimeProvider.Default);
             controller.ModelState.AddModelError("WalletName", "A walletname is required.");
-            IActionResult result = controller.GetBalance(new WalletBalanceRequest
+            IActionResult result = await controller.GetBalance(new WalletBalanceRequest
             {
                 WalletName = ""
             });
@@ -1483,14 +1478,15 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
         }
 
         [Fact]
-        public void GetBalanceWithExceptionReturnsBadRequest()
+        public async Task GetBalanceWithExceptionReturnsBadRequest()
         {
-            var mockWalletManager = new Mock<IWalletManager>();
+            var mockWalletManager = this.ConfigureMock<IWalletManager>();
             mockWalletManager.Setup(m => m.GetBalances("myWallet", WalletManager.DefaultAccount, It.IsAny<int>()))
-                  .Throws(new InvalidOperationException("Issue retrieving accounts."));
+                .Throws(new InvalidOperationException("Issue retrieving accounts."));
 
-            var controller = new WalletController(this.LoggerFactory.Object, mockWalletManager.Object, new Mock<IWalletTransactionHandler>().Object, new Mock<IWalletSyncManager>().Object, It.IsAny<ConnectionManager>(), this.Network, this.chainIndexer, new Mock<IBroadcasterManager>().Object, DateTimeProvider.Default);
-            IActionResult result = controller.GetBalance(new WalletBalanceRequest
+            var controller = this.GetWalletController();
+
+            IActionResult result = await controller.GetBalance(new WalletBalanceRequest
             {
                 WalletName = "myWallet"
             });
@@ -1506,19 +1502,26 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
         }
 
         [Fact]
-        public void GetAddressBalanceWithValidModelStateReturnsAddressBalanceModel()
+        public async Task GetAddressBalanceWithValidModelStateReturnsAddressBalanceModel()
         {
             HdAccount account = WalletTestsHelpers.CreateAccount("account 1");
             HdAddress accountAddress = WalletTestsHelpers.CreateAddress(true);
             account.InternalAddresses.Add(accountAddress);
 
-            var addressBalance = new AddressBalance { Address = accountAddress.Address, AmountConfirmed = new Money(75000), AmountUnconfirmed = new Money(500000), SpendableAmount = new Money(75000)};
+            var addressBalance = new AddressBalance
+            {
+                Address = accountAddress.Address,
+                AmountConfirmed = new Money(75000),
+                AmountUnconfirmed = new Money(500000),
+                SpendableAmount = new Money(75000)
+            };
 
-            var mockWalletManager = new Mock<IWalletManager>();
+            var mockWalletManager = this.ConfigureMock<IWalletManager>();
             mockWalletManager.Setup(w => w.GetAddressBalance(accountAddress.Address)).Returns(addressBalance);
 
-            var controller = new WalletController(this.LoggerFactory.Object, mockWalletManager.Object, new Mock<IWalletTransactionHandler>().Object, new Mock<IWalletSyncManager>().Object, It.IsAny<ConnectionManager>(), this.Network, this.chainIndexer, new Mock<IBroadcasterManager>().Object, DateTimeProvider.Default);
-            IActionResult result = controller.GetReceivedByAddress(new ReceivedByAddressRequest
+            var controller = this.GetWalletController();
+
+            IActionResult result = await controller.GetReceivedByAddress(new ReceivedByAddressRequest
             {
                 Address = accountAddress.Address
             });
@@ -1534,14 +1537,15 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
         }
 
         [Fact]
-        public void GetAddressBalanceWithExceptionReturnsBadRequest()
+        public async Task GetAddressBalanceWithExceptionReturnsBadRequest()
         {
-            var mockWalletManager = new Mock<IWalletManager>();
+            var mockWalletManager = this.ConfigureMock<IWalletManager>();
             mockWalletManager.Setup(m => m.GetAddressBalance("MyAddress"))
-                  .Throws(new InvalidOperationException("Issue retrieving address balance."));
+                .Throws(new InvalidOperationException("Issue retrieving address balance."));
 
-            var controller = new WalletController(this.LoggerFactory.Object, mockWalletManager.Object, new Mock<IWalletTransactionHandler>().Object, new Mock<IWalletSyncManager>().Object, It.IsAny<ConnectionManager>(), this.Network, this.chainIndexer, new Mock<IBroadcasterManager>().Object, DateTimeProvider.Default);
-            IActionResult result = controller.GetReceivedByAddress(new ReceivedByAddressRequest
+            var controller = this.GetWalletController();
+
+            IActionResult result = await controller.GetReceivedByAddress(new ReceivedByAddressRequest
             {
                 Address = "MyAddress"
             });
@@ -1557,13 +1561,12 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
         }
 
         [Fact]
-        public void GetAddressBalanceWithInvalidModelStateReturnsBadRequest()
+        public async Task GetAddressBalanceWithInvalidModelStateReturnsBadRequest()
         {
-            var mockWalletManager = new Mock<IWalletManager>();
+            var controller = this.GetWalletController();
 
-            var controller = new WalletController(this.LoggerFactory.Object, mockWalletManager.Object, new Mock<IWalletTransactionHandler>().Object, new Mock<IWalletSyncManager>().Object, It.IsAny<ConnectionManager>(), this.Network, this.chainIndexer, new Mock<IBroadcasterManager>().Object, DateTimeProvider.Default);
             controller.ModelState.AddModelError("Address", "An address is required.");
-            IActionResult result = controller.GetReceivedByAddress(new ReceivedByAddressRequest
+            IActionResult result = await controller.GetReceivedByAddress(new ReceivedByAddressRequest
             {
                 Address = ""
             });
@@ -1578,22 +1581,29 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
         }
 
         [Fact]
-        public void BuildTransactionWithValidRequestAllowingUnconfirmedReturnsWalletBuildTransactionModel()
+        public async Task BuildTransactionWithValidRequestAllowingUnconfirmedReturnsWalletBuildTransactionModel()
         {
-            var mockWalletManager = new Mock<IWalletManager>();
-            var mockWalletTransactionHandler = new Mock<IWalletTransactionHandler>();
+            var mockWalletTransactionHandler = this.ConfigureMock<IWalletTransactionHandler>();
+
             var key = new Key();
             var sentTrx = new Transaction();
             mockWalletTransactionHandler.Setup(m => m.BuildTransaction(It.IsAny<TransactionBuildContext>()))
                 .Returns(sentTrx);
 
-            var controller = new WalletController(this.LoggerFactory.Object, mockWalletManager.Object, mockWalletTransactionHandler.Object, new Mock<IWalletSyncManager>().Object, It.IsAny<ConnectionManager>(), this.Network, this.chainIndexer, new Mock<IBroadcasterManager>().Object, DateTimeProvider.Default);
+            var controller = this.GetWalletController();
 
-            IActionResult result = controller.BuildTransaction(new BuildTransactionRequest
+            IActionResult result = await controller.BuildTransaction(new BuildTransactionRequest
             {
                 AccountName = "Account 1",
                 AllowUnconfirmed = true,
-                Recipients = new List<RecipientModel> { new RecipientModel { DestinationAddress = key.PubKey.GetAddress(this.Network).ToString(), Amount = new Money(150000).ToString() } },
+                Recipients = new List<RecipientModel>
+                {
+                    new RecipientModel
+                    {
+                        DestinationAddress = key.PubKey.GetAddress(this.Network).ToString(),
+                        Amount = new Money(150000).ToString()
+                    }
+                },
                 FeeType = "105",
                 Password = "test",
                 WalletName = "myWallet"
@@ -1608,21 +1618,30 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
         }
 
         [Fact]
-        public void BuildTransactionWithCustomFeeAmountAndFeeTypeReturnsWalletBuildTransactionModelWithFeeAmount()
+        public async Task BuildTransactionWithCustomFeeAmountAndFeeTypeReturnsWalletBuildTransactionModelWithFeeAmount()
         {
-            var mockWalletManager = new Mock<IWalletManager>();
-            var mockWalletTransactionHandler = new Mock<IWalletTransactionHandler>();
             var key = new Key();
-            var sentTrx = new Transaction();
-            mockWalletTransactionHandler.Setup(m => m.BuildTransaction(It.IsAny<TransactionBuildContext>()))
-                .Returns(sentTrx);
+            this.ConfigureMock<IWalletTransactionHandler>(mock =>
+            {
+                var sentTrx = new Transaction();
+                mock.Setup(m => m.BuildTransaction(It.IsAny<TransactionBuildContext>()))
+                    .Returns(sentTrx);
+            });
 
-            var controller = new WalletController(this.LoggerFactory.Object, mockWalletManager.Object, mockWalletTransactionHandler.Object, new Mock<IWalletSyncManager>().Object, It.IsAny<ConnectionManager>(), this.Network, this.chainIndexer, new Mock<IBroadcasterManager>().Object, DateTimeProvider.Default);
-            IActionResult result = controller.BuildTransaction(new BuildTransactionRequest
+            var controller = this.GetWalletController();
+
+            IActionResult result = await controller.BuildTransaction(new BuildTransactionRequest
             {
                 AccountName = "Account 1",
                 AllowUnconfirmed = true,
-                Recipients = new List<RecipientModel> { new RecipientModel { DestinationAddress = key.PubKey.GetAddress(this.Network).ToString(), Amount = new Money(150000).ToString() } },
+                Recipients = new List<RecipientModel>
+                {
+                    new RecipientModel
+                    {
+                        DestinationAddress = key.PubKey.GetAddress(this.Network).ToString(),
+                        Amount = new Money(150000).ToString()
+                    }
+                },
                 FeeType = "105",
                 FeeAmount = "0.1234",
                 Password = "test",
@@ -1637,21 +1656,31 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
         }
 
         [Fact]
-        public void BuildTransactionWithCustomFeeAmountAndNoFeeTypeReturnsWalletBuildTransactionModelWithFeeAmount()
+        public async Task
+            BuildTransactionWithCustomFeeAmountAndNoFeeTypeReturnsWalletBuildTransactionModelWithFeeAmount()
         {
-            var mockWalletManager = new Mock<IWalletManager>();
-            var mockWalletTransactionHandler = new Mock<IWalletTransactionHandler>();
             var key = new Key();
-            var sentTrx = new Transaction();
-            mockWalletTransactionHandler.Setup(m => m.BuildTransaction(It.IsAny<TransactionBuildContext>()))
-                .Returns(sentTrx);
+            this.ConfigureMock<IWalletTransactionHandler>(mock =>
+            {
+                var sentTrx = new Transaction();
+                mock.Setup(m => m.BuildTransaction(It.IsAny<TransactionBuildContext>()))
+                    .Returns(sentTrx);
+            });
 
-            var controller = new WalletController(this.LoggerFactory.Object, mockWalletManager.Object, mockWalletTransactionHandler.Object, new Mock<IWalletSyncManager>().Object, It.IsAny<ConnectionManager>(), this.Network, this.chainIndexer, new Mock<IBroadcasterManager>().Object, DateTimeProvider.Default);
-            IActionResult result = controller.BuildTransaction(new BuildTransactionRequest
+            var controller = this.GetWalletController();
+
+            IActionResult result = await controller.BuildTransaction(new BuildTransactionRequest
             {
                 AccountName = "Account 1",
                 AllowUnconfirmed = true,
-                Recipients = new List<RecipientModel> { new RecipientModel { DestinationAddress = key.PubKey.GetAddress(this.Network).ToString(), Amount = new Money(150000).ToString() } },
+                Recipients = new List<RecipientModel>
+                {
+                    new RecipientModel
+                    {
+                        DestinationAddress = key.PubKey.GetAddress(this.Network).ToString(),
+                        Amount = new Money(150000).ToString()
+                    }
+                },
                 FeeAmount = "0.1234",
                 Password = "test",
                 WalletName = "myWallet"
@@ -1665,21 +1694,30 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
         }
 
         [Fact]
-        public void BuildTransactionWithValidRequestNotAllowingUnconfirmedReturnsWalletBuildTransactionModel()
+        public async Task BuildTransactionWithValidRequestNotAllowingUnconfirmedReturnsWalletBuildTransactionModel()
         {
-            var mockWalletManager = new Mock<IWalletManager>();
-            var mockWalletTransactionHandler = new Mock<IWalletTransactionHandler>();
             var key = new Key();
             var sentTrx = new Transaction();
-            mockWalletTransactionHandler.Setup(m => m.BuildTransaction(It.IsAny<TransactionBuildContext>()))
-                .Returns(sentTrx);
+            this.ConfigureMock<IWalletTransactionHandler>(mock =>
+            {
+                mock.Setup(m => m.BuildTransaction(It.IsAny<TransactionBuildContext>()))
+                    .Returns(sentTrx);
+            });
 
-            var controller = new WalletController(this.LoggerFactory.Object, mockWalletManager.Object, mockWalletTransactionHandler.Object, new Mock<IWalletSyncManager>().Object, It.IsAny<ConnectionManager>(), this.Network, this.chainIndexer, new Mock<IBroadcasterManager>().Object, DateTimeProvider.Default);
-            IActionResult result = controller.BuildTransaction(new BuildTransactionRequest
+            var controller = this.GetWalletController();
+
+            IActionResult result = await controller.BuildTransaction(new BuildTransactionRequest
             {
                 AccountName = "Account 1",
                 AllowUnconfirmed = false,
-                Recipients = new List<RecipientModel> { new RecipientModel { DestinationAddress = key.PubKey.GetAddress(this.Network).ToString(), Amount = new Money(150000).ToString() } },
+                Recipients = new List<RecipientModel>
+                {
+                    new RecipientModel
+                    {
+                        DestinationAddress = key.PubKey.GetAddress(this.Network).ToString(),
+                        Amount = new Money(150000).ToString()
+                    }
+                },
                 FeeType = "105",
                 Password = "test",
                 WalletName = "myWallet"
@@ -1694,31 +1732,30 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
         }
 
         [Fact]
-        public void BuildTransactionWithChangeAddressReturnsWalletBuildTransactionModel()
+        public async Task BuildTransactionWithChangeAddressReturnsWalletBuildTransactionModel()
         {
             string walletName = "myWallet";
 
             HdAddress usedReceiveAddress = WalletTestsHelpers.CreateAddress();
 
-            var receiveAddresses = new List<HdAddress> { usedReceiveAddress };
-            var changeAddresses = new List<HdAddress>();
-
             Wallet wallet = WalletTestsHelpers.CreateWallet(walletName);
             HdAccount account = wallet.AddNewAccount((ExtPubKey)null, accountName: "Account 0");
             account.ExternalAddresses.Add(usedReceiveAddress);
 
-            var mockWalletManager = new Mock<IWalletManager>();
+            this.ConfigureMock<IWalletManager>(mock =>
+                mock.Setup(m => m.GetWallet(walletName)).Returns(wallet));
 
-            mockWalletManager.Setup(m => m.GetWallet(walletName)).Returns(wallet);
+            var mockWalletTransactionHandler = this.ConfigureMock<IWalletTransactionHandler>(mock =>
+            {
+                var sentTrx = new Transaction();
+                mock.Setup(m =>
+                        m.BuildTransaction(It.Is<TransactionBuildContext>(t => t.ChangeAddress == usedReceiveAddress)))
+                    .Returns(sentTrx);
+            });
 
-            var mockWalletTransactionHandler = new Mock<IWalletTransactionHandler>();
+            var controller = this.GetWalletController();
 
-            var sentTrx = new Transaction();
-            mockWalletTransactionHandler.Setup(m => m.BuildTransaction(It.Is<TransactionBuildContext>(t => t.ChangeAddress == usedReceiveAddress)))
-                .Returns(sentTrx);
-
-            var controller = new WalletController(this.LoggerFactory.Object, mockWalletManager.Object, mockWalletTransactionHandler.Object, new Mock<IWalletSyncManager>().Object, It.IsAny<ConnectionManager>(), this.Network, this.chainIndexer, new Mock<IBroadcasterManager>().Object, DateTimeProvider.Default);
-            IActionResult result = controller.BuildTransaction(new BuildTransactionRequest
+            IActionResult result = await controller.BuildTransaction(new BuildTransactionRequest
             {
                 AccountName = "Account 0",
                 Recipients = new List<RecipientModel>(),
@@ -1730,29 +1767,31 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
             var model = viewResult.Value as WalletBuildTransactionModel;
 
             // Verify the transaction builder was invoked with the change address.
-            mockWalletTransactionHandler.Verify(w => w.BuildTransaction(It.Is<TransactionBuildContext>(t => t.ChangeAddress == usedReceiveAddress)), Times.Once);
+            mockWalletTransactionHandler.Verify(
+                w => w.BuildTransaction(It.Is<TransactionBuildContext>(t => t.ChangeAddress == usedReceiveAddress)),
+                Times.Once);
 
             Assert.NotNull(model);
         }
 
         [Fact]
-        public void BuildTransactionWithChangeAddressNotInWalletReturnsBadRequest()
+        public async Task BuildTransactionWithChangeAddressNotInWalletReturnsBadRequest()
         {
             string walletName = "myWallet";
 
             Wallet wallet = WalletTestsHelpers.CreateWallet(walletName);
-            HdAccount account = wallet.AddNewAccount((ExtPubKey)null, accountName: "Account 0");
+            wallet.AccountsRoot.First().Accounts.Add(WalletTestsHelpers.CreateAccount("Account 0"));
 
-            var mockWalletManager = new Mock<IWalletManager>();
+            this.ConfigureMock<IWalletManager>(mock =>
+                mock.Setup(m => m.GetWallet(walletName)).Returns(wallet));
 
-            mockWalletManager.Setup(m => m.GetWallet(walletName)).Returns(wallet);
-
-            var mockWalletTransactionHandler = new Mock<IWalletTransactionHandler>();
+            var mockWalletTransactionHandler = this.ConfigureMock<IWalletTransactionHandler>();
 
             HdAddress addressNotInWallet = WalletTestsHelpers.CreateAddress();
 
-            var controller = new WalletController(this.LoggerFactory.Object, mockWalletManager.Object, mockWalletTransactionHandler.Object, new Mock<IWalletSyncManager>().Object, It.IsAny<ConnectionManager>(), this.Network, this.chainIndexer, new Mock<IBroadcasterManager>().Object, DateTimeProvider.Default);
-            IActionResult result = controller.BuildTransaction(new BuildTransactionRequest
+            var controller = this.GetWalletController();
+
+            IActionResult result = await controller.BuildTransaction(new BuildTransactionRequest
             {
                 AccountName = "Account 0",
                 Recipients = new List<RecipientModel>(),
@@ -1761,7 +1800,8 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
             });
 
             // Verify the transaction builder was never invoked.
-            mockWalletTransactionHandler.Verify(w => w.BuildTransaction(It.IsAny<TransactionBuildContext>()), Times.Never);
+            mockWalletTransactionHandler.Verify(w => w.BuildTransaction(It.IsAny<TransactionBuildContext>()),
+                Times.Never);
 
             var errorResult = Assert.IsType<ErrorResult>(result);
             var errorResponse = Assert.IsType<ErrorResponse>(errorResult.Value);
@@ -1773,23 +1813,23 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
         }
 
         [Fact]
-        public void BuildTransactionWithChangeAddressAccountNotInWalletReturnsBadRequest()
+        public async Task BuildTransactionWithChangeAddressAccountNotInWalletReturnsBadRequest()
         {
             string walletName = "myWallet";
 
             // Create a wallet with no accounts.
             Wallet wallet = WalletTestsHelpers.CreateWallet(walletName);
 
-            var mockWalletManager = new Mock<IWalletManager>();
+            this.ConfigureMock<IWalletManager>(mock =>
+                mock.Setup(m => m.GetWallet(walletName)).Returns(wallet));
 
-            mockWalletManager.Setup(m => m.GetWallet(walletName)).Returns(wallet);
-
-            var mockWalletTransactionHandler = new Mock<IWalletTransactionHandler>();
+            var mockWalletTransactionHandler = this.ConfigureMock<IWalletTransactionHandler>();
 
             HdAddress addressNotInWallet = WalletTestsHelpers.CreateAddress();
 
-            var controller = new WalletController(this.LoggerFactory.Object, mockWalletManager.Object, mockWalletTransactionHandler.Object, new Mock<IWalletSyncManager>().Object, It.IsAny<ConnectionManager>(), this.Network, this.chainIndexer, new Mock<IBroadcasterManager>().Object, DateTimeProvider.Default);
-            IActionResult result = controller.BuildTransaction(new BuildTransactionRequest
+            var controller = this.GetWalletController();
+
+            IActionResult result = await controller.BuildTransaction(new BuildTransactionRequest
             {
                 AccountName = "Account 0",
                 Recipients = new List<RecipientModel>(),
@@ -1798,7 +1838,8 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
             });
 
             // Verify the transaction builder was never invoked.
-            mockWalletTransactionHandler.Verify(w => w.BuildTransaction(It.IsAny<TransactionBuildContext>()), Times.Never);
+            mockWalletTransactionHandler.Verify(w => w.BuildTransaction(It.IsAny<TransactionBuildContext>()),
+                Times.Never);
 
             var errorResult = Assert.IsType<ErrorResult>(result);
             var errorResponse = Assert.IsType<ErrorResponse>(errorResult.Value);
@@ -1810,13 +1851,12 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
         }
 
         [Fact]
-        public void BuildTransactionWithInvalidModelStateReturnsBadRequest()
+        public async Task BuildTransactionWithInvalidModelStateReturnsBadRequest()
         {
-            var mockWalletManager = new Mock<IWalletManager>();
+            var controller = this.GetWalletController();
 
-            var controller = new WalletController(this.LoggerFactory.Object, mockWalletManager.Object, new Mock<IWalletTransactionHandler>().Object, new Mock<IWalletSyncManager>().Object, It.IsAny<ConnectionManager>(), this.Network, this.chainIndexer, new Mock<IBroadcasterManager>().Object, DateTimeProvider.Default);
             controller.ModelState.AddModelError("WalletName", "A walletname is required.");
-            IActionResult result = controller.BuildTransaction(new BuildTransactionRequest
+            IActionResult result = await controller.BuildTransaction(new BuildTransactionRequest
             {
                 WalletName = ""
             });
@@ -1831,21 +1871,29 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
         }
 
         [Fact]
-        public void BuildTransactionWithExceptionReturnsBadRequest()
+        public async Task BuildTransactionWithExceptionReturnsBadRequest()
         {
-            var mockWalletManager = new Mock<IWalletManager>();
-            var mockWalletTransactionHandler = new Mock<IWalletTransactionHandler>();
-
             var key = new Key();
-            mockWalletTransactionHandler.Setup(m => m.BuildTransaction(It.IsAny<TransactionBuildContext>()))
-                .Throws(new InvalidOperationException("Issue building transaction."));
+            this.ConfigureMock<IWalletTransactionHandler>(mock =>
+            {
+                mock.Setup(m => m.BuildTransaction(It.IsAny<TransactionBuildContext>()))
+                    .Throws(new InvalidOperationException("Issue building transaction."));
+            });
 
-            var controller = new WalletController(this.LoggerFactory.Object, mockWalletManager.Object, mockWalletTransactionHandler.Object, new Mock<IWalletSyncManager>().Object, It.IsAny<ConnectionManager>(), this.Network, this.chainIndexer, new Mock<IBroadcasterManager>().Object, DateTimeProvider.Default);
-            IActionResult result = controller.BuildTransaction(new BuildTransactionRequest
+            var controller = this.GetWalletController();
+
+            IActionResult result = await controller.BuildTransaction(new BuildTransactionRequest
             {
                 AccountName = "Account 1",
                 AllowUnconfirmed = false,
-                Recipients = new List<RecipientModel> { new RecipientModel { DestinationAddress = key.PubKey.GetAddress(this.Network).ToString(), Amount = new Money(150000).ToString() } },
+                Recipients = new List<RecipientModel>
+                {
+                    new RecipientModel
+                    {
+                        DestinationAddress = key.PubKey.GetAddress(this.Network).ToString(),
+                        Amount = new Money(150000).ToString()
+                    }
+                },
                 FeeType = "105",
                 Password = "test",
                 WalletName = "myWallet"
@@ -1862,27 +1910,30 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
         }
 
         [Fact]
-        public void SendTransactionSuccessfulReturnsWalletSendTransactionModelResponse()
+        public async Task SendTransactionSuccessfulReturnsWalletSendTransactionModelResponse()
         {
-            string transactionHex = "010000000189c041f79aac3aa7e7a72804a9a55cd9eceba41a0586640f602eb9823540ce89010000006b483045022100ab9597b37cb8796aefa30b207abb248c8003d4d153076997e375b0daf4f9f7050220546397fee1cefe54c49210ea653e9e61fb88adf51b68d2c04ad6d2b46ddf97a30121035cc9de1f233469dad8a3bbd1e61b699a7dd8e0d8370c6f3b1f2a16167da83546ffffffff02f6400a00000000001976a914accf603142aaa5e22dc82500d3e187caf712f11588ac3cf61700000000001976a91467872601dda216fbf4cab7891a03ebace87d8e7488ac00000000";
+            string transactionHex =
+                "010000000189c041f79aac3aa7e7a72804a9a55cd9eceba41a0586640f602eb9823540ce89010000006b483045022100ab9597b37cb8796aefa30b207abb248c8003d4d153076997e375b0daf4f9f7050220546397fee1cefe54c49210ea653e9e61fb88adf51b68d2c04ad6d2b46ddf97a30121035cc9de1f233469dad8a3bbd1e61b699a7dd8e0d8370c6f3b1f2a16167da83546ffffffff02f6400a00000000001976a914accf603142aaa5e22dc82500d3e187caf712f11588ac3cf61700000000001976a91467872601dda216fbf4cab7891a03ebace87d8e7488ac00000000";
 
-            var mockBroadcasterManager = new Mock<IBroadcasterManager>();
+            var mockBroadcasterManager = this.ConfigureMock<IBroadcasterManager>();
 
-            mockBroadcasterManager.Setup(m => m.GetTransaction(It.IsAny<uint256>())).Returns(new TransactionBroadcastEntry(this.Network.CreateTransaction(transactionHex), State.Broadcasted, null));
+            mockBroadcasterManager.Setup(m => m.GetTransaction(It.IsAny<uint256>())).Returns(
+                new TransactionBroadcastEntry(this.Network.CreateTransaction(transactionHex), State.Broadcasted, null));
 
-            var connectionManagerMock = new Mock<IConnectionManager>();
+            var connectionManagerMock = this.ConfigureMock<IConnectionManager>();
             var peers = new List<INetworkPeer>();
             peers.Add(null);
             connectionManagerMock.Setup(c => c.ConnectedPeers).Returns(new TestReadOnlyNetworkPeerCollection(peers));
 
-            var controller = new WalletController(this.LoggerFactory.Object, new Mock<IWalletManager>().Object, new Mock<IWalletTransactionHandler>().Object,
-                new Mock<IWalletSyncManager>().Object, connectionManagerMock.Object, this.Network, this.chainIndexer, mockBroadcasterManager.Object, DateTimeProvider.Default);
-            IActionResult result = controller.SendTransaction(new SendTransactionRequest(transactionHex));
+            var controller = this.GetWalletController();
+
+            IActionResult result = await controller.SendTransaction(new SendTransactionRequest(transactionHex));
 
             var viewResult = Assert.IsType<JsonResult>(result);
             var model = viewResult.Value as WalletSendTransactionModel;
             Assert.NotNull(model);
-            Assert.Equal(new uint256("96b4f0c2f0aa2cecd43fa66b5e3227c56afd8791e18fcc572d9625ee05d6741c"), model.TransactionId);
+            Assert.Equal(new uint256("96b4f0c2f0aa2cecd43fa66b5e3227c56afd8791e18fcc572d9625ee05d6741c"),
+                model.TransactionId);
             Assert.Equal("1GkjeiT7Y6RdPPL3p3nUME9DLJchhLNCsJ", model.Outputs.First().Address);
             Assert.Equal(new Money(671990), model.Outputs.First().Amount);
             Assert.Equal("1ASQW3EkkQ1zCpq3HAVfrGyVrSwVz4cbzU", model.Outputs.ElementAt(1).Address);
@@ -1890,18 +1941,18 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
         }
 
         [Fact]
-        public void SendTransactionFailedBecauseNoNodesConnected()
+        public async Task SendTransactionFailedBecauseNoNodesConnected()
         {
-            var mockBroadcasterManager = new Mock<IBroadcasterManager>();
+            var mockBroadcasterManager = this.ConfigureMock<IBroadcasterManager>();
 
-            var connectionManagerMock = new Mock<IConnectionManager>();
+            var connectionManagerMock = this.ConfigureMock<IConnectionManager>();
             connectionManagerMock.Setup(c => c.ConnectedPeers)
                 .Returns(new NetworkPeerCollection());
 
-            var controller = new WalletController(this.LoggerFactory.Object, new Mock<IWalletManager>().Object, new Mock<IWalletTransactionHandler>().Object,
-                new Mock<IWalletSyncManager>().Object, connectionManagerMock.Object, this.Network, this.chainIndexer, mockBroadcasterManager.Object, DateTimeProvider.Default);
+            var controller = this.GetWalletController();
 
-            IActionResult result = controller.SendTransaction(new SendTransactionRequest(new uint256(15555).ToString()));
+            IActionResult result =
+                await controller.SendTransaction(new SendTransactionRequest(new uint256(15555).ToString()));
 
             var errorResult = Assert.IsType<ErrorResult>(result);
             var errorResponse = Assert.IsType<ErrorResponse>(errorResult.Value);
@@ -1909,17 +1960,17 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
 
             ErrorModel error = errorResponse.Errors[0];
             Assert.Equal(403, error.Status);
-            Assert.Equal("Can't send transaction: sending transaction requires at least one connection!", error.Message);
+            Assert.Equal("Can't send transaction: sending transaction requires at least one connection!",
+                error.Message);
         }
 
         [Fact]
-        public void SendTransactionWithInvalidModelStateReturnsBadRequest()
+        public async Task SendTransactionWithInvalidModelStateReturnsBadRequest()
         {
-            var mockWalletManager = new Mock<IWalletManager>();
+            var controller = this.GetWalletController();
 
-            var controller = new WalletController(this.LoggerFactory.Object, mockWalletManager.Object, new Mock<IWalletTransactionHandler>().Object, new Mock<IWalletSyncManager>().Object, It.IsAny<ConnectionManager>(), this.Network, this.chainIndexer, new Mock<IBroadcasterManager>().Object, DateTimeProvider.Default);
             controller.ModelState.AddModelError("Hex", "Hex required.");
-            IActionResult result = controller.SendTransaction(new SendTransactionRequest(""));
+            IActionResult result = await controller.SendTransaction(new SendTransactionRequest(""));
 
             var errorResult = Assert.IsType<ErrorResult>(result);
             var errorResponse = Assert.IsType<ErrorResponse>(errorResult.Value);
@@ -1931,18 +1982,18 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
         }
 
         [Fact]
-        public void ListWalletFilesWithExistingWalletFilesReturnsWalletFileModel()
+        public async Task ListWalletFilesWithExistingWalletFilesReturnsWalletFileModel()
         {
             string walletPath = "walletPath";
-            var walletManager = new Mock<IWalletManager>();
+            var walletManager = this.ConfigureMock<IWalletManager>();
             walletManager.Setup(m => m.GetWalletsNames())
-                .Returns( new[] { "wallet1.wallet.json", "wallet2.wallet.json" });
+                .Returns(new[] { "wallet1.wallet.json", "wallet2.wallet.json" });
 
             walletManager.Setup(m => m.GetWalletFileExtension()).Returns("wallet.json");
 
-            var controller = new WalletController(this.LoggerFactory.Object, walletManager.Object, new Mock<IWalletTransactionHandler>().Object, new Mock<IWalletSyncManager>().Object, It.IsAny<ConnectionManager>(), this.Network, this.chainIndexer, new Mock<IBroadcasterManager>().Object, DateTimeProvider.Default);
+            var controller = this.GetWalletController();
 
-            IActionResult result = controller.ListWallets();
+            IActionResult result = await controller.ListWallets();
 
             var viewResult = Assert.IsType<JsonResult>(result);
             var model = viewResult.Value as WalletInfoModel;
@@ -1954,16 +2005,16 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
         }
 
         [Fact]
-        public void ListWalletFilesWithoutExistingWalletFilesReturnsWalletFileModel()
+        public async Task ListWalletFilesWithoutExistingWalletFilesReturnsWalletFileModel()
         {
-            string walletPath = "walletPath";
-            var walletManager = new Mock<IWalletManager>();
+            var walletManager = this.ConfigureMock<IWalletManager>();
+
             walletManager.Setup(m => m.GetWalletsNames())
                 .Returns(Enumerable.Empty<string>());
 
-            var controller = new WalletController(this.LoggerFactory.Object, walletManager.Object, new Mock<IWalletTransactionHandler>().Object, new Mock<IWalletSyncManager>().Object, It.IsAny<ConnectionManager>(), this.Network, this.chainIndexer, new Mock<IBroadcasterManager>().Object, DateTimeProvider.Default);
+            var controller = this.GetWalletController();
 
-            IActionResult result = controller.ListWallets();
+            IActionResult result = await controller.ListWallets();
 
             var viewResult = Assert.IsType<JsonResult>(result);
             var model = viewResult.Value as WalletInfoModel;
@@ -1973,15 +2024,15 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
         }
 
         [Fact]
-        public void ListWalletFilesWithExceptionReturnsBadRequest()
+        public async Task ListWalletFilesWithExceptionReturnsBadRequest()
         {
-            var walletManager = new Mock<IWalletManager>();
+            var walletManager = this.ConfigureMock<IWalletManager>();
             walletManager.Setup(m => m.GetWalletsNames())
                 .Throws(new Exception("something happened."));
 
-            var controller = new WalletController(this.LoggerFactory.Object, walletManager.Object, new Mock<IWalletTransactionHandler>().Object, new Mock<IWalletSyncManager>().Object, It.IsAny<ConnectionManager>(), this.Network, this.chainIndexer, new Mock<IBroadcasterManager>().Object, DateTimeProvider.Default);
+            var controller = this.GetWalletController();
 
-            IActionResult result = controller.ListWallets();
+            IActionResult result = await controller.ListWallets();
 
             var errorResult = Assert.IsType<ErrorResult>(result);
             var errorResponse = Assert.IsType<ErrorResponse>(errorResult.Value);
@@ -1993,14 +2044,15 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
         }
 
         [Fact]
-        public void CreateNewAccountWithValidModelReturnsAccountName()
+        public async Task CreateNewAccountWithValidModelReturnsAccountName()
         {
-            var mockWalletManager = new Mock<IWalletManager>();
+            var mockWalletManager = this.ConfigureMock<IWalletManager>();
             mockWalletManager.Setup(m => m.GetUnusedAccount("myWallet", "test"))
                 .Returns(new HdAccount { Name = "Account 1" });
 
-            var controller = new WalletController(this.LoggerFactory.Object, mockWalletManager.Object, new Mock<IWalletTransactionHandler>().Object, new Mock<IWalletSyncManager>().Object, It.IsAny<ConnectionManager>(), this.Network, this.chainIndexer, new Mock<IBroadcasterManager>().Object, DateTimeProvider.Default);
-            IActionResult result = controller.CreateNewAccount(new GetUnusedAccountModel
+            var controller = this.GetWalletController();
+
+            IActionResult result = await controller.CreateNewAccount(new GetUnusedAccountModel
             {
                 WalletName = "myWallet",
                 Password = "test"
@@ -2011,14 +2063,15 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
         }
 
         [Fact]
-        public void CreateNewAccountWithInvalidValidModelReturnsBadRequest()
+        public async Task CreateNewAccountWithInvalidValidModelReturnsBadRequest()
         {
             var mockWalletManager = new Mock<IWalletManager>();
 
-            var controller = new WalletController(this.LoggerFactory.Object, mockWalletManager.Object, new Mock<IWalletTransactionHandler>().Object, new Mock<IWalletSyncManager>().Object, It.IsAny<ConnectionManager>(), this.Network, this.chainIndexer, new Mock<IBroadcasterManager>().Object, DateTimeProvider.Default);
+            var controller = this.GetWalletController();
+
             controller.ModelState.AddModelError("Password", "A password is required.");
 
-            IActionResult result = controller.CreateNewAccount(new GetUnusedAccountModel
+            IActionResult result = await controller.CreateNewAccount(new GetUnusedAccountModel
             {
                 WalletName = "myWallet",
                 Password = ""
@@ -2034,14 +2087,15 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
         }
 
         [Fact]
-        public void CreateNewAccountWithExceptionReturnsBadRequest()
+        public async Task CreateNewAccountWithExceptionReturnsBadRequest()
         {
-            var mockWalletManager = new Mock<IWalletManager>();
+            var mockWalletManager = this.ConfigureMock<IWalletManager>();
             mockWalletManager.Setup(m => m.GetUnusedAccount("myWallet", "test"))
                 .Throws(new InvalidOperationException("Wallet not found."));
 
-            var controller = new WalletController(this.LoggerFactory.Object, mockWalletManager.Object, new Mock<IWalletTransactionHandler>().Object, new Mock<IWalletSyncManager>().Object, It.IsAny<ConnectionManager>(), this.Network, this.chainIndexer, new Mock<IBroadcasterManager>().Object, DateTimeProvider.Default);
-            IActionResult result = controller.CreateNewAccount(new GetUnusedAccountModel
+            var controller = this.GetWalletController();
+
+            IActionResult result = await controller.CreateNewAccount(new GetUnusedAccountModel
             {
                 WalletName = "myWallet",
                 Password = "test"
@@ -2058,18 +2112,21 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
         }
 
         [Fact]
-        public void ListAccountsWithValidModelStateReturnsAccounts()
+        public async Task ListAccountsWithValidModelStateReturnsAccounts()
         {
             string walletName = "wallet 1";
             Wallet wallet = WalletTestsHelpers.CreateWallet(walletName);
             wallet.AddNewAccount((ExtPubKey)null);
             wallet.AddNewAccount((ExtPubKey)null);
 
-            var mockWalletManager = new Mock<IWalletManager>();
-            mockWalletManager.Setup(m => m.GetAccounts(walletName)).Returns(wallet.AccountsRoot.SelectMany(x => x.Accounts));
+            var mockWalletManager = this.ConfigureMock<IWalletManager>();
 
-            var controller = new WalletController(this.LoggerFactory.Object, mockWalletManager.Object, new Mock<IWalletTransactionHandler>().Object, new Mock<IWalletSyncManager>().Object, It.IsAny<ConnectionManager>(), this.Network, this.chainIndexer, new Mock<IBroadcasterManager>().Object, DateTimeProvider.Default);
-            IActionResult result = controller.ListAccounts(new ListAccountsModel
+            mockWalletManager.Setup(m => m.GetAccounts(walletName))
+                .Returns(wallet.AccountsRoot.SelectMany(x => x.Accounts));
+
+            var controller = this.GetWalletController();
+
+            IActionResult result = await controller.ListAccounts(new ListAccountsModel
             {
                 WalletName = "wallet 1"
             });
@@ -2084,14 +2141,13 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
         }
 
         [Fact]
-        public void ListAccountsWithInvalidModelReturnsBadRequest()
+        public async Task ListAccountsWithInvalidModelReturnsBadRequest()
         {
-            var mockWalletManager = new Mock<IWalletManager>();
+            var controller = this.GetWalletController();
 
-            var controller = new WalletController(this.LoggerFactory.Object, mockWalletManager.Object, new Mock<IWalletTransactionHandler>().Object, new Mock<IWalletSyncManager>().Object, It.IsAny<ConnectionManager>(), this.Network, this.chainIndexer, new Mock<IBroadcasterManager>().Object, DateTimeProvider.Default);
             controller.ModelState.AddModelError("WalletName", "A wallet name is required.");
 
-            IActionResult result = controller.ListAccounts(new ListAccountsModel
+            IActionResult result = await controller.ListAccounts(new ListAccountsModel
             {
                 WalletName = ""
             });
@@ -2106,14 +2162,15 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
         }
 
         [Fact]
-        public void ListAccountsWithExceptionReturnsBadRequest()
+        public async Task ListAccountsWithExceptionReturnsBadRequest()
         {
-            var mockWalletManager = new Mock<IWalletManager>();
+            var mockWalletManager = this.ConfigureMock<IWalletManager>();
             mockWalletManager.Setup(m => m.GetAccounts("wallet 0"))
                 .Throws(new InvalidOperationException("Wallet not found."));
 
-            var controller = new WalletController(this.LoggerFactory.Object, mockWalletManager.Object, new Mock<IWalletTransactionHandler>().Object, new Mock<IWalletSyncManager>().Object, It.IsAny<ConnectionManager>(), this.Network, this.chainIndexer, new Mock<IBroadcasterManager>().Object, DateTimeProvider.Default);
-            IActionResult result = controller.ListAccounts(new ListAccountsModel
+            var controller = this.GetWalletController();
+
+            IActionResult result = await controller.ListAccounts(new ListAccountsModel
             {
                 WalletName = "wallet 0",
             });
@@ -2129,15 +2186,16 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
         }
 
         [Fact]
-        public void GetUnusedAddressWithValidModelReturnsUnusedAddress()
+        public async Task GetUnusedAddressWithValidModelReturnsUnusedAddress()
         {
             HdAddress address = WalletTestsHelpers.CreateAddress();
-            var mockWalletManager = new Mock<IWalletManager>();
+            var mockWalletManager = this.ConfigureMock<IWalletManager>();
             mockWalletManager.Setup(m => m.GetUnusedAddress(new WalletAccountReference("myWallet", "Account 1")))
                 .Returns(address);
 
-            var controller = new WalletController(this.LoggerFactory.Object, mockWalletManager.Object, new Mock<IWalletTransactionHandler>().Object, new Mock<IWalletSyncManager>().Object, It.IsAny<ConnectionManager>(), this.Network, this.chainIndexer, new Mock<IBroadcasterManager>().Object, DateTimeProvider.Default);
-            IActionResult result = controller.GetUnusedAddress(new GetUnusedAddressModel
+            var controller = this.GetWalletController();
+
+            IActionResult result = await controller.GetUnusedAddress(new GetUnusedAddressModel
             {
                 WalletName = "myWallet",
                 AccountName = "Account 1"
@@ -2148,14 +2206,13 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
         }
 
         [Fact]
-        public void GetUnusedAddressWithInvalidValidModelReturnsBadRequest()
+        public async Task GetUnusedAddressWithInvalidValidModelReturnsBadRequest()
         {
-            var mockWalletManager = new Mock<IWalletManager>();
+            var controller = this.GetWalletController();
 
-            var controller = new WalletController(this.LoggerFactory.Object, mockWalletManager.Object, new Mock<IWalletTransactionHandler>().Object, new Mock<IWalletSyncManager>().Object, It.IsAny<ConnectionManager>(), this.Network, this.chainIndexer, new Mock<IBroadcasterManager>().Object, DateTimeProvider.Default);
             controller.ModelState.AddModelError("AccountName", "An account name is required.");
 
-            IActionResult result = controller.GetUnusedAddress(new GetUnusedAddressModel
+            IActionResult result = await controller.GetUnusedAddress(new GetUnusedAddressModel
             {
                 WalletName = "myWallet",
                 AccountName = ""
@@ -2171,14 +2228,15 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
         }
 
         [Fact]
-        public void GetUnusedAddressWithExceptionReturnsBadRequest()
+        public async Task GetUnusedAddressWithExceptionReturnsBadRequest()
         {
-            var mockWalletManager = new Mock<IWalletManager>();
+            var mockWalletManager = this.ConfigureMock<IWalletManager>();
             mockWalletManager.Setup(m => m.GetUnusedAddress(new WalletAccountReference("myWallet", "Account 1")))
                 .Throws(new InvalidOperationException("Wallet not found."));
 
-            var controller = new WalletController(this.LoggerFactory.Object, mockWalletManager.Object, new Mock<IWalletTransactionHandler>().Object, new Mock<IWalletSyncManager>().Object, It.IsAny<ConnectionManager>(), this.Network, this.chainIndexer, new Mock<IBroadcasterManager>().Object, DateTimeProvider.Default);
-            IActionResult result = controller.GetUnusedAddress(new GetUnusedAddressModel
+            var controller = this.GetWalletController();
+
+            IActionResult result = await controller.GetUnusedAddress(new GetUnusedAddressModel
             {
                 WalletName = "myWallet",
                 AccountName = "Account 1"
@@ -2195,13 +2253,14 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
         }
 
         [Fact]
-        public void GetAllAddressesWithValidModelReturnsAllAddresses()
+        public async Task GetAllAddressesWithValidModelReturnsAllAddresses()
         {
             string walletName = "myWallet";
 
             // Receive address with a transaction
             HdAddress usedReceiveAddress = WalletTestsHelpers.CreateAddress();
-            TransactionData receiveTransaction = WalletTestsHelpers.CreateTransaction(new uint256(1), new Money(500000), 1);
+            TransactionData receiveTransaction =
+                WalletTestsHelpers.CreateTransaction(new uint256(1), new Money(500000), 1);
             usedReceiveAddress.Transactions.Add(receiveTransaction);
 
             // Receive address without a transaction
@@ -2209,7 +2268,8 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
 
             // Change address with a transaction
             HdAddress usedChangeAddress = WalletTestsHelpers.CreateAddress(true);
-            TransactionData changeTransaction = WalletTestsHelpers.CreateTransaction(new uint256(1), new Money(500000), 1);
+            TransactionData changeTransaction =
+                WalletTestsHelpers.CreateTransaction(new uint256(1), new Money(500000), 1);
             usedChangeAddress.Transactions.Add(changeTransaction);
 
             // Change address without a transaction
@@ -2226,15 +2286,21 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
             foreach (HdAddress addr in changeAddresses)
                 account.InternalAddresses.Add(addr);
 
-            var mockWalletManager = new Mock<IWalletManager>();
+            var mockWalletManager = this.ConfigureMock<IWalletManager>();
             mockWalletManager.Setup(m => m.GetWallet(walletName)).Returns(wallet);
-            mockWalletManager.Setup(m => m.GetUnusedAddresses(It.IsAny<WalletAccountReference>(), false)).Returns(new[] { unusedReceiveAddress }.ToList());
-            mockWalletManager.Setup(m => m.GetUnusedAddresses(It.IsAny<WalletAccountReference>(), true)).Returns(new[] { unusedChangeAddress }.ToList());
-            mockWalletManager.Setup(m => m.GetUsedAddresses(It.IsAny<WalletAccountReference>(), false)).Returns(new[] { (usedReceiveAddress, Money.Zero, Money.Zero) }.ToList());
-            mockWalletManager.Setup(m => m.GetUsedAddresses(It.IsAny<WalletAccountReference>(), true)).Returns(new[] { (usedChangeAddress, Money.Zero, Money.Zero) }.ToList());
+            mockWalletManager.Setup(m => m.GetUnusedAddresses(It.IsAny<WalletAccountReference>(), false))
+                .Returns(new[] { unusedReceiveAddress }.ToList());
+            mockWalletManager.Setup(m => m.GetUnusedAddresses(It.IsAny<WalletAccountReference>(), true))
+                .Returns(new[] { unusedChangeAddress }.ToList());
+            mockWalletManager.Setup(m => m.GetUsedAddresses(It.IsAny<WalletAccountReference>(), false))
+                .Returns(new[] { (usedReceiveAddress, Money.Zero, Money.Zero) }.ToList());
+            mockWalletManager.Setup(m => m.GetUsedAddresses(It.IsAny<WalletAccountReference>(), true))
+                .Returns(new[] { (usedChangeAddress, Money.Zero, Money.Zero) }.ToList());
 
-            var controller = new WalletController(this.LoggerFactory.Object, mockWalletManager.Object, new Mock<IWalletTransactionHandler>().Object, new Mock<IWalletSyncManager>().Object, It.IsAny<ConnectionManager>(), this.Network, this.chainIndexer, new Mock<IBroadcasterManager>().Object, DateTimeProvider.Default);
-            IActionResult result = controller.GetAllAddresses(new GetAllAddressesModel { WalletName = "myWallet", AccountName = "Account 0" });
+            var controller = this.GetWalletController();
+
+            IActionResult result = await controller.GetAllAddresses(new GetAllAddressesModel
+            { WalletName = "myWallet", AccountName = "Account 0" });
 
             var viewResult = Assert.IsType<JsonResult>(result);
             var model = viewResult.Value as AddressesModel;
@@ -2243,32 +2309,40 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
             Assert.Equal(4, model.Addresses.Count());
 
             AddressModel modelUsedReceiveAddress = model.Addresses.Single(a => a.Address == usedReceiveAddress.Address);
-            Assert.Equal(modelUsedReceiveAddress.Address, model.Addresses.Single(a => a.Address == modelUsedReceiveAddress.Address).Address);
+            Assert.Equal(modelUsedReceiveAddress.Address,
+                model.Addresses.Single(a => a.Address == modelUsedReceiveAddress.Address).Address);
             Assert.False(model.Addresses.Single(a => a.Address == modelUsedReceiveAddress.Address).IsChange);
             Assert.True(model.Addresses.Single(a => a.Address == modelUsedReceiveAddress.Address).IsUsed);
 
-            AddressModel modelUnusedReceiveAddress = model.Addresses.Single(a => a.Address == unusedReceiveAddress.Address);
-            Assert.Equal(modelUnusedReceiveAddress.Address, model.Addresses.Single(a => a.Address == modelUnusedReceiveAddress.Address).Address);
+            AddressModel modelUnusedReceiveAddress =
+                model.Addresses.Single(a => a.Address == unusedReceiveAddress.Address);
+            Assert.Equal(modelUnusedReceiveAddress.Address,
+                model.Addresses.Single(a => a.Address == modelUnusedReceiveAddress.Address).Address);
             Assert.False(model.Addresses.Single(a => a.Address == modelUnusedReceiveAddress.Address).IsChange);
             Assert.False(model.Addresses.Single(a => a.Address == modelUnusedReceiveAddress.Address).IsUsed);
 
             AddressModel modelUsedChangeAddress = model.Addresses.Single(a => a.Address == usedChangeAddress.Address);
-            Assert.Equal(modelUsedChangeAddress.Address, model.Addresses.Single(a => a.Address == modelUsedChangeAddress.Address).Address);
+            Assert.Equal(modelUsedChangeAddress.Address,
+                model.Addresses.Single(a => a.Address == modelUsedChangeAddress.Address).Address);
             Assert.True(model.Addresses.Single(a => a.Address == modelUsedChangeAddress.Address).IsChange);
             Assert.True(model.Addresses.Single(a => a.Address == modelUsedChangeAddress.Address).IsUsed);
 
-            AddressModel modelUnusedChangeAddress = model.Addresses.Single(a => a.Address == unusedChangeAddress.Address);
-            Assert.Equal(modelUnusedChangeAddress.Address, model.Addresses.Single(a => a.Address == modelUnusedChangeAddress.Address).Address);
+            AddressModel modelUnusedChangeAddress =
+                model.Addresses.Single(a => a.Address == unusedChangeAddress.Address);
+            Assert.Equal(modelUnusedChangeAddress.Address,
+                model.Addresses.Single(a => a.Address == modelUnusedChangeAddress.Address).Address);
             Assert.True(model.Addresses.Single(a => a.Address == modelUnusedChangeAddress.Address).IsChange);
             Assert.False(model.Addresses.Single(a => a.Address == modelUnusedChangeAddress.Address).IsUsed);
         }
 
         [Fact]
-        public void GetMaximumBalanceWithValidModelStateReturnsMaximumBalance()
+        public async Task GetMaximumBalanceWithValidModelStateReturnsMaximumBalance()
         {
-            var controller = new WalletController(this.LoggerFactory.Object, new Mock<IWalletManager>().Object, new Mock<IWalletTransactionHandler>().Object, new Mock<IWalletSyncManager>().Object, It.IsAny<ConnectionManager>(), this.Network, this.chainIndexer, new Mock<IBroadcasterManager>().Object, DateTimeProvider.Default);
+            var controller = this.GetWalletController();
+
             controller.ModelState.AddModelError("Error in model", "There was an error in the model.");
-            IActionResult result = controller.GetMaximumSpendableBalance(new WalletMaximumBalanceRequest
+
+            IActionResult result = await controller.GetMaximumSpendableBalance(new WalletMaximumBalanceRequest
             {
                 WalletName = "myWallet",
                 AccountName = "account 1",
@@ -2287,13 +2361,16 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
         }
 
         [Fact]
-        public void GetMaximumBalanceSuccessfullyReturnsMaximumBalanceAndFee()
+        public async Task GetMaximumBalanceSuccessfullyReturnsMaximumBalanceAndFee()
         {
-            var mockWalletTransactionHandler = new Mock<IWalletTransactionHandler>();
-            mockWalletTransactionHandler.Setup(w => w.GetMaximumSpendableAmount(It.IsAny<WalletAccountReference>(), It.IsAny<FeeType>(), true)).Returns((new Money(1000000), new Money(100)));
+            var mockWalletTransactionHandler = this.ConfigureMock<IWalletTransactionHandler>();
+            mockWalletTransactionHandler
+                .Setup(w => w.GetMaximumSpendableAmount(It.IsAny<WalletAccountReference>(), It.IsAny<FeeType>(), true))
+                .Returns((new Money(1000000), new Money(100)));
 
-            var controller = new WalletController(this.LoggerFactory.Object, new Mock<IWalletManager>().Object, mockWalletTransactionHandler.Object, new Mock<IWalletSyncManager>().Object, It.IsAny<ConnectionManager>(), this.Network, this.chainIndexer, new Mock<IBroadcasterManager>().Object, DateTimeProvider.Default);
-            IActionResult result = controller.GetMaximumSpendableBalance(new WalletMaximumBalanceRequest
+            var controller = this.GetWalletController();
+
+            IActionResult result = await controller.GetMaximumSpendableBalance(new WalletMaximumBalanceRequest
             {
                 WalletName = "myWallet",
                 AccountName = "account 1",
@@ -2310,13 +2387,16 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
         }
 
         [Fact]
-        public void GetMaximumBalanceWithExceptionReturnsBadRequest()
+        public async Task GetMaximumBalanceWithExceptionReturnsBadRequest()
         {
-            var mockWalletTransactionHandler = new Mock<IWalletTransactionHandler>();
-            mockWalletTransactionHandler.Setup(w => w.GetMaximumSpendableAmount(It.IsAny<WalletAccountReference>(), It.IsAny<FeeType>(), true)).Throws(new Exception("failure"));
+            var mockWalletTransactionHandler = this.ConfigureMock<IWalletTransactionHandler>();
+            mockWalletTransactionHandler
+                .Setup(w => w.GetMaximumSpendableAmount(It.IsAny<WalletAccountReference>(), It.IsAny<FeeType>(), true))
+                .Throws(new Exception("failure"));
 
-            var controller = new WalletController(this.LoggerFactory.Object, new Mock<IWalletManager>().Object, mockWalletTransactionHandler.Object, new Mock<IWalletSyncManager>().Object, It.IsAny<ConnectionManager>(), this.Network, this.chainIndexer, new Mock<IBroadcasterManager>().Object, DateTimeProvider.Default);
-            IActionResult result = controller.GetMaximumSpendableBalance(new WalletMaximumBalanceRequest
+            var controller = this.GetWalletController();
+
+            IActionResult result = await controller.GetMaximumSpendableBalance(new WalletMaximumBalanceRequest
             {
                 WalletName = "myWallet",
                 AccountName = "account 1",
@@ -2332,20 +2412,28 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
         }
 
         [Fact]
-        public void GetTransactionFeeEstimateWithValidRequestReturnsFee()
+        public async Task GetTransactionFeeEstimateWithValidRequestReturnsFee()
         {
-            var mockWalletManager = new Mock<IWalletManager>();
-            var mockWalletTransactionHandler = new Mock<IWalletTransactionHandler>();
+            var mockWalletManager = this.ConfigureMock<IWalletManager>();
+            var mockWalletTransactionHandler = this.ConfigureMock<IWalletTransactionHandler>();
             var key = new Key();
             var expectedFee = new Money(1000);
             mockWalletTransactionHandler.Setup(m => m.EstimateFee(It.IsAny<TransactionBuildContext>()))
                 .Returns(expectedFee);
 
-            var controller = new WalletController(this.LoggerFactory.Object, mockWalletManager.Object, mockWalletTransactionHandler.Object, new Mock<IWalletSyncManager>().Object, It.IsAny<ConnectionManager>(), this.Network, this.chainIndexer, new Mock<IBroadcasterManager>().Object, DateTimeProvider.Default);
-            IActionResult result = controller.GetTransactionFeeEstimate(new TxFeeEstimateRequest
+            var controller = this.GetWalletController();
+
+            IActionResult result = await controller.GetTransactionFeeEstimate(new TxFeeEstimateRequest
             {
                 AccountName = "Account 1",
-                Recipients = new List<RecipientModel> { new RecipientModel { DestinationAddress = key.PubKey.GetAddress(this.Network).ToString(), Amount = new Money(150000).ToString() } },
+                Recipients = new List<RecipientModel>
+                {
+                    new RecipientModel
+                    {
+                        DestinationAddress = key.PubKey.GetAddress(this.Network).ToString(),
+                        Amount = new Money(150000).ToString()
+                    }
+                },
                 FeeType = "105",
                 WalletName = "myWallet"
             });
@@ -2358,7 +2446,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
         }
 
         [Fact]
-        public void RemoveAllTransactionsWithSyncEnabledSyncsAfterRemoval()
+        public async Task RemoveAllTransactionsWithSyncEnabledSyncsAfterRemoval()
         {
             // Arrange.
             string walletName = "wallet1";
@@ -2370,13 +2458,14 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
             resultModel.Add((trxId1, DateTimeOffset.Now));
             resultModel.Add((trxId2, DateTimeOffset.Now));
 
-            var walletManager = new Mock<IWalletManager>();
-            var walletSyncManager = new Mock<IWalletSyncManager>();
+            var walletManager = this.ConfigureMock<IWalletManager>();
+            var walletSyncManager = this.ConfigureMock<IWalletSyncManager>();
             walletManager.Setup(manager => manager.RemoveAllTransactions(walletName)).Returns(resultModel);
             walletSyncManager.Setup(manager => manager.SyncFromHeight(It.IsAny<int>(), It.IsAny<string>()));
             ChainIndexer chainIndexer = WalletTestsHelpers.GenerateChainWithHeight(3, this.Network);
 
-            var controller = new WalletController(this.LoggerFactory.Object, walletManager.Object, new Mock<IWalletTransactionHandler>().Object, walletSyncManager.Object, It.IsAny<ConnectionManager>(), this.Network, chainIndexer, new Mock<IBroadcasterManager>().Object, DateTimeProvider.Default);
+            var controller = this.GetWalletController();
+
             var requestModel = new RemoveTransactionsModel
             {
                 WalletName = walletName,
@@ -2385,11 +2474,12 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
             };
 
             // Act.
-            IActionResult result = controller.RemoveTransactions(requestModel);
+            IActionResult result = await controller.RemoveTransactions(requestModel);
 
             // Assert.
             walletManager.VerifyAll();
-            walletSyncManager.Verify(manager => manager.SyncFromHeight(It.IsAny<int>(), It.IsAny<string>()), Times.Once);
+            walletSyncManager.Verify(manager => manager.SyncFromHeight(It.IsAny<int>(), It.IsAny<string>()),
+                Times.Once);
 
             var viewResult = Assert.IsType<JsonResult>(result);
             var model = viewResult.Value as IEnumerable<RemovedTransactionModel>;
@@ -2400,7 +2490,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
         }
 
         [Fact]
-        public void RemoveAllTransactionsWithSyncDisabledDoesNotSyncAfterRemoval()
+        public async Task RemoveAllTransactionsWithSyncDisabledDoesNotSyncAfterRemoval()
         {
             // Arrange.
             string walletName = "wallet1";
@@ -2410,12 +2500,13 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
             resultModel.Add((trxId1, DateTimeOffset.Now));
             resultModel.Add((trxId2, DateTimeOffset.Now));
 
-            var walletManager = new Mock<IWalletManager>();
-            var walletSyncManager = new Mock<IWalletSyncManager>();
+            var walletManager = this.ConfigureMock<IWalletManager>();
+            var walletSyncManager = this.ConfigureMock<IWalletSyncManager>();
             walletManager.Setup(manager => manager.RemoveAllTransactions(walletName)).Returns(resultModel);
             ChainIndexer chainIndexer = WalletTestsHelpers.GenerateChainWithHeight(3, this.Network);
 
-            var controller = new WalletController(this.LoggerFactory.Object, walletManager.Object, new Mock<IWalletTransactionHandler>().Object, walletSyncManager.Object, It.IsAny<ConnectionManager>(), this.Network, chainIndexer, new Mock<IBroadcasterManager>().Object, DateTimeProvider.Default);
+            var controller = this.GetWalletController();
+
             var requestModel = new RemoveTransactionsModel
             {
                 WalletName = walletName,
@@ -2424,11 +2515,12 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
             };
 
             // Act.
-            IActionResult result = controller.RemoveTransactions(requestModel);
+            IActionResult result = await controller.RemoveTransactions(requestModel);
 
             // Assert.
             walletManager.VerifyAll();
-            walletSyncManager.Verify(manager => manager.SyncFromHeight(It.IsAny<int>(), It.IsAny<string>()), Times.Never);
+            walletSyncManager.Verify(manager => manager.SyncFromHeight(It.IsAny<int>(), It.IsAny<string>()),
+                Times.Never);
 
             var viewResult = Assert.IsType<JsonResult>(result);
             var model = viewResult.Value as IEnumerable<RemovedTransactionModel>;
@@ -2439,7 +2531,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
         }
 
         [Fact]
-        public void RemoveTransactionsWithIdsRemovesAllTransactionsByIds()
+        public async Task RemoveTransactionsWithIdsRemovesAllTransactionsByIds()
         {
             // Arrange.
             string walletName = "wallet1";
@@ -2449,13 +2541,15 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
             var resultModel = new HashSet<(uint256 trxId, DateTimeOffset creationTime)>();
             resultModel.Add((trxId1, DateTimeOffset.Now));
 
-            var walletManager = new Mock<IWalletManager>();
-            var walletSyncManager = new Mock<IWalletSyncManager>();
-            walletManager.Setup(manager => manager.RemoveTransactionsByIds(walletName, new[] { trxId1 })).Returns(resultModel);
+            var walletManager = this.ConfigureMock<IWalletManager>();
+            var walletSyncManager = this.ConfigureMock<IWalletSyncManager>();
+            walletManager.Setup(manager => manager.RemoveTransactionsByIds(walletName, new[] { trxId1 }))
+                .Returns(resultModel);
             walletSyncManager.Setup(manager => manager.SyncFromHeight(It.IsAny<int>(), It.IsAny<string>()));
             ChainIndexer chainIndexer = WalletTestsHelpers.GenerateChainWithHeight(3, this.Network);
 
-            var controller = new WalletController(this.LoggerFactory.Object, walletManager.Object, new Mock<IWalletTransactionHandler>().Object, walletSyncManager.Object, It.IsAny<ConnectionManager>(), this.Network, chainIndexer, new Mock<IBroadcasterManager>().Object, DateTimeProvider.Default);
+            var controller = this.GetWalletController();
+
             var requestModel = new RemoveTransactionsModel
             {
                 WalletName = walletName,
@@ -2464,12 +2558,13 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
             };
 
             // Act.
-            IActionResult result = controller.RemoveTransactions(requestModel);
+            IActionResult result = await controller.RemoveTransactions(requestModel);
 
             // Assert.
             walletManager.VerifyAll();
             walletManager.Verify(manager => manager.RemoveAllTransactions(It.IsAny<string>()), Times.Never);
-            walletSyncManager.Verify(manager => manager.SyncFromHeight(It.IsAny<int>(), It.IsAny<string>()), Times.Once);
+            walletSyncManager.Verify(manager => manager.SyncFromHeight(It.IsAny<int>(), It.IsAny<string>()),
+                Times.Once);
 
             var viewResult = Assert.IsType<JsonResult>(result);
             var model = viewResult.Value as IEnumerable<RemovedTransactionModel>;
@@ -2477,52 +2572,60 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
             Assert.Single(model);
             Assert.True(model.SingleOrDefault(t => t.TransactionId == trxId1) != null);
         }
-    }
 
-    public class TestReadOnlyNetworkPeerCollection : IReadOnlyNetworkPeerCollection
-    {
-        public event EventHandler<NetworkPeerEventArgs> Added;
-        public event EventHandler<NetworkPeerEventArgs> Removed;
-
-        private List<INetworkPeer> networkPeers;
-
-        public TestReadOnlyNetworkPeerCollection()
+        private TMock ConfigureMockInstance<TMock>(TMock value) where TMock : class
         {
-            this.Added = new EventHandler<NetworkPeerEventArgs>((obj, eventArgs) => { });
-            this.Removed = new EventHandler<NetworkPeerEventArgs>((obj, eventArgs) => { });
-            this.networkPeers = new List<INetworkPeer>();
+            if (!this.configuredMocks.ContainsKey(typeof(TMock)))
+            {
+                this.configuredMocks.Add(typeof(TMock), value);
+            }
+
+            return (TMock) this.configuredMocks[typeof(TMock)];
         }
 
-        public TestReadOnlyNetworkPeerCollection(List<INetworkPeer> peers)
+        private Mock<TMock> ConfigureMock<TMock>(Action<Mock<TMock>> setup = null) where TMock : class
         {
-            this.Added = new EventHandler<NetworkPeerEventArgs>((obj, eventArgs) => { });
-            this.Removed = new EventHandler<NetworkPeerEventArgs>((obj, eventArgs) => { });
-            this.networkPeers = peers;
+            if (!this.configuredMocks.ContainsKey(typeof(TMock)))
+            {
+                this.configuredMocks.Add(typeof(TMock), new Mock<TMock>());
+            }
+
+            setup?.Invoke((Mock<TMock>)this.configuredMocks[typeof(TMock)]);
+            return (Mock<TMock>)this.configuredMocks[typeof(TMock)];
         }
 
-        public INetworkPeer FindByEndpoint(IPEndPoint endpoint)
+        private TMock GetMock<TMock>(bool createIfNotExists = false) where TMock : class
         {
-            return null;
+            if (this.configuredMocks.ContainsKey(typeof(TMock))
+                && this.configuredMocks[typeof(TMock)] as Mock<TMock> != null)
+            {
+                return ((Mock<TMock>) this.configuredMocks[typeof(TMock)]).Object;
+            }
+
+            return this.configuredMocks.ContainsKey(typeof(TMock))
+                ? (TMock) this.configuredMocks[typeof(TMock)]
+                : createIfNotExists
+                    ? new Mock<TMock>().Object
+                    : null;
         }
 
-        public List<INetworkPeer> FindByIp(IPAddress ip)
+        private WalletController GetWalletController()
         {
-            return null;
-        }
+            var mocker = new AutoMocker();
 
-        public INetworkPeer FindLocal()
-        {
-            return null;
-        }
+            mocker.Use(typeof(ILoggerFactory), this.GetMock<ILoggerFactory>() ?? this.LoggerFactory.Object);
+            mocker.Use(typeof(IWalletManager), this.GetMock<IWalletManager>(true));
+            mocker.Use(typeof(IWalletTransactionHandler), this.GetMock<IWalletTransactionHandler>(true));
+            mocker.Use(typeof(IWalletSyncManager), this.GetMock<IWalletSyncManager>(true));
+            mocker.Use(typeof(Network), this.GetMock<Network>() ?? this.Network);
+            mocker.Use(typeof(ChainIndexer), this.GetMock<ChainIndexer>() ?? this.chainIndexer);
+            mocker.Use(typeof(IBroadcasterManager), this.GetMock<IBroadcasterManager>(true));
+            mocker.Use(typeof(IConsensusManager), this.GetMock<IConsensusManager>(true));
+            mocker.Use(typeof(IDateTimeProvider), this.GetMock<IDateTimeProvider>() ?? DateTimeProvider.Default);
+            mocker.Use(typeof(IConnectionManager), this.GetMock<IConnectionManager>(true));
+            mocker.Use(typeof(IWalletService), this.GetMock<WalletService>() ?? mocker.CreateInstance<WalletService>());
 
-        public IEnumerator<INetworkPeer> GetEnumerator()
-        {
-            return this.networkPeers.GetEnumerator();
-        }
-
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
-        {
-            return this.GetEnumerator();
+            return mocker.CreateInstance<WalletController>();
         }
     }
 }

--- a/src/Stratis.Bitcoin.Features.Wallet/Controllers/WalletController.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Controllers/WalletController.cs
@@ -1,21 +1,16 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Net;
-using System.Security;
-using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using NBitcoin;
-using Stratis.Bitcoin.Connection;
-using Stratis.Bitcoin.Features.Wallet.Broadcasting;
-using Stratis.Bitcoin.Features.Wallet.Helpers;
+using Stratis.Bitcoin.Builder.Feature;
 using Stratis.Bitcoin.Features.Wallet.Interfaces;
 using Stratis.Bitcoin.Features.Wallet.Models;
-using Stratis.Bitcoin.Utilities;
+using Stratis.Bitcoin.Features.Wallet.Services;
 using Stratis.Bitcoin.Utilities.JsonErrors;
-using Stratis.Bitcoin.Utilities.ModelStateErrors;
 
 namespace Stratis.Bitcoin.Features.Wallet.Controllers
 {
@@ -24,54 +19,25 @@ namespace Stratis.Bitcoin.Features.Wallet.Controllers
     /// </summary>
     [ApiVersion("1")]
     [Route("api/[controller]")]
-    public class WalletController : Controller
+    public class WalletController : FeatureControllerBase
     {
-        public const int MaxHistoryItemsPerAccount = 1000;
-
+        private readonly IWalletService walletService;
         private readonly IWalletManager walletManager;
-
-        private readonly IWalletTransactionHandler walletTransactionHandler;
-
         private readonly IWalletSyncManager walletSyncManager;
-
-        private readonly CoinType coinType;
-
-        /// <summary>Specification of the network the node runs on - regtest/testnet/mainnet.</summary>
-        private readonly Network network;
-
-        private readonly IConnectionManager connectionManager;
-
         private readonly ChainIndexer chainIndexer;
-
-        /// <summary>Instance logger.</summary>
-        private readonly ILogger logger;
-
-        private readonly IBroadcasterManager broadcasterManager;
-
-        /// <summary>Provider of date time functionality.</summary>
-        private readonly IDateTimeProvider dateTimeProvider;
 
         public WalletController(
             ILoggerFactory loggerFactory,
+            IWalletService walletService,
             IWalletManager walletManager,
-            IWalletTransactionHandler walletTransactionHandler,
             IWalletSyncManager walletSyncManager,
-            IConnectionManager connectionManager,
-            Network network,
-            ChainIndexer chainIndexer,
-            IBroadcasterManager broadcasterManager,
-            IDateTimeProvider dateTimeProvider)
+            ChainIndexer chainIndexer)
+            : base(loggerFactory.CreateLogger(typeof(WalletController).FullName))
         {
+            this.walletService = walletService;
             this.walletManager = walletManager;
-            this.walletTransactionHandler = walletTransactionHandler;
             this.walletSyncManager = walletSyncManager;
-            this.connectionManager = connectionManager;
-            this.network = network;
-            this.coinType = (CoinType)network.Consensus.CoinType;
             this.chainIndexer = chainIndexer;
-            this.logger = loggerFactory.CreateLogger(this.GetType().FullName);
-            this.broadcasterManager = broadcasterManager;
-            this.dateTimeProvider = dateTimeProvider;
         }
 
         /// <summary>
@@ -79,237 +45,106 @@ namespace Stratis.Bitcoin.Features.Wallet.Controllers
         /// </summary>
         /// <param name="language">The language for the words in the mnemonic. The options are: English, French, Spanish, Japanese, ChineseSimplified and ChineseTraditional. Defaults to English.</param>
         /// <param name="wordCount">The number of words in the mnemonic. The options are: 12,15,18,21 or 24. Defaults to 12.</param>
+        /// <param name="cancellationToken">The Cancellation Token</param>
         /// <returns>A JSON object containing the generated mnemonic.</returns>
         [Route("mnemonic")]
         [HttpGet]
-        public IActionResult GenerateMnemonic([FromQuery] string language = "English", int wordCount = 12)
+        public async Task<IActionResult> GenerateMnemonic([FromQuery] string language = "English", int wordCount = 12,
+            CancellationToken cancellationToken = default(CancellationToken))
         {
-            try
-            {
-                Wordlist wordList;
-                switch (language.ToLowerInvariant())
-                {
-                    case "english":
-                        wordList = Wordlist.English;
-                        break;
-
-                    case "french":
-                        wordList = Wordlist.French;
-                        break;
-
-                    case "spanish":
-                        wordList = Wordlist.Spanish;
-                        break;
-
-                    case "japanese":
-                        wordList = Wordlist.Japanese;
-                        break;
-
-                    case "chinesetraditional":
-                        wordList = Wordlist.ChineseTraditional;
-                        break;
-
-                    case "chinesesimplified":
-                        wordList = Wordlist.ChineseSimplified;
-                        break;
-
-                    default:
-                        throw new FormatException($"Invalid language '{language}'. Choices are: English, French, Spanish, Japanese, ChineseSimplified and ChineseTraditional.");
-                }
-
-                var count = (WordCount)wordCount;
-
-                // generate the mnemonic
-                var mnemonic = new Mnemonic(wordList, count);
-                return this.Json(mnemonic.ToString());
-            }
-            catch (Exception e)
-            {
-                this.logger.LogError("Exception occurred: {0}", e.ToString());
-                return ErrorHelpers.BuildErrorResponse(HttpStatusCode.BadRequest, e.Message, e.ToString());
-            }
+            return await this.ExecuteAsAsync(new {Language = language, WordCount = wordCount},
+                cancellationToken, (req, token) =>
+                    // Generate the Mnemonic
+                    this.Json(new Mnemonic(language, (WordCount) wordCount).ToString()));
         }
 
         /// <summary>
         /// Creates a new wallet on this full node.
         /// </summary>
         /// <param name="request">An object containing the necessary parameters to create a wallet.</param>
+        /// <param name="cancellationToken">The Cancellation Token</param>
         /// <returns>A JSON object containing the mnemonic created for the new wallet.</returns>
         [Route("create")]
         [HttpPost]
-        public IActionResult Create([FromBody]WalletCreationRequest request)
+        public async Task<IActionResult> Create([FromBody] WalletCreationRequest request,
+            CancellationToken cancellationToken = default(CancellationToken))
         {
-            Guard.NotNull(request, nameof(request));
-
-            // checks the request is valid
-            if (!this.ModelState.IsValid)
-            {
-                return ModelStateErrors.BuildErrorResponse(this.ModelState);
-            }
-
-            try
-            {
-                Mnemonic requestMnemonic = string.IsNullOrEmpty(request.Mnemonic) ? null : new Mnemonic(request.Mnemonic);
-
-                (_, Mnemonic mnemonic) = this.walletManager.CreateWallet(request.Password, request.Name, request.Passphrase, mnemonic: requestMnemonic);
-
-                return this.Json(mnemonic.ToString());
-            }
-            catch (WalletException e)
-            {
-                // indicates that this wallet already exists
-                this.logger.LogError("Exception occurred: {0}", e.ToString());
-                return ErrorHelpers.BuildErrorResponse(HttpStatusCode.Conflict, e.Message, e.ToString());
-            }
-            catch (NotSupportedException e)
-            {
-                this.logger.LogError("Exception occurred: {0}", e.ToString());
-                return ErrorHelpers.BuildErrorResponse(HttpStatusCode.BadRequest, "There was a problem creating a wallet.", e.ToString());
-            }
+            return await this.Execute(request, cancellationToken,
+                async (req, token) => this.Json(await this.walletService.CreateWallet(req, token)));
         }
 
         /// <summary>
         /// Signs a message and returns the signature.
         /// </summary>
         /// <param name="request">The object containing the parameters used to sign a message.</param>
+        /// <param name="cancellationToken">The cancellation token</param>
         /// <returns>A JSON object containing the generated signature.</returns>
         [Route("signmessage")]
         [HttpPost]
-        public IActionResult SignMessage([FromBody]SignMessageRequest request)
+        public async Task<IActionResult> SignMessage([FromBody] SignMessageRequest request,
+            CancellationToken cancellationToken = default(CancellationToken))
         {
-            Guard.NotNull(request, nameof(request));
-
-            // checks the request is valid
-            if (!this.ModelState.IsValid)
+            return await this.ExecuteAsAsync(request, cancellationToken, (req, token) =>
             {
-                return ModelStateErrors.BuildErrorResponse(this.ModelState);
-            }
-
-            try
-            {
-                string signature = this.walletManager.SignMessage(request.Password, request.WalletName, request.ExternalAddress, request.Message);
+                string signature =
+                    this.walletManager.SignMessage(req.Password, req.WalletName, req.ExternalAddress, req.Message);
                 return this.Json(signature);
-            }
-            catch (Exception e)
-            {
-                this.logger.LogError("Exception occurred: {0}", e.ToString());
-                return ErrorHelpers.BuildErrorResponse(HttpStatusCode.BadRequest, e.Message, e.ToString());
-            }
+            });
         }
 
         /// <summary>
         /// Verifies the signature of a message.
         /// </summary>
         /// <param name="request">The object containing the parameters verify a signature.</param>
+        /// <param name="cancellationToken">The Cancellation Token</param>
         /// <returns>A JSON object containing the result of the verification.</returns>
         [Route("verifymessage")]
         [HttpPost]
-        public IActionResult VerifyMessage([FromBody]VerifyRequest request)
+        public async Task<IActionResult> VerifyMessage([FromBody] VerifyRequest request,
+            CancellationToken cancellationToken = default(CancellationToken))
         {
-            Guard.NotNull(request, nameof(request));
-
-            // checks the request is valid
-            if (!this.ModelState.IsValid)
+            return await this.ExecuteAsAsync(request, cancellationToken, (req, token) =>
             {
-                return ModelStateErrors.BuildErrorResponse(this.ModelState);
-            }
-
-            try
-            {
-                bool result = this.walletManager.VerifySignedMessage(request.ExternalAddress, request.Message, request.Signature);
+                bool result =
+                    this.walletManager.VerifySignedMessage(request.ExternalAddress, req.Message, req.Signature);
                 return this.Json(result.ToString());
-            }
-            catch (Exception e)
-            {
-                this.logger.LogError("Exception occurred: {0}", e.ToString());
-                return ErrorHelpers.BuildErrorResponse(HttpStatusCode.BadRequest, e.Message, e.ToString());
-            }
+            });
         }
 
         /// <summary>
         /// Loads a previously created wallet.
         /// </summary>
         /// <param name="request">An object containing the necessary parameters to load an existing wallet</param>
+        /// <param name="cancellationToken">The Cancellation Token</param>
+        /// <returns>Ok or Error result</returns>
         [Route("load")]
         [HttpPost]
-        public IActionResult Load([FromBody]WalletLoadRequest request)
+        public async Task<IActionResult> Load([FromBody] WalletLoadRequest request,
+            CancellationToken cancellationToken = default(CancellationToken))
         {
-            Guard.NotNull(request, nameof(request));
-
-            // checks the request is valid
-            if (!this.ModelState.IsValid)
+            return await this.Execute(request, cancellationToken, async (req, token) =>
             {
-                return ModelStateErrors.BuildErrorResponse(this.ModelState);
-            }
-
-            try
-            {
-                Wallet wallet = this.walletManager.LoadWallet(request.Password, request.Name);
-                return this.Ok();
-            }
-            catch (FileNotFoundException e)
-            {
-                this.logger.LogError("Exception occurred: {0}", e.ToString());
-                return ErrorHelpers.BuildErrorResponse(HttpStatusCode.NotFound, "This wallet was not found at the specified location.", e.ToString());
-            }
-            catch (WalletException e)
-            {
-                this.logger.LogError("Exception occurred: {0}", e.ToString());
-                return ErrorHelpers.BuildErrorResponse(HttpStatusCode.NotFound, "This wallet was not found at the specified location.", e.ToString());
-            }
-            catch (SecurityException e)
-            {
-                // indicates that the password is wrong
-                this.logger.LogError("Exception occurred: {0}", e.ToString());
-                return ErrorHelpers.BuildErrorResponse(HttpStatusCode.Forbidden, "Wrong password, please try again.", e.ToString());
-            }
-            catch (Exception e)
-            {
-                this.logger.LogError("Exception occurred: {0}", e.ToString());
-                return ErrorHelpers.BuildErrorResponse(HttpStatusCode.BadRequest, e.Message, e.ToString());
-            }
+                await this.walletService.LoadWallet(req, token);
+                return Ok();
+            });
         }
 
         /// <summary>
         /// Recovers an existing wallet.
         /// </summary>
         /// <param name="request">An object containing the parameters used to recover a wallet.</param>
+        /// <param name="cancellationToken">The Cancellation Token</param>
         /// <returns>A value of Ok if the wallet was successfully recovered.</returns>
         [Route("recover")]
         [HttpPost]
-        public IActionResult Recover([FromBody]WalletRecoveryRequest request)
+        public async Task<IActionResult> Recover([FromBody] WalletRecoveryRequest request,
+            CancellationToken cancellationToken = default(CancellationToken))
         {
-            Guard.NotNull(request, nameof(request));
-
-            // checks the request is valid
-            if (!this.ModelState.IsValid)
+            return await this.Execute(request, cancellationToken, async (req, token) =>
             {
-                return ModelStateErrors.BuildErrorResponse(this.ModelState);
-            }
-
-            try
-            {
-                Wallet wallet = this.walletManager.RecoverWallet(request.Password, request.Name, request.Mnemonic, request.CreationDate, passphrase: request.Passphrase);
-
-                return this.Ok();
-            }
-            catch (WalletException e)
-            {
-                // indicates that this wallet already exists
-                this.logger.LogError("Exception occurred: {0}", e.ToString());
-                return ErrorHelpers.BuildErrorResponse(HttpStatusCode.Conflict, e.Message, e.ToString());
-            }
-            catch (FileNotFoundException e)
-            {
-                // indicates that this wallet does not exist
-                this.logger.LogError("Exception occurred: {0}", e.ToString());
-                return ErrorHelpers.BuildErrorResponse(HttpStatusCode.NotFound, "Wallet not found.", e.ToString());
-            }
-            catch (Exception e)
-            {
-                this.logger.LogError("Exception occurred: {0}", e.ToString());
-                return ErrorHelpers.BuildErrorResponse(HttpStatusCode.BadRequest, e.Message, e.ToString());
-            }
+                await this.walletService.RecoverWallet(req, token);
+                return Ok();
+            });
         }
 
         /// <summary>
@@ -317,48 +152,18 @@ namespace Stratis.Bitcoin.Features.Wallet.Controllers
         /// only suitable for returning the wallet history using further API calls.
         /// </summary>
         /// <param name="request">An object containing the parameters used to recover a wallet using its extended public key.</param>
+        /// <param name="cancellationToken">The Cancellation Token</param>
         /// <returns>A value of Ok if the wallet was successfully recovered.</returns>
         [Route("recover-via-extpubkey")]
         [HttpPost]
-        public IActionResult RecoverViaExtPubKey([FromBody]WalletExtPubRecoveryRequest request)
+        public async Task<IActionResult> RecoverViaExtPubKey([FromBody] WalletExtPubRecoveryRequest request,
+            CancellationToken cancellationToken = default(CancellationToken))
         {
-            Guard.NotNull(request, nameof(request));
-
-            if (!this.ModelState.IsValid)
+            return await this.Execute(request, cancellationToken, async (req, token) =>
             {
-                this.logger.LogTrace("(-)[MODEL_STATE_INVALID]");
-                return ModelStateErrors.BuildErrorResponse(this.ModelState);
-            }
-
-            try
-            {
-                string accountExtPubKey =
-                    this.network.IsBitcoin()
-                        ? request.ExtPubKey
-                        : LegacyExtPubKeyConverter.ConvertIfInLegacyStratisFormat(request.ExtPubKey, this.network);
-
-                this.walletManager.RecoverWallet(request.Name, ExtPubKey.Parse(accountExtPubKey), request.AccountIndex,
-                    request.CreationDate);
-
-                return this.Ok();
-            }
-            catch (WalletException e)
-            {
-                // Wallet already exists.
-                this.logger.LogError("Exception occurred: {0}", e.ToString());
-                return ErrorHelpers.BuildErrorResponse(HttpStatusCode.Conflict, e.Message, e.ToString());
-            }
-            catch (FileNotFoundException e)
-            {
-                // Wallet does not exist.
-                this.logger.LogError("Exception occurred: {0}", e.ToString());
-                return ErrorHelpers.BuildErrorResponse(HttpStatusCode.NotFound, "Wallet not found.", e.ToString());
-            }
-            catch (Exception e)
-            {
-                this.logger.LogError("Exception occurred: {0}", e.ToString());
-                return ErrorHelpers.BuildErrorResponse(HttpStatusCode.BadRequest, e.Message, e.ToString());
-            }
+                await this.walletService.RecoverViaExtPubKey(req, token);
+                return Ok();
+            });
         }
 
         /// <summary>
@@ -367,272 +172,49 @@ namespace Stratis.Bitcoin.Features.Wallet.Controllers
         /// and the number of connected nodes.
         /// </summary>
         /// <param name="request">The name of the wallet to get the information for.</param>
+        /// <param name="cancellationToken">The cancellation token</param>
         /// <returns>A JSON object containing the wallet information.</returns>
         [Route("general-info")]
         [HttpGet]
-        public IActionResult GetGeneralInfo([FromQuery] WalletName request)
+        public Task<IActionResult> GetGeneralInfo([FromQuery] WalletName request,
+            CancellationToken cancellationToken = default(CancellationToken))
         {
-            Guard.NotNull(request, nameof(request));
-
-            // checks the request is valid
-            if (!this.ModelState.IsValid)
-            {
-                return ModelStateErrors.BuildErrorResponse(this.ModelState);
-            }
-
-            try
-            {
-                Wallet wallet = this.walletManager.GetWallet(request.Name);
-
-                var model = new WalletGeneralInfoModel
-                {
-                    WalletName = wallet.Name,
-                    Network = wallet.Network,
-                    CreationTime = wallet.CreationTime,
-                    LastBlockSyncedHeight = wallet.AccountsRoot.Single().LastBlockSyncedHeight,
-                    ConnectedNodes = this.connectionManager.ConnectedPeers.Count(),
-                    ChainTip = this.chainIndexer.Tip.Height,
-                    IsChainSynced = this.chainIndexer.IsDownloaded(),
-                    IsDecrypted = true
-                };
-
-                return this.Json(model);
-            }
-            catch (Exception e)
-            {
-                this.logger.LogError(e, "Exception occurred: {0}");
-                return ErrorHelpers.BuildErrorResponse(HttpStatusCode.BadRequest, e.Message, e.ToString());
-            }
+            return this.Execute(request, cancellationToken, async (req, token) =>
+                this.Json(await this.walletService.GetWalletGeneralInfo(req.Name, token)));
         }
 
-         /// <summary>
+        /// <summary>
+        /// Get the transaction count for the specified Wallet and Account.
+        /// </summary>
+        /// <param name="request">The Transaction Count request Object</param>
+        /// <param name="cancellationToken">The Cancellation Token</param>
+        /// <returns>Transaction Count</returns>
+        [Route("transactionCount")]
+        [HttpGet]
+        public async Task<IActionResult> GetTransactionCount([FromQuery] WalletTransactionCountRequest request,
+            CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return await this.ExecuteAsAsync(request, cancellationToken,
+                (req, token) => this.Json(new
+                {
+                    TransactionCount = this.walletManager.GetTransactionCount(req.WalletName, req.AccountName)
+                }));
+        }
+
+        /// <summary>
         /// Gets the history of a wallet. This includes the transactions held by the entire wallet
         /// or a single account if one is specified.
         /// </summary>
         /// <param name="request">An object containing the parameters used to retrieve a wallet's history.</param>
+        /// <param name="cancellationToken">The Cancellation Token</param>
         /// <returns>A JSON object containing the wallet history.</returns>
         [Route("history")]
         [HttpGet]
-        public IActionResult GetHistory([FromQuery] WalletHistoryRequest request) 
-        { 
-            Guard.NotNull(request, nameof(request));
-
-            if (!this.ModelState.IsValid)
-            {
-                return ModelStateErrors.BuildErrorResponse(this.ModelState);
-            }
-
-            // TODO: Extract this code to its own file + start from scratch, with tests.
-
-            try
-            {
-                var model = new WalletHistoryModel();
-
-                // Get a list of all the transactions found in an account (or in a wallet if no account is specified), with the addresses associated with them.
-                IEnumerable<AccountHistory> accountsHistory = this.walletManager.GetHistory(request.WalletName, request.AccountName);
-
-                foreach (AccountHistory accountHistory in accountsHistory)
-                {
-                    var transactionItems = new List<TransactionItemModel>();
-                    var uniqueProcessedTxIds = new HashSet<uint256>();
-
-                    IEnumerable<FlatHistory> query = accountHistory.History;
-
-                    if (!string.IsNullOrEmpty(request.Address))
-                    {
-                        query = query.Where(x => x.Address.Address == request.Address);
-                    }
-
-                    // Sorting the history items by descending dates. That includes received and sent dates.
-                    List<FlatHistory> items = query
-                                                .OrderBy(o => o.Transaction.IsConfirmed() ? 1 : 0)
-                                                .ThenByDescending(o => o.Transaction.SpendingDetails?.CreationTime ?? o.Transaction.CreationTime)
-                                                .ToList();
-
-                    var lookup = items.ToLookup(i => i.Transaction.Id, i => i);
-                    
-                    // Represents a sublist containing only the transactions that have already been spent.
-                    var spendingDetails = items.Where(t => t.Transaction.SpendingDetails != null)
-                        .ToLookup(s => s.Transaction.SpendingDetails.TransactionId, s => s);
-
-                    // Represents a sublist of 'change' transactions.
-                    // NB: Not currently used
-                    // List<FlatHistory> allchange = items.Where(t => t.Address.IsChangeAddress()).ToList();
-
-                    // Represents a sublist of transactions associated with receive addresses + a sublist of already spent transactions associated with change addresses.
-                    // In effect, we filter out 'change' transactions that are not spent, as we don't want to show these in the history.
-                    foreach (FlatHistory item in items.Where(t => !t.Address.IsChangeAddress() || (t.Address.IsChangeAddress() && t.Transaction.IsSpent())))
-                    {
-                        // Count only unique transactions and limit it to MaxHistoryItemsPerAccount.
-                        int processedTransactions = uniqueProcessedTxIds.Count;
-                        if (processedTransactions >= MaxHistoryItemsPerAccount)
-                        {
-                            break;
-                        }
-
-                        TransactionData transaction = item.Transaction;
-                        HdAddress address = item.Address;
-
-                        // First we look for staking transaction as they require special attention.
-                        // A staking transaction spends some of our inputs into 2 outputs or more, paid to the same address.
-                        if (transaction.SpendingDetails?.IsCoinStake != null && transaction.SpendingDetails.IsCoinStake.Value)
-                        {
-                            // If another input has already triggered the building of this history item, we need to remove the amount of this input from the Amount.
-                            // This will only ever happen when there are multiple inputs in a CoinStake. StratisX does this in certain situations.
-                            if (uniqueProcessedTxIds.Contains(transaction.SpendingDetails.TransactionId))
-                            {
-                                TransactionItemModel existingStakeItem = transactionItems.Last(x => x.Id == transaction.SpendingDetails.TransactionId);
-                                existingStakeItem.Amount -= transaction.Amount;
-                            }
-                            else
-                            {
-                                // We look for the output(s) related to our spending input.
-                                List<FlatHistory> relatedOutputs = lookup.Contains(transaction.Id)
-                                    ? lookup[transaction.SpendingDetails.TransactionId].Where(h =>
-                                        h.Transaction.IsCoinStake != null && h.Transaction.IsCoinStake.Value).ToList()
-                                    : null;
-
-                                if (false != relatedOutputs?.Any())
-                                {
-                                    // Add staking transaction details.
-                                    // The staked amount is calculated as the difference between the sum of the outputs and the input and should normally be equal to 1.
-                                    var stakingItem = new TransactionItemModel
-                                    {
-                                        Type = TransactionItemType.Staked,
-                                        ToAddress = address.Address,
-                                        Amount = relatedOutputs.Sum(o => o.Transaction.Amount) - transaction.Amount,
-                                        Id = transaction.SpendingDetails.TransactionId,
-                                        Timestamp = transaction.SpendingDetails.CreationTime,
-                                        ConfirmedInBlock = transaction.SpendingDetails.BlockHeight,
-                                        BlockIndex = transaction.SpendingDetails.BlockIndex
-                                    };
-
-                                    transactionItems.Add(stakingItem);
-                                    uniqueProcessedTxIds.Add(stakingItem.Id);
-                                }
-                            }
-
-                            // No need for further processing if the transaction itself is the output of a staking transaction.
-                            if (transaction.IsCoinStake == true)
-                            {
-                                continue;
-                            }
-                        }
-
-                        // If this is a normal transaction (not staking) that has been spent, add outgoing fund transaction details.
-                        if (transaction.SpendingDetails != null && transaction.SpendingDetails.IsCoinStake != true)
-                        {
-                            // Create a record for a 'send' transaction.
-                            uint256 spendingTransactionId = transaction.SpendingDetails.TransactionId;
-                            var sentItem = new TransactionItemModel
-                            {
-                                Type = TransactionItemType.Send,
-                                Id = spendingTransactionId,
-                                Timestamp = transaction.SpendingDetails.CreationTime,
-                                ConfirmedInBlock = transaction.SpendingDetails.BlockHeight,
-                                BlockIndex = transaction.SpendingDetails.BlockIndex,
-                                Amount = Money.Zero
-                            };
-
-                            // If this 'send' transaction has made some external payments, i.e the funds were not sent to another address in the wallet.
-                            if (transaction.SpendingDetails.Payments != null)
-                            {
-                                sentItem.Payments = new List<PaymentDetailModel>();
-                                foreach (PaymentDetails payment in transaction.SpendingDetails.Payments)
-                                {
-                                    sentItem.Payments.Add(new PaymentDetailModel
-                                    {
-                                        DestinationAddress = payment.DestinationAddress,
-                                        Amount = payment.Amount
-                                    });
-
-                                    sentItem.Amount += payment.Amount;
-                                }
-                            }
-
-                            Money changeAmount = transaction.SpendingDetails.Change.Sum(d => d.Amount);
-
-                            // Get the change address for this spending transaction.
-                            // NB: Not currently used
-                            // FlatHistory changeAddress = allchange.FirstOrDefault(a => a.Transaction.Id == spendingTransactionId);
-
-                            // Find all the spending details containing the spending transaction id and aggregate the sums.
-                            // This is our best shot at finding the total value of inputs for this transaction.
-                            var inputsAmount = new Money(spendingDetails.Contains(spendingTransactionId) ? spendingDetails[spendingTransactionId].Sum(t => t.Transaction.Amount) : 0);
-
-                            // The fee is calculated as follows: funds in utxo - amount spent - amount sent as change.
-                            sentItem.Fee = inputsAmount - sentItem.Amount - changeAmount;
-
-                            // Mined/staked coins add more coins to the total out.
-                            // That makes the fee negative. If that's the case ignore the fee.
-                            if (sentItem.Fee < 0)
-                                sentItem.Fee = 0;
-
-                            transactionItems.Add(sentItem);
-                            uniqueProcessedTxIds.Add(sentItem.Id);
-                        }
-
-                        // We don't show in history transactions that are outputs of staking transactions.
-                        if (transaction.IsCoinStake != null && transaction.IsCoinStake.Value && transaction.SpendingDetails == null)
-                        {
-                            continue;
-                        }
-
-                        // Create a record for a 'receive' transaction.
-                        if (!address.IsChangeAddress())
-                        {
-                            // First check if we already have a similar transaction output, in which case we just sum up the amounts
-                            TransactionItemModel existingReceivedItem = this.FindSimilarReceivedTransactionOutput(transactionItems, transaction);
-
-                            if (existingReceivedItem == null)
-                            {
-                                // Add incoming fund transaction details.
-                                var receivedItem = new TransactionItemModel
-                                {
-                                    Type = TransactionItemType.Received,
-                                    ToAddress = address.Address,
-                                    Amount = transaction.Amount,
-                                    Id = transaction.Id,
-                                    Timestamp = transaction.CreationTime,
-                                    ConfirmedInBlock = transaction.BlockHeight,
-                                    BlockIndex = transaction.BlockIndex
-                                };
-
-                                transactionItems.Add(receivedItem);
-                                uniqueProcessedTxIds.Add(receivedItem.Id);
-                            }
-                            else
-                            {
-                                existingReceivedItem.Amount += transaction.Amount;
-                            }
-                        }
-                    }
-
-                    transactionItems = transactionItems.Distinct(new SentTransactionItemModelComparer()).Select(e => e).ToList();
-
-                    // Sort and filter the history items.
-                    List<TransactionItemModel> itemsToInclude = transactionItems.OrderByDescending(t => t.Timestamp)
-                        .Where(x => string.IsNullOrEmpty(request.SearchQuery) || (x.Id.ToString() == request.SearchQuery || x.ToAddress == request.SearchQuery || x.Payments.Any(p => p.DestinationAddress == request.SearchQuery)))
-                        .Skip(request.Skip ?? 0)
-                        .Take(request.Take ?? transactionItems.Count)
-                        .ToList();
-
-                    model.AccountsHistoryModel.Add(new AccountHistoryModel
-                    {
-                        TransactionsHistory = itemsToInclude,
-                        Name = accountHistory.Account.Name,
-                        CoinType = this.coinType,
-                        HdPath = accountHistory.Account.HdPath
-                    });
-                }
-
-                return this.Json(model);
-            }
-            catch (Exception e)
-            {
-                this.logger.LogError("Exception occurred: {0}", e.ToString());
-                return ErrorHelpers.BuildErrorResponse(HttpStatusCode.BadRequest, e.Message, e.ToString());
-            }
+        public async Task<IActionResult> GetHistory([FromQuery] WalletHistoryRequest request,
+            CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return await this.Execute(request, cancellationToken,
+                async (req, token) => this.Json(await this.walletService.GetHistory(req, token)));
         }
 
 
@@ -640,61 +222,17 @@ namespace Stratis.Bitcoin.Features.Wallet.Controllers
         /// Gets the balance of a wallet in STRAT (or sidechain coin). Both the confirmed and unconfirmed balance are returned.
         /// </summary>
         /// <param name="request">An object containing the parameters used to retrieve a wallet's balance.</param>
+        /// <param name="cancellationToken">The cancellation token</param>
         /// <returns>A JSON object containing the wallet balance.</returns>
         [Route("balance")]
         [HttpGet]
-        public IActionResult GetBalance([FromQuery] WalletBalanceRequest request)
+        public async Task<IActionResult> GetBalance([FromQuery] WalletBalanceRequest request,
+            CancellationToken cancellationToken = default(CancellationToken))
         {
-            Guard.NotNull(request, nameof(request));
-
-            // checks the request is valid
-            if (!this.ModelState.IsValid)
-            {
-                return ModelStateErrors.BuildErrorResponse(this.ModelState);
-            }
-
-            try
-            {
-                var model = new WalletBalanceModel();
-
-                IEnumerable<AccountBalance> balances = this.walletManager.GetBalances(request.WalletName, request.AccountName);
-
-                if (request.AccountName != null && !balances.Any())
-                    throw new Exception($"No account with the name '{request.AccountName}' could be found.");
-
-                foreach (AccountBalance balance in balances)
-                {
-                    HdAccount account = balance.Account;
-                    model.AccountsBalances.Add(new AccountBalanceModel
-                    {
-                        CoinType = this.coinType,
-                        Name = account.Name,
-                        HdPath = account.HdPath,
-                        AmountConfirmed = balance.AmountConfirmed,
-                        AmountUnconfirmed = balance.AmountUnconfirmed,
-                        SpendableAmount = balance.SpendableAmount,
-                        Addresses = request.IncludeBalanceByAddress ?  account.GetCombinedAddresses().Select(address =>
-                        {
-                            (Money confirmedAmount, Money unConfirmedAmount) = address.GetBalances();
-                            return new AddressModel
-                            {
-                                Address = address.Address,
-                                IsUsed = address.Transactions.Any(),
-                                IsChange = address.IsChangeAddress(),
-                                AmountConfirmed = confirmedAmount,
-                                AmountUnconfirmed = unConfirmedAmount
-                            };
-                        }) : null
-                    });
-                }
-
-                return this.Json(model);
-            }
-            catch (Exception e)
-            {
-                this.logger.LogError("Exception occurred: {0}", e.ToString());
-                return ErrorHelpers.BuildErrorResponse(HttpStatusCode.BadRequest, e.Message, e.ToString());
-            }
+            return await this.Execute(request, cancellationToken,
+                async (req, token) => this.Json(await this.walletService.GetBalance(req.WalletName, req.AccountName,
+                    req.IncludeBalanceByAddress, token))
+            );
         }
 
         /// <summary>
@@ -704,36 +242,16 @@ namespace Stratis.Bitcoin.Features.Wallet.Controllers
         /// </summary>
         /// <param name="request">An object containing the parameters used to retrieve the balance
         /// at a specific wallet address.</param>
+        /// <param name="cancellationToken">The cancellation token</param>
         /// <returns>A JSON object containing the balance, fee, and an address for the balance.</returns>
         [Route("received-by-address")]
         [HttpGet]
-        public IActionResult GetReceivedByAddress([FromQuery] ReceivedByAddressRequest request)
+        public async Task<IActionResult> GetReceivedByAddress([FromQuery] ReceivedByAddressRequest request,
+            CancellationToken cancellationToken = default(CancellationToken))
         {
-            Guard.NotNull(request, nameof(request));
-
-            // Checks the request is valid
-            if (!this.ModelState.IsValid)
-            {
-                return ModelStateErrors.BuildErrorResponse(this.ModelState);
-            }
-
-            try
-            {
-                AddressBalance balanceResult = this.walletManager.GetAddressBalance(request.Address);
-                return this.Json(new AddressBalanceModel
-                {
-                    CoinType = this.coinType,
-                    Address = balanceResult.Address,
-                    AmountConfirmed = balanceResult.AmountConfirmed,
-                    AmountUnconfirmed = balanceResult.AmountUnconfirmed,
-                    SpendableAmount = balanceResult.SpendableAmount
-                });
-            }
-            catch (Exception e)
-            {
-                this.logger.LogError("Exception occurred: {0}", e.ToString());
-                return ErrorHelpers.BuildErrorResponse(HttpStatusCode.BadRequest, e.Message, e.ToString());
-            }
+            return await this.Execute(request, cancellationToken,
+                async (req, token) =>
+                    this.Json(await this.walletService.GetReceivedByAddress(request.Address, cancellationToken)));
         }
 
         /// <summary>
@@ -741,34 +259,17 @@ namespace Stratis.Bitcoin.Features.Wallet.Controllers
         /// </summary>
         /// <param name="request">An object containing the parameters used to retrieve the
         /// maximum spendable balance on an account.</param>
+        /// <param name="cancellationToken">The Cancellation Token</param>
         /// <returns>A JSON object containing the maximum spendable balance for an account
         /// along with the fee required to spend it.</returns>
         [Route("maxbalance")]
         [HttpGet]
-        public IActionResult GetMaximumSpendableBalance([FromQuery] WalletMaximumBalanceRequest request)
+        public async Task<IActionResult> GetMaximumSpendableBalance([FromQuery] WalletMaximumBalanceRequest request,
+            CancellationToken cancellationToken = default(CancellationToken))
         {
-            Guard.NotNull(request, nameof(request));
-
-            // Checks the request is valid.
-            if (!this.ModelState.IsValid)
-            {
-                return ModelStateErrors.BuildErrorResponse(this.ModelState);
-            }
-
-            try
-            {
-                (Money maximumSpendableAmount, Money Fee) transactionResult = this.walletTransactionHandler.GetMaximumSpendableAmount(new WalletAccountReference(request.WalletName, request.AccountName), FeeParser.Parse(request.FeeType), request.AllowUnconfirmed);
-                return this.Json(new MaxSpendableAmountModel
-                {
-                    MaxSpendableAmount = transactionResult.maximumSpendableAmount,
-                    Fee = transactionResult.Fee
-                });
-            }
-            catch (Exception e)
-            {
-                this.logger.LogError("Exception occurred: {0}", e.ToString());
-                return ErrorHelpers.BuildErrorResponse(HttpStatusCode.BadRequest, e.Message, e.ToString());
-            }
+            return await this.Execute(request, cancellationToken,
+                async (req, token) =>
+                    this.Json(await this.walletService.GetMaximumSpendableBalance(request, cancellationToken)));
         }
 
         /// <summary>
@@ -777,42 +278,15 @@ namespace Stratis.Bitcoin.Features.Wallet.Controllers
         /// </summary>
         /// <param name="request">An object containing the parameters used to retrieve the spendable
         /// transactions for an account.</param>
+        /// <param name="cancellationToken">The Cancellation Token</param>
         /// <returns>A JSON object containing the spendable transactions for an account.</returns>
         [Route("spendable-transactions")]
         [HttpGet]
-        public IActionResult GetSpendableTransactions([FromQuery] SpendableTransactionsRequest request)
+        public async Task<IActionResult> GetSpendableTransactions([FromQuery] SpendableTransactionsRequest request,
+            CancellationToken cancellationToken = default(CancellationToken))
         {
-            Guard.NotNull(request, nameof(request));
-
-            // Checks the request is valid.
-            if (!this.ModelState.IsValid)
-            {
-                return ModelStateErrors.BuildErrorResponse(this.ModelState);
-            }
-
-            try
-            {
-                IEnumerable<UnspentOutputReference> spendableTransactions = this.walletManager.GetSpendableTransactionsInAccount(new WalletAccountReference(request.WalletName, request.AccountName), request.MinConfirmations);
-
-                return this.Json(new SpendableTransactionsModel
-                {
-                    SpendableTransactions = spendableTransactions.Select(st => new SpendableTransactionModel
-                    {
-                        Id = st.Transaction.Id,
-                        Amount = st.Transaction.Amount,
-                        Address = st.Address.Address,
-                        Index = st.Transaction.Index,
-                        IsChange = st.Address.IsChangeAddress(),
-                        CreationTime = st.Transaction.CreationTime,
-                        Confirmations = st.Confirmations
-                    }).ToList()
-                });
-            }
-            catch (Exception e)
-            {
-                this.logger.LogError("Exception occurred: {0}", e.ToString());
-                return ErrorHelpers.BuildErrorResponse(HttpStatusCode.BadRequest, e.Message, e.ToString());
-            }
+            return await this.Execute(request, cancellationToken,
+                async (req, token) => Json(await this.walletService.GetSpendableTransactions(req, token)));
         }
 
         /// <summary>
@@ -822,136 +296,31 @@ namespace Stratis.Bitcoin.Features.Wallet.Controllers
         /// </summary>
         /// <param name="request">An object containing the parameters used to estimate the fee
         /// for a specific transaction.</param>
+        /// <param name="cancellationToken">The Cancellation Token</param>
         /// <returns>The estimated fee for the transaction.</returns>
         [Route("estimate-txfee")]
         [HttpPost]
-        public IActionResult GetTransactionFeeEstimate([FromBody]TxFeeEstimateRequest request)
+        public async Task<IActionResult> GetTransactionFeeEstimate([FromBody] TxFeeEstimateRequest request,
+            CancellationToken cancellationToken = default(CancellationToken))
         {
-            Guard.NotNull(request, nameof(request));
-
-            // checks the request is valid
-            if (!this.ModelState.IsValid)
-            {
-                return ModelStateErrors.BuildErrorResponse(this.ModelState);
-            }
-
-            try
-            {
-                var recipients = new List<Recipient>();
-                foreach (RecipientModel recipientModel in request.Recipients)
-                {
-                    recipients.Add(new Recipient
-                    {
-                        ScriptPubKey = BitcoinAddress.Create(recipientModel.DestinationAddress, this.network).ScriptPubKey,
-                        Amount = recipientModel.Amount
-                    });
-                }
-
-                var context = new TransactionBuildContext(this.network)
-                {
-                    AccountReference = new WalletAccountReference(request.WalletName, request.AccountName),
-                    FeeType = FeeParser.Parse(request.FeeType),
-                    MinConfirmations = request.AllowUnconfirmed ? 0 : 1,
-                    Recipients = recipients,
-                    OpReturnData = request.OpReturnData,
-                    OpReturnAmount = string.IsNullOrEmpty(request.OpReturnAmount) ? null : Money.Parse(request.OpReturnAmount),
-                    Sign = false
-                };
-
-                return this.Json(this.walletTransactionHandler.EstimateFee(context));
-            }
-            catch (Exception e)
-            {
-                this.logger.LogError("Exception occurred: {0}", e.ToString());
-                return ErrorHelpers.BuildErrorResponse(HttpStatusCode.BadRequest, e.Message, e.ToString());
-            }
+            return await this.Execute(request, cancellationToken,
+                async (req, token) => Json(await this.walletService.GetTransactionFeeEstimate(req, token)));
         }
 
         /// <summary>
         /// Builds a transaction and returns the hex to use when executing the transaction.
         /// </summary>
         /// <param name="request">An object containing the parameters used to build a transaction.</param>
+        /// <param name="cancellationToken">The Cancellation Token</param>
         /// <returns>A JSON object including the transaction ID, the hex used to execute
         /// the transaction, and the transaction fee.</returns>
         [Route("build-transaction")]
         [HttpPost]
-        public IActionResult BuildTransaction([FromBody] BuildTransactionRequest request)
+        public async Task<IActionResult> BuildTransaction([FromBody] BuildTransactionRequest request,
+            CancellationToken cancellationToken = default(CancellationToken))
         {
-            Guard.NotNull(request, nameof(request));
-
-            // checks the request is valid
-            if (!this.ModelState.IsValid)
-            {
-                return ModelStateErrors.BuildErrorResponse(this.ModelState);
-            }
-
-            try
-            {
-                var recipients = new List<Recipient>();
-                foreach (RecipientModel recipientModel in request.Recipients)
-                {
-                    recipients.Add(new Recipient
-                    {
-                        ScriptPubKey = BitcoinAddress.Create(recipientModel.DestinationAddress, this.network).ScriptPubKey,
-                        Amount = recipientModel.Amount
-                    });
-                }
-
-                // If specified, get the change address, which must already exist in the wallet.
-                HdAddress changeAddress = null;
-                if (!string.IsNullOrWhiteSpace(request.ChangeAddress))
-                {
-                    Wallet wallet = this.walletManager.GetWallet(request.WalletName);
-                    HdAccount account = wallet.GetAccount(request.AccountName);
-                    if (account == null)
-                    {
-                        return ErrorHelpers.BuildErrorResponse(HttpStatusCode.BadRequest, "Account not found.", $"No account with the name '{request.AccountName}' could be found in wallet {wallet.Name}.");
-                    }
-
-                    changeAddress = account.GetCombinedAddresses().FirstOrDefault(x => x.Address == request.ChangeAddress);
-
-                    if (changeAddress == null)
-                    {
-                        return ErrorHelpers.BuildErrorResponse(HttpStatusCode.BadRequest, "Change address not found.", $"No changed address '{request.ChangeAddress}' could be found in wallet {wallet.Name}.");
-                    }
-                }
-
-                var context = new TransactionBuildContext(this.network)
-                {
-                    AccountReference = new WalletAccountReference(request.WalletName, request.AccountName),
-                    TransactionFee = string.IsNullOrEmpty(request.FeeAmount) ? null : Money.Parse(request.FeeAmount),
-                    MinConfirmations = request.AllowUnconfirmed ? 0 : 1,
-                    Shuffle = request.ShuffleOutputs ?? true, // We shuffle transaction outputs by default as it's better for anonymity.
-                    OpReturnData = request.OpReturnData,
-                    OpReturnAmount = string.IsNullOrEmpty(request.OpReturnAmount) ? null : Money.Parse(request.OpReturnAmount),
-                    WalletPassword = request.Password,
-                    SelectedInputs = request.Outpoints?.Select(u => new OutPoint(uint256.Parse(u.TransactionId), u.Index)).ToList(),
-                    AllowOtherInputs = false,
-                    Recipients = recipients,
-                    ChangeAddress = changeAddress
-                };
-
-                if (!string.IsNullOrEmpty(request.FeeType))
-                {
-                    context.FeeType = FeeParser.Parse(request.FeeType);
-                }
-
-                Transaction transactionResult = this.walletTransactionHandler.BuildTransaction(context);
-
-                var model = new WalletBuildTransactionModel
-                {
-                    Hex = transactionResult.ToHex(),
-                    Fee = context.TransactionFee,
-                    TransactionId = transactionResult.GetHash()
-                };
-
-                return this.Json(model);
-            }
-            catch (Exception e)
-            {
-                this.logger.LogError("Exception occurred: {0}", e.ToString());
-                return ErrorHelpers.BuildErrorResponse(HttpStatusCode.BadRequest, e.Message, e.ToString());
-            }
+            return await this.Execute(request, cancellationToken,
+                async (req, token) => Json(await this.walletService.BuildTransaction(req, token)));
         }
 
         /// <summary>
@@ -959,63 +328,15 @@ namespace Stratis.Bitcoin.Features.Wallet.Controllers
         /// Use the /api/Wallet/build-transaction call to create transactions.
         /// </summary>
         /// <param name="request">An object containing the necessary parameters used to a send transaction request.</param>
+        /// <param name="cancellationToken">The Cancellation Token</param>
         /// <returns>A JSON object containing information about the sent transaction.</returns>
         [Route("send-transaction")]
         [HttpPost]
-        public IActionResult SendTransaction([FromBody] SendTransactionRequest request)
+        public async Task<IActionResult> SendTransaction([FromBody] SendTransactionRequest request,
+            CancellationToken cancellationToken = default(CancellationToken))
         {
-            Guard.NotNull(request, nameof(request));
-
-            // checks the request is valid
-            if (!this.ModelState.IsValid)
-            {
-                return ModelStateErrors.BuildErrorResponse(this.ModelState);
-            }
-
-            if (!this.connectionManager.ConnectedPeers.Any())
-            {
-                this.logger.LogTrace("(-)[NO_CONNECTED_PEERS]");
-                return ErrorHelpers.BuildErrorResponse(HttpStatusCode.Forbidden, "Can't send transaction: sending transaction requires at least one connection!", string.Empty);
-            }
-
-            try
-            {
-                Transaction transaction = this.network.CreateTransaction(request.Hex);
-
-                var model = new WalletSendTransactionModel
-                {
-                    TransactionId = transaction.GetHash(),
-                    Outputs = new List<TransactionOutputModel>()
-                };
-
-                foreach (TxOut output in transaction.Outputs)
-                {
-                    bool isUnspendable = output.ScriptPubKey.IsUnspendable;
-                    model.Outputs.Add(new TransactionOutputModel
-                    {
-                        Address = isUnspendable ? null : output.ScriptPubKey.GetDestinationAddress(this.network)?.ToString(),
-                        Amount = output.Value,
-                        OpReturnData = isUnspendable ? Encoding.UTF8.GetString(output.ScriptPubKey.ToOps().Last().PushData) : null
-                    });
-                }
-
-                this.broadcasterManager.BroadcastTransactionAsync(transaction).GetAwaiter().GetResult();
-
-                TransactionBroadcastEntry transactionBroadCastEntry = this.broadcasterManager.GetTransaction(transaction.GetHash());
-
-                if (transactionBroadCastEntry.State == State.CantBroadcast)
-                {
-                    this.logger.LogError("Exception occurred: {0}", transactionBroadCastEntry.ErrorMessage);
-                    return ErrorHelpers.BuildErrorResponse(HttpStatusCode.BadRequest, transactionBroadCastEntry.ErrorMessage, "Transaction Exception");
-                }
-
-                return this.Json(model);
-            }
-            catch (Exception e)
-            {
-                this.logger.LogError("Exception occurred: {0}", e.ToString());
-                return ErrorHelpers.BuildErrorResponse(HttpStatusCode.BadRequest, e.Message, e.ToString());
-            }
+            return await this.Execute(request, cancellationToken,
+                async (req, token) => Json(await this.walletService.SendTransaction(req, token)));
         }
 
         /// <summary>
@@ -1023,24 +344,13 @@ namespace Stratis.Bitcoin.Features.Wallet.Controllers
         /// </summary>
         /// <returns>A JSON object containing the available wallet name
         /// </returns>
+        /// <param name="cancellationToken">The Cancellation Token</param>
         [Route("list-wallets")]
         [HttpGet]
-        public IActionResult ListWallets()
+        public async Task<IActionResult> ListWallets(CancellationToken cancellationToken = default(CancellationToken))
         {
-            try
-            {
-                var model = new WalletInfoModel()
-                {
-                    WalletNames = this.walletManager.GetWalletsNames()
-                };
-
-                return this.Json(model);
-            }
-            catch (Exception e)
-            {
-                this.logger.LogError("Exception occurred: {0}", e.ToString());
-                return ErrorHelpers.BuildErrorResponse(HttpStatusCode.BadRequest, e.Message, e.ToString());
-            }
+            return await this.ExecuteAsAsync((object) null, cancellationToken, (req, token) =>
+                this.Json(new WalletInfoModel(this.walletManager.GetWalletsNames())), false);
         }
 
         /// <summary>
@@ -1055,64 +365,45 @@ namespace Stratis.Bitcoin.Features.Wallet.Controllers
         /// for a given seed (or mnemonic) are always the same.
         /// </summary>
         /// <param name="request">An object containing the necessary parameters to create a new account in a wallet.</param>
+        /// <param name="cancellationToken">The Cancellation Token</param>
         /// <returns>A JSON object containing the name of the new account or an existing account
         /// containing no transactions.</returns>
         [Route("account")]
         [HttpPost]
-        public IActionResult CreateNewAccount([FromBody]GetUnusedAccountModel request)
+        public async Task<IActionResult> CreateNewAccount([FromBody] GetUnusedAccountModel request,
+            CancellationToken cancellationToken = default(CancellationToken))
         {
-            Guard.NotNull(request, nameof(request));
-
-            // checks the request is valid
-            if (!this.ModelState.IsValid)
+            return await this.ExecuteAsAsync(request, cancellationToken, (req, token) =>
             {
-                return ModelStateErrors.BuildErrorResponse(this.ModelState);
-            }
-
-            try
-            {
-                HdAccount result = this.walletManager.GetUnusedAccount(request.WalletName, request.Password);
-                return this.Json(result.Name);
-            }
-            catch (CannotAddAccountToXpubKeyWalletException e)
-            {
-                this.logger.LogError("Exception occurred: {0}", e.ToString());
-                return ErrorHelpers.BuildErrorResponse(HttpStatusCode.Forbidden, e.Message, string.Empty);
-            }
-            catch (Exception e)
-            {
-                this.logger.LogError("Exception occurred: {0}", e.ToString());
-                return ErrorHelpers.BuildErrorResponse(HttpStatusCode.BadRequest, e.Message, e.ToString());
-            }
+                try
+                {
+                    HdAccount result = this.walletManager.GetUnusedAccount(request.WalletName, request.Password);
+                    return this.Json(result.Name);
+                }
+                catch (CannotAddAccountToXpubKeyWalletException e)
+                {
+                    this.Logger.LogError("Exception occurred: {0}", e.ToString());
+                    return ErrorHelpers.BuildErrorResponse(HttpStatusCode.Forbidden, e.Message, string.Empty);
+                }
+            });
         }
 
         /// <summary>
         /// Gets a list of accounts for the specified wallet.
         /// </summary>
         /// <param name="request">An object containing the necessary parameters to list the accounts for a wallet.</param>
+        /// <param name="cancellationToken">The Cancellation Token</param>
         /// <returns>A JSON object containing a list of accounts for the specified wallet.</returns>
         [Route("accounts")]
         [HttpGet]
-        public IActionResult ListAccounts([FromQuery]ListAccountsModel request)
+        public async Task<IActionResult> ListAccounts([FromQuery] ListAccountsModel request,
+            CancellationToken cancellationToken = default(CancellationToken))
         {
-            Guard.NotNull(request, nameof(request));
-
-            // checks the request is valid
-            if (!this.ModelState.IsValid)
-            {
-                return ModelStateErrors.BuildErrorResponse(this.ModelState);
-            }
-
-            try
+            return await this.ExecuteAsAsync(request, cancellationToken, (req, token) =>
             {
                 IEnumerable<HdAccount> result = this.walletManager.GetAccounts(request.WalletName);
                 return this.Json(result.Select(a => a.Name));
-            }
-            catch (Exception e)
-            {
-                this.logger.LogError("Exception occurred: {0}", e.ToString());
-                return ErrorHelpers.BuildErrorResponse(HttpStatusCode.BadRequest, e.Message, e.ToString());
-            }
+            });
         }
 
         /// <summary>
@@ -1121,126 +412,60 @@ namespace Stratis.Bitcoin.Features.Wallet.Controllers
         /// </summary>
         /// <param name="request">An object containing the necessary parameters to retrieve an
         /// unused address for a wallet account.</param>
+        /// <param name="cancellationToken">The Cancellation Token</param>
         /// <returns>A JSON object containing the last created and unused address (in Base58 format).</returns>
         [Route("unusedaddress")]
         [HttpGet]
-        public IActionResult GetUnusedAddress([FromQuery]GetUnusedAddressModel request)
+        public async Task<IActionResult> GetUnusedAddress([FromQuery] GetUnusedAddressModel request,
+            CancellationToken cancellationToken = default(CancellationToken))
         {
-            Guard.NotNull(request, nameof(request));
-
-            // checks the request is valid
-            if (!this.ModelState.IsValid)
+            return await this.ExecuteAsAsync(request, cancellationToken, (req, token) =>
             {
-                return ModelStateErrors.BuildErrorResponse(this.ModelState);
-            }
-
-            try
-            {
-                HdAddress result = this.walletManager.GetUnusedAddress(new WalletAccountReference(request.WalletName, request.AccountName));
+                HdAddress result = this.walletManager.GetUnusedAddress(new WalletAccountReference(
+                    request.WalletName,
+                    request.AccountName));
                 return this.Json(result.Address);
-            }
-            catch (Exception e)
-            {
-                this.logger.LogError("Exception occurred: {0}", e.ToString());
-                return ErrorHelpers.BuildErrorResponse(HttpStatusCode.BadRequest, e.Message, e.ToString());
-            }
+            });
         }
 
         /// <summary>
         /// Gets a specified number of unused addresses (in the Base58 format) for a wallet account. These addresses
         /// will not have been assigned to any known UTXO (neither to pay funds into the wallet or to pay change back
         /// to the wallet).
+        /// </summary>
+        /// <returns>A JSON object containing the required amount of unused addresses (in Base58 format).</returns>
         /// <param name="request">An object containing the necessary parameters to retrieve
         /// unused addresses for a wallet account.</param>
-        /// <returns>A JSON object containing the required amount of unused addresses (in Base58 format).</returns>
-        /// </summary>
+        /// <param name="cancellationToken">The Cancellation Token</param>
         [Route("unusedaddresses")]
         [HttpGet]
-        public IActionResult GetUnusedAddresses([FromQuery]GetUnusedAddressesModel request)
+        public async Task<IActionResult> GetUnusedAddresses([FromQuery] GetUnusedAddressesModel request,
+            CancellationToken cancellationToken = default(CancellationToken))
         {
-            Guard.NotNull(request, nameof(request));
-            int count = int.Parse(request.Count);
+            return await this.ExecuteAsAsync(request, cancellationToken, (req, token) =>
+            {
+                var result = this.walletManager.GetUnusedAddresses(
+                        new WalletAccountReference(request.WalletName, req.AccountName), int.Parse(req.Count))
+                    .Select(x => x.Address).ToArray();
 
-            // checks the request is valid
-            if (!this.ModelState.IsValid)
-            {
-                return ModelStateErrors.BuildErrorResponse(this.ModelState);
-            }
-
-            try
-            {
-                IEnumerable<HdAddress> result = this.walletManager.GetUnusedAddresses(new WalletAccountReference(request.WalletName, request.AccountName), count);
-                return this.Json(result.Select(x => x.Address).ToArray());
-            }
-            catch (Exception e)
-            {
-                this.logger.LogError("Exception occurred: {0}", e.ToString());
-                return ErrorHelpers.BuildErrorResponse(HttpStatusCode.BadRequest, e.Message, e.ToString());
-            }
+                return this.Json(result);
+            });
         }
 
         /// <summary>
         /// Gets all addresses for a wallet account.
+        /// </summary>
+        /// <returns>A JSON object containing all addresses for a wallet account (in Base58 format).</returns>
         /// <param name="request">An object containing the necessary parameters to retrieve
         /// all addresses for a wallet account.</param>
-        /// <returns>A JSON object containing all addresses for a wallet account (in Base58 format).</returns>
-        /// </summary>
+        /// <param name="cancellationToken">The Cancellation Token</param>
         [Route("addresses")]
         [HttpGet]
-        public IActionResult GetAllAddresses([FromQuery]GetAllAddressesModel request)
+        public async Task<IActionResult> GetAllAddresses([FromQuery] GetAllAddressesModel request,
+            CancellationToken cancellationToken = default(CancellationToken))
         {
-            Guard.NotNull(request, nameof(request));
-
-            // Checks the request is valid.
-            if (!this.ModelState.IsValid)
-            {
-                return ModelStateErrors.BuildErrorResponse(this.ModelState);
-            }
-
-            try
-            {
-                Wallet wallet = this.walletManager.GetWallet(request.WalletName);
-                HdAccount account = wallet.GetAccount(request.AccountName);
-                if (account == null)
-                    throw new WalletException($"No account with the name '{request.AccountName}' could be found.");
-
-                var accRef = new WalletAccountReference(request.WalletName, request.AccountName);
-
-                var unusedNonChange = this.walletManager.GetUnusedAddresses(accRef, false)
-                    .Select(a => (address: a, isUsed: false, isChange: false, confirmed: Money.Zero, total: Money.Zero)).ToList();
-                var unusedChange = this.walletManager.GetUnusedAddresses(accRef, true)
-                    .Select(a => (address: a, isUsed: false, isChange: true, confirmed: Money.Zero, total: Money.Zero)).ToList();
-                var usedNonChange = this.walletManager.GetUsedAddresses(accRef, false)
-                    .Select(a => (address: a.address, isUsed: true, isChange: false, confirmed: a.confirmed, total: a.total)).ToList();
-                var usedChange = this.walletManager.GetUsedAddresses(accRef, true)
-                    .Select(a => (address: a.address, isUsed: true, isChange: true, confirmed: a.confirmed, total: a.total)).ToList();
-
-                var model = new AddressesModel()
-                {
-                    Addresses = unusedNonChange
-                    .Concat(unusedChange)
-                    .Concat(usedNonChange)
-                    .Concat(usedChange)
-                    .Select(a =>
-                    {
-                        return new AddressModel
-                        {
-                            Address = a.address.Address,
-                            IsUsed = a.isUsed,
-                            IsChange = a.isChange,
-                            AmountConfirmed = a.confirmed,
-                            AmountUnconfirmed = a.total - a.confirmed
-                        };
-                    })
-                };
-
-                return this.Json(model);
-            }
-            catch (Exception e)
-            {
-                this.logger.LogError("Exception occurred: {0}", e.ToString());
-                return ErrorHelpers.BuildErrorResponse(HttpStatusCode.BadRequest, e.Message, e.ToString());
-            }
+            return await this.Execute(request, cancellationToken,
+                async (req, token) => this.Json(await this.walletService.GetAllAddresses(req, token)));
         }
 
         /// <summary>
@@ -1255,99 +480,37 @@ namespace Stratis.Bitcoin.Features.Wallet.Controllers
         /// proceeds to resync from there reinstating the confirmed transactions in the wallet. You can also cherry pick
         /// transactions to remove by specifying their transaction ID.
         ///
-        /// <param name="request">An object containing the necessary parameters to remove transactions
-        /// from a wallet. The includes several options for specifying the transactions to remove.</param>
+        /// </summary>
         /// <returns>A JSON object containing all removed transactions identified by their
         /// transaction ID and creation time.</returns>
-        /// </summary>
+        /// <param name="request">An object containing the necessary parameters to remove transactions
+        /// from a wallet. The includes several options for specifying the transactions to remove.</param>
+        /// <param name="cancellationToken">The Cancellation Token</param>
         [Route("remove-transactions")]
         [HttpDelete]
-        public IActionResult RemoveTransactions([FromQuery]RemoveTransactionsModel request)
+        public async Task<IActionResult> RemoveTransactions([FromQuery] RemoveTransactionsModel request,
+            CancellationToken cancellationToken = default(CancellationToken))
         {
-            Guard.NotNull(request, nameof(request));
-
-            // Checks the request is valid.
-            if (!this.ModelState.IsValid)
-            {
-                return ModelStateErrors.BuildErrorResponse(this.ModelState);
-            }
-
-            try
-            {
-                HashSet<(uint256 transactionId, DateTimeOffset creationTime)> result;
-
-                if (request.DeleteAll)
-                {
-                    result = this.walletManager.RemoveAllTransactions(request.WalletName);
-                }
-                else if (request.FromDate != default(DateTime))
-                {
-                    result = this.walletManager.RemoveTransactionsFromDate(request.WalletName, request.FromDate);
-                }
-                else if (request.TransactionsIds != null)
-                {
-                    IEnumerable<uint256> ids = request.TransactionsIds.Select(uint256.Parse);
-                    result = this.walletManager.RemoveTransactionsByIds(request.WalletName, ids);
-                }
-                else
-                {
-                    throw new WalletException("A filter specifying what transactions to remove must be set.");
-                }
-
-                // If the user chose to resync the wallet after removing transactions.
-                if (result.Any() && request.ReSync)
-                {
-                    // From the list of removed transactions, check which one is the oldest and retrieve the block right before that time.
-                    DateTimeOffset earliestDate = result.Min(r => r.creationTime);
-                    ChainedHeader chainedHeader = this.chainIndexer.GetHeader(this.chainIndexer.GetHeightAtTime(earliestDate.DateTime));
-
-                    // Start the syncing process from the block before the earliest transaction was seen.
-                    this.walletSyncManager.SyncFromHeight(chainedHeader.Height - 1, request.WalletName);
-                }
-
-                IEnumerable<RemovedTransactionModel> model = result.Select(r => new RemovedTransactionModel
-                {
-                    TransactionId = r.transactionId,
-                    CreationTime = r.creationTime
-                });
-
-                return this.Json(model);
-            }
-            catch (Exception e)
-            {
-                this.logger.LogError("Exception occurred: {0}", e.ToString());
-                return ErrorHelpers.BuildErrorResponse(HttpStatusCode.BadRequest, e.Message, e.ToString());
-            }
+            return await this.Execute(request, cancellationToken,
+                async (req, token) => this.Json(await this.walletService.RemoveTransactions(req, token)));
         }
 
         /// <summary>
         /// Gets the extended public key of a specified wallet account.
-        /// <param name="request">An object containing the necessary parameters to retrieve
-        /// the extended public key for a wallet account.</param>
-        /// <returns>A JSON object containing the extended public key for a wallet account.</returns>
+        /// the extended public key for a wallet account
         /// </summary>
+        /// <param name="request">An object containing the necessary parameters to retrieve.</param>
+        /// <param name="cancellationToken">The Cancellation Token</param>
+        /// <returns>A JSON object containing the extended public key for a wallet account.</returns>
         [Route("extpubkey")]
         [HttpGet]
-        public IActionResult GetExtPubKey([FromQuery]GetExtPubKeyModel request)
+        public async Task<IActionResult> GetExtPubKey([FromQuery] GetExtPubKeyModel request,
+            CancellationToken cancellationToken = default(CancellationToken))
         {
-            Guard.NotNull(request, nameof(request));
-
-            // checks the request is valid
-            if (!this.ModelState.IsValid)
-            {
-                return ModelStateErrors.BuildErrorResponse(this.ModelState);
-            }
-
-            try
-            {
-                string result = this.walletManager.GetExtPubKey(new WalletAccountReference(request.WalletName, request.AccountName));
-                return this.Json(result);
-            }
-            catch (Exception e)
-            {
-                this.logger.LogError("Exception occurred: {0}", e.ToString());
-                return ErrorHelpers.BuildErrorResponse(HttpStatusCode.BadRequest, e.Message, e.ToString());
-            }
+            return await this.ExecuteAsAsync(request, cancellationToken,
+                (req, token) =>
+                    this.Json(this.walletManager.GetExtPubKey(new WalletAccountReference(request.WalletName,
+                        request.AccountName))));
         }
 
         /// <summary>
@@ -1355,27 +518,26 @@ namespace Stratis.Bitcoin.Features.Wallet.Controllers
         /// Internally, the specified block is taken as the new wallet tip
         /// and all blocks after it are resynced.
         /// </summary>
-        /// <param name="request">An object containing the necessary parameters
-        /// to request a resync.</param>
-        /// <returns>A value of Ok if the resync was successful.</returns>
+        /// <param name="model">The Hash of the block to Sync From</param>
+        /// <param name="cancellationToken">The Cancellation Token</param>
+        /// <returns>A value of Ok if the re-sync was successful.</returns>
         [HttpPost]
         [Route("sync")]
-        public IActionResult Sync([FromBody] HashModel model)
+        public async Task<IActionResult> Sync([FromBody] HashModel model,
+            CancellationToken cancellationToken = default(CancellationToken))
         {
-            if (!this.ModelState.IsValid)
+            return await this.ExecuteAsAsync(model, cancellationToken, (req, token) =>
             {
-                return ModelStateErrors.BuildErrorResponse(this.ModelState);
-            }
+                ChainedHeader block = this.chainIndexer.GetHeader(uint256.Parse(model.Hash));
+                if (block == null)
+                {
+                    return ErrorHelpers.BuildErrorResponse(HttpStatusCode.BadRequest,
+                        $"Block with hash {model.Hash} was not found on the blockchain.", string.Empty);
+                }
 
-            ChainedHeader block = this.chainIndexer.GetHeader(uint256.Parse(model.Hash));
-
-            if (block == null)
-            {
-                return ErrorHelpers.BuildErrorResponse(HttpStatusCode.BadRequest, $"Block with hash {model.Hash} was not found on the blockchain.", string.Empty);
-            }
-
-            this.walletSyncManager.SyncFromHeight(block.Height);
-            return this.Ok();
+                this.walletSyncManager.SyncFromHeight(block.Height);
+                return this.Ok();
+            });
         }
 
         /// <summary>
@@ -1385,152 +547,48 @@ namespace Stratis.Bitcoin.Features.Wallet.Controllers
         /// </summary>
         /// <param name="request">An object containing the necessary parameters
         /// to request a resync.</param>
+        /// <param name="cancellationToken">The Cancellation Token</param>
         /// <returns>A value of Ok if the resync was successful.</returns>
         [HttpPost]
         [Route("sync-from-date")]
-        public IActionResult SyncFromDate([FromBody] WalletSyncRequest request)
+        public async Task<IActionResult> SyncFromDate([FromBody] WalletSyncRequest request,
+            CancellationToken cancellationToken = default(CancellationToken))
         {
-            if (!this.ModelState.IsValid)
+            return await this.ExecuteAsAsync(request, cancellationToken, (req, token) =>
             {
-                return ModelStateErrors.BuildErrorResponse(this.ModelState);
-            }
+                if (!request.All)
+                {
+                    this.walletSyncManager.SyncFromDate(request.Date, request.WalletName);
+                }
+                else
+                {
+                    this.walletSyncManager.SyncFromHeight(0, request.WalletName);
+                }
 
-            if (!request.All)
-            {
-                this.walletSyncManager.SyncFromDate(request.Date, request.WalletName);
-            }
-            else
-            {
-                this.walletSyncManager.SyncFromHeight(0, request.WalletName);
-            }
-
-            return this.Ok();
+                return this.Ok();
+            });
         }
 
         [Route("wallet-stats")]
         [HttpGet]
-        public IActionResult WalletStats([FromQuery] WalletStatsRequest request)
+        public async Task<IActionResult> WalletStats([FromQuery] WalletStatsRequest request,
+            CancellationToken cancellationToken = default(CancellationToken))
         {
-            Guard.NotNull(request, nameof(request));
-
-            var model = new WalletStatsModel
-            {
-                WalletName = request.WalletName
-            };
-
-            if (!this.ModelState.IsValid)
-                return ModelStateErrors.BuildErrorResponse(this.ModelState);
-
-            try
-            {
-                IEnumerable<UnspentOutputReference> spendableTransactions = this.walletManager.GetSpendableTransactionsInAccount(new WalletAccountReference(request.WalletName, request.AccountName), request.MinConfirmations);
-
-                model.TotalUtxoCount = spendableTransactions.Count();
-                model.UniqueTransactionCount = spendableTransactions.GroupBy(s => s.Transaction.Id).Select(s => s.Key).Count();
-                model.UniqueBlockCount = spendableTransactions.GroupBy(s => s.Transaction.BlockHeight).Select(s => s.Key).Count();
-                model.FinalizedTransactions = spendableTransactions.Count(s => s.Confirmations >= this.network.Consensus.MaxReorgLength);
-
-                if (request.Verbose)
-                {
-                    model.UtxoAmounts = spendableTransactions
-                                        .GroupBy(s => s.Transaction.Amount)
-                                        .OrderByDescending(sg => sg.Count())
-                                        .Select(sg => new UtxoAmountModel { Amount = sg.Key.ToDecimal(MoneyUnit.BTC), Count = sg.Count() })
-                                        .ToList();
-
-                    // This is number of UTXO originating from the same transaction
-                    // WalletInputsPerTransaction = 2000 and Count = 1; would be the result of one split coin operation into 2000 UTXOs
-                    model.UtxoPerTransaction = spendableTransactions
-                                               .GroupBy(s => s.Transaction.Id)
-                                               .GroupBy(sg => sg.Count())
-                                               .OrderByDescending(sgg => sgg.Count())
-                                               .Select(utxo => new UtxoPerTransactionModel { WalletInputsPerTransaction = utxo.Key, Count = utxo.Count() })
-                                               .ToList();
-
-                    model.UtxoPerBlock = spendableTransactions
-                                               .GroupBy(s => s.Transaction.BlockHeight)
-                                               .GroupBy(sg => sg.Count())
-                                               .OrderByDescending(sgg => sgg.Count())
-                                               .Select(utxo => new UtxoPerBlockModel { WalletInputsPerBlock = utxo.Key, Count = utxo.Count() })
-                                               .ToList();
-                }
-
-                return this.Json(model);
-            }
-            catch (Exception e)
-            {
-                this.logger.LogError("Exception occurred: {0}", e.ToString());
-                return ErrorHelpers.BuildErrorResponse(HttpStatusCode.BadRequest, e.Message, e.ToString());
-            }
+            return await this.Execute(request, cancellationToken,
+                async (req, token) => this.Json(await this.walletService.GetWalletStats(req, token)));
         }
 
         /// <summary>Creates requested amount of UTXOs each of equal value.</summary>
+        /// <returns><placeholder>A <see cref="Task"/> representing the asynchronous operation.</placeholder></returns>
+        /// <param name="request">An object containing the necessary parameters.</param>
+        /// <param name="cancellationToken">The Cancellation Token</param>
         [HttpPost]
         [Route("splitcoins")]
-        public IActionResult SplitCoins([FromBody] SplitCoinsRequest request)
+        public async Task<IActionResult> SplitCoins([FromBody] SplitCoinsRequest request,
+            CancellationToken cancellationToken = default(CancellationToken))
         {
-            Guard.NotNull(request, nameof(request));
-
-            // checks the request is valid
-            if (!this.ModelState.IsValid)
-            {
-                return ModelStateErrors.BuildErrorResponse(this.ModelState);
-            }
-
-            try
-            {
-                var walletReference = new WalletAccountReference(request.WalletName, request.AccountName);
-                HdAddress address = this.walletManager.GetUnusedAddress(walletReference);
-
-                Money totalAmount = request.TotalAmountToSplit;
-                Money singleUtxoAmount = totalAmount / request.UtxosCount;
-
-                var recipients = new List<Recipient>(request.UtxosCount);
-                for (int i = 0; i < request.UtxosCount; i++)
-                    recipients.Add(new Recipient { ScriptPubKey = address.ScriptPubKey, Amount = singleUtxoAmount });
-
-                var context = new TransactionBuildContext(this.network)
-                {
-                    AccountReference = walletReference,
-                    MinConfirmations = 1,
-                    Shuffle = true,
-                    WalletPassword = request.WalletPassword,
-                    Recipients = recipients,
-                    Time = (uint)this.dateTimeProvider.GetAdjustedTimeAsUnixTimestamp()
-                };
-
-                Transaction transactionResult = this.walletTransactionHandler.BuildTransaction(context);
-
-                return this.SendTransaction(new SendTransactionRequest(transactionResult.ToHex()));
-            }
-            catch (Exception e)
-            {
-                this.logger.LogError("Exception occurred: {0}", e.ToString());
-                return ErrorHelpers.BuildErrorResponse(HttpStatusCode.BadRequest, e.Message, e.ToString());
-            }
-        }
-
-        /*
-        private void SyncFromBestHeightForRecoveredWallets(DateTime walletCreationDate)
-        {
-            // After recovery the wallet needs to be synced.
-            // We only sync if the syncing process needs to go back.
-            int blockHeightToSyncFrom = this.chainIndexer.GetHeightAtTime(walletCreationDate);
-            int currentSyncingHeight = this.walletSyncManager.WalletTip.Height;
-
-            if (blockHeightToSyncFrom < currentSyncingHeight)
-            {
-                this.walletSyncManager.SyncFromHeight(blockHeightToSyncFrom);
-            }
-        }
-        */
-
-        private TransactionItemModel FindSimilarReceivedTransactionOutput(List<TransactionItemModel> items, TransactionData transaction)
-        {
-            TransactionItemModel existingTransaction = items.FirstOrDefault(i => i.Id == transaction.Id &&
-                                                                                 i.Type == TransactionItemType.Received &&
-                                                                                 i.ConfirmedInBlock == transaction.BlockHeight);
-            return existingTransaction;
+            return await this.Execute(request, cancellationToken,
+                async (req, token) => this.Json(await this.walletService.SplitCoins(req, token)));
         }
     }
 }

--- a/src/Stratis.Bitcoin.Features.Wallet/HdAddress.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/HdAddress.cs
@@ -13,6 +13,9 @@ namespace Stratis.Bitcoin.Features.Wallet
 {
     public class TransactionCollection : ICollection<TransactionData>
     {
+        private readonly TransactionData previous;
+        private readonly int limit;
+
         private ICollection<TransactionData> transactions;
         public HdAddress Address { get; set; }
         private HdAccount account => this.Address?.AddressCollection?.Account;
@@ -34,7 +37,7 @@ namespace Stratis.Bitcoin.Features.Wallet
                 if (this.repository == null)
                     this.transactions = this.transactions ?? new List<TransactionData>();
                 else
-                    this.transactions = this.repository.GetAllTransactions(this.Address).ToList();
+                    this.transactions = this.repository.GetAllTransactions(this.Address, this.limit, this.previous).ToList();
             }
 
             return this.transactions;
@@ -61,9 +64,11 @@ namespace Stratis.Bitcoin.Features.Wallet
                     this.Add(transaction);
         }
 
-        public TransactionCollection(HdAddress address)
+        public TransactionCollection(HdAddress address, TransactionData previous = null, int limit = int.MaxValue)
             : this(address, new List<TransactionData>())
         {
+            this.previous = previous;
+            this.limit = limit;
         }
 
         public void Add(TransactionData transaction)
@@ -121,6 +126,21 @@ namespace Stratis.Bitcoin.Features.Wallet
         public HdAddress(ICollection<TransactionData> transactions = null)
         {
             this.Transactions = (transactions == null ) ? new TransactionCollection(this) : new TransactionCollection(this, transactions);
+        }
+
+        public HdAddress AsPaginated(long? prevOutputTxTime, int? prevOutputIndex, int limit = int.MaxValue)
+        {
+            TransactionData transactionData = (null != prevOutputTxTime && null != prevOutputIndex)
+                ? new TransactionData
+                {
+                    Index = prevOutputIndex.Value,
+                    CreationTime = DateTimeOffset.FromUnixTimeSeconds(prevOutputTxTime.Value)
+                }
+                : null;
+                
+            this.Transactions = new TransactionCollection(this, transactionData, limit);
+
+            return this;
         }
 
         /// <summary>

--- a/src/Stratis.Bitcoin.Features.Wallet/Interfaces/IWalletManager.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Interfaces/IWalletManager.cs
@@ -218,6 +218,18 @@ namespace Stratis.Bitcoin.Features.Wallet.Interfaces
         IEnumerable<AccountHistory> GetHistory(string walletName, string accountName = null);
 
         /// <summary>
+        /// Gets the history of transactions contained in an account.
+        /// If no account name is specified, history will be returned for all accounts in the wallet.
+        /// </summary>
+        /// <param name="walletName">The wallet name.</param>
+        /// <param name="accountName">The account name.</param>
+        /// <param name="prevOutputTxTime">Previous OutputTxTime, used for pagination</param>
+        /// <param name="prevOutputIndex">Previous prevOutputIndex, used for pagination</param>
+        /// <param name="take">Number of records to Take</param>
+        /// <returns>Collection of address history and transaction pairs.</returns>
+        IEnumerable<AccountHistory> GetHistory(string walletName, string accountName = null, long? prevOutputTxTime = null, int? prevOutputIndex = null, int? take = int.MaxValue);
+
+        /// <summary>
         /// Gets the history of the transactions in addresses contained in this account.
         /// </summary>
         /// <param name="account">The account for which to get history.</param>
@@ -392,5 +404,13 @@ namespace Stratis.Bitcoin.Features.Wallet.Interfaces
         /// <param name="tip">Identifies the height to sync from.</param>
         /// <param name="walletName">The optional wallet name if only a specific wallet should be synced.</param>
         void UpdateLastBlockSyncedHeight(ChainedHeader tip, string walletName = null);
+
+        /// <summary>
+        /// Get the Transaction Count for the specified Wallet and Account
+        /// </summary>
+        /// <param name="walletName">The Wallet Name to query</param>
+        /// <param name="accountName">The AccountName to query</param>
+        /// <returns>The transaction count</returns>
+        int GetTransactionCount(string walletName, string accountName = null);
     }
 }

--- a/src/Stratis.Bitcoin.Features.Wallet/Interfaces/IWalletRepository.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Interfaces/IWalletRepository.cs
@@ -335,5 +335,13 @@ namespace Stratis.Bitcoin.Features.Wallet.Interfaces
         /// Provides a default for the "force" flag when calling <see cref="AddWatchOnlyAddresses"/> or <see cref="AddWatchOnlyTransactions"/>.
         /// </summary>
         bool TestMode { get; set; }
+
+        /// <summary>
+        /// Returns the Transaction Count for the specified Wallet and Account
+        /// </summary>
+        /// <param name="walletName">The Wallet Name to Query</param>
+        /// <param name="accountName">The Account Name to Query</param>
+        /// <returns>The Transaction Count</returns>
+        int GetTransactionCount(string walletName, string accountName = null);
     }
 }

--- a/src/Stratis.Bitcoin.Features.Wallet/Models/RequestModels.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Models/RequestModels.cs
@@ -155,6 +155,21 @@ namespace Stratis.Bitcoin.Features.Wallet.Models
         public DateTime CreationDate { get; set; }
     }
 
+    public class WalletTransactionCountRequest : RequestModel
+    {
+        /// <summary>
+        /// The name of the wallet to query transaction count for.
+        /// </summary>
+        [Required(ErrorMessage = "The name of the wallet is missing.")]
+        public string WalletName { get; set; }
+
+        /// <summary>
+        /// Optional. The name of the account to query transaction count for. If no account name is specified,
+        /// the default account is used.
+        /// </summary>
+        public string AccountName { get; set; }
+    }
+
     /// <summary>
     /// A class containing the necessary parameters for a wallet history request.
     /// </summary>
@@ -198,6 +213,16 @@ namespace Stratis.Bitcoin.Features.Wallet.Models
         public int? Take { get; set; }
 
         /// <summary>
+        /// Optional, Previous OutputTxTime, used for pagination
+        /// </summary>
+        public int? PrevOutputTxTime { get; set; }
+
+        /// <summary>
+        /// Optional, Previous PrevOutputIndex, used for pagination
+        /// </summary>
+        public int? PrevOutputIndex { get; set; }
+
+        /// <summary>
         /// An optional string that can be used to match different data in the transaction records.
         /// It is possible to match on the following: the transaction ID, the address at which funds where received,
         /// and the address to which funds where sent.
@@ -227,7 +252,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Models
         /// then the balance for the entire wallet (all accounts) is retrieved.
         /// </summary>         
         public string AccountName { get; set; }
-        
+
         /// <summary>
         /// For Cirrus we need to get Balances By Address
         /// </summary>
@@ -277,14 +302,12 @@ namespace Stratis.Bitcoin.Features.Wallet.Models
     /// <seealso cref="Stratis.Bitcoin.Features.Wallet.Models.RequestModel" />
     public class ReceivedByAddressRequest : RequestModel
     {
-
         [Required(ErrorMessage = "An address is required.")]
         public string Address { get; set; }
     }
 
     public class WalletName : RequestModel
     {
-        
         [Required(ErrorMessage = "The name of the wallet is missing.")]
         public string Name { get; set; }
     }
@@ -440,12 +463,10 @@ namespace Stratis.Bitcoin.Features.Wallet.Models
     /// </summary>
     public class SendTransactionRequest : RequestModel
     {
-        
         public SendTransactionRequest()
         {
         }
 
-        
         public SendTransactionRequest(string transactionHex)
         {
             this.Hex = transactionHex;
@@ -675,7 +696,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Models
         /// </summary>
         public string WalletName { get; set; }
     }
-    
+
     /// <summary>
     /// A class containing the necessary parameters for a wallet stats request.
     /// </summary>
@@ -709,7 +730,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Models
         /// </summary>
         public bool Verbose { get; set; }
     }
-    
+
     /// <summary>
     /// A class containing the necessary parameters to perform an add address book entry request.
     /// </summary>

--- a/src/Stratis.Bitcoin.Features.Wallet/Models/WalletHistoryModel.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Models/WalletHistoryModel.cs
@@ -81,6 +81,12 @@ namespace Stratis.Bitcoin.Features.Wallet.Models
         [JsonConverter(typeof(DateTimeOffsetConverter))]
         public DateTimeOffset Timestamp { get; set; }
 
+        [JsonProperty(PropertyName = "txOutputTime")]
+        public long TxOutputTime => Timestamp.ToUnixTimeSeconds();
+        
+        [JsonProperty(PropertyName = "txOutputIndex")]
+        public int TxOutputIndex { get; set; }
+
         /// <summary>
         /// The index of this transaction in the block in which it is contained.
         /// </summary>

--- a/src/Stratis.Bitcoin.Features.Wallet/Models/WalletInfoModel.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Models/WalletInfoModel.cs
@@ -5,6 +5,15 @@ namespace Stratis.Bitcoin.Features.Wallet.Models
 {
     public class WalletInfoModel
     {
+        public WalletInfoModel()
+        {
+        }
+
+        public WalletInfoModel(IEnumerable<string> walletNames)
+        {
+            this.WalletNames = walletNames;
+        }
+
         [JsonProperty(PropertyName = "walletNames")]
         public IEnumerable<string> WalletNames { get; set; }
     }

--- a/src/Stratis.Bitcoin.Features.Wallet/Services/IWalletService.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Services/IWalletService.cs
@@ -1,0 +1,52 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using NBitcoin;
+using Stratis.Bitcoin.Features.Wallet.Models;
+
+namespace Stratis.Bitcoin.Features.Wallet.Services
+{
+    public interface IWalletService
+    {
+        Task<IEnumerable<string>> GetWalletNames(CancellationToken cancellationToken);
+
+        Task<string> CreateWallet(WalletCreationRequest request, CancellationToken cancellationToken);
+
+        Task<AddressBalanceModel> GetReceivedByAddress(string address, CancellationToken cancellationToken);
+
+        Task<WalletBalanceModel> GetBalance(string requestWalletName, string requestAccountName,
+            bool requestIncludeBalanceByAddress, CancellationToken cancellationToken);
+
+        Task<WalletHistoryModel> GetHistory(WalletHistoryRequest request, CancellationToken cancellationToken);
+        Task<WalletGeneralInfoModel> GetWalletGeneralInfo(string walletName, CancellationToken cancellationToken);
+
+        Task<WalletStatsModel> GetWalletStats(WalletStatsRequest request, CancellationToken cancellationToken);
+
+        Task<WalletSendTransactionModel> SplitCoins(SplitCoinsRequest request, CancellationToken cancellationToken);
+
+        Task<WalletSendTransactionModel> SendTransaction(SendTransactionRequest request,
+            CancellationToken cancellationToken);
+
+        Task<IEnumerable<RemovedTransactionModel>> RemoveTransactions(RemoveTransactionsModel request,
+            CancellationToken cancellationToken);
+
+        Task<AddressesModel> GetAllAddresses(GetAllAddressesModel request, CancellationToken cancellationToken);
+
+        Task<WalletBuildTransactionModel> BuildTransaction(BuildTransactionRequest request,
+            CancellationToken cancellationToken);
+
+        Task<Money> GetTransactionFeeEstimate(TxFeeEstimateRequest request, CancellationToken cancellationToken);
+
+        Task RecoverViaExtPubKey(WalletExtPubRecoveryRequest request, CancellationToken token);
+
+        Task RecoverWallet(WalletRecoveryRequest request, CancellationToken cancellationToken);
+
+        Task LoadWallet(WalletLoadRequest request, CancellationToken cancellationToken);
+
+        Task<MaxSpendableAmountModel> GetMaximumSpendableBalance(WalletMaximumBalanceRequest request,
+            CancellationToken cancellationToken);
+
+        Task<SpendableTransactionsModel> GetSpendableTransactions(SpendableTransactionsRequest request,
+            CancellationToken cancellationToken);
+    }
+}

--- a/src/Stratis.Bitcoin.Features.Wallet/Services/WalletService.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Services/WalletService.cs
@@ -1,0 +1,839 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Security;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using NBitcoin;
+using Stratis.Bitcoin.Builder.Feature;
+using Stratis.Bitcoin.Connection;
+using Stratis.Bitcoin.Consensus;
+using Stratis.Bitcoin.Features.Wallet.Broadcasting;
+using Stratis.Bitcoin.Features.Wallet.Controllers;
+using Stratis.Bitcoin.Features.Wallet.Helpers;
+using Stratis.Bitcoin.Features.Wallet.Interfaces;
+using Stratis.Bitcoin.Features.Wallet.Models;
+using Stratis.Bitcoin.Utilities;
+
+namespace Stratis.Bitcoin.Features.Wallet.Services
+{
+    public class WalletService : IWalletService
+    {
+        private const int MaxHistoryItemsPerAccount = 1000;
+        private readonly IWalletManager walletManager;
+        private readonly IWalletTransactionHandler walletTransactionHandler;
+        private readonly IWalletSyncManager walletSyncManager;
+        private readonly IConnectionManager connectionManager;
+        private readonly IConsensusManager consensusManager;
+        private readonly Network network;
+        private readonly ChainIndexer chainIndexer;
+        private readonly IBroadcasterManager broadcasterManager;
+        private readonly IDateTimeProvider dateTimeProvider;
+        private readonly CoinType coinType;
+        private readonly ILogger logger;
+
+        public WalletService(ILoggerFactory loggerFactory,
+            IWalletManager walletManager,
+            IConsensusManager consensusManager,
+            IWalletTransactionHandler walletTransactionHandler,
+            IWalletSyncManager walletSyncManager,
+            IConnectionManager connectionManager,
+            Network network,
+            ChainIndexer chainIndexer,
+            IBroadcasterManager broadcasterManager,
+            IDateTimeProvider dateTimeProvider)
+        {
+            this.walletManager = walletManager;
+            this.consensusManager = consensusManager;
+            this.walletTransactionHandler = walletTransactionHandler;
+            this.walletSyncManager = walletSyncManager;
+            this.connectionManager = connectionManager;
+            this.network = network;
+            this.chainIndexer = chainIndexer;
+            this.broadcasterManager = broadcasterManager;
+            this.dateTimeProvider = dateTimeProvider;
+            this.coinType = (CoinType)network.Consensus.CoinType;
+            this.logger = loggerFactory.CreateLogger(this.GetType().FullName);
+        }
+
+        public async Task<IEnumerable<string>> GetWalletNames(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return await Task.Run(() => this.walletManager.GetWalletsNames(), cancellationToken);
+        }
+
+        public async Task<string> CreateWallet(WalletCreationRequest request, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return await Task.Run(() =>
+            {
+                try
+                {
+                    Mnemonic requestMnemonic =
+                        string.IsNullOrEmpty(request.Mnemonic) ? null : new Mnemonic(request.Mnemonic);
+
+                    (_, Mnemonic mnemonic) = this.walletManager.CreateWallet(request.Password, request.Name,
+                        request.Passphrase, mnemonic: requestMnemonic);
+
+                    return mnemonic.ToString();
+                }
+                catch (WalletException e)
+                {
+                    // indicates that this wallet already exists
+                    this.logger.LogError("Exception occurred: {0}", e.ToString());
+                    throw new FeatureException(HttpStatusCode.Conflict, e.Message, e.ToString());
+                }
+                catch (NotSupportedException e)
+                {
+                    this.logger.LogError("Exception occurred: {0}", e.ToString());
+                    throw new FeatureException(HttpStatusCode.BadRequest,
+                        "There was a problem creating a wallet.", e.ToString());
+                }
+            }, cancellationToken);
+        }
+
+        public async Task<AddressBalanceModel> GetReceivedByAddress(string address, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return await Task.Run(() =>
+            {
+                AddressBalance balanceResult = this.walletManager.GetAddressBalance(address);
+                return new AddressBalanceModel
+                {
+                    CoinType = this.coinType,
+                    Address = balanceResult.Address,
+                    AmountConfirmed = balanceResult.AmountConfirmed,
+                    AmountUnconfirmed = balanceResult.AmountUnconfirmed,
+                    SpendableAmount = balanceResult.SpendableAmount
+                };
+            }, cancellationToken);
+        }
+
+        public async Task<WalletGeneralInfoModel> GetWalletGeneralInfo(string walletName, CancellationToken cancellationToken)
+        {
+            return await Task.Run(() =>
+            {
+                Wallet wallet = this.walletManager.GetWallet(walletName);
+
+                return new WalletGeneralInfoModel
+                {
+                    WalletName = wallet.Name,
+                    Network = wallet.Network,
+                    CreationTime = wallet.CreationTime,
+                    LastBlockSyncedHeight = wallet.AccountsRoot.Single().LastBlockSyncedHeight,
+                    ConnectedNodes = this.connectionManager.ConnectedPeers.Count(),
+                    ChainTip = this.consensusManager.HeaderTip,
+                    IsChainSynced = this.chainIndexer.IsDownloaded(),
+                    IsDecrypted = true
+                };
+            }, cancellationToken);
+        }
+
+        public async Task<WalletBalanceModel> GetBalance(
+            string walletName, string accountName, bool includeBalanceByAddress = false, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return await Task.Run(() =>
+            {
+                var model = new WalletBalanceModel();
+
+                IEnumerable<AccountBalance> balances = this.walletManager.GetBalances(walletName, accountName).ToList();
+
+                if (accountName != null && !balances.Any())
+                    throw new Exception($"No account with the name '{accountName}' could be found.");
+
+                foreach (AccountBalance balance in balances)
+                {
+                    HdAccount account = balance.Account;
+                    model.AccountsBalances.Add(new AccountBalanceModel
+                    {
+                        CoinType = this.coinType,
+                        Name = account.Name,
+                        HdPath = account.HdPath,
+                        AmountConfirmed = balance.AmountConfirmed,
+                        AmountUnconfirmed = balance.AmountUnconfirmed,
+                        SpendableAmount = balance.SpendableAmount,
+                        Addresses = includeBalanceByAddress
+                            ? account.GetCombinedAddresses().Select(address =>
+                            {
+                                (Money confirmedAmount, Money unConfirmedAmount) = address.GetBalances();
+                                return new AddressModel
+                                {
+                                    Address = address.Address,
+                                    IsUsed = address.Transactions.Any(),
+                                    IsChange = address.IsChangeAddress(),
+                                    AmountConfirmed = confirmedAmount,
+                                    AmountUnconfirmed = unConfirmedAmount
+                                };
+                            })
+                            : null
+                    });
+                }
+
+                return model;
+            }, cancellationToken);
+        }
+
+        public async Task<WalletHistoryModel> GetHistory(WalletHistoryRequest request, CancellationToken cancellationToken)
+        {
+            return await Task.Run(() =>
+            {
+                var model = new WalletHistoryModel();
+
+                // Get a list of all the transactions found in an account (or in a wallet if no account is specified), with the addresses associated with them.
+                IEnumerable<AccountHistory> accountsHistory =
+                    this.walletManager.GetHistory(request.WalletName, request.AccountName);
+
+                foreach (AccountHistory accountHistory in accountsHistory)
+                {
+                    var transactionItems = new List<TransactionItemModel>();
+                    var uniqueProcessedTxIds = new HashSet<uint256>();
+
+                    IEnumerable<FlatHistory> query = accountHistory.History;
+
+                    if (!string.IsNullOrEmpty(request.Address))
+                    {
+                        query = query.Where(x => x.Address.Address == request.Address);
+                    }
+
+                    // Sorting the history items by descending dates. That includes received and sent dates.
+                    List<FlatHistory> items = query
+                        .OrderBy(o => o.Transaction.IsConfirmed() ? 1 : 0)
+                        .ThenByDescending(
+                            o => o.Transaction.SpendingDetails?.CreationTime ?? o.Transaction.CreationTime)
+                        .ToList();
+
+                    var lookup = items.ToLookup(i => i.Transaction.Id, i => i);
+
+                    // Represents a sublist containing only the transactions that have already been spent.
+                    var spendingDetails = items.Where(t => t.Transaction.SpendingDetails != null)
+                        .ToLookup(s => s.Transaction.SpendingDetails.TransactionId, s => s);
+
+                    // Represents a sublist of 'change' transactions.
+                    // NB: Not currently used
+                    // List<FlatHistory> allchange = items.Where(t => t.Address.IsChangeAddress()).ToList();
+
+                    // Represents a sublist of transactions associated with receive addresses + a sublist of already spent transactions associated with change addresses.
+                    // In effect, we filter out 'change' transactions that are not spent, as we don't want to show these in the history.
+                    foreach (FlatHistory item in items.Where(t =>
+                        !t.Address.IsChangeAddress() || (t.Address.IsChangeAddress() && t.Transaction.IsSpent())))
+                    {
+                        // Count only unique transactions and limit it to MaxHistoryItemsPerAccount.
+                        int processedTransactions = uniqueProcessedTxIds.Count;
+                        if (processedTransactions >= MaxHistoryItemsPerAccount)
+                        {
+                            break;
+                        }
+
+                        TransactionData transaction = item.Transaction;
+                        HdAddress address = item.Address;
+
+                        // First we look for staking transaction as they require special attention.
+                        // A staking transaction spends some of our inputs into 2 outputs or more, paid to the same address.
+                        if (transaction.SpendingDetails?.IsCoinStake != null &&
+                            transaction.SpendingDetails.IsCoinStake.Value)
+                        {
+                            // If another input has already triggered the building of this history item, we need to remove the amount of this input from the Amount.
+                            // This will only ever happen when there are multiple inputs in a CoinStake. StratisX does this in certain situations.
+                            if (uniqueProcessedTxIds.Contains(transaction.SpendingDetails.TransactionId))
+                            {
+                                TransactionItemModel existingStakeItem =
+                                    transactionItems.Last(x => x.Id == transaction.SpendingDetails.TransactionId);
+                                existingStakeItem.Amount -= transaction.Amount;
+                            }
+                            else
+                            {
+                                // We look for the output(s) related to our spending input.
+                                List<FlatHistory> relatedOutputs = lookup.Contains(transaction.Id)
+                                    ? lookup[transaction.SpendingDetails.TransactionId].Where(h =>
+                                        h.Transaction.IsCoinStake != null && h.Transaction.IsCoinStake.Value).ToList()
+                                    : null;
+
+                                if (false != relatedOutputs?.Any())
+                                {
+                                    // Add staking transaction details.
+                                    // The staked amount is calculated as the difference between the sum of the outputs and the input and should normally be equal to 1.
+                                    var stakingItem = new TransactionItemModel
+                                    {
+                                        Type = TransactionItemType.Staked,
+                                        ToAddress = address.Address,
+                                        Amount = relatedOutputs.Sum(o => o.Transaction.Amount) - transaction.Amount,
+                                        Id = transaction.SpendingDetails.TransactionId,
+                                        Timestamp = transaction.SpendingDetails.CreationTime,
+                                        ConfirmedInBlock = transaction.SpendingDetails.BlockHeight,
+                                        BlockIndex = transaction.SpendingDetails.BlockIndex
+                                    };
+
+                                    transactionItems.Add(stakingItem);
+                                    uniqueProcessedTxIds.Add(stakingItem.Id);
+                                }
+                            }
+
+                            // No need for further processing if the transaction itself is the output of a staking transaction.
+                            if (transaction.IsCoinStake == true)
+                            {
+                                continue;
+                            }
+                        }
+
+                        // If this is a normal transaction (not staking) that has been spent, add outgoing fund transaction details.
+                        if (transaction.SpendingDetails != null && transaction.SpendingDetails.IsCoinStake != true)
+                        {
+                            // Create a record for a 'send' transaction.
+                            uint256 spendingTransactionId = transaction.SpendingDetails.TransactionId;
+                            var sentItem = new TransactionItemModel
+                            {
+                                Type = TransactionItemType.Send,
+                                Id = spendingTransactionId,
+                                Timestamp = transaction.SpendingDetails.CreationTime,
+                                ConfirmedInBlock = transaction.SpendingDetails.BlockHeight,
+                                BlockIndex = transaction.SpendingDetails.BlockIndex,
+                                Amount = Money.Zero
+                            };
+
+                            // If this 'send' transaction has made some external payments, i.e the funds were not sent to another address in the wallet.
+                            if (transaction.SpendingDetails.Payments != null)
+                            {
+                                sentItem.Payments = new List<PaymentDetailModel>();
+                                foreach (PaymentDetails payment in transaction.SpendingDetails.Payments)
+                                {
+                                    sentItem.Payments.Add(new PaymentDetailModel
+                                    {
+                                        DestinationAddress = payment.DestinationAddress,
+                                        Amount = payment.Amount
+                                    });
+
+                                    sentItem.Amount += payment.Amount;
+                                }
+                            }
+
+                            Money changeAmount = transaction.SpendingDetails.Change.Sum(d => d.Amount);
+
+                            // Get the change address for this spending transaction.
+                            // NB: Not currently used
+                            // FlatHistory changeAddress = allchange.FirstOrDefault(a => a.Transaction.Id == spendingTransactionId);
+
+                            // Find all the spending details containing the spending transaction id and aggregate the sums.
+                            // This is our best shot at finding the total value of inputs for this transaction.
+                            var inputsAmount = new Money(spendingDetails.Contains(spendingTransactionId)
+                                ? spendingDetails[spendingTransactionId].Sum(t => t.Transaction.Amount)
+                                : 0);
+
+                            // The fee is calculated as follows: funds in utxo - amount spent - amount sent as change.
+                            sentItem.Fee = inputsAmount - sentItem.Amount - changeAmount;
+
+                            // Mined/staked coins add more coins to the total out.
+                            // That makes the fee negative. If that's the case ignore the fee.
+                            if (sentItem.Fee < 0)
+                                sentItem.Fee = 0;
+
+                            transactionItems.Add(sentItem);
+                            uniqueProcessedTxIds.Add(sentItem.Id);
+                        }
+
+                        // We don't show in history transactions that are outputs of staking transactions.
+                        if (transaction.IsCoinStake != null && transaction.IsCoinStake.Value &&
+                            transaction.SpendingDetails == null)
+                        {
+                            continue;
+                        }
+
+                        // Create a record for a 'receive' transaction.
+                        if (!address.IsChangeAddress())
+                        {
+                            // First check if we already have a similar transaction output, in which case we just sum up the amounts
+                            TransactionItemModel existingReceivedItem =
+                                this.FindSimilarReceivedTransactionOutput(transactionItems, transaction);
+
+                            if (existingReceivedItem == null)
+                            {
+                                // Add incoming fund transaction details.
+                                var receivedItem = new TransactionItemModel
+                                {
+                                    Type = TransactionItemType.Received,
+                                    ToAddress = address.Address,
+                                    Amount = transaction.Amount,
+                                    Id = transaction.Id,
+                                    Timestamp = transaction.CreationTime,
+                                    ConfirmedInBlock = transaction.BlockHeight,
+                                    BlockIndex = transaction.BlockIndex
+                                };
+
+                                transactionItems.Add(receivedItem);
+                                uniqueProcessedTxIds.Add(receivedItem.Id);
+                            }
+                            else
+                            {
+                                existingReceivedItem.Amount += transaction.Amount;
+                            }
+                        }
+                    }
+
+                    transactionItems = transactionItems.Distinct(new SentTransactionItemModelComparer()).Select(e => e)
+                        .ToList();
+
+                    // Sort and filter the history items.
+                    List<TransactionItemModel> itemsToInclude = transactionItems.OrderByDescending(t => t.Timestamp)
+                        .Where(x => string.IsNullOrEmpty(request.SearchQuery) ||
+                                    (x.Id.ToString() == request.SearchQuery || x.ToAddress == request.SearchQuery ||
+                                     x.Payments.Any(p => p.DestinationAddress == request.SearchQuery)))
+                        .Skip(request.Skip ?? 0)
+                        .Take(request.Take ?? transactionItems.Count)
+                        .ToList();
+
+                    model.AccountsHistoryModel.Add(new AccountHistoryModel
+                    {
+                        TransactionsHistory = itemsToInclude,
+                        Name = accountHistory.Account.Name,
+                        CoinType = this.coinType,
+                        HdPath = accountHistory.Account.HdPath
+                    });
+                }
+
+                return model;
+            }, cancellationToken);
+        }
+
+        public async Task<WalletStatsModel> GetWalletStats(WalletStatsRequest request, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return await Task.Run(() =>
+            {
+                var model = new WalletStatsModel
+                {
+                    WalletName = request.WalletName
+                };
+
+                IEnumerable<UnspentOutputReference> spendableTransactions =
+                    this.walletManager.GetSpendableTransactionsInAccount(
+                            new WalletAccountReference(request.WalletName, request.AccountName),
+                            request.MinConfirmations)
+                        .ToList();
+
+                model.TotalUtxoCount = spendableTransactions.Count();
+                model.UniqueTransactionCount =
+                    spendableTransactions.GroupBy(s => s.Transaction.Id).Select(s => s.Key).Count();
+                model.UniqueBlockCount = spendableTransactions.GroupBy(s => s.Transaction.BlockHeight)
+                    .Select(s => s.Key).Count();
+                model.FinalizedTransactions =
+                    spendableTransactions.Count(s => s.Confirmations >= this.network.Consensus.MaxReorgLength);
+
+                if (!request.Verbose)
+                {
+                    return model;
+                }
+
+                model.UtxoAmounts = spendableTransactions
+                    .GroupBy(s => s.Transaction.Amount)
+                    .OrderByDescending(sg => sg.Count())
+                    .Select(sg => new UtxoAmountModel
+                    { Amount = sg.Key.ToDecimal(MoneyUnit.BTC), Count = sg.Count() })
+                    .ToList();
+
+                // This is number of UTXO originating from the same transaction
+                // WalletInputsPerTransaction = 2000 and Count = 1; would be the result of one split coin operation into 2000 UTXOs
+                model.UtxoPerTransaction = spendableTransactions
+                    .GroupBy(s => s.Transaction.Id)
+                    .GroupBy(sg => sg.Count())
+                    .OrderByDescending(sgg => sgg.Count())
+                    .Select(utxo => new UtxoPerTransactionModel
+                    { WalletInputsPerTransaction = utxo.Key, Count = utxo.Count() })
+                    .ToList();
+
+                model.UtxoPerBlock = spendableTransactions
+                    .GroupBy(s => s.Transaction.BlockHeight)
+                    .GroupBy(sg => sg.Count())
+                    .OrderByDescending(sgg => sgg.Count())
+                    .Select(utxo => new UtxoPerBlockModel { WalletInputsPerBlock = utxo.Key, Count = utxo.Count() })
+                    .ToList();
+
+                return model;
+            }, cancellationToken);
+        }
+
+        public async Task<WalletSendTransactionModel> SplitCoins(SplitCoinsRequest request, CancellationToken cancellationToken)
+        {
+            return await Task.Run(() =>
+            {
+                var walletReference = new WalletAccountReference(request.WalletName, request.AccountName);
+                HdAddress address = this.walletManager.GetUnusedAddress(walletReference);
+
+                Money totalAmount = request.TotalAmountToSplit;
+                Money singleUtxoAmount = totalAmount / request.UtxosCount;
+
+                var recipients = new List<Recipient>(request.UtxosCount);
+                for (int i = 0; i < request.UtxosCount; i++)
+                    recipients.Add(new Recipient { ScriptPubKey = address.ScriptPubKey, Amount = singleUtxoAmount });
+
+                var context = new TransactionBuildContext(this.network)
+                {
+                    AccountReference = walletReference,
+                    MinConfirmations = 1,
+                    Shuffle = true,
+                    WalletPassword = request.WalletPassword,
+                    Recipients = recipients,
+                    Time = (uint)this.dateTimeProvider.GetAdjustedTimeAsUnixTimestamp()
+                };
+
+                Transaction transactionResult = this.walletTransactionHandler.BuildTransaction(context);
+
+                return this.SendTransaction(new SendTransactionRequest(transactionResult.ToHex()),
+                    CancellationToken.None);
+            }, cancellationToken);
+        }
+
+        public async Task<WalletSendTransactionModel> SendTransaction(SendTransactionRequest request, CancellationToken cancellationToken)
+        {
+            return await Task.Run(() =>
+            {
+                if (!this.connectionManager.ConnectedPeers.Any())
+                {
+                    this.logger.LogTrace("(-)[NO_CONNECTED_PEERS]");
+
+                    throw new FeatureException(HttpStatusCode.Forbidden,
+                        "Can't send transaction: sending transaction requires at least one connection!", string.Empty);
+                }
+
+                Transaction transaction = this.network.CreateTransaction(request.Hex);
+
+                var model = new WalletSendTransactionModel
+                {
+                    TransactionId = transaction.GetHash(),
+                    Outputs = new List<TransactionOutputModel>()
+                };
+
+                foreach (TxOut output in transaction.Outputs)
+                {
+                    bool isUnspendable = output.ScriptPubKey.IsUnspendable;
+                    model.Outputs.Add(new TransactionOutputModel
+                    {
+                        Address = isUnspendable
+                            ? null
+                            : output.ScriptPubKey.GetDestinationAddress(this.network)?.ToString(),
+                        Amount = output.Value,
+                        OpReturnData = isUnspendable
+                            ? Encoding.UTF8.GetString(output.ScriptPubKey.ToOps().Last().PushData)
+                            : null
+                    });
+                }
+
+                this.broadcasterManager.BroadcastTransactionAsync(transaction).GetAwaiter().GetResult();
+
+                TransactionBroadcastEntry transactionBroadCastEntry =
+                    this.broadcasterManager.GetTransaction(transaction.GetHash());
+
+                if (transactionBroadCastEntry.State == State.CantBroadcast)
+                {
+                    this.logger.LogError("Exception occurred: {0}", transactionBroadCastEntry.ErrorMessage);
+
+                    throw new FeatureException(HttpStatusCode.BadRequest,
+                        transactionBroadCastEntry.ErrorMessage, "Transaction Exception");
+                }
+
+                return model;
+            }, cancellationToken);
+        }
+
+        public async Task<IEnumerable<RemovedTransactionModel>> RemoveTransactions(RemoveTransactionsModel request, CancellationToken cancellationToken)
+        {
+            return await Task.Run(() =>
+            {
+                HashSet<(uint256 transactionId, DateTimeOffset creationTime)> result;
+
+                if (request.DeleteAll)
+                {
+                    result = this.walletManager.RemoveAllTransactions(request.WalletName);
+                }
+                else if (request.FromDate != default(DateTime))
+                {
+                    result = this.walletManager.RemoveTransactionsFromDate(request.WalletName, request.FromDate);
+                }
+                else if (request.TransactionsIds != null)
+                {
+                    IEnumerable<uint256> ids = request.TransactionsIds.Select(uint256.Parse);
+                    result = this.walletManager.RemoveTransactionsByIds(request.WalletName, ids);
+                }
+                else
+                {
+                    throw new WalletException("A filter specifying what transactions to remove must be set.");
+                }
+
+                // If the user chose to resync the wallet after removing transactions.
+                if (result.Any() && request.ReSync)
+                {
+                    // From the list of removed transactions, check which one is the oldest and retrieve the block right before that time.
+                    DateTimeOffset earliestDate = result.Min(r => r.creationTime);
+                    ChainedHeader chainedHeader =
+                        this.chainIndexer.GetHeader(this.chainIndexer.GetHeightAtTime(earliestDate.DateTime));
+
+                    // Start the syncing process from the block before the earliest transaction was seen.
+                    this.walletSyncManager.SyncFromHeight(chainedHeader.Height - 1, request.WalletName);
+                }
+
+                return result.Select(r => new RemovedTransactionModel
+                {
+                    TransactionId = r.transactionId,
+                    CreationTime = r.creationTime
+                });
+            }, cancellationToken);
+        }
+
+        public async Task<AddressesModel> GetAllAddresses(GetAllAddressesModel request, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return await Task.Run(() =>
+            {
+                Wallet wallet = this.walletManager.GetWallet(request.WalletName);
+                HdAccount account = wallet.GetAccount(request.AccountName);
+                if (account == null)
+                    throw new WalletException($"No account with the name '{request.AccountName}' could be found.");
+
+                var accRef = new WalletAccountReference(request.WalletName, request.AccountName);
+
+                var unusedNonChange = this.walletManager.GetUnusedAddresses(accRef, false)
+                    .Select(a => (address: a, isUsed: false, isChange: false, confirmed: Money.Zero, total: Money.Zero))
+                    .ToList();
+                var unusedChange = this.walletManager.GetUnusedAddresses(accRef, true)
+                    .Select(a => (address: a, isUsed: false, isChange: true, confirmed: Money.Zero, total: Money.Zero))
+                    .ToList();
+                var usedNonChange = this.walletManager.GetUsedAddresses(accRef, false)
+                    .Select(a => (a.address, isUsed: true, isChange: false, a.confirmed, a.total)).ToList();
+                var usedChange = this.walletManager.GetUsedAddresses(accRef, true)
+                    .Select(a => (a.address, isUsed: true, isChange: true, a.confirmed, a.total)).ToList();
+
+                return new AddressesModel()
+                {
+                    Addresses = unusedNonChange
+                        .Concat(unusedChange)
+                        .Concat(usedNonChange)
+                        .Concat(usedChange)
+                        .Select(a => new AddressModel
+                        {
+                            Address = a.address.Address,
+                            IsUsed = a.isUsed,
+                            IsChange = a.isChange,
+                            AmountConfirmed = a.confirmed,
+                            AmountUnconfirmed = a.total - a.confirmed
+                        })
+                };
+            }, cancellationToken);
+        }
+
+        public async Task<WalletBuildTransactionModel> BuildTransaction(BuildTransactionRequest request, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return await Task.Run(() =>
+            {
+                var recipients = request.Recipients.Select(recipientModel => new Recipient
+                {
+                    ScriptPubKey = BitcoinAddress.Create(recipientModel.DestinationAddress, this.network).ScriptPubKey,
+                    Amount = recipientModel.Amount
+                }).ToList();
+
+                // If specified, get the change address, which must already exist in the wallet.
+                HdAddress changeAddress = null;
+                if (!string.IsNullOrWhiteSpace(request.ChangeAddress))
+                {
+                    Wallet wallet = this.walletManager.GetWallet(request.WalletName);
+                    HdAccount account = wallet.GetAccount(request.AccountName);
+                    if (account == null)
+                    {
+                        throw new FeatureException(HttpStatusCode.BadRequest, "Account not found.",
+                            $"No account with the name '{request.AccountName}' could be found in wallet {wallet.Name}.");
+                    }
+
+                    changeAddress = account.GetCombinedAddresses()
+                        .FirstOrDefault(x => x.Address == request.ChangeAddress);
+
+                    if (changeAddress == null)
+                    {
+                        throw new FeatureException(HttpStatusCode.BadRequest, "Change address not found.",
+                            $"No changed address '{request.ChangeAddress}' could be found in wallet {wallet.Name}.");
+                    }
+                }
+
+                var context = new TransactionBuildContext(this.network)
+                {
+                    AccountReference = new WalletAccountReference(request.WalletName, request.AccountName),
+                    TransactionFee = string.IsNullOrEmpty(request.FeeAmount) ? null : Money.Parse(request.FeeAmount),
+                    MinConfirmations = request.AllowUnconfirmed ? 0 : 1,
+                    Shuffle = request.ShuffleOutputs ??
+                              true, // We shuffle transaction outputs by default as it's better for anonymity.
+                    OpReturnData = request.OpReturnData,
+                    OpReturnAmount = string.IsNullOrEmpty(request.OpReturnAmount)
+                        ? null
+                        : Money.Parse(request.OpReturnAmount),
+                    WalletPassword = request.Password,
+                    SelectedInputs = request.Outpoints
+                        ?.Select(u => new OutPoint(uint256.Parse(u.TransactionId), u.Index)).ToList(),
+                    AllowOtherInputs = false,
+                    Recipients = recipients,
+                    ChangeAddress = changeAddress
+                };
+
+                if (!string.IsNullOrEmpty(request.FeeType))
+                {
+                    context.FeeType = FeeParser.Parse(request.FeeType);
+                }
+
+                Transaction transactionResult = this.walletTransactionHandler.BuildTransaction(context);
+
+                return new WalletBuildTransactionModel
+                {
+                    Hex = transactionResult.ToHex(),
+                    Fee = context.TransactionFee,
+                    TransactionId = transactionResult.GetHash()
+                };
+            }, cancellationToken);
+        }
+
+        public async Task<Money> GetTransactionFeeEstimate(TxFeeEstimateRequest request, CancellationToken cancellationToken)
+        {
+            return await Task.Run(() =>
+            {
+                var recipients = request.Recipients.Select(recipientModel => new Recipient
+                {
+                    ScriptPubKey = BitcoinAddress.Create(recipientModel.DestinationAddress, this.network).ScriptPubKey,
+                    Amount = recipientModel.Amount
+                }).ToList();
+
+                var context = new TransactionBuildContext(this.network)
+                {
+                    AccountReference = new WalletAccountReference(request.WalletName, request.AccountName),
+                    FeeType = FeeParser.Parse(request.FeeType),
+                    MinConfirmations = request.AllowUnconfirmed ? 0 : 1,
+                    Recipients = recipients,
+                    OpReturnData = request.OpReturnData,
+                    OpReturnAmount = string.IsNullOrEmpty(request.OpReturnAmount)
+                        ? null
+                        : Money.Parse(request.OpReturnAmount),
+                    Sign = false
+                };
+
+                return this.walletTransactionHandler.EstimateFee(context);
+            }, cancellationToken);
+        }
+
+        public async Task RecoverViaExtPubKey(WalletExtPubRecoveryRequest request, CancellationToken token)
+        {
+            await Task.Run(() =>
+            {
+                try
+                {
+                    string accountExtPubKey =
+                        this.network.IsBitcoin()
+                            ? request.ExtPubKey
+                            : LegacyExtPubKeyConverter.ConvertIfInLegacyStratisFormat(request.ExtPubKey, this.network);
+
+                    this.walletManager.RecoverWallet(request.Name, ExtPubKey.Parse(accountExtPubKey),
+                        request.AccountIndex,
+                        request.CreationDate, null);
+                }
+                catch (WalletException e)
+                {
+                    // Wallet already exists.
+                    throw new FeatureException(HttpStatusCode.Conflict, e.Message, e.ToString());
+                }
+                catch (FileNotFoundException e)
+                {
+                    // Wallet does not exist.
+                    throw new FeatureException(HttpStatusCode.NotFound, "Wallet not found.", e.ToString());
+                }
+            }, token);
+        }
+
+        public async Task RecoverWallet(WalletRecoveryRequest request, CancellationToken cancellationToken)
+        {
+            await Task.Run(() =>
+            {
+                try
+                {
+                    this.walletManager.RecoverWallet(request.Password, request.Name, request.Mnemonic,
+                        request.CreationDate, passphrase: request.Passphrase);
+                }
+                catch (WalletException e)
+                {
+                    // indicates that this wallet already exists
+                    throw new FeatureException(HttpStatusCode.Conflict, e.Message, e.ToString());
+                }
+                catch (FileNotFoundException e)
+                {
+                    // indicates that this wallet does not exist
+                    throw new FeatureException(HttpStatusCode.NotFound, "Wallet not found.", e.ToString());
+                }
+            }, cancellationToken);
+        }
+
+        public async Task LoadWallet(WalletLoadRequest request, CancellationToken cancellationToken)
+        {
+            await Task.Run(() =>
+            {
+                try
+                {
+                    this.walletManager.LoadWallet(request.Password, request.Name);
+                }
+                catch (FileNotFoundException e)
+                {
+                    throw new FeatureException(HttpStatusCode.NotFound,
+                        "This wallet was not found at the specified location.", e.ToString());
+                }
+                catch (WalletException e)
+                {
+                    throw new FeatureException(HttpStatusCode.NotFound,
+                        "This wallet was not found at the specified location.", e.ToString());
+                }
+                catch (SecurityException e)
+                {
+                    // indicates that the password is wrong
+                    throw new FeatureException(HttpStatusCode.Forbidden,
+                        "Wrong password, please try again.",
+                        e.ToString());
+                }
+            }, cancellationToken);
+        }
+
+        public async Task<MaxSpendableAmountModel> GetMaximumSpendableBalance(WalletMaximumBalanceRequest request, CancellationToken cancellationToken)
+        {
+            return await Task.Run(() =>
+            {
+                (Money maximumSpendableAmount, Money fee) = this.walletTransactionHandler.GetMaximumSpendableAmount(
+                    new WalletAccountReference(request.WalletName, request.AccountName),
+                    FeeParser.Parse(request.FeeType), request.AllowUnconfirmed);
+
+                return new MaxSpendableAmountModel
+                {
+                    MaxSpendableAmount = maximumSpendableAmount,
+                    Fee = fee
+                };
+            }, cancellationToken);
+        }
+
+        public async Task<SpendableTransactionsModel> GetSpendableTransactions(SpendableTransactionsRequest request, CancellationToken cancellationToken)
+        {
+            return await Task.Run(() =>
+            {
+                IEnumerable<UnspentOutputReference> spendableTransactions =
+                    this.walletManager.GetSpendableTransactionsInAccount(
+                        new WalletAccountReference(request.WalletName, request.AccountName), request.MinConfirmations);
+
+                return new SpendableTransactionsModel
+                {
+                    SpendableTransactions = spendableTransactions.Select(st => new SpendableTransactionModel
+                    {
+                        Id = st.Transaction.Id,
+                        Amount = st.Transaction.Amount,
+                        Address = st.Address.Address,
+                        Index = st.Transaction.Index,
+                        IsChange = st.Address.IsChangeAddress(),
+                        CreationTime = st.Transaction.CreationTime,
+                        Confirmations = st.Confirmations
+                    }).ToList()
+                };
+            }, cancellationToken);
+        }
+
+        private TransactionItemModel FindSimilarReceivedTransactionOutput(List<TransactionItemModel> items, TransactionData transaction)
+        {
+            return items.FirstOrDefault(i => i.Id == transaction.Id &&
+                                             i.Type == TransactionItemType.Received &&
+                                             i.ConfirmedInBlock == transaction.BlockHeight);
+        }
+    }
+}

--- a/src/Stratis.Bitcoin.Features.Wallet/Services/WalletService.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Services/WalletService.cs
@@ -181,8 +181,10 @@ namespace Stratis.Bitcoin.Features.Wallet.Services
                 var model = new WalletHistoryModel();
 
                 // Get a list of all the transactions found in an account (or in a wallet if no account is specified), with the addresses associated with them.
-                IEnumerable<AccountHistory> accountsHistory =
-                    this.walletManager.GetHistory(request.WalletName, request.AccountName);
+                IEnumerable<AccountHistory> accountsHistory = request.Take == null
+                    ? this.walletManager.GetHistory(request.WalletName, request.AccountName)
+                    : this.walletManager.GetHistory(request.WalletName, request.AccountName, request.PrevOutputTxTime,
+                        request.PrevOutputIndex, request.Take);
 
                 foreach (AccountHistory accountHistory in accountsHistory)
                 {

--- a/src/Stratis.Bitcoin.Features.Wallet/WalletFeature.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/WalletFeature.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿
+using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -17,6 +18,7 @@ using Stratis.Bitcoin.Features.Wallet.Broadcasting;
 using Stratis.Bitcoin.Features.Wallet.Interfaces;
 using Stratis.Bitcoin.Interfaces;
 using Stratis.Bitcoin.Utilities;
+using Stratis.Bitcoin.Features.Wallet.Services;
 
 namespace Stratis.Bitcoin.Features.Wallet
 {
@@ -167,7 +169,8 @@ namespace Stratis.Bitcoin.Features.Wallet
                 .DependOn<BlockStoreFeature>()
                 .DependOn<RPCFeature>()
                 .FeatureServices(services =>
-                    {
+                {
+                        services.AddSingleton<IWalletService, WalletService>();
                         services.AddSingleton<IWalletSyncManager, WalletSyncManager>();
                         services.AddSingleton<IWalletTransactionHandler, WalletTransactionHandler>();
                         services.AddSingleton<IWalletManager, WalletManager>();

--- a/src/Stratis.Bitcoin.IntegrationTests/BlockStore/ProofOfWorkSpendingSteps.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/BlockStore/ProofOfWorkSpendingSteps.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.Threading.Tasks;
 using FluentAssertions;
 using NBitcoin;
 using Stratis.Bitcoin.Features.Wallet;
@@ -67,7 +68,7 @@ namespace Stratis.Bitcoin.IntegrationTests.BlockStore
             TestHelper.MineBlocks(this.sendingStratisBitcoinNode, this.coinbaseMaturity);
         }
 
-        private void spending_the_coins_from_original_block()
+        private async Task spending_the_coins_from_original_block()
         {
             HdAddress sendtoAddress = this.receivingStratisBitcoinNode.FullNode.WalletManager().GetUnusedAddress();
 
@@ -89,7 +90,7 @@ namespace Stratis.Bitcoin.IntegrationTests.BlockStore
                 this.lastTransaction = this.sendingStratisBitcoinNode.FullNode.WalletTransactionHandler()
                     .BuildTransaction(transactionBuildContext);
 
-                this.sendingStratisBitcoinNode.FullNode.NodeController<WalletController>()
+                await this.sendingStratisBitcoinNode.FullNode.NodeController<WalletController>()
                     .SendTransaction(new SendTransactionRequest(this.lastTransaction.ToHex()));
             }
             catch (Exception exception)

--- a/src/Stratis.Bitcoin.IntegrationTests/BlockStore/RetrieveFromBlockStoreSteps.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/BlockStore/RetrieveFromBlockStoreSteps.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using FluentAssertions;
 using NBitcoin;
 using Stratis.Bitcoin.Features.Wallet;
@@ -100,7 +101,7 @@ namespace Stratis.Bitcoin.IntegrationTests.BlockStore
             TestHelper.WaitForNodeToSync(this.node, this.transactionNode);
         }
 
-        private void a_real_transaction()
+        private async Task a_real_transaction()
         {
             var transactionBuildContext = new TransactionBuildContext(this.node.FullNode.Network)
             {
@@ -112,7 +113,7 @@ namespace Stratis.Bitcoin.IntegrationTests.BlockStore
 
             this.transaction = this.node.FullNode.WalletTransactionHandler().BuildTransaction(transactionBuildContext);
 
-            this.node.FullNode.NodeController<WalletController>()
+            await this.node.FullNode.NodeController<WalletController>()
                 .SendTransaction(new SendTransactionRequest(this.transaction.ToHex()));
         }
 

--- a/src/Stratis.Bitcoin.IntegrationTests/Wallet/SendingStakedCoinsBeforeMaturity_Steps.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/Wallet/SendingStakedCoinsBeforeMaturity_Steps.cs
@@ -74,7 +74,8 @@ namespace Stratis.Bitcoin.IntegrationTests.Wallet
             if (walletTransactionModel == null)
                 return null;
 
-            return this.proofOfStakeSteps.PremineNodeWithCoins.FullNode.NodeController<WalletController>().SendTransaction(new SendTransactionRequest(walletTransactionModel.Hex));
+            return this.proofOfStakeSteps.PremineNodeWithCoins.FullNode.NodeController<WalletController>()
+                .SendTransaction(new SendTransactionRequest(walletTransactionModel.Hex)).GetAwaiter().GetResult();
         }
 
         private IActionResult BuildTransaction()
@@ -89,7 +90,7 @@ namespace Stratis.Bitcoin.IntegrationTests.Wallet
                     Password = this.proofOfStakeSteps.PremineWalletPassword,
                     WalletName = this.proofOfStakeSteps.PremineWallet,
                     FeeAmount = Money.Satoshis(20000).ToString()
-                });
+                }).GetAwaiter().GetResult();
 
             return transactionResult;
         }
@@ -109,7 +110,7 @@ namespace Stratis.Bitcoin.IntegrationTests.Wallet
 
         private WalletHistoryModel GetWalletHistory(CoreNode node, string walletName)
         {
-            var walletHistory = node.FullNode.NodeController<WalletController>().GetHistory(new WalletHistoryRequest { WalletName = walletName }) as JsonResult;
+            var walletHistory = node.FullNode.NodeController<WalletController>().GetHistory(new WalletHistoryRequest { WalletName = walletName }).GetAwaiter().GetResult() as JsonResult;
             return walletHistory?.Value as WalletHistoryModel;
         }
 

--- a/src/Stratis.Bitcoin.IntegrationTests/Wallet/WalletAddressGenerationAndFundsVisibility_Steps.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/Wallet/WalletAddressGenerationAndFundsVisibility_Steps.cs
@@ -1,5 +1,6 @@
 ﻿using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using FluentAssertions;
 using NBitcoin;
 using Stratis.Bitcoin.Features.Wallet;
@@ -74,7 +75,7 @@ namespace Stratis.Bitcoin.IntegrationTests.Wallet
             this.MineSpendableCoins();
         }
 
-        private void a_wallet_with_funds_at_index_20_which_is_beyond_default_gap_limit()
+        private async Task a_wallet_with_funds_at_index_20_which_is_beyond_default_gap_limit()
         {
             ExtPubKey xPublicKey = this.GetExtendedPublicKey(this.receivingStratisBitcoinNode);
             var recipientAddressBeyondGapLimit = xPublicKey.Derive(new KeyPath("0/20")).PubKey.GetAddress(KnownNetworks.RegTest);
@@ -95,8 +96,9 @@ namespace Stratis.Bitcoin.IntegrationTests.Wallet
             var transaction = this.sendingStratisBitcoinNode.FullNode.WalletTransactionHandler()
                  .BuildTransaction(transactionBuildContext);
 
-            this.sendingStratisBitcoinNode.FullNode.NodeController<WalletController>()
+            await this.sendingStratisBitcoinNode.FullNode.NodeController<WalletController>()
                 .SendTransaction(new SendTransactionRequest(transaction.ToHex()));
+                
 
             TestHelper.MineBlocks(this.sendingStratisBitcoinNode, 1);
         }

--- a/src/Stratis.Bitcoin.IntegrationTests/Wallet/WalletTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/Wallet/WalletTests.cs
@@ -377,7 +377,7 @@ namespace Stratis.Bitcoin.IntegrationTests.Wallet
                                     .GetUnusedAddress(new WalletAccountReference(WalletName, Account)).Address
                             }
                         }
-                    });
+                    }).GetAwaiter().GetResult();
 
                 JsonResult jsonResult = (JsonResult)result;
                 Assert.NotNull(((WalletBuildTransactionModel)jsonResult.Value).TransactionId);
@@ -549,7 +549,8 @@ namespace Stratis.Bitcoin.IntegrationTests.Wallet
 
             // Broadcast to the other node.
 
-            IActionResult result = node.FullNode.NodeController<WalletController>().SendTransaction(new SendTransactionRequest(trx.ToHex()));
+            IActionResult result = node.FullNode.NodeController<WalletController>()
+                .SendTransaction(new SendTransactionRequest(trx.ToHex())).GetAwaiter().GetResult();
             if (result is ErrorResult errorResult)
             {
                 var errorResponse = (ErrorResponse)errorResult.Value;

--- a/src/Stratis.Bitcoin/Builder/Feature/FeatureControllerBase.cs
+++ b/src/Stratis.Bitcoin/Builder/Feature/FeatureControllerBase.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Stratis.Bitcoin.Utilities;
+using Stratis.Bitcoin.Utilities.JsonErrors;
+using Stratis.Bitcoin.Utilities.ModelStateErrors;
+
+namespace Stratis.Bitcoin.Builder.Feature
+{
+    /// <summary>
+    /// Base RestAPI Controller class for features.
+    /// Has boilerplate code for consistent request validation, handling and mapping of errors without the need to
+    /// duplicate lots of code.
+    /// </summary>
+    public abstract class FeatureControllerBase : Controller
+    {
+        public readonly ILogger Logger;
+
+        protected FeatureControllerBase(ILogger logger)
+        {
+            this.Logger = logger;
+        }
+
+        protected async Task<IActionResult> Execute<TRequest>(TRequest request, CancellationToken token,
+            Func<TRequest, CancellationToken, Task<IActionResult>> action, bool checkModelState = true)
+        {
+            if (checkModelState && !this.ModelState.IsValid)
+            {
+                Guard.NotNull(request, nameof(request));
+                this.Logger.LogTrace($"{nameof(request)}(-)[MODEL_STATE_INVALID]");
+                return ModelStateErrors.BuildErrorResponse(this.ModelState);
+            }
+
+            try
+            {
+                return await action(request, token);
+            }
+            catch (FeatureException e)
+            {
+                this.Logger.LogError("Exception occurred: {0}", e.ToString());
+                return e.MapToErrorResponse();
+            }
+            catch (Exception e)
+            {
+                this.Logger.LogError("Exception occurred: {0}", e.ToString());
+                return ErrorHelpers.BuildErrorResponse(HttpStatusCode.BadRequest, e.Message, e.ToString());
+            }
+        }
+
+        protected Task<IActionResult> ExecuteAsAsync<TRequest>(TRequest request,
+            CancellationToken cancellationToken,
+            Func<TRequest, CancellationToken, IActionResult> action, bool checkModelState = true)
+        {
+            return this.Execute(request, cancellationToken, (req, token)
+                => Task.Run(() => action(req, token), token), checkModelState);
+        }
+    }
+}

--- a/src/Stratis.Bitcoin/Builder/Feature/FeatureException.cs
+++ b/src/Stratis.Bitcoin/Builder/Feature/FeatureException.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Net;
+
+namespace Stratis.Bitcoin.Builder.Feature
+{
+    public class FeatureException : Exception
+    {
+        public FeatureException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+
+        public FeatureException(HttpStatusCode httpStatusCode, string message, string description,
+            Exception innerException = null)
+            : this(message, innerException)
+        {
+            this.HttpStatusCode = httpStatusCode;
+            this.Description = description;
+        }
+
+        public HttpStatusCode HttpStatusCode { get; set; }
+
+        public string Description { get; set; }
+    }
+}

--- a/src/Stratis.Bitcoin/Utilities/JsonErrors/ErrorHelpers.cs
+++ b/src/Stratis.Bitcoin/Utilities/JsonErrors/ErrorHelpers.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Net;
+using Stratis.Bitcoin.Builder.Feature;
 
 namespace Stratis.Bitcoin.Utilities.JsonErrors
 {
@@ -20,7 +21,25 @@ namespace Stratis.Bitcoin.Utilities.JsonErrors
                 }
             };
 
-            return new ErrorResult((int)statusCode, errorResponse);
+            return new ErrorResult((int) statusCode, errorResponse);
+        }
+
+        public static ErrorResult MapToErrorResponse(this FeatureException featureException )
+        {
+            var errorResponse = new ErrorResponse
+            {
+                Errors = new List<ErrorModel>
+                {
+                    new ErrorModel
+                    {
+                        Status = (int) featureException.HttpStatusCode,
+                        Message = featureException.Message,
+                        Description = featureException.Description
+                    }
+                }
+            };
+
+            return new ErrorResult((int) featureException.HttpStatusCode, errorResponse);
         }
     }
 }

--- a/src/Stratis.Features.SQLiteWalletRepository/SQLiteWalletRepository.cs
+++ b/src/Stratis.Features.SQLiteWalletRepository/SQLiteWalletRepository.cs
@@ -1279,6 +1279,14 @@ namespace Stratis.Features.SQLiteWalletRepository
         {
             return this.GetWalletContainer(walletName).TransactionsOfInterest;
         }
+        
+        /// <inheritdoc />
+        public int GetTransactionCount(string walletName, string accountName = null)
+        {
+            var identifier = this.GetAddressIdentifier(walletName, accountName);
+
+            return HDTransactionData.GetTransactionCount(this.GetConnection(walletName), identifier.WalletId, identifier.AccountIndex);
+        }
 
         /// <inheritdoc />
         public IEnumerable<TransactionData> GetAllTransactions(HdAddress hdAddress, int limit = int.MaxValue, TransactionData prev = null, bool descending = true)

--- a/src/Stratis.Features.SQLiteWalletRepository/Tables/HDTransactionData.cs
+++ b/src/Stratis.Features.SQLiteWalletRepository/Tables/HDTransactionData.cs
@@ -101,6 +101,18 @@ namespace Stratis.Features.SQLiteWalletRepository.Tables
                 LIMIT   {strLimit}");
         }
 
+        internal static int GetTransactionCount(DBConnection conn, int walletId, int? accountIndex)
+        {
+            string strWalletId = DBParameter.Create(walletId);
+            string strAccountIndex = DBParameter.Create(accountIndex);
+            return conn.ExecuteScalar<int>($@"
+                SELECT  Count (*)
+                FROM    HDTransactionData
+                WHERE   WalletId = {strWalletId} {(accountIndex == null ? $@"
+                AND     AccountIndex IN (SELECT AccountIndex FROM HDAccount WHERE WalletId = {strWalletId})" : $@"
+                AND     AccountIndex = {strAccountIndex}")}");
+        }
+
         internal static IEnumerable<HDTransactionData> GetSpendableTransactions(DBConnection conn, int walletId, int accountIndex, int currentChainHeight, long coinbaseMaturity, int confirmations = 0)
         {
             int maxConfirmationHeight = (currentChainHeight + 1) - confirmations;


### PR DESCRIPTION
This PR patches in the Wallet Service and SignalR improvements that we in 3.0.8.0 into 3.0.7.0 as these are pre-requisites for 3.0.7.0 and we cannot use 3.8.0 for Stratis Core 2.0 as this is a major .net core upgrade and not fully tested yet