### PR TITLE
Progress on putting ECRecover functionality into contracts

### DIFF
--- a/src/NBitcoin/Crypto/ECKey.cs
+++ b/src/NBitcoin/Crypto/ECKey.cs
@@ -191,4 +191,12 @@ namespace NBitcoin.Crypto
         }
 
     }
+
+    public static class ECKeyUtils
+    {
+        public static PubKey RecoverFromSignature(int recId, ECDSASignature sig, uint256 message, bool compressed)
+        {
+            return ECKey.RecoverFromSignature(recId, sig, message, compressed).GetPubKey(compressed);
+        }
+    }
 }

--- a/src/Stratis.Bitcoin.Features.SmartContracts.Tests/Stratis.Bitcoin.Features.SmartContracts.Tests.csproj
+++ b/src/Stratis.Bitcoin.Features.SmartContracts.Tests/Stratis.Bitcoin.Features.SmartContracts.Tests.csproj
@@ -18,7 +18,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="Stratis.SmartContracts" Version="1.2.1" />
+    <PackageReference Include="Stratis.SmartContracts" Version="1.2.2-dev" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/src/Stratis.Bitcoin.Features.SmartContracts/SmartContractFeature.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts/SmartContractFeature.cs
@@ -115,6 +115,7 @@ namespace Stratis.Bitcoin.Features.SmartContracts
                         services.AddSingleton<SmartContractTransactionPolicy>();
                         services.AddSingleton<IStateProcessor, StateProcessor>();
                         services.AddSingleton<ISmartContractStateFactory, SmartContractStateFactory>();
+                        services.AddSingleton<IEcRecoverProvider, EcRecoverProvider>();
                         services.AddSingleton<ILocalExecutor, LocalExecutor>();
                         services.AddSingleton<IBlockExecutionResultCache, BlockExecutionResultCache>();
 

--- a/src/Stratis.Bitcoin.Features.SmartContracts/Stratis.Bitcoin.Features.SmartContracts.csproj
+++ b/src/Stratis.Bitcoin.Features.SmartContracts/Stratis.Bitcoin.Features.SmartContracts.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <PackageReference Include="CSharpFunctionalExtensions" Version="1.10.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="3.0.1" />
-    <PackageReference Include="Stratis.SmartContracts" Version="1.2.1" />
+    <PackageReference Include="Stratis.SmartContracts" Version="1.2.2-dev" />
     <PackageReference Include="Tracer.Fody" Version="3.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/src/Stratis.SmartContracts.CLR.Tests/AuctionTests.cs
+++ b/src/Stratis.SmartContracts.CLR.Tests/AuctionTests.cs
@@ -44,6 +44,7 @@ namespace Stratis.SmartContracts.CLR.Tests
                 null,
                 getBalance,
                 null,
+                null, 
                 null
             );
         }
@@ -88,7 +89,8 @@ namespace Stratis.SmartContracts.CLR.Tests
             IInternalTransactionExecutor transactionExecutor,
             Func<ulong> getBalance,
             IInternalHashHelper hashHelper,
-            IContractLogger contractLogger)
+            IContractLogger contractLogger,
+            IEcRecoverProvider ecRecoverProvider)
         {
             this.Block = block;
             this.Message = message;
@@ -99,6 +101,7 @@ namespace Stratis.SmartContracts.CLR.Tests
             this.GetBalance = getBalance;
             this.InternalHashHelper = hashHelper;
             this.ContractLogger = contractLogger;
+            this.EcRecoverProvider = ecRecoverProvider;
         }
 
         public IBlock Block { get; }
@@ -110,6 +113,7 @@ namespace Stratis.SmartContracts.CLR.Tests
         public Func<ulong> GetBalance { get; }
         public IInternalHashHelper InternalHashHelper { get; }
         public IContractLogger ContractLogger { get; }
+        public IEcRecoverProvider EcRecoverProvider { get; }
     }
 
     public class TestBlock : IBlock

