### PR TITLE
Fix the node blocking inbounds after an inordinate amount of disconnects due to a peer being banned

### DIFF
--- a/src/Stratis.Bitcoin.IntegrationTests.Common/EnvironmentMockUpHelpers/CoreNode.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests.Common/EnvironmentMockUpHelpers/CoreNode.cs
@@ -4,7 +4,6 @@ using System.IO;
 using System.IO.Compression;
 using System.Linq;
 using System.Net;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
@@ -255,6 +254,8 @@ namespace Stratis.Bitcoin.IntegrationTests.Common.EnvironmentMockUpHelpers
             var ibdState = new Mock<IInitialBlockDownloadState>();
             ibdState.Setup(x => x.IsInitialBlockDownload()).Returns(() => true);
 
+            var peerAddressManager = new Mock<IPeerAddressManager>().Object;
+
             var networkPeerFactory = new NetworkPeerFactory(this.runner.Network,
                 DateTimeProvider.Default,
                 this.loggerFactory,
@@ -262,7 +263,8 @@ namespace Stratis.Bitcoin.IntegrationTests.Common.EnvironmentMockUpHelpers
                 selfEndPointTracker,
                 ibdState.Object,
                 connectionManagerSettings,
-                this.GetOrCreateAsyncProvider()
+                this.GetOrCreateAsyncProvider(),
+                peerAddressManager
                 );
 
             return networkPeerFactory.CreateConnectedNetworkPeerAsync("127.0.0.1:" + this.ProtocolPort).ConfigureAwait(false).GetAwaiter().GetResult();

--- a/src/Stratis.Bitcoin.IntegrationTests/Connectivity/ConnectivityTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/Connectivity/ConnectivityTests.cs
@@ -300,7 +300,7 @@ namespace Stratis.Bitcoin.IntegrationTests.Connectivity
 
                 // Inbound peer count should still be 0.
                 var server = node1.FullNode.ConnectionManager.Servers.First();
-                Assert.True(server.NetworkPeerDisposer.ConnectedInboundPeersCount == 0);
+                Assert.True(server.ConnectedInboundPeersCount == 0);
             }
         }
 

--- a/src/Stratis.Bitcoin.IntegrationTests/Connectivity/ConnectivityTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/Connectivity/ConnectivityTests.cs
@@ -169,34 +169,6 @@ namespace Stratis.Bitcoin.IntegrationTests.Connectivity
         }
 
         [Fact]
-        public void Node_Gets_Banned_Subsequent_Connections_DoesNot_Affect_InbounfCount()
-        {
-            using (NodeBuilder builder = NodeBuilder.Create(this))
-            {
-                CoreNode node1 = builder.CreateStratisPosNode(this.posNetwork, "conn-5-node1").Start();
-                CoreNode node2 = builder.CreateStratisPosNode(this.posNetwork, "conn-5-node2").Start();
-
-                TestHelper.Connect(node1, node2);
-
-                var service = node1.FullNode.NodeService<IPeerBanning>();
-                service.BanAndDisconnectPeer(node2.Endpoint);
-
-                TestBase.WaitLoop(() => TestHelper.IsNodeConnectedTo(node1, node2) == false);
-
-                TestHelper.ConnectNoCheck(node2, node1);
-                Task.Delay(TimeSpan.FromSeconds(5)).GetAwaiter().GetResult();
-                TestHelper.ConnectNoCheck(node2, node1);
-                Task.Delay(TimeSpan.FromSeconds(5)).GetAwaiter().GetResult();
-                TestHelper.ConnectNoCheck(node2, node1);
-                Task.Delay(TimeSpan.FromSeconds(5)).GetAwaiter().GetResult();
-                TestHelper.ConnectNoCheck(node2, node1);
-                Task.Delay(TimeSpan.FromSeconds(5)).GetAwaiter().GetResult();
-                TestHelper.ConnectNoCheck(node2, node1);
-                Task.Delay(TimeSpan.FromSeconds(5)).GetAwaiter().GetResult();
-            }
-        }
-
-        [Fact]
         public void Not_Fail_IfTry_ToConnect_ToNonExisting_NodeAsync()
         {
             // TS106_Connectivity_CanErrorHandleConnectionToNonExistingNodes.
@@ -301,6 +273,37 @@ namespace Stratis.Bitcoin.IntegrationTests.Connectivity
                 TestHelper.DisconnectAll(node1, node2);
             }
         }
