### PR TITLE
[FN] Additional handling for malformed peers.json

### DIFF
--- a/src/Stratis.Bitcoin/P2P/PeerAddressManager.cs
+++ b/src/Stratis.Bitcoin/P2P/PeerAddressManager.cs
@@ -59,7 +59,25 @@ namespace Stratis.Bitcoin.P2P
         /// <inheritdoc />
         public void LoadPeers()
         {
-            List<PeerAddress> loadedPeers = this.fileStorage.LoadByFileName(PeerFileName);
+            List<PeerAddress> loadedPeers;
+
+            try
+            {
+                loadedPeers = this.fileStorage.LoadByFileName(PeerFileName);
+            }
+            catch (Exception e)
+            {
+                this.logger.LogError("Error loading peers JSON, defaulting to empty list: {0}", e);
+
+                loadedPeers = new List<PeerAddress>();
+            }
+
+            if (loadedPeers == null)
+                loadedPeers = new List<PeerAddress>();
+
+            // If the loaded peers is still empty at this point, we rely on the discovery loop to find new peers to connect to.
+            // The discovery loop will only not run if -connect is used or if there are un-attempted peers left, so as long as
+            // there are seed nodes & DNS seeds available we should get something to connect to relatively rapidly.
 
             this.logger.LogDebug("{0} peers were loaded.", loadedPeers.Count);
 

--- a/src/Stratis.Bitcoin/Utilities/FileStorage.cs
+++ b/src/Stratis.Bitcoin/Utilities/FileStorage.cs
@@ -53,10 +53,11 @@ namespace Stratis.Bitcoin.Utilities
         internal JsonSerializerSettings GetSerializationSettings()
         {
             // get default Json serializer settings
-            var settings = new JsonSerializerSettings();
-
-            settings.NullValueHandling = this.SerializeNullValues ? NullValueHandling.Include : NullValueHandling.Ignore;
-
+            var settings = new JsonSerializerSettings
+            {
+                NullValueHandling = this.SerializeNullValues ? NullValueHandling.Include : NullValueHandling.Ignore
+            };
+            
             return settings;
         }
     }
@@ -188,7 +189,7 @@ namespace Stratis.Bitcoin.Utilities
             string filePath = Path.Combine(this.FolderPath, fileName);
 
             if (!File.Exists(filePath))
-                throw new FileNotFoundException($"No wallet file found at {filePath}");
+                throw new FileNotFoundException($"No file found at {filePath}");
 
             return JsonConvert.DeserializeObject<T>(File.ReadAllText(filePath));
         }


### PR DESCRIPTION
I have carefully re-reviewed the logic around peer discovery; I do not actually see how a node with acceptable network connectivity can remain without peers for an extended period even if the `peers.json` somehow got corrupted.

Nevertheless, this traps for any exceptions (if the deserialisation of the JSON happens to throw any - this is somewhat doubtful), and initialises an empty list if the deserialised object is ever `null`.

The expected behaviour if this occurs is that the `PeerDiscoveryLoop` will in any case run almost immediately after startup and determine that there are no known peers. It will then add the DNS seeds & seed nodes as discovery candidates, which should elicit some connectable peers.