### PR TITLE
Split the Check Collateral Full Validation Rule

### DIFF
--- a/src/Stratis.Bitcoin.Features.PoA/PoAConsensusErrors.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/PoAConsensusErrors.cs
@@ -21,7 +21,7 @@ namespace Stratis.Bitcoin.Features.PoA
         // Collateral related errors.
         public static ConsensusError InvalidCollateralAmount => new ConsensusError("invalid-collateral-amount", "collateral requirement is not fulfilled");
 
-        public static ConsensusError InvalidCollateralAmountNoCommitment => new ConsensusError("collateral-commitment-not-found", "collateral commitment not found");
+        public static ConsensusError CollateralCommitmentHeightMissing => new ConsensusError("collateral-commitment-height-missing", "collateral commitment height missing");
 
         public static ConsensusError InvalidCollateralAmountCommitmentTooNew => new ConsensusError("collateral-commitment-too-new", "collateral commitment too new");
     }

--- a/src/Stratis.Bitcoin.Features.SmartContracts/PoA/SmartContractPoARuleRegistration.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts/PoA/SmartContractPoARuleRegistration.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Extensions.DependencyInjection;
-using NBitcoin;
 using NBitcoin.Rules;
 using Stratis.Bitcoin.Consensus.Rules;
 using Stratis.Bitcoin.Features.Consensus.Rules.CommonRules;
@@ -14,14 +13,10 @@ using Stratis.Bitcoin.Features.SmartContracts.Rules;
 
 namespace Stratis.Bitcoin.Features.SmartContracts.PoA
 {
+    /// <inheritdoc />
     public class SmartContractPoARuleRegistration : IRuleRegistration
     {
-        protected readonly Network network;
-
-        public SmartContractPoARuleRegistration()
-        {
-        }
-
+        /// <inheritdoc />
         public virtual void RegisterRules(IServiceCollection services)
         {
             // TODO: Do what the rest of the FN code did and move the rule registration to the network class.
@@ -43,16 +38,42 @@ namespace Stratis.Bitcoin.Features.SmartContracts.PoA
                 typeof(CanGetSenderRule),
                 typeof(P2PKHNotContractRule)
             })
+            {
                 services.AddSingleton(typeof(IFullValidationConsensusRule), ruleType);
+            }
 
-            // Replace coinview rule
-            foreach (ServiceDescriptor serviceDescriptor in services.Where(f => f.ImplementationType == typeof(PoACoinviewRule)).ToList()) services.Remove(serviceDescriptor);
-            foreach (ServiceDescriptor serviceDescriptor in services.Where(f => f.ImplementationType == typeof(SmartContractPoACoinviewRule)).ToList()) services.Remove(serviceDescriptor);
+            // Remove the base POA coinview rule.
+            foreach (ServiceDescriptor serviceDescriptor in services.Where(f => f.ImplementationType == typeof(PoACoinviewRule)).ToList())
+            {
+                services.Remove(serviceDescriptor);
+            }
+
+            // Remove the SmartContractPoACoinviewRule as it is position wrong in the order of execution.
+            foreach (ServiceDescriptor serviceDescriptor in services.Where(f => f.ImplementationType == typeof(SmartContractPoACoinviewRule)).ToList())
+            {
+                services.Remove(serviceDescriptor);
+            }
+
+            // Re-add it to the "back" of the rules list.
             services.AddSingleton(typeof(IFullValidationConsensusRule), typeof(SmartContractPoACoinviewRule));
 
-            // SaveCoinviewRule must be the last rule executed because actually it calls CachedCoinView.SaveChanges that causes internal CachedCoinView to be updated
-            // see https://dev.azure.com/Stratisplatformuk/StratisBitcoinFullNode/_workitems/edit/3770
-            foreach (ServiceDescriptor serviceDescriptor in services.Where(f => f.ImplementationType == typeof(SaveCoinviewRule)).ToList()) services.Remove(serviceDescriptor);
+            AddSaveCoinViewAsLastRule(services);
+        }
+
+        /// <summary>
+        /// Adds the <see cref="SaveCoinviewRule"/> to the back of the rules collection.
+        /// <para>
+        /// SaveCoinviewRule must be the last rule executed because actually it calls CachedCoinView.SaveChanges that causes internal CachedCoinView to be updated
+        /// see https://dev.azure.com/Stratisplatformuk/StratisBitcoinFullNode/_workitems/edit/3770.
+        /// </para>
+        /// </summary>
+        public void AddSaveCoinViewAsLastRule(IServiceCollection services)
+        {
+            foreach (ServiceDescriptor serviceDescriptor in services.Where(f => f.ImplementationType == typeof(SaveCoinviewRule)).ToList())
+            {
+                services.Remove(serviceDescriptor);
+            }
+
             services.AddSingleton(typeof(IFullValidationConsensusRule), typeof(SaveCoinviewRule));
         }
     }