+
+        [Fact]
+        public void Node_Gets_Banned_Subsequent_Connections_DoesNot_Affect_InboundCount()
+        {
+            using (NodeBuilder builder = NodeBuilder.Create(this))
+            {
+                CoreNode node1 = builder.CreateStratisPosNode(this.posNetwork, "conn-10-node1").Start();
+                CoreNode node2 = builder.CreateStratisPosNode(this.posNetwork, "conn-10-node2").Start();
+
+                TestHelper.Connect(node1, node2);
+
+                // node1 bans node2
+                var service = node1.FullNode.NodeService<IPeerBanning>();
+                service.BanAndDisconnectPeer(node2.Endpoint);
+
+                // Ensure the node is disconnected.
+                TestBase.WaitLoop(() => TestHelper.IsNodeConnectedTo(node1, node2) == false);
+
+                // Try and connect to the node that banned me 10 times.
+                for (int i = 0; i < 10; i++)
+                {
+                    TestHelper.ConnectNoCheck(node2, node1);
+                    Task.Delay(TimeSpan.FromSeconds(1)).GetAwaiter().GetResult();
+                }
+
+                // Inbound peer count should still be 0.
+                var server = node1.FullNode.ConnectionManager.Servers.First();
+                Assert.True(server.NetworkPeerDisposer.ConnectedInboundPeersCount == 0);
+            }
+        }
+
 
         private CoreNode BanNode(CoreNode sourceNode, CoreNode nodeToBan)
         {

--- a/src/Stratis.Bitcoin.Tests.Common/ConsensusManagerHelper.cs
+++ b/src/Stratis.Bitcoin.Tests.Common/ConsensusManagerHelper.cs
@@ -57,17 +57,19 @@ namespace Stratis.Bitcoin.Tests.Common
 
             var connectionManagerSettings = new ConnectionManagerSettings(nodeSettings);
 
+            var connectionSettings = new ConnectionManagerSettings(nodeSettings);
+            var selfEndpointTracker = new SelfEndpointTracker(loggerFactory, connectionSettings);
+            var peerAddressManager = new PeerAddressManager(DateTimeProvider.Default, nodeSettings.DataFolder, loggerFactory, selfEndpointTracker);
+
             var networkPeerFactory = new NetworkPeerFactory(network,
                 dateTimeProvider,
                 loggerFactory, new PayloadProvider().DiscoverPayloads(),
                 new SelfEndpointTracker(loggerFactory, connectionManagerSettings),
                 new Mock<IInitialBlockDownloadState>().Object,
                 connectionManagerSettings,
-                asyncProvider);
+                asyncProvider,
+                peerAddressManager);
 
-            var connectionSettings = new ConnectionManagerSettings(nodeSettings);
-            var selfEndpointTracker = new SelfEndpointTracker(loggerFactory, connectionSettings);
-            var peerAddressManager = new PeerAddressManager(DateTimeProvider.Default, nodeSettings.DataFolder, loggerFactory, selfEndpointTracker);
             var peerDiscovery = new PeerDiscovery(asyncProvider, loggerFactory, network, networkPeerFactory, new NodeLifetime(), nodeSettings, peerAddressManager);
             var connectionManager = new ConnectionManager(dateTimeProvider, loggerFactory, network, networkPeerFactory, nodeSettings,
                 new NodeLifetime(), new NetworkPeerConnectionParameters(), peerAddressManager, new IPeerConnector[] { },

--- a/src/Stratis.Bitcoin.Tests/Consensus/ConsensusTestContext.cs
+++ b/src/Stratis.Bitcoin.Tests/Consensus/ConsensusTestContext.cs
@@ -123,14 +123,17 @@ namespace Stratis.Bitcoin.Tests.Consensus
                   this.ConsensusSettings,
                   this.hashStore);
 