--- a/src/Stratis.SmartContracts.CLR.Tests/ContractExecutorTestContext.cs
+++ b/src/Stratis.SmartContracts.CLR.Tests/ContractExecutorTestContext.cs
@@ -31,6 +31,7 @@ namespace Stratis.SmartContracts.CLR.Tests
         public IContractAssemblyCache ContractCache { get; }
         public ReflectionVirtualMachine Vm { get; }
         public ISmartContractStateFactory SmartContractStateFactory { get; }
+        public IEcRecoverProvider EcRecoverProvider { get; }
         public StateProcessor StateProcessor { get; }
         public Serializer Serializer { get; }
 
@@ -51,7 +52,8 @@ namespace Stratis.SmartContracts.CLR.Tests
             this.Vm = new ReflectionVirtualMachine(this.Validator, this.LoggerFactory, this.AssemblyLoader, this.ModuleDefinitionReader, this.ContractCache);
             this.StateProcessor = new StateProcessor(this.Vm, this.AddressGenerator);
             this.InternalTxExecutorFactory = new InternalExecutorFactory(this.LoggerFactory, this.StateProcessor);
-            this.SmartContractStateFactory = new SmartContractStateFactory(this.ContractPrimitiveSerializer, this.InternalTxExecutorFactory, this.Serializer);
+            this.EcRecoverProvider = new EcRecoverProvider(this.Network);
+            this.SmartContractStateFactory = new SmartContractStateFactory(this.ContractPrimitiveSerializer, this.InternalTxExecutorFactory, this.Serializer, this.EcRecoverProvider);
         }
     }
 }

--- a/src/Stratis.SmartContracts.CLR.Tests/ContractExecutorTests.cs
+++ b/src/Stratis.SmartContracts.CLR.Tests/ContractExecutorTests.cs
@@ -41,6 +41,7 @@ namespace Stratis.SmartContracts.CLR.Tests
         private readonly IStateProcessor stateProcessor;
         private readonly ISmartContractStateFactory smartContractStateFactory;
         private readonly ISerializer serializer;
+        private readonly IEcRecoverProvider ecRecoverProvider;
 
         public ContractExecutorTests()
         {
@@ -61,7 +62,8 @@ namespace Stratis.SmartContracts.CLR.Tests
             this.vm = new ReflectionVirtualMachine(this.validator, this.loggerFactory, this.assemblyLoader, this.moduleDefinitionReader, this.contractCache);
             this.stateProcessor = new StateProcessor(this.vm, this.addressGenerator);
             this.internalTxExecutorFactory = new InternalExecutorFactory(this.loggerFactory, this.stateProcessor);
-            this.smartContractStateFactory = new SmartContractStateFactory(this.contractPrimitiveSerializer, this.internalTxExecutorFactory, this.serializer);
+            this.ecRecoverProvider = new EcRecoverProvider(this.network);
+            this.smartContractStateFactory = new SmartContractStateFactory(this.contractPrimitiveSerializer, this.internalTxExecutorFactory, this.serializer, this.ecRecoverProvider);
             
             this.callDataSerializer = new CallDataSerializer(this.contractPrimitiveSerializer);
 

--- a/src/Stratis.SmartContracts.CLR.Tests/ContractLogHolderTests.cs
+++ b/src/Stratis.SmartContracts.CLR.Tests/ContractLogHolderTests.cs
@@ -29,11 +29,11 @@ namespace Stratis.SmartContracts.CLR.Tests
             var contractAddress1 = new uint160(1);
             var contractAddress2 = new uint160(2);
 
-            var state1 = new TestSmartContractState(null, new TestMessage { ContractAddress = contractAddress1.ToAddress() }, null, null, null, null, null, null, null);
+            var state1 = new TestSmartContractState(null, new TestMessage { ContractAddress = contractAddress1.ToAddress() }, null, null, null, null, null, null, null, null);
             var log1 = new Example1("Jordan", 12345);
             var log2 = new Example1("John", 123);
 
-            var state2 = new TestSmartContractState(null, new TestMessage { ContractAddress = contractAddress2.ToAddress() }, null, null, null, null, null, null, null);
+            var state2 = new TestSmartContractState(null, new TestMessage { ContractAddress = contractAddress2.ToAddress() }, null, null, null, null, null, null, null, null);
             var log3 = new Example2("0x95D34980095380851902ccd9A1Fb4C813C2cb639".HexToAddress(), 16, "This is a test message.");
 
             this.logHolder.Log(state1, log1);

--- a/src/Stratis.SmartContracts.CLR.Tests/ObserverInstanceRewriterTests.cs
+++ b/src/Stratis.SmartContracts.CLR.Tests/ObserverInstanceRewriterTests.cs
@@ -128,7 +128,8 @@ namespace Stratis.SmartContracts.CLR.Tests
                 new ContractLogHolder(),
                 Mock.Of<IInternalTransactionExecutor>(),
                 new InternalHashHelper(),
-                () => 1000);
+                () => 1000,
+                Mock.Of<IEcRecoverProvider>());
 
             this.rewriter = new ObserverInstanceRewriter();
         }

