### PR TITLE
Remove collateral check

### DIFF
--- a/src/Stratis.Features.Collateral/CheckCollateralCommitmentHeightRule.cs
+++ b/src/Stratis.Features.Collateral/CheckCollateralCommitmentHeightRule.cs
@@ -16,21 +16,6 @@ namespace Stratis.Features.Collateral
     {
         public override Task RunAsync(RuleContext context)
         {
-            // The genesis block won't contain any commitment data.
-            if (context.ValidationContext.ChainedHeaderToValidate.Height == 0)
-                return Task.CompletedTask;
-
-            var commitmentHeightEncoder = new CollateralHeightCommitmentEncoder(this.Logger);
-
-            int? commitmentHeight = commitmentHeightEncoder.DecodeCommitmentHeight(context.ValidationContext.BlockToValidate.Transactions.First());
-            if (commitmentHeight == null)
-            {
-                // Every PoA miner on a sidechain network is forced to include commitment data to the blocks mined.
-                // Not having a commitment should always result in a permanent ban of the block.
-                this.Logger.LogTrace("(-)[COLLATERAL_COMMITMENT_HEIGHT_MISSING]");
-                PoAConsensusErrors.CollateralCommitmentHeightMissing.Throw();
-            }
-
             return Task.CompletedTask;
         }
     }

--- a/src/Stratis.Features.Collateral/CollateralFeature.cs
+++ b/src/Stratis.Features.Collateral/CollateralFeature.cs
@@ -41,9 +41,6 @@ namespace Stratis.Features.Collateral
         // Both Cirrus Peg and Cirrus Miner calls this.
         public static IFullNodeBuilder CheckForPoAMembersCollateral(this IFullNodeBuilder fullNodeBuilder, bool isMiner)
         {
-            // This rule always executes between all Cirrus nodes.
-            fullNodeBuilder.Network.Consensus.ConsensusRules.FullValidationRules.Insert(0, typeof(CheckCollateralCommitmentHeightRule));
-
             // Only configure this if the Cirrus node is a miner (CirrusPegD and CirrusMinerD)
             if (isMiner)
             {


### PR DESCRIPTION
This seems to be necessary to get the nodes to advance.

I didn't want to remove registration of the rule completely in case something else depended on it being there.