+            this.peerAddressManager = new PeerAddressManager(DateTimeProvider.Default, this.nodeSettings.DataFolder, this.loggerFactory, this.selfEndpointTracker);
+
             this.networkPeerFactory = new NetworkPeerFactory(this.Network,
                 this.dateTimeProvider,
                 this.loggerFactory, new PayloadProvider().DiscoverPayloads(),
                 this.selfEndpointTracker,
                 this.ibd.Object,
-                new ConnectionManagerSettings(this.nodeSettings), this.asyncProvider);
+                new ConnectionManagerSettings(this.nodeSettings),
+                this.asyncProvider,
+                this.peerAddressManager);
 
-            this.peerAddressManager = new PeerAddressManager(DateTimeProvider.Default, this.nodeSettings.DataFolder, this.loggerFactory, this.selfEndpointTracker);
             var peerDiscovery = new PeerDiscovery(this.asyncProvider, this.loggerFactory, this.Network, this.networkPeerFactory, this.nodeLifetime, this.nodeSettings, this.peerAddressManager);
 
             this.connectionManager = new ConnectionManager(this.dateTimeProvider, this.loggerFactory, this.Network, this.networkPeerFactory, this.nodeSettings,

--- a/src/Stratis.Bitcoin.Tests/P2P/NetworkPeerServerTests.cs
+++ b/src/Stratis.Bitcoin.Tests/P2P/NetworkPeerServerTests.cs
@@ -7,9 +7,11 @@ using Stratis.Bitcoin.Configuration;
 using Stratis.Bitcoin.Configuration.Logging;
 using Stratis.Bitcoin.Configuration.Settings;
 using Stratis.Bitcoin.Interfaces;
+using Stratis.Bitcoin.P2P;
 using Stratis.Bitcoin.P2P.Peer;
 using Stratis.Bitcoin.Tests.Common;
 using Stratis.Bitcoin.Tests.Common.Logging;
+using Stratis.Bitcoin.Utilities;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -51,9 +53,19 @@ namespace Stratis.Bitcoin.Tests.P2P
 
             var asyncProvider = this.CreateAsyncProvider();
 
+            var peerAddressManager = new Mock<IPeerAddressManager>().Object;
+
             var networkPeerServer = new NetworkPeerServer(this.Network,
-                endpointAddNode, endpointAddNode, ProtocolVersion.PROTOCOL_VERSION, this.extendedLoggerFactory,
-                networkPeerFactory.Object, initialBlockDownloadState.Object, connectionManagerSettings, asyncProvider);
+                endpointAddNode,
+                endpointAddNode,
+                ProtocolVersion.PROTOCOL_VERSION,
+                this.extendedLoggerFactory,
+                networkPeerFactory.Object,
+                initialBlockDownloadState.Object,
+                connectionManagerSettings,
+                asyncProvider,
+                peerAddressManager,
+                DateTimeProvider.Default);
 
             // Mimic external client
             const int portNumber = 80;

--- a/src/Stratis.Bitcoin.Tests/P2P/NetworkPeerServerTests.cs
+++ b/src/Stratis.Bitcoin.Tests/P2P/NetworkPeerServerTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Net;
+﻿using System.Collections.Generic;
+using System.Net;
 using System.Net.Sockets;
 using System.Threading.Tasks;
 using Moq;
@@ -53,7 +54,8 @@ namespace Stratis.Bitcoin.Tests.P2P
 
             var asyncProvider = this.CreateAsyncProvider();
 