--- a/src/Stratis.SmartContracts.CLR.Tests/ObserverTests.cs
+++ b/src/Stratis.SmartContracts.CLR.Tests/ObserverTests.cs
@@ -127,7 +127,8 @@ namespace Stratis.SmartContracts.CLR.Tests
                 new ContractLogHolder(),
                 Mock.Of<IInternalTransactionExecutor>(),
                 new InternalHashHelper(),
-                () => 1000);
+                () => 1000,
+                Mock.Of<IEcRecoverProvider>());
 
             this.rewriter = new ObserverRewriter(new Observer(this.gasMeter, new MemoryMeter(ReflectionVirtualMachine.MemoryUnitLimit)));
         }

--- a/src/Stratis.SmartContracts.CLR.Tests/ReflectionVirtualMachineTests.cs
+++ b/src/Stratis.SmartContracts.CLR.Tests/ReflectionVirtualMachineTests.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Reflection;
 using System.Text;
-using CSharpFunctionalExtensions;
 using Moq;
 using NBitcoin;
 using Stratis.SmartContracts.CLR.Caching;
@@ -46,7 +45,8 @@ namespace Stratis.SmartContracts.CLR.Tests
                 new ContractLogHolder(),
                 Mock.Of<IInternalTransactionExecutor>(),
                 new InternalHashHelper(),
-                () => 1000);
+                () => 1000,
+                Mock.Of<IEcRecoverProvider>());
             this.gasMeter = new GasMeter((RuntimeObserver.Gas)50_000);
         }
 

--- a/src/Stratis.SmartContracts.CLR.Validation/Stratis.SmartContracts.CLR.Validation.csproj
+++ b/src/Stratis.SmartContracts.CLR.Validation/Stratis.SmartContracts.CLR.Validation.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Mono.Cecil" Version="0.10.1" />
-    <PackageReference Include="Stratis.SmartContracts" Version="1.2.1" />
+    <PackageReference Include="Stratis.SmartContracts" Version="1.2.2-dev" />
     <PackageReference Include="Stratis.SmartContracts.Standards" Version="1.0.0" />
     <PackageReference Include="Tracer.Fody" Version="3.1.0">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Stratis.SmartContracts.CLR/EcRecover.cs