--- a/src/Stratis.CirrusD/Program.cs
+++ b/src/Stratis.CirrusD/Program.cs
@@ -8,14 +8,15 @@ using Stratis.Bitcoin.Features.Api;
 using Stratis.Bitcoin.Features.BlockStore;
 using Stratis.Bitcoin.Features.MemoryPool;
 using Stratis.Bitcoin.Features.RPC;
+using Stratis.Bitcoin.Features.SignalR;
+using Stratis.Bitcoin.Features.SignalR.Broadcasters;
+using Stratis.Bitcoin.Features.SignalR.Events;
 using Stratis.Bitcoin.Features.SmartContracts;
 using Stratis.Bitcoin.Features.SmartContracts.PoA;
 using Stratis.Bitcoin.Features.SmartContracts.Wallet;
 using Stratis.Bitcoin.Utilities;
+using Stratis.Features.Collateral;
 using Stratis.Features.Diagnostic;
-using Stratis.Bitcoin.Features.SignalR;
-using Stratis.Bitcoin.Features.SignalR.Broadcasters;
-using Stratis.Bitcoin.Features.SignalR.Events;
 using Stratis.Sidechains.Networks;
 
 namespace Stratis.CirrusD
@@ -60,6 +61,7 @@ namespace Stratis.CirrusD
                 })
                 .UseSmartContractPoAConsensus()
                 .UseSmartContractPoAMining()
+                .CheckForPoAMembersCollateral(false) // This is a non-mining node so we will only check the commitment height data and not do the full set of collateral checks.
                 .UseSmartContractWallet()
                 .UseApi()
                 .AddRPC()

--- a/src/Stratis.CirrusDnsD/Program.cs
+++ b/src/Stratis.CirrusDnsD/Program.cs
@@ -13,6 +13,7 @@ using Stratis.Bitcoin.Features.SmartContracts;
 using Stratis.Bitcoin.Features.SmartContracts.PoA;
 using Stratis.Bitcoin.Features.SmartContracts.Wallet;
 using Stratis.Bitcoin.Utilities;
+using Stratis.Features.Collateral;
 using Stratis.Sidechains.Networks;
 
 namespace Stratis.CirrusDnsD
@@ -76,6 +77,7 @@ namespace Stratis.CirrusDnsD
                 })
                 .UseSmartContractPoAConsensus()
                 .UseSmartContractPoAMining()
+                .CheckForPoAMembersCollateral(false) // This is a non-mining node so we will only check the commitment height data and not do the full set of collateral checks.
                 .UseSmartContractWallet()
                 .UseApi()
                 .AddRPC()

--- a/src/Stratis.CirrusDnsD/Stratis.CirrusDnsD.csproj
+++ b/src/Stratis.CirrusDnsD/Stratis.CirrusDnsD.csproj
@@ -23,6 +23,7 @@
       <ProjectReference Include="..\Stratis.Bitcoin.Features.Api\Stratis.Bitcoin.Features.Api.csproj" />
       <ProjectReference Include="..\Stratis.Bitcoin.Features.Dns\Stratis.Bitcoin.Features.Dns.csproj" />
       <ProjectReference Include="..\Stratis.Bitcoin\Stratis.Bitcoin.csproj" />