-            var peerAddressManager = new Mock<IPeerAddressManager>().Object;
+            var peerAddressManager = new Mock<IPeerAddressManager>();
+            peerAddressManager.Setup(pam => pam.FindPeersByIp(It.IsAny<IPEndPoint>())).Returns(new List<PeerAddress>());
 
             var networkPeerServer = new NetworkPeerServer(this.Network,
                 endpointAddNode,
@@ -64,7 +66,7 @@ namespace Stratis.Bitcoin.Tests.P2P
                 initialBlockDownloadState.Object,
                 connectionManagerSettings,
                 asyncProvider,
-                peerAddressManager,
+                peerAddressManager.Object,
                 DateTimeProvider.Default);
 
             // Mimic external client

--- a/src/Stratis.Bitcoin.Tests/P2P/PeerAddressManagerBehaviourTests.cs
+++ b/src/Stratis.Bitcoin.Tests/P2P/PeerAddressManagerBehaviourTests.cs
@@ -31,8 +31,8 @@ namespace Stratis.Bitcoin.Tests.P2P
             this.extendedLoggerFactory = new ExtendedLoggerFactory();
             this.extendedLoggerFactory.AddConsoleWithFilters();
             this.connectionManagerSettings = new ConnectionManagerSettings(NodeSettings.Default(this.Network));
-            this.signals = new Bitcoin.Signals.Signals(extendedLoggerFactory, null);
-            this.asyncProvider = new AsyncProvider(extendedLoggerFactory, this.signals, new NodeLifetime());
+            this.signals = new Bitcoin.Signals.Signals(this.extendedLoggerFactory, null);
+            this.asyncProvider = new AsyncProvider(this.extendedLoggerFactory, this.signals, new NodeLifetime());
 
             this.networkPeerFactory = new NetworkPeerFactory(this.Network,
                 DateTimeProvider.Default,
@@ -41,7 +41,8 @@ namespace Stratis.Bitcoin.Tests.P2P
                 new SelfEndpointTracker(this.extendedLoggerFactory, this.connectionManagerSettings),
                 new Mock<IInitialBlockDownloadState>().Object,
                 this.connectionManagerSettings,
-                this.asyncProvider);
+                this.asyncProvider,
+                new Mock<IPeerAddressManager>().Object);
         }
 
         [Fact]
@@ -65,7 +66,7 @@ namespace Stratis.Bitcoin.Tests.P2P
             var stateChanged = new AsyncExecutionEvent<INetworkPeer, NetworkPeerState>();
             networkPeer.SetupGet(n => n.StateChanged).Returns(stateChanged);
 
-            var behaviour = new PeerAddressManagerBehaviour(DateTimeProvider.Default, addressManager, new Mock<IPeerBanning>().Object,  this.extendedLoggerFactory) { Mode = PeerAddressManagerBehaviourMode.AdvertiseDiscover };
+            var behaviour = new PeerAddressManagerBehaviour(DateTimeProvider.Default, addressManager, new Mock<IPeerBanning>().Object, this.extendedLoggerFactory) { Mode = PeerAddressManagerBehaviourMode.AdvertiseDiscover };
             behaviour.Attach(networkPeer.Object);
 
             var incomingMessage = new IncomingMessage();

--- a/src/Stratis.Bitcoin/P2P/Peer/NetworkPeerFactory.cs
+++ b/src/Stratis.Bitcoin/P2P/Peer/NetworkPeerFactory.cs
@@ -87,9 +87,6 @@ namespace Stratis.Bitcoin.P2P.Peer
 
         private readonly ISelfEndpointTracker selfEndpointTracker;
 
-        /// <summary>Instance logger.</summary>
-        private readonly ILogger logger;
-
         /// <summary>Provider of time functions.</summary>
         private readonly IDateTimeProvider dateTimeProvider;
 
@@ -110,6 +107,8 @@ namespace Stratis.Bitcoin.P2P.Peer
         /// <summary>Callback that is invoked just before a message is to be sent to a peer, or <c>null</c> when nothing needs to be called.</summary>
         private Action<IPEndPoint, Payload> onSendingMessage;
 
