### PR TITLE
Update Seeders and Seeds & Increase Checkpoint Heights

### DIFF
--- a/src/NBitcoin.Tests/NetworkTests.cs
+++ b/src/NBitcoin.Tests/NetworkTests.cs
@@ -323,7 +323,7 @@ namespace NBitcoin.Tests
         {
             Network network = this.stratisMain;
 
-            Assert.Equal(31, network.Checkpoints.Count);
+            Assert.Equal(33, network.Checkpoints.Count);
             Assert.Equal(2, network.DNSSeeds.Count);
             Assert.Equal(4, network.SeedNodes.Count);
 
@@ -379,7 +379,7 @@ namespace NBitcoin.Tests
             Assert.Equal(105, network.Consensus.CoinType);
             Assert.Equal(new BigInteger(uint256.Parse("00000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff").ToBytes(false)), network.Consensus.ProofOfStakeLimit);
             Assert.Equal(new BigInteger(uint256.Parse("000000000000ffffffffffffffffffffffffffffffffffffffffffffffffffff").ToBytes(false)), network.Consensus.ProofOfStakeLimitV2);
-            Assert.Equal(new uint256("0x50497017e7bb256df205fcbc2caccbe5b516cb33491e1a11737a3bfe83959b9f"), network.Consensus.DefaultAssumeValid);
+            Assert.Equal(new uint256("0x6ad909469bc8fa15f48533fd30ae3217fceca413c0df69cf4ac314188f4df1c4"), network.Consensus.DefaultAssumeValid);
             Assert.Equal(50, network.Consensus.CoinbaseMaturity);
             Assert.Equal(Money.Coins(98000000), network.Consensus.PremineReward);
             Assert.Equal(2, network.Consensus.PremineHeight);
@@ -399,7 +399,7 @@ namespace NBitcoin.Tests
         {
             Network network = this.stratisTest;
 
-            Assert.Equal(13, network.Checkpoints.Count);
+            Assert.Equal(15, network.Checkpoints.Count);
             Assert.Equal(2, network.DNSSeeds.Count);
             Assert.Equal(2, network.SeedNodes.Count);
 
@@ -455,7 +455,7 @@ namespace NBitcoin.Tests
             Assert.Equal(105, network.Consensus.CoinType);
             Assert.Equal(new BigInteger(uint256.Parse("00000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff").ToBytes(false)), network.Consensus.ProofOfStakeLimit);
             Assert.Equal(new BigInteger(uint256.Parse("000000000000ffffffffffffffffffffffffffffffffffffffffffffffffffff").ToBytes(false)), network.Consensus.ProofOfStakeLimitV2);
-            Assert.Equal(new uint256("0xc9a15c9dd87c6219b273f93442b87fdaf9eebb4f3059d8ed8239c41a4ab3e730"), network.Consensus.DefaultAssumeValid);
+            Assert.Equal(new uint256("0x690e7e30ae3fa6c10855db0f8bc10110a54f5c73019f5581ee038186154397d0"), network.Consensus.DefaultAssumeValid);
             Assert.Equal(10, network.Consensus.CoinbaseMaturity);
             Assert.Equal(Money.Coins(98000000), network.Consensus.PremineReward);
             Assert.Equal(2, network.Consensus.PremineHeight);

--- a/src/NBitcoin.Tests/NetworkTests.cs
+++ b/src/NBitcoin.Tests/NetworkTests.cs
@@ -325,7 +325,7 @@ namespace NBitcoin.Tests
 
             Assert.Equal(31, network.Checkpoints.Count);
             Assert.Equal(2, network.DNSSeeds.Count);
-            Assert.Equal(2, network.SeedNodes.Count);
+            Assert.Equal(4, network.SeedNodes.Count);
 
             Assert.Equal("StratisMain", network.Name);
             Assert.Equal(StratisMain.StratisRootFolderName, network.RootFolderName);

--- a/src/Stratis.Bitcoin.Networks/StratisMain.cs
+++ b/src/Stratis.Bitcoin.Networks/StratisMain.cs
@@ -196,6 +196,9 @@ namespace Stratis.Bitcoin.Networks
             {
                 new NetworkAddress(IPAddress.Parse("138.68.145.243"), 16178), // dan public node
                 new NetworkAddress(IPAddress.Parse("169.1.13.216"), 16178),
+                new NetworkAddress(IPAddress.Parse("213.125.242.234"), 16178),
+                new NetworkAddress(IPAddress.Parse("45.58.55.21"), 16178),
+
             };
 
             this.StandardScriptsRegistry = new StratisStandardScriptsRegistry();

--- a/src/Stratis.Bitcoin.Networks/StratisMain.cs
+++ b/src/Stratis.Bitcoin.Networks/StratisMain.cs
@@ -188,24 +188,13 @@ namespace Stratis.Bitcoin.Networks
 
             this.DNSSeeds = new List<DNSSeedData>
             {
-                new DNSSeedData("mainnet1.stratisplatform.com", "mainnet1.stratisplatform.com"),
-                new DNSSeedData("mainnet2.stratisnetwork.com", "mainnet2.stratisnetwork.com"),
-                new DNSSeedData("mainnet3.stratisplatform.com", "mainnet3.stratisplatform.com"),
-                new DNSSeedData("mainnet4.stratisnetwork.com", "mainnet4.stratisnetwork.com")
+                new DNSSeedData("mainnet1.stratisnetwork.com", "mainnet1.stratisnetwork.com"),
+                new DNSSeedData("mainnet2.stratisnetwork.com", "mainnet2.stratisnetwork.com")
             };
 
             this.SeedNodes = new List<NetworkAddress>
             {
-                new NetworkAddress(IPAddress.Parse("51.140.231.125"), 16178), // danger cloud node
-                new NetworkAddress(IPAddress.Parse("13.70.81.5"), 16178), // beard cloud node
-                new NetworkAddress(IPAddress.Parse("191.235.85.131"), 16178), // fassa cloud node
-                new NetworkAddress(IPAddress.Parse("46.22.163.55"), 16178), // majic public node
-                new NetworkAddress(IPAddress.Parse("86.173.103.49"), 16178 ), // lukasz public node
-
-                new NetworkAddress(IPAddress.Parse("137.116.46.151"), 16178), // public node
-                new NetworkAddress(IPAddress.Parse("40.78.80.159"), 16178), // public node
-                new NetworkAddress(IPAddress.Parse("52.151.86.242"), 16178), // public node
-                new NetworkAddress(IPAddress.Parse("40.74.67.242"), 16178), // public node
+                new NetworkAddress(IPAddress.Parse("138.68.145.243"), 16178), // dan public node
             };
 
             this.StandardScriptsRegistry = new StratisStandardScriptsRegistry();

--- a/src/Stratis.Bitcoin.Networks/StratisMain.cs
+++ b/src/Stratis.Bitcoin.Networks/StratisMain.cs
@@ -109,7 +109,7 @@ namespace Stratis.Bitcoin.Networks
                 bip34Hash: new uint256("0x000000000000024b89b42a942fe0d9fea3bb44ab7bd1b19115dd6a759c0808b8"),
                 minerConfirmationWindow: 2016, // nPowTargetTimespan / nPowTargetSpacing
                 maxReorgLength: 500,
-                defaultAssumeValid: new uint256("0x50497017e7bb256df205fcbc2caccbe5b516cb33491e1a11737a3bfe83959b9f"), // 1213518
+                defaultAssumeValid: new uint256("0x6ad909469bc8fa15f48533fd30ae3217fceca413c0df69cf4ac314188f4df1c4"), // 1600000
                 maxMoney: long.MaxValue,
                 coinbaseMaturity: 50,
                 premineHeight: 2,
@@ -175,7 +175,9 @@ namespace Stratis.Bitcoin.Networks
                 { 850000, new CheckpointInfo(new uint256("0xc3a249b01795b22858aa00fd0973471fcd769a14f4f9cf0abe6651ac3e6ade19"), new uint256("0x5de8766ed4cfcc3ce9d74f38196596c6f91b9ff62cbd20abbfa991dca54d2bd4")) },
                 { 1000000, new CheckpointInfo(new uint256("0x3cdd812d9a7e249e7ad825cb372fbb0889f5b515a4a924a4aa3281d8e334d559"), new uint256("0x36a51839ceb5866b3251c9e5e0049a0209fe0b1861b2ada118fe00a8cacf62df")) },
                 { 1150000, new CheckpointInfo(new uint256("0x2bdb553600592655dd50f0d2e1632e5ac3bad99a5e1864f8b8ac02f768721e17"), new uint256("0x0ae7676da03bee9c8005680058a06b8a5009fb584d84811fc29ae1aeb7665426")) }, // 13-01-2019
-                { 1344000, new CheckpointInfo(new uint256("0xb7196b5b1982bc671f4e631661c09019aaf27b85902790d3d61616c245c407be"), new uint256("0xb7af5aaeb28d6ceebe872567a835efc42b3f2fccbecf74b1e095272b560d0354")) }
+                { 1344000, new CheckpointInfo(new uint256("0xb7196b5b1982bc671f4e631661c09019aaf27b85902790d3d61616c245c407be"), new uint256("0xb7af5aaeb28d6ceebe872567a835efc42b3f2fccbecf74b1e095272b560d0354")) },
+                { 1450000, new CheckpointInfo(new uint256("0x040bdceb331aa6adefb418ded32dccb7338fe538a8cce5303cb6eec2aa6644c7"), new uint256("0x7af96688dd0009d12619f83e0ad8adc0c1de1998ce802193fdd81b7f464d0a9e")) },
+                { 1620000, new CheckpointInfo(new uint256("0xee112d326d0fa2d0ca1009d8c00bfe4fd4a5961dd317162df21e83c80b519479"), new uint256("0xe0a85aac292b6216331d58acd9c55b104dd4769c051dfbd6d2496f19bf0e8d38")) }
             };
 
             this.Bech32Encoders = new Bech32Encoder[2];

--- a/src/Stratis.Bitcoin.Networks/StratisMain.cs
+++ b/src/Stratis.Bitcoin.Networks/StratisMain.cs
@@ -195,6 +195,7 @@ namespace Stratis.Bitcoin.Networks
             this.SeedNodes = new List<NetworkAddress>
             {
                 new NetworkAddress(IPAddress.Parse("138.68.145.243"), 16178), // dan public node
+                new NetworkAddress(IPAddress.Parse("169.1.13.216"), 16178),
             };
 
             this.StandardScriptsRegistry = new StratisStandardScriptsRegistry();

--- a/src/Stratis.Bitcoin.Networks/StratisTest.cs
+++ b/src/Stratis.Bitcoin.Networks/StratisTest.cs
@@ -135,17 +135,13 @@ namespace Stratis.Bitcoin.Networks
 
             this.DNSSeeds = new List<DNSSeedData>
             {
-                new DNSSeedData("testnet1.stratisplatform.com", "testnet1.stratisplatform.com"),
-                new DNSSeedData("testnet2.stratisplatform.com", "testnet2.stratisplatform.com"),
-                new DNSSeedData("testnet3.stratisplatform.com", "testnet3.stratisplatform.com"),
-                new DNSSeedData("testnet4.stratisplatform.com", "testnet4.stratisplatform.com")
+                new DNSSeedData("testnet1.stratisnetwork.com", "testnet1.stratisnetwork.com"),
+                new DNSSeedData("testnet2.stratisnetwork.com", "testnet2.stratisnetwork.com")
             };
 
             this.SeedNodes = new List<NetworkAddress>
             {
                 new NetworkAddress(IPAddress.Parse("51.140.231.125"), 26178), // danger cloud node
-                new NetworkAddress(IPAddress.Parse("13.70.81.5"), 26178), // beard cloud node
-                new NetworkAddress(IPAddress.Parse("191.235.85.131"), 26178), // fassa cloud node
             };
 
             this.StandardScriptsRegistry = new StratisStandardScriptsRegistry();

--- a/src/Stratis.Bitcoin.Networks/StratisTest.cs
+++ b/src/Stratis.Bitcoin.Networks/StratisTest.cs
@@ -142,6 +142,7 @@ namespace Stratis.Bitcoin.Networks
             this.SeedNodes = new List<NetworkAddress>
             {
                 new NetworkAddress(IPAddress.Parse("51.140.231.125"), 26178), // danger cloud node
+                new NetworkAddress(IPAddress.Parse("169.1.13.216"), 26178),
             };
 
             this.StandardScriptsRegistry = new StratisStandardScriptsRegistry();

--- a/src/Stratis.Bitcoin.Networks/StratisTest.cs
+++ b/src/Stratis.Bitcoin.Networks/StratisTest.cs
@@ -92,7 +92,7 @@ namespace Stratis.Bitcoin.Networks
                 bip34Hash: new uint256("0x000000000000024b89b42a942fe0d9fea3bb44ab7bd1b19115dd6a759c0808b8"),
                 minerConfirmationWindow: 2016, // nPowTargetTimespan / nPowTargetSpacing
                 maxReorgLength: 500,
-                defaultAssumeValid: new uint256("0xc9a15c9dd87c6219b273f93442b87fdaf9eebb4f3059d8ed8239c41a4ab3e730"), // 780785
+                defaultAssumeValid: new uint256("0x690e7e30ae3fa6c10855db0f8bc10110a54f5c73019f5581ee038186154397d0"), // 1100000
                 maxMoney: long.MaxValue,
                 coinbaseMaturity: 10,
                 premineHeight: 2,
@@ -115,7 +115,7 @@ namespace Stratis.Bitcoin.Networks
             this.Base58Prefixes[(int)Base58Type.PUBKEY_ADDRESS] = new byte[] { (65) };
             this.Base58Prefixes[(int)Base58Type.SCRIPT_ADDRESS] = new byte[] { (196) };
             this.Base58Prefixes[(int)Base58Type.SECRET_KEY] = new byte[] { (65 + 128) };
-
+            
             this.Checkpoints = new Dictionary<int, CheckpointInfo>
             {
                 { 0, new CheckpointInfo(new uint256("0x00000e246d7b73b88c9ab55f2e5e94d9e22d471def3df5ea448f5576b1d156b9"), new uint256("0x0000000000000000000000000000000000000000000000000000000000000000")) },
@@ -130,8 +130,10 @@ namespace Stratis.Bitcoin.Networks
                 { 400000, new CheckpointInfo(new uint256("0xb6abcb933d3e3590345ca5d3abb697461093313f8886568ac8ae740d223e56f6"), new uint256("0xfaf5fcebee3ec0df5155393a99da43de18b12e620fef5edb111a791ecbfaa63a")) },
                 { 650000, new CheckpointInfo(new uint256("0x7065de13f14749798ebf70993af4debeb5bb2a968f5862ca232a2436fbac2fd0"), new uint256("0x175eb3708ffd9a1ca5938b0df0bf1f55af39ec8e2e4c396ed97c1406c4a5d701")) },
                 { 720000, new CheckpointInfo(new uint256("0x041fb27f49f96be3a10034db0148290e9e2551b1c6196823b46521c36c69fbe2"), new uint256("0xba96e9c84c4134a2204d07e41b7738a9ae6e56c4322f443dcfe11421f1643e6e")) }, // 14-01-2019
-                { 900000, new CheckpointInfo(new uint256("0xd48702aabf727570d96bbcd8bad220427a35113efa90c3adc91ae94a4b09c6e5"), new uint256("0x31515a27d55f819131f2dc0a263f46fb63c56ec0ff129bcb0b1c13d5922a62c2")) } // 14-01-2019
-            };
+                { 900000, new CheckpointInfo(new uint256("0xd48702aabf727570d96bbcd8bad220427a35113efa90c3adc91ae94a4b09c6e5"), new uint256("0x31515a27d55f819131f2dc0a263f46fb63c56ec0ff129bcb0b1c13d5922a62c2")) }, // 14-01-2019
+                { 1000000, new CheckpointInfo(new uint256("0xa8775bca139bb50c16c803a64e324f83eec70e3f9b5e762265e590cc773b9930"), new uint256("0x3664cc8571bfea578cc22a2b8478148da05704226624ce203f2ea646a7339a38")) },
+                { 1150000, new CheckpointInfo(new uint256("0xca63e5cc3b023f98bfddbf7f8df8dcb3dc90f37bec79b6396823b3da77ab9a24"), new uint256("0xd0a2024250b92ba7dbc8348e6e5dd3a83a770154e6a2ca7f7280284c8a25ba18")) }
+             };
 
             this.DNSSeeds = new List<DNSSeedData>
             {

--- a/src/Stratis.Bitcoin.Tests/Consensus/CheckpointsTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Consensus/CheckpointsTest.cs
@@ -74,7 +74,7 @@ namespace Stratis.Bitcoin.Tests.Consensus
 
             int result = checkpoints.GetLastCheckpointHeight();
 
-            Assert.Equal(1344000, result);
+            Assert.Equal(1620000, result);
         }
 
         [Fact]