+++ b/src/Stratis.SmartContracts.CLR/EcRecover.cs
@@ -1,0 +1,38 @@
+﻿using NBitcoin;
+using NBitcoin.Crypto;
+using Stratis.SmartContracts.Core.Hashing;
+
+namespace Stratis.SmartContracts.CLR
+{
+    /// <summary>
+    /// Holds logic for the equivalent of the ECRECOVER opcode.
+    ///
+    /// This is static for now but when we know more about how we are going to use it we will adjust as necessary.
+    /// </summary>
+    public static class EcRecover
+    {
+        // TODO: Not sure what this is yet.
+        private const int RecId = 0;
+
+        public static ECDSASignature SignMessage(Key privateKey, byte[] message)
+        {
+            uint256 hashedUint256 = GetUint256FromMessage(message);
+            return privateKey.Sign(hashedUint256);
+        }
+
+        public static Address GetAddressFromSignatureAndMessage(byte[] signature, byte[] message, Network network)
+        {
+            // TODO: Error handling for incorrect signature format etc.
+
+            uint256 hashedUint256 = GetUint256FromMessage(message);
+            ECDSASignature loadedSignature = new ECDSASignature(signature);
+            PubKey pubKey = ECKeyUtils.RecoverFromSignature(RecId, loadedSignature, hashedUint256, true);
+            return pubKey.GetAddress(network).ToString().ToAddress(network);
+        }
+
+        private static uint256 GetUint256FromMessage(byte[] message)
+        {
+            return new uint256(HashHelper.Keccak256(message));
+        }
+    }
+}

--- a/src/Stratis.SmartContracts.CLR/EcRecover.cs
+++ b/src/Stratis.SmartContracts.CLR/EcRecover.cs
@@ -12,7 +12,7 @@ namespace Stratis.SmartContracts.CLR
     public static class EcRecover
     {
         // TODO: Not sure what this is yet.
-        private const int RecId = 0;
+        private const int RecId = 1;
 
         public static ECDSASignature SignMessage(Key privateKey, byte[] message)
         {

--- a/src/Stratis.SmartContracts.CLR/SmartContractState.cs
+++ b/src/Stratis.SmartContracts.CLR/SmartContractState.cs
@@ -15,7 +15,8 @@ namespace Stratis.SmartContracts.CLR
             IContractLogger contractLogger,
             IInternalTransactionExecutor internalTransactionExecutor,
             IInternalHashHelper internalHashHelper,
-            Func<ulong> getBalance)
+            Func<ulong> getBalance,
+            IEcRecoverProvider ecRecoverProvider)
         {
             this.Block = block;
             this.Message = message;
@@ -25,6 +26,7 @@ namespace Stratis.SmartContracts.CLR
             this.InternalTransactionExecutor = internalTransactionExecutor;
             this.InternalHashHelper = internalHashHelper;
             this.GetBalance = getBalance;
+            this.EcRecoverProvider = ecRecoverProvider;
         }
 
         public IBlock Block { get; }
@@ -34,6 +36,7 @@ namespace Stratis.SmartContracts.CLR
         public IPersistentState PersistentState { get; }
 
         public ISerializer Serializer { get; }
+        public IEcRecoverProvider EcRecoverProvider { get; }
 
         public IContractLogger ContractLogger { get; }
 

--- a/src/Stratis.SmartContracts.CLR/SmartContractStateFactory.cs
+++ b/src/Stratis.SmartContracts.CLR/SmartContractStateFactory.cs
@@ -9,13 +9,17 @@ namespace Stratis.SmartContracts.CLR
     {
         private readonly ISerializer serializer;
 
+        private readonly IEcRecoverProvider ecRecoverProvider;
+
         public SmartContractStateFactory(IContractPrimitiveSerializer primitiveSerializer,
             IInternalExecutorFactory internalTransactionExecutorFactory,
-            ISerializer serializer)
+            ISerializer serializer,
+            IEcRecoverProvider ecRecoverProvider)
         {
             this.serializer = serializer;
             this.PrimitiveSerializer = primitiveSerializer;
             this.InternalTransactionExecutorFactory = internalTransactionExecutorFactory;
+            this.ecRecoverProvider = ecRecoverProvider;
         }
 
         public IContractPrimitiveSerializer PrimitiveSerializer { get; }
@@ -44,7 +48,8 @@ namespace Stratis.SmartContracts.CLR
                 contractLogger,
                 this.InternalTransactionExecutorFactory.Create(gasMeter, state),
                 new InternalHashHelper(),
-                () => state.GetBalance(address));
+                () => state.GetBalance(address),
+                this.ecRecoverProvider);
 
             return contractState;
         }