+        private IPeerAddressManager peerAddressManager;
+
         /// <summary>
         /// Initializes a new instance of the factory.
         /// </summary>
@@ -127,7 +126,8 @@ namespace Stratis.Bitcoin.P2P.Peer
             ISelfEndpointTracker selfEndpointTracker,
             IInitialBlockDownloadState initialBlockDownloadState,
             ConnectionManagerSettings connectionManagerSettings,
-            IAsyncProvider asyncProvider)
+            IAsyncProvider asyncProvider,
+            IPeerAddressManager peerAddressManager)
         {
             Guard.NotNull(network, nameof(network));
             Guard.NotNull(dateTimeProvider, nameof(dateTimeProvider));
@@ -138,11 +138,11 @@ namespace Stratis.Bitcoin.P2P.Peer
             this.loggerFactory = loggerFactory;
             this.payloadProvider = payloadProvider;
             this.selfEndpointTracker = selfEndpointTracker;
-            this.logger = loggerFactory.CreateLogger(this.GetType().FullName);
             this.lastClientId = 0;
             this.initialBlockDownloadState = initialBlockDownloadState;
             this.connectionManagerSettings = connectionManagerSettings;
             this.asyncProvider = Guard.NotNull(asyncProvider, nameof(asyncProvider));
+            this.peerAddressManager = peerAddressManager;
         }
 
         /// <inheritdoc/>
@@ -219,7 +219,7 @@ namespace Stratis.Bitcoin.P2P.Peer
             Guard.NotNull(localEndPoint, nameof(localEndPoint));
             Guard.NotNull(externalEndPoint, nameof(externalEndPoint));
 
-            return new NetworkPeerServer(this.network, localEndPoint, externalEndPoint, version, this.loggerFactory, this, this.initialBlockDownloadState, this.connectionManagerSettings, this.asyncProvider);
+            return new NetworkPeerServer(this.network, localEndPoint, externalEndPoint, version, this.loggerFactory, this, this.initialBlockDownloadState, this.connectionManagerSettings, this.asyncProvider, this.peerAddressManager, this.dateTimeProvider);
         }
 
         /// <inheritdoc/>

