### PR TITLE
Adjustable RPC Content Type

### DIFF
--- a/src/Stratis.Bitcoin.Features.RPC.Tests/RPCMiddlewareTest.cs
+++ b/src/Stratis.Bitcoin.Features.RPC.Tests/RPCMiddlewareTest.cs
@@ -2,7 +2,6 @@
 using System.IO;
 using System.Net;
 using System.Text;
-using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
@@ -10,6 +9,7 @@ using Microsoft.Extensions.Logging;
 using Moq;
 using Newtonsoft.Json.Linq;
 using Stratis.Bitcoin.Configuration;
+using Stratis.Bitcoin.Networks;
 using Stratis.Bitcoin.Tests.Common.Logging;
 using Xunit;
 
@@ -25,6 +25,7 @@ namespace Stratis.Bitcoin.Features.RPC.Tests
         private HttpResponseFeature response;
         private FeatureCollection featureCollection;
         private HttpRequestFeature request;
+        private RpcSettings rpcSettings;
 
         public RPCMiddlewareTest()
         {
@@ -45,7 +46,11 @@ namespace Stratis.Bitcoin.Features.RPC.Tests
                 return newHttpContext;
             });
 
-            this.middleware = new RPCMiddleware(this.delegateContext.Object, this.authorization.Object, this.LoggerFactory.Object, this.httpContextFactory.Object, new DataFolder(string.Empty));
+            var nodeSettings = new NodeSettings(new StratisRegTest());
+
+            this.rpcSettings = new RpcSettings(nodeSettings);
+
+            this.middleware = new RPCMiddleware(this.delegateContext.Object, this.authorization.Object, this.LoggerFactory.Object, this.httpContextFactory.Object, new DataFolder(string.Empty), this.rpcSettings);
         }
 
         [Fact]

--- a/src/Stratis.Bitcoin.Features.RPC/RPCFeature.cs
+++ b/src/Stratis.Bitcoin.Features.RPC/RPCFeature.cs
@@ -59,6 +59,8 @@ namespace Stratis.Bitcoin.Features.RPC
             builder.AppendLine("#rpcbind=127.0.0.1");
             builder.AppendLine("#Ip address allowed to connect to RPC (default all: 0.0.0.0 and ::)");
             builder.AppendLine("#rpcallowip=127.0.0.1");
+            builder.AppendLine("#Adjust RPC Content Type (default: application/json; charset=utf-8)");
+            builder.AppendLine("#rpccontenttype=application/json; charset=utf-8");
         }
 
         public override Task InitializeAsync()

--- a/src/Stratis.Bitcoin.Features.RPC/RPCMiddleware.cs
+++ b/src/Stratis.Bitcoin.Features.RPC/RPCMiddleware.cs
@@ -31,9 +31,15 @@ namespace Stratis.Bitcoin.Features.RPC
         private readonly IHttpContextFactory httpContextFactory;
         private readonly DataFolder dataFolder;
 
-        public const string ContentType = "application/json; charset=utf-8";
+        public readonly string ContentType;
 
-        public RPCMiddleware(RequestDelegate next, IRPCAuthorization authorization, ILoggerFactory loggerFactory, IHttpContextFactory httpContextFactory, DataFolder dataFolder)
+        public RPCMiddleware(
+            RequestDelegate next,
+            IRPCAuthorization authorization,
+            ILoggerFactory loggerFactory,
+            IHttpContextFactory httpContextFactory,
+            DataFolder dataFolder,
+            string contentType = "application/json; charset=utf-8")
         {
             Guard.NotNull(next, nameof(next));
             Guard.NotNull(authorization, nameof(authorization));
@@ -43,6 +49,7 @@ namespace Stratis.Bitcoin.Features.RPC
             this.logger = loggerFactory.CreateLogger(this.GetType().FullName);
             this.httpContextFactory = httpContextFactory;
             this.dataFolder = dataFolder;
+            this.ContentType = contentType;
         }
 
         public async Task InvokeAsync(HttpContext httpContext)

--- a/src/Stratis.Bitcoin.Features.RPC/RpcSettings.cs
+++ b/src/Stratis.Bitcoin.Features.RPC/RpcSettings.cs
@@ -40,6 +40,9 @@ namespace Stratis.Bitcoin.Features.RPC
         /// <summary>List of IP addresses that are allowed to connect to RPC interfaces.</summary>
         public List<IPAddressBlock> AllowIp { get; set; }
 
+        /// <summary>You can adjust the RPC Content Type.</summary>
+        public string RPCContentType { get; set; }
+
         /// <summary>
         /// Initializes an instance of the object from the node configuration.
         /// </summary>
@@ -71,6 +74,7 @@ namespace Stratis.Bitcoin.Features.RPC
 
             this.Server = config.GetOrDefault<bool>("server", false, this.logger);
             this.RPCPort = config.GetOrDefault<int>("rpcport", nodeSettings.Network.DefaultRPCPort, this.logger);
+            this.RPCContentType = config.GetOrDefault("rpccontenttype", "application/json; charset=utf-8", this.logger);
 
             if (this.Server)
             {

--- a/src/Stratis.Bitcoin.Features.RPC/Startup.cs
+++ b/src/Stratis.Bitcoin.Features.RPC/Startup.cs
@@ -61,7 +61,7 @@ namespace Stratis.Bitcoin.Features.RPC
 
             MvcJsonOptions options = GetMVCOptions(serviceProvider);
             Serializer.RegisterFrontConverters(options.SerializerSettings, fullNode.Network);
-            app.UseMiddleware(typeof(RPCMiddleware), authorizedAccess, rpcSettings.RPCContentType);
+            app.UseMiddleware(typeof(RPCMiddleware), authorizedAccess);
             app.UseRPC();
         }
 

--- a/src/Stratis.Bitcoin.Features.RPC/Startup.cs
+++ b/src/Stratis.Bitcoin.Features.RPC/Startup.cs
@@ -61,7 +61,7 @@ namespace Stratis.Bitcoin.Features.RPC
 
             MvcJsonOptions options = GetMVCOptions(serviceProvider);
             Serializer.RegisterFrontConverters(options.SerializerSettings, fullNode.Network);
-            app.UseMiddleware(typeof(RPCMiddleware), authorizedAccess);
+            app.UseMiddleware(typeof(RPCMiddleware), authorizedAccess, rpcSettings.RPCContentType);
             app.UseRPC();
         }
 

--- a/src/Stratis.Bitcoin/Utilities/FileStorage.cs
+++ b/src/Stratis.Bitcoin/Utilities/FileStorage.cs
@@ -188,7 +188,7 @@ namespace Stratis.Bitcoin.Utilities
             string filePath = Path.Combine(this.FolderPath, fileName);
 
             if (!File.Exists(filePath))
-                throw new FileNotFoundException($"No wallet file found at {filePath}");
+                throw new FileNotFoundException($"No file found at {filePath}");
 
             return JsonConvert.DeserializeObject<T>(File.ReadAllText(filePath));
         }


### PR DESCRIPTION
Add adjustable RPC content type to be compatible with other services.
Our default Content Type is set to `application/json; charset=utf-8`
While e.g. ElectrumX only accepts `application/json`