+      <ProjectReference Include="..\Stratis.Features.Collateral\Stratis.Features.Collateral.csproj" />
       <ProjectReference Include="..\Stratis.Sidechains.Networks\Stratis.Sidechains.Networks.csproj" />
     </ItemGroup>
 

--- a/src/Stratis.CirrusMinerD/Program.cs
+++ b/src/Stratis.CirrusMinerD/Program.cs
@@ -79,7 +79,7 @@ namespace Stratis.CirrusMinerD
                 .SetCounterChainNetwork(MainChainNetworks[nodeSettings.Network.NetworkType]())
                 .UseSmartContractPoAConsensus()
                 .UseSmartContractCollateralPoAMining()
-                .CheckForPoAMembersCollateral()
+                .CheckForPoAMembersCollateral(true) // This is a mining node so we will check the commitment height data as well as the full set of collateral checks.
                 .UseTransactionNotification()
                 .UseBlockNotification()
                 .UseApi()

--- a/src/Stratis.CirrusPegD/Program.cs
+++ b/src/Stratis.CirrusPegD/Program.cs
@@ -126,7 +126,7 @@ namespace Stratis.CirrusPegD
                 .SetCounterChainNetwork(MainChainNetworks[nodeSettings.Network.NetworkType]())
                 .UseFederatedPegPoAMining()
                 .AddFederatedPeg(fedPegOptions)
-                .CheckForPoAMembersCollateral()
+                .CheckForPoAMembersCollateral(true) // This is a mining node so we will check the commitment height data as well as the full set of collateral checks.
                 .UseTransactionNotification()
                 .UseBlockNotification()
                 .UseApi()