--- a/src/Stratis.SmartContracts.IntegrationTests/ECRecoverTests.cs
+++ b/src/Stratis.SmartContracts.IntegrationTests/ECRecoverTests.cs
@@ -33,7 +33,7 @@ namespace Stratis.SmartContracts.IntegrationTests
             ECDSASignature offChainSignature = EcRecoverProvider.SignMessage(privateKey, message);
 
             // Get the address out of the signature
-            Address recoveredAddress = this.ecRecover.GetSigner(offChainSignature.ToDER(), message);
+            Address recoveredAddress = this.ecRecover.GetSigner(message, offChainSignature.ToDER());
 
             // Check that the address matches that generated from the private key.
             Assert.Equal(address, recoveredAddress);

--- a/src/Stratis.SmartContracts.IntegrationTests/ECRecoverTests.cs
+++ b/src/Stratis.SmartContracts.IntegrationTests/ECRecoverTests.cs
@@ -1,0 +1,43 @@
+﻿using NBitcoin;
+using NBitcoin.Crypto;
+using Stratis.SmartContracts.CLR;
+using Stratis.SmartContracts.Networks;
+using Xunit;
+using Key = NBitcoin.Key;
+
+namespace Stratis.SmartContracts.IntegrationTests
+{
+    public class ECRecoverTests
+    {
+        private readonly Network network;
+
+        public ECRecoverTests()
+        {
+            this.network = new SmartContractsPoARegTest();
+        }
+
+        // 2 things to test: 
+
+        // 1) That we have the ECDSA code and can make it available.
+
+        [Fact]
+        public void CanSignAndRetrieveSender()
+        {
+            Key privateKey = new Key();
+            Address address = privateKey.PubKey.GetAddress(this.network).ToString().ToAddress(this.network);
+
+            byte[] message = new byte[] { 0x69, 0x76, 0xAA };
+
+            ECDSASignature offChainSignature = EcRecover.SignMessage(privateKey, message);
+
+            Address recoveredAddress = EcRecover.GetAddressFromSignatureAndMessage(offChainSignature.ToDER(), message, this.network);
+
+            Assert.Equal(address, recoveredAddress);
+        }
+
+        // 2) That we can enable the method in new contracts without affecting the older contracts
+
+        // TODO
+
+    }
+}

