### PR TITLE
CheckCollateralCommitmentHeightRule should ignore the Genesis block

### DIFF
--- a/src/Stratis.Bitcoin.Features.Api/Stratis.Bitcoin.Features.Api.csproj
+++ b/src/Stratis.Bitcoin.Features.Api/Stratis.Bitcoin.Features.Api.csproj
@@ -22,7 +22,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.12" />
+    <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="3.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" Version="3.0.1" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="4.0.1" />

--- a/src/Stratis.Bitcoin.Features.SignalR/Stratis.Bitcoin.Features.SignalR.csproj
+++ b/src/Stratis.Bitcoin.Features.SignalR/Stratis.Bitcoin.Features.SignalR.csproj
@@ -7,7 +7,7 @@
     
     <ItemGroup>
         <PackageReference Include="CSharpFunctionalExtensions" Version="1.10.0" />
-        <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.12" />
+        <PackageReference Include="Microsoft.AspNetCore.App"/>
     </ItemGroup>
     
     <ItemGroup>

--- a/src/Stratis.Bitcoin.IntegrationTests/Stratis.Bitcoin.IntegrationTests.csproj
+++ b/src/Stratis.Bitcoin.IntegrationTests/Stratis.Bitcoin.IntegrationTests.csproj
@@ -34,6 +34,7 @@
   <ItemGroup>
     <PackageReference Include="Flurl" Version="2.8.0" />
     <PackageReference Include="Flurl.Http" Version="2.4.0" />
+    <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.7" />
     <PackageReference Include="NSubstitute" Version="3.1.0" />
   </ItemGroup>
 

--- a/src/Stratis.Features.Collateral/CheckCollateralCommitmentHeightRule.cs
+++ b/src/Stratis.Features.Collateral/CheckCollateralCommitmentHeightRule.cs
@@ -16,6 +16,10 @@ namespace Stratis.Features.Collateral
     {
         public override Task RunAsync(RuleContext context)
         {
+            // The genesis block won't contain any commitment data.
+            if (context.ValidationContext.ChainedHeaderToValidate.Height == 0)
+                return Task.CompletedTask;
+
             var commitmentHeightEncoder = new CollateralHeightCommitmentEncoder(this.Logger);
 
             int? commitmentHeight = commitmentHeightEncoder.DecodeCommitmentHeight(context.ValidationContext.BlockToValidate.Transactions.First());


### PR DESCRIPTION
The genesis block won't contain any height commitment data.