@@ -84,7 +84,7 @@ namespace Stratis.Bitcoin.Tests.Consensus
 
             int result = checkpoints.GetLastCheckpointHeight();
 
-            Assert.Equal(900000, result);
+            Assert.Equal(1150000, result);
         }
 
         [Fact()]

--- a/src/Stratis.Sidechains.Networks/CirrusMain.cs
+++ b/src/Stratis.Sidechains.Networks/CirrusMain.cs
@@ -199,9 +199,7 @@ namespace Stratis.Sidechains.Networks
 
             this.DNSSeeds = new List<DNSSeedData>
             {
-
-                new DNSSeedData("cirrusmain1.stratisplatform.com", "cirrusmain1.stratisplatform.com")
-
+                new DNSSeedData("cirrusmain1.stratisnetwork.com", "cirrusmain1.stratisnetwork.com")
             };
 
             this.StandardScriptsRegistry = new SmartContractsStandardScriptsRegistry();

--- a/src/Stratis.Sidechains.Networks/CirrusMain.cs
+++ b/src/Stratis.Sidechains.Networks/CirrusMain.cs
@@ -202,6 +202,12 @@ namespace Stratis.Sidechains.Networks
                 new DNSSeedData("cirrusmain1.stratisnetwork.com", "cirrusmain1.stratisnetwork.com")
             };
 
