### PR TITLE
[WIP] Wallet history logic

### DIFF
--- a/src/Stratis.Bitcoin.Features.Wallet/Services/WalletService.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Services/WalletService.cs
@@ -352,7 +352,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Services
                                 // Add incoming fund transaction details.
                                 var receivedItem = new TransactionItemModel
                                 {
-                                    Type = TransactionItemType.Received,
+                                    Type = (transaction.IsCoinStake != null && transaction.IsCoinStake.Value) ? TransactionItemType.Staked : TransactionItemType.Received,
                                     ToAddress = address.Address,
                                     Amount = transaction.Amount,
                                     Id = transaction.Id,


### PR DESCRIPTION
I am not entirely convinced this is all that needs to be done. We still need a test for histories containing staking transactions.

There is also a residual issue; if the history contains large numbers of items (i.e. it reaches the maximum without traversing the entire wallet) then staking transaction amounts appear incorrectly. This is because the input that will cause the amount to be normalised (i.e. to 1) does not get processed.