--- a/src/Stratis.Bitcoin/P2P/Peer/NetworkPeerServer.cs
+++ b/src/Stratis.Bitcoin/P2P/Peer/NetworkPeerServer.cs
@@ -214,11 +214,12 @@ namespace Stratis.Bitcoin.P2P.Peer
         {
             var clientLocalEndPoint = tcpClient.Client.LocalEndPoint as IPEndPoint;
 
-            var peer = this.peerAddressManager.FindPeer(clientLocalEndPoint);
-            if (peer != null && peer.IsBanned(this.dateTimeProvider.GetUtcNow()))
+            var peers = this.peerAddressManager.FindPeersByIp(clientLocalEndPoint);
+            var bannedPeer = peers.FirstOrDefault(p => p.IsBanned(this.dateTimeProvider.GetUtcNow()));
+            if (bannedPeer != null)
             {
                 this.logger.LogTrace("(-)[PEER_BANNED]:false");
-                return (false, $"Inbound Refused: Peer {peer.Endpoint} is banned until {peer.BanUntil}.");
+                return (false, $"Inbound Refused: Peer {clientLocalEndPoint} is banned until {bannedPeer.BanUntil}.");
             }
 
             if (this.networkPeerDisposer.ConnectedInboundPeersCount >= this.connectionManagerSettings.MaxInboundConnections)

--- a/src/Stratis.Bitcoin/P2P/Peer/NetworkPeerServer.cs
+++ b/src/Stratis.Bitcoin/P2P/Peer/NetworkPeerServer.cs
@@ -58,6 +58,10 @@ namespace Stratis.Bitcoin.P2P.Peer
         /// <summary>Configuration related to incoming and outgoing connections.</summary>
         private readonly ConnectionManagerSettings connectionManagerSettings;
 
+        private readonly IPeerAddressManager peerAddressManager;
+
+        private readonly IDateTimeProvider dateTimeProvider;
+
         /// <summary>Used to publish application events.</summary>
         private readonly ISignals signals;
 
@@ -80,7 +84,9 @@ namespace Stratis.Bitcoin.P2P.Peer
             INetworkPeerFactory networkPeerFactory,
             IInitialBlockDownloadState initialBlockDownloadState,
             ConnectionManagerSettings connectionManagerSettings,
-            IAsyncProvider asyncProvider)
+            IAsyncProvider asyncProvider,
+            IPeerAddressManager peerAddressManager,
+            IDateTimeProvider dateTimeProvider)
         {
             this.logger = loggerFactory.CreateLogger(this.GetType().FullName, $"[{localEndPoint}] ");
             this.signals = asyncProvider.Signals;
@@ -88,6 +94,8 @@ namespace Stratis.Bitcoin.P2P.Peer
             this.networkPeerDisposer = new NetworkPeerDisposer(loggerFactory, asyncProvider);
             this.initialBlockDownloadState = initialBlockDownloadState;
             this.connectionManagerSettings = connectionManagerSettings;
+            this.peerAddressManager = peerAddressManager;
+            this.dateTimeProvider = dateTimeProvider;
 
             this.InboundNetworkPeerConnectionParameters = new NetworkPeerConnectionParameters();
 
@@ -144,7 +152,7 @@ namespace Stratis.Bitcoin.P2P.Peer
                     if (!successful)
                     {
                         this.signals.Publish(new PeerConnectionAttemptFailed(true, (IPEndPoint)tcpClient.Client.RemoteEndPoint, reason));
-                        this.logger.LogDebug("Connection from client '{0}' was rejected and will be closed.", tcpClient.Client.RemoteEndPoint);
+                        this.logger.LogInformation("Connection from client '{0}' was rejected and will be closed, reason: {1}", tcpClient.Client.RemoteEndPoint, reason);
                         tcpClient.Close();
                         continue;
                     }
@@ -201,10 +209,19 @@ namespace Stratis.Bitcoin.P2P.Peer
         /// <returns>When criteria is met returns <c>true</c>, to allow connection.</returns>
         private (bool successful, string reason) AllowClientConnection(TcpClient tcpClient)
         {
+            var clientLocalEndPoint = tcpClient.Client.LocalEndPoint as IPEndPoint;
+
+            var peer = this.peerAddressManager.FindPeer(clientLocalEndPoint);
+            if (peer != null && peer.IsBanned(this.dateTimeProvider.GetUtcNow()))
+            {
+                this.logger.LogTrace("(-)[PEER_BANNED]:false");
+                return (false, $"Inbound Refused: Peer {peer.Endpoint} is banned until {peer.BanUntil}.");
+            }
+
             if (this.networkPeerDisposer.ConnectedInboundPeersCount >= this.connectionManagerSettings.MaxInboundConnections)
             {
                 this.logger.LogTrace("(-)[MAX_CONNECTION_THRESHOLD_REACHED]:false");
-                return (false, "Inbound Refused: Max Connection Threshold Reached.");
+                return (false, $"Inbound Refused: Max Inbound Connection Threshold Reached, inbounds: {this.networkPeerDisposer.ConnectedInboundPeersCount}");
             }
 
             if (!this.initialBlockDownloadState.IsInitialBlockDownload())
@@ -213,7 +230,6 @@ namespace Stratis.Bitcoin.P2P.Peer
                 return (true, "Inbound Accepted: IBD Complete.");
             }
 
-            var clientLocalEndPoint = tcpClient.Client.LocalEndPoint as IPEndPoint;
             var clientRemoteEndPoint = tcpClient.Client.RemoteEndPoint as IPEndPoint;
 
             bool endpointCanBeWhiteListed = this.connectionManagerSettings.Bind.Where(x => x.Whitelisted).Any(x => x.Endpoint.Contains(clientLocalEndPoint));
@@ -224,7 +240,7 @@ namespace Stratis.Bitcoin.P2P.Peer
                 return (true, "Inbound Accepted: Whitelisted endpoint connected during IBD.");
             }
 