--- a/src/Stratis.SmartContracts.IntegrationTests/ECRecoverTests.cs
+++ b/src/Stratis.SmartContracts.IntegrationTests/ECRecoverTests.cs
@@ -10,10 +10,12 @@ namespace Stratis.SmartContracts.IntegrationTests
     public class ECRecoverTests
     {
         private readonly Network network;
+        private readonly EcRecoverProvider ecRecover;
 
         public ECRecoverTests()
         {
             this.network = new SmartContractsPoARegTest();
+            this.ecRecover = new EcRecoverProvider(this.network);
         }
 
         // 2 things to test: 
@@ -28,10 +30,10 @@ namespace Stratis.SmartContracts.IntegrationTests
             byte[] message = new byte[] { 0x69, 0x76, 0xAA };
 
             // Sign a message
-            ECDSASignature offChainSignature = EcRecover.SignMessage(privateKey, message);
+            ECDSASignature offChainSignature = EcRecoverProvider.SignMessage(privateKey, message);
 
             // Get the address out of the signature
-            Address recoveredAddress = EcRecover.GetAddressFromSignatureAndMessage(offChainSignature.ToDER(), message, this.network);
+            Address recoveredAddress = this.ecRecover.GetSigner(offChainSignature.ToDER(), message);
 
             // Check that the address matches that generated from the private key.
             Assert.Equal(address, recoveredAddress);

--- a/src/Stratis.SmartContracts.IntegrationTests/ECRecoverTests.cs
+++ b/src/Stratis.SmartContracts.IntegrationTests/ECRecoverTests.cs
@@ -25,13 +25,15 @@ namespace Stratis.SmartContracts.IntegrationTests
         {
             Key privateKey = new Key();
             Address address = privateKey.PubKey.GetAddress(this.network).ToString().ToAddress(this.network);
-
             byte[] message = new byte[] { 0x69, 0x76, 0xAA };
 
+            // Sign a message
             ECDSASignature offChainSignature = EcRecover.SignMessage(privateKey, message);
 
+            // Get the address out of the signature
             Address recoveredAddress = EcRecover.GetAddressFromSignatureAndMessage(offChainSignature.ToDER(), message, this.network);
 
+            // Check that the address matches that generated from the private key.
             Assert.Equal(address, recoveredAddress);
         }
 

--- a/src/Stratis.SmartContracts.IntegrationTests/PoW/SmartContractMinerTests.cs
+++ b/src/Stratis.SmartContracts.IntegrationTests/PoW/SmartContractMinerTests.cs
@@ -177,6 +177,7 @@ namespace Stratis.SmartContracts.IntegrationTests.PoW
             private StateProcessor stateProcessor;
             private SmartContractStateFactory smartContractStateFactory;
             public IBlockExecutionResultCache executionCache;
+            private IEcRecoverProvider ecRecoverProvider;
             public SmartContractPowConsensusFactory ConsensusFactory { get; private set; }
 
             #endregion
@@ -346,7 +347,8 @@ namespace Stratis.SmartContracts.IntegrationTests.PoW
                 this.internalTxExecutorFactory = new InternalExecutorFactory(this.loggerFactory, this.stateProcessor);
                 this.primitiveSerializer = new ContractPrimitiveSerializer(this.network);
                 this.serializer = new Serializer(this.primitiveSerializer);
-                this.smartContractStateFactory = new SmartContractStateFactory(this.primitiveSerializer, this.internalTxExecutorFactory, this.serializer);
+                this.ecRecoverProvider = new EcRecoverProvider(this.network);
+                this.smartContractStateFactory = new SmartContractStateFactory(this.primitiveSerializer, this.internalTxExecutorFactory, this.serializer, this.ecRecoverProvider);
                 this.stateFactory = new StateFactory(this.smartContractStateFactory);
                 this.ExecutorFactory = new ReflectionExecutorFactory(this.loggerFactory, this.callDataSerializer, this.refundProcessor, this.transferProcessor, this.stateFactory, this.stateProcessor, this.primitiveSerializer);
             }

--- a/src/Stratis.SmartContracts.IntegrationTests/SmartContracts/EcRecoverContract.cs
+++ b/src/Stratis.SmartContracts.IntegrationTests/SmartContracts/EcRecoverContract.cs
@@ -1,0 +1,30 @@
+﻿
+using Stratis.SmartContracts;
+
+public class EcRecoverContract : SmartContract
+{
+        public Address ThirdPartySigner
+        {
+            get
+            {
+                return this.PersistentState.GetAddress(nameof(this.ThirdPartySigner));
+            }
+            set
+            {
+                this.PersistentState.SetAddress(nameof(this.ThirdPartySigner), value);
+            }
+        }
+
+        public EcRecoverContract(ISmartContractState state, Address thirdPartySigner) : base(state)
+        {
+            this.ThirdPartySigner = thirdPartySigner;
+        }
+
+        public void CheckThirdPartySignature()
+        {
+            byte[] message = new byte[] { 0, 1, 2, 3 };
+            Address signerOfMessage = this.EcRecover()
+        }
+
+
+}


### PR DESCRIPTION
Ethereum contracts increasingly use the ECRecover opcode which returns the address of the private key that signed a message.

This PR introduces that functionality and was just starting to test it. It needs more work before being merged.

The new functionality was enabled in the Stratis.SmartContracts v1.2.2-dev package.

It needs:
- An integration test deploying a contract that uses this opcode and then testing that it gets the correct address and can verify that something was signed off-chain
-The Stratis.SmartContracts package 1.2.3 to be released with this enabled.
- Cirrus nodes to be upgraded (hard fork) to the new Stratis.SmartContracts package.