### PR TITLE
Add CollateralHeightCheck to CirrusTest (PoANetwork)

### DIFF
--- a/src/Stratis.Bitcoin.Features.PoA/PoANetwork.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/PoANetwork.cs
@@ -30,6 +30,11 @@ namespace Stratis.Bitcoin.Features.PoA
 
         public PoAConsensusOptions ConsensusOptions => this.Consensus.Options as PoAConsensusOptions;
 
+        /// <summary>
+        /// This is the height at which collateral commitment height data was committed to blocks.
+        /// </summary>
+        public int CollateralCommitmentActivationHeight { get; set; }
+
         public PoANetwork()
         {
             // The message start string is designed to be unlikely to occur in normal data.

--- a/src/Stratis.Features.Collateral/CheckCollateralCommitmentHeightRule.cs
+++ b/src/Stratis.Features.Collateral/CheckCollateralCommitmentHeightRule.cs
@@ -20,6 +20,10 @@ namespace Stratis.Features.Collateral
             if (context.ValidationContext.ChainedHeaderToValidate.Height == 0)
                 return Task.CompletedTask;
 
+            // If the network's CollateralCommitmentActivationHeight is set then check that the current height is less than than that.
+            if (context.ValidationContext.ChainedHeaderToValidate.Height < (this.Parent.Network as PoANetwork).CollateralCommitmentActivationHeight)
+                return Task.CompletedTask;
+
             var commitmentHeightEncoder = new CollateralHeightCommitmentEncoder(this.Logger);
 
             int? commitmentHeight = commitmentHeightEncoder.DecodeCommitmentHeight(context.ValidationContext.BlockToValidate.Transactions.First());

--- a/src/Stratis.Sidechains.Networks/CirrusTest.cs
+++ b/src/Stratis.Sidechains.Networks/CirrusTest.cs
@@ -175,6 +175,8 @@ namespace Stratis.Sidechains.Networks
 
             this.StandardScriptsRegistry = new SmartContractsStandardScriptsRegistry();
 
+            this.CollateralCommitmentActivationHeight = 25810;
+
             // 16 below should be changed to TargetSpacingSeconds when we move that field.
             Assert(this.DefaultBanTimeSeconds <= this.Consensus.MaxReorgLength * 16 / 2);
             Assert(this.Consensus.HashGenesisBlock == uint256.Parse("0000af9ab2c8660481328d0444cf167dfd31f24ca2dbba8e5e963a2434cffa93"));


### PR DESCRIPTION
The CirrusTest network only had collateral height commitment data written to it's block at height 25810 and onwards and as we check each block from Genesis we have to ignore everything before height.