-            this.logger.LogDebug("Node '{0}' is not whitelisted via endpoint '{1}' during initial block download.", clientRemoteEndPoint, clientLocalEndPoint);
+            this.logger.LogInformation("Node '{0}' is not whitelisted via endpoint '{1}' during initial block download.", clientRemoteEndPoint, clientLocalEndPoint);
 
             return (false, "Inbound Refused: Non Whitelisted endpoint connected during IBD.");
         }

--- a/src/Stratis.Bitcoin/P2P/Peer/NetworkPeerServer.cs
+++ b/src/Stratis.Bitcoin/P2P/Peer/NetworkPeerServer.cs
@@ -212,14 +212,14 @@ namespace Stratis.Bitcoin.P2P.Peer
         /// <returns>When criteria is met returns <c>true</c>, to allow connection.</returns>
         private (bool successful, string reason) AllowClientConnection(TcpClient tcpClient)
         {
-            var clientLocalEndPoint = tcpClient.Client.LocalEndPoint as IPEndPoint;
+            var clientRemoteEndPoint = tcpClient.Client.RemoteEndPoint as IPEndPoint;
 
-            var peers = this.peerAddressManager.FindPeersByIp(clientLocalEndPoint);
+            var peers = this.peerAddressManager.FindPeersByIp(clientRemoteEndPoint);
             var bannedPeer = peers.FirstOrDefault(p => p.IsBanned(this.dateTimeProvider.GetUtcNow()));
             if (bannedPeer != null)
             {
                 this.logger.LogTrace("(-)[PEER_BANNED]:false");
-                return (false, $"Inbound Refused: Peer {clientLocalEndPoint} is banned until {bannedPeer.BanUntil}.");
+                return (false, $"Inbound Refused: Peer {clientRemoteEndPoint} is banned until {bannedPeer.BanUntil}.");
             }
 
             if (this.networkPeerDisposer.ConnectedInboundPeersCount >= this.connectionManagerSettings.MaxInboundConnections)
@@ -234,7 +234,7 @@ namespace Stratis.Bitcoin.P2P.Peer
                 return (true, "Inbound Accepted: IBD Complete.");
             }
 
-            var clientRemoteEndPoint = tcpClient.Client.RemoteEndPoint as IPEndPoint;
+            var clientLocalEndPoint = tcpClient.Client.LocalEndPoint as IPEndPoint;
 
             bool endpointCanBeWhiteListed = this.connectionManagerSettings.Bind.Where(x => x.Whitelisted).Any(x => x.Endpoint.Contains(clientLocalEndPoint));
 


### PR DESCRIPTION
This fixes a long standing issue whereby the node would stop receiving inbound connections.

The bug is that we add the connected peer to the network peer disposer after it has been disconnected because of a ban. The result is that the connected peers collection in the network peer disposer constantly increases as we never have the peer in the collection by the time the other node has disconnected it due to a ban. Eventually the max inbound count is reached and the node stops incoming connections here:

```
            if (this.networkPeerDisposer.ConnectedInboundPeersCount >= this.connectionManagerSettings.MaxInboundConnections)
            {
                this.logger.LogTrace("(-)[MAX_CONNECTION_THRESHOLD_REACHED]:false");
                return (false, $"Inbound Refused: Max Inbound Connection Threshold Reached, inbounds: {this.networkPeerDisposer.ConnectedInboundPeersCount}");
            }
```

It has been decided that to fix the race condition is unnecessary as we shouldn't even be allowing the inbound when it is banned.