--- a/src/Stratis.Features.Collateral/CheckCollateralCommitmentHeightRule.cs
+++ b/src/Stratis.Features.Collateral/CheckCollateralCommitmentHeightRule.cs
@@ -1,0 +1,50 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Stratis.Bitcoin.Consensus.Rules;
+using Stratis.Bitcoin.Features.PoA;
+using Stratis.Bitcoin.Interfaces;
+
+namespace Stratis.Features.Collateral
+{
+    /// <summary>
+    /// Ensures that a block that was produced on a collateral aware network contains height commitment data in the coinbase transaction.
+    /// <para>
+    /// Blocks that are found to have this data missing data will have the peer that served the header, banned.
+    /// </para>
+    /// <para>
+    /// This rule will be skipped in IBD as the blocks would have already passed consensus validation.
+    /// </para>
+    /// </summary>
+    public sealed class CheckCollateralCommitmentHeightRule : FullValidationConsensusRule
+    {
+        private readonly IInitialBlockDownloadState ibdState;
+
+        public CheckCollateralCommitmentHeightRule(IInitialBlockDownloadState ibdState)
+        {
+            this.ibdState = ibdState;
+        }
+
+        public override Task RunAsync(RuleContext context)
+        {
+            if (this.ibdState.IsInitialBlockDownload())
+            {
+                this.Logger.LogTrace("(-)[SKIPPED_IN_IBD]");
+                return Task.CompletedTask;
+            }
+
+            var commitmentHeightEncoder = new CollateralHeightCommitmentEncoder(this.Logger);
+
+            int? commitmentHeight = commitmentHeightEncoder.DecodeCommitmentHeight(context.ValidationContext.BlockToValidate.Transactions.First());
+            if (commitmentHeight == null)
+            {
+                // Every PoA miner on a sidechain network is forced to include commitment data to the blocks mined.
+                // Not having a commitment should always result in a permanent ban of the block.
+                this.Logger.LogTrace("(-)[COLLATERAL_COMMITMENT_HEIGHT_MISSING]");
+                PoAConsensusErrors.CollateralCommitmentHeightMissing.Throw();
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/Stratis.Features.Collateral/CheckCollateralCommitmentHeightRule.cs
+++ b/src/Stratis.Features.Collateral/CheckCollateralCommitmentHeightRule.cs
@@ -3,7 +3,6 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Stratis.Bitcoin.Consensus.Rules;
 using Stratis.Bitcoin.Features.PoA;
-using Stratis.Bitcoin.Interfaces;
 
 namespace Stratis.Features.Collateral
 {
@@ -12,27 +11,11 @@ namespace Stratis.Features.Collateral
     /// <para>
     /// Blocks that are found to have this data missing data will have the peer that served the header, banned.
     /// </para>
-    /// <para>
-    /// This rule will be skipped in IBD as the blocks would have already passed consensus validation.
-    /// </para>
     /// </summary>
     public sealed class CheckCollateralCommitmentHeightRule : FullValidationConsensusRule
     {
-        private readonly IInitialBlockDownloadState ibdState;
-
-        public CheckCollateralCommitmentHeightRule(IInitialBlockDownloadState ibdState)
-        {
-            this.ibdState = ibdState;
-        }
-
         public override Task RunAsync(RuleContext context)
         {
-            if (this.ibdState.IsInitialBlockDownload())
-            {
-                this.Logger.LogTrace("(-)[SKIPPED_IN_IBD]");
-                return Task.CompletedTask;
-            }
-
             var commitmentHeightEncoder = new CollateralHeightCommitmentEncoder(this.Logger);
 
             int? commitmentHeight = commitmentHeightEncoder.DecodeCommitmentHeight(context.ValidationContext.BlockToValidate.Transactions.First());

--- a/src/Stratis.Features.Collateral/CollateralFeature.cs
+++ b/src/Stratis.Features.Collateral/CollateralFeature.cs
@@ -38,20 +38,23 @@ namespace Stratis.Features.Collateral
     /// </summary>
     public static class FullNodeBuilderCollateralFeatureExtension
     {
-        public static IFullNodeBuilder CheckForPoAMembersCollateral(this IFullNodeBuilder fullNodeBuilder)
+        public static IFullNodeBuilder CheckForPoAMembersCollateral(this IFullNodeBuilder fullNodeBuilder, bool isMiner)
         {
             fullNodeBuilder.ConfigureFeature(features =>
             {
-                features.AddFeature<CollateralFeature>()
-                    .DependOn<CounterChainFeature>()
-                    .DependOn<PoAFeature>()
-                    .FeatureServices(services =>
-                    {
-                        services.AddSingleton<IFederationManager, CollateralFederationManager>();
-                        services.AddSingleton<ICollateralChecker, CollateralChecker>();
+                new SmartContractCollateralPoARuleRegistration(isMiner).RegisterRules(fullNodeBuilder.Services);
 
-                        new SmartContractCollateralPoARuleRegistration().RegisterRules(services);
-                    });
+                if (isMiner)
+                {
+                    features.AddFeature<CollateralFeature>()
+                        .DependOn<CounterChainFeature>()
+                        .DependOn<PoAFeature>()
+                        .FeatureServices(services =>
+                        {
+                            services.AddSingleton<IFederationManager, CollateralFederationManager>();
+                            services.AddSingleton<ICollateralChecker, CollateralChecker>();
+                        });
+                }
             });
 
             return fullNodeBuilder;

--- a/src/Stratis.Features.FederatedPeg.IntegrationTests/Utils/SidechainFederationNodeRunner.cs
+++ b/src/Stratis.Features.FederatedPeg.IntegrationTests/Utils/SidechainFederationNodeRunner.cs
@@ -21,7 +21,7 @@ namespace Stratis.Features.FederatedPeg.IntegrationTests.Utils
 {
     public class SidechainFederationNodeRunner : NodeRunner
     {
-        private bool testingFederation;
+        private readonly bool testingFederation;
 
         private readonly IDateTimeProvider timeProvider;
 
@@ -49,7 +49,7 @@ namespace Stratis.Features.FederatedPeg.IntegrationTests.Utils
                 .SetCounterChainNetwork(this.counterChainNetwork)
                 .UseFederatedPegPoAMining()
                 .AddFederatedPeg()
-                .CheckForPoAMembersCollateral()
+                .CheckForPoAMembersCollateral(true)
                 .UseTransactionNotification()
                 .UseBlockNotification()
                 .UseApi()
@@ -70,7 +70,7 @@ namespace Stratis.Features.FederatedPeg.IntegrationTests.Utils
                 builder.UseTestFedPegBlockDefinition();
             }
 
-            this.FullNode = (FullNode) builder.Build();
+            this.FullNode = (FullNode)builder.Build();
         }
     }
 }

--- a/src/Stratis.Features.FederatedPeg.IntegrationTests/Utils/SidechainMinerNodeRunner.cs
+++ b/src/Stratis.Features.FederatedPeg.IntegrationTests/Utils/SidechainMinerNodeRunner.cs
@@ -45,7 +45,7 @@ namespace Stratis.Features.FederatedPeg.IntegrationTests.Utils
                 .SetCounterChainNetwork(this.counterChainNetwork)
                 .UseSmartContractPoAConsensus()
                 .UseSmartContractCollateralPoAMining()
-                .CheckForPoAMembersCollateral()
+                .CheckForPoAMembersCollateral(true)
                 .UseTransactionNotification()
                 .UseBlockNotification()
                 .UseApi()

--- a/src/Stratis.Features.FederatedPeg.Tests/CheckCollateralFullValidationRuleTests.cs
+++ b/src/Stratis.Features.FederatedPeg.Tests/CheckCollateralFullValidationRuleTests.cs
@@ -67,7 +67,7 @@ namespace Stratis.Features.FederatedPeg.Tests
             block.Transactions[0].AddOutput(Money.Zero, votingOutputScript);
 
             var commitmentHeightEncoder = new CollateralHeightCommitmentEncoder(logger);
-            byte[] encodedHeight = commitmentHeightEncoder.EncodeWithPrefix(1000);
+            byte[] encodedHeight = commitmentHeightEncoder.EncodeCommitmentHeight(1000);
             var commitmentHeightData = new Script(OpcodeType.OP_RETURN, Op.GetPushOp(encodedHeight));
             block.Transactions[0].AddOutput(Money.Zero, commitmentHeightData);
 

--- a/src/Stratis.Features.FederatedPeg.Tests/CollateralHeightCommitmentEncoderTests.cs
+++ b/src/Stratis.Features.FederatedPeg.Tests/CollateralHeightCommitmentEncoderTests.cs
@@ -27,15 +27,13 @@ namespace Stratis.Features.FederatedPeg.Tests
             {
                 int randomValue = this.r.Next();
 
-                byte[] encodedWithPrefix = this.encoder.EncodeWithPrefix(randomValue);
+                byte[] encodedWithPrefix = this.encoder.EncodeCommitmentHeight(randomValue);
 
                 var votingOutputScript = new Script(OpcodeType.OP_RETURN, Op.GetPushOp(encodedWithPrefix));
                 var tx = new Transaction();
                 tx.AddOutput(Money.Zero, votingOutputScript);
 
-                byte[] rawData = this.encoder.ExtractRawCommitmentData(tx);
-
-                int decodedValue = this.encoder.Decode(rawData);
+                int? decodedValue = this.encoder.DecodeCommitmentHeight(tx);
 
                 Assert.Equal(randomValue, decodedValue);
             }


### PR DESCRIPTION
CirrusD nodes also needs to validate whether blocks that they receive contain valid commitment height, otherwise they are potentially relaying invalid block. This is causing these nodes to get banned incorrectly.

So the approach here is the split the commitment height check into its own rule so that CirrusD and CirrusDnsD run just that and then the miners the full set of checks.