+            this.SeedNodes = new List<NetworkAddress>
+            {
+                new NetworkAddress(IPAddress.Parse("213.125.242.234"), 16179),
+                new NetworkAddress(IPAddress.Parse("45.58.55.21"), 16179),
+            };
+
             this.StandardScriptsRegistry = new SmartContractsStandardScriptsRegistry();
 
             // 16 below should be changed to TargetSpacingSeconds when we move that field.

--- a/src/Stratis.Sidechains.Networks/CirrusMain.cs
+++ b/src/Stratis.Sidechains.Networks/CirrusMain.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Collections.Generic;
+using System.Net;
 using NBitcoin;
 using NBitcoin.DataEncoders;
+using NBitcoin.Protocol;
 using Stratis.Bitcoin.Features.Consensus.Rules.CommonRules;
 using Stratis.Bitcoin.Features.MemoryPool.Rules;
 using Stratis.Bitcoin.Features.PoA;

--- a/src/Stratis.Sidechains.Networks/CirrusTest.cs
+++ b/src/Stratis.Sidechains.Networks/CirrusTest.cs
@@ -168,8 +168,7 @@ namespace Stratis.Sidechains.Networks
 
             this.DNSSeeds = new List<DNSSeedData>
             {
-                new DNSSeedData("cirrustest1.stratisplatform.com", "cirrustest1.stratisplatform.com")
-
+                new DNSSeedData("cirrustest1.stratisnetwork.com", "cirrustest1.stratisnetwork.com")
             };
 
             this.SeedNodes = new List<NetworkAddress>();


### PR DESCRIPTION
This PR removes stale entries from the seeds for all networks and updates the Stratis seeder domains to stratisnetwork.